### PR TITLE
feat(ui-components): add alert/toast component

### DIFF
--- a/packages/ui-components/src/assets/icons.ts
+++ b/packages/ui-components/src/assets/icons.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared SVG icon constants for ui-components.
+ * All icons use `currentColor` for stroke/fill so they inherit the parent's `color`.
+ */
+
+/** Chevron-down arrow (accordion expand indicator). */
+export const ICON_CHEVRON = `<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M5 7.5L10 12.5L15 7.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
+
+/** Close / dismiss X icon. */
+export const ICON_CLOSE = `<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><line x1="5" y1="5" x2="15" y2="15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><line x1="15" y1="5" x2="5" y2="15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>`;
+
+/** Error X icon (thicker stroke for status indicators). */
+export const ICON_ERROR = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="5" y1="5" x2="15" y2="15"/><line x1="15" y1="5" x2="5" y2="15"/></svg>`;
+
+/** Success checkmark icon. */
+export const ICON_SUCCESS = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 10 8 14 16 6"/></svg>`;
+
+/** Warning triangle icon. */
+export const ICON_WARNING = `<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M10 7v4M10 13h.01M3.5 16h13L10 4 3.5 16z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
+
+/** Loading spinner arc icon. */
+export const ICON_LOADING = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M10 2a8 8 0 0 1 8 8"/></svg>`;

--- a/packages/ui-components/src/components/ui-accordion-item.ts
+++ b/packages/ui-components/src/components/ui-accordion-item.ts
@@ -6,15 +6,7 @@ export type AccordionSize = "s" | "m" | "l";
 export type AccordionEmphasis = "bold" | "subtle";
 export type AccordionStatus = "none" | "error" | "warning" | "success";
 
-// ─── SVG icons ───────────────────────────────────────────────────────────────
-
-const ICON_CHEVRON = `<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M5 7.5L10 12.5L15 7.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
-
-const ICON_ERROR = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="5" y1="5" x2="15" y2="15"/><line x1="15" y1="5" x2="5" y2="15"/></svg>`;
-
-const ICON_WARNING = `<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M10 7v4M10 13h.01M3.5 16h13L10 4 3.5 16z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
-
-const ICON_SUCCESS = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 10 8 14 16 6"/></svg>`;
+import { ICON_CHEVRON, ICON_ERROR, ICON_WARNING, ICON_SUCCESS } from "../assets/icons.js";
 
 // ─── Token constants ─────────────────────────────────────────────────────────
 

--- a/packages/ui-components/src/components/ui-alert.test.ts
+++ b/packages/ui-components/src/components/ui-alert.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "./ui-alert.js";
+
+describe("ui-alert", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-alert");
+    document.body.appendChild(el);
+  });
+
+  // ── Registration ─────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-alert")).toBeDefined();
+  });
+
+  // ── Default attributes ───────────────────────────────────────────────────
+
+  it("defaults size to 'm'", () => {
+    expect((el as unknown as { size: string }).size).toBe("m");
+  });
+
+  it("defaults emphasis to 'bold'", () => {
+    expect((el as unknown as { emphasis: string }).emphasis).toBe("bold");
+  });
+
+  it("defaults status to 'none'", () => {
+    expect((el as unknown as { status: string }).status).toBe("none");
+  });
+
+  it("defaults dismissable to false", () => {
+    expect((el as unknown as { dismissable: boolean }).dismissable).toBe(false);
+  });
+
+  it("defaults leadingIcon to false", () => {
+    expect((el as unknown as { leadingIcon: boolean }).leadingIcon).toBe(false);
+  });
+
+  // ── Size attribute ──────────────────────────────────────────────────────
+
+  it("reflects size='s' to attribute", () => {
+    (el as unknown as { size: string }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("reflects size='m' to attribute", () => {
+    (el as unknown as { size: string }).size = "m";
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("reflects size='l' to attribute", () => {
+    (el as unknown as { size: string }).size = "l";
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  // ── Emphasis attribute ──────────────────────────────────────────────────
+
+  it("reflects emphasis='bold' to attribute", () => {
+    (el as unknown as { emphasis: string }).emphasis = "bold";
+    expect(el.getAttribute("emphasis")).toBe("bold");
+  });
+
+  it("reflects emphasis='subtle' to attribute", () => {
+    (el as unknown as { emphasis: string }).emphasis = "subtle";
+    expect(el.getAttribute("emphasis")).toBe("subtle");
+  });
+
+  // ── Status attribute ────────────────────────────────────────────────────
+
+  it("reflects status='none' to attribute", () => {
+    (el as unknown as { status: string }).status = "none";
+    expect(el.getAttribute("status")).toBe("none");
+  });
+
+  it("reflects status='information' to attribute", () => {
+    (el as unknown as { status: string }).status = "information";
+    expect(el.getAttribute("status")).toBe("information");
+  });
+
+  it("reflects status='success' to attribute", () => {
+    (el as unknown as { status: string }).status = "success";
+    expect(el.getAttribute("status")).toBe("success");
+  });
+
+  it("reflects status='error' to attribute", () => {
+    (el as unknown as { status: string }).status = "error";
+    expect(el.getAttribute("status")).toBe("error");
+  });
+
+  it("reflects status='warning' to attribute", () => {
+    (el as unknown as { status: string }).status = "warning";
+    expect(el.getAttribute("status")).toBe("warning");
+  });
+
+  // ── Dismissable attribute ───────────────────────────────────────────────
+
+  it("sets dismissable attribute when property is true", () => {
+    (el as unknown as { dismissable: boolean }).dismissable = true;
+    expect(el.hasAttribute("dismissable")).toBe(true);
+  });
+
+  it("removes dismissable attribute when property is false", () => {
+    (el as unknown as { dismissable: boolean }).dismissable = true;
+    (el as unknown as { dismissable: boolean }).dismissable = false;
+    expect(el.hasAttribute("dismissable")).toBe(false);
+  });
+
+  // ── Leading icon attribute ──────────────────────────────────────────────
+
+  it("sets leading-icon attribute when leadingIcon property is true", () => {
+    (el as unknown as { leadingIcon: boolean }).leadingIcon = true;
+    expect(el.hasAttribute("leading-icon")).toBe(true);
+  });
+
+  it("removes leading-icon attribute when leadingIcon property is false", () => {
+    (el as unknown as { leadingIcon: boolean }).leadingIcon = true;
+    (el as unknown as { leadingIcon: boolean }).leadingIcon = false;
+    expect(el.hasAttribute("leading-icon")).toBe(false);
+  });
+
+  // ── Close button dispatches dismiss event ───────────────────────────────
+
+  it("dispatches dismiss event when close button is clicked", () => {
+    el.setAttribute("dismissable", "");
+    const shadow = el.shadowRoot!;
+    const closeBtn = shadow.querySelector(".close-btn") as HTMLElement;
+    let eventFired = false;
+    el.addEventListener("dismiss", () => {
+      eventFired = true;
+    });
+    closeBtn.click();
+    expect(eventFired).toBe(true);
+  });
+
+  it("dismiss event has bubbles and composed set to true", () => {
+    el.setAttribute("dismissable", "");
+    const shadow = el.shadowRoot!;
+    const closeBtn = shadow.querySelector(".close-btn") as HTMLElement;
+    let event: CustomEvent | null = null;
+    el.addEventListener("dismiss", (e: Event) => {
+      event = e as CustomEvent;
+    });
+    closeBtn.click();
+    expect(event).toBeTruthy();
+    expect(event!.bubbles).toBe(true);
+    expect(event!.composed).toBe(true);
+  });
+
+  // ── Close button hidden when not dismissable ───────────────────────────
+
+  it("close button is not visible when dismissable is absent", () => {
+    const shadow = el.shadowRoot!;
+    const closeBtn = shadow.querySelector(".close-btn") as HTMLElement;
+    expect(closeBtn).toBeTruthy();
+    // The button exists in DOM but is hidden via CSS :host([dismissable]) .close-btn
+    // Without the attribute, display is 'none'
+    expect(el.hasAttribute("dismissable")).toBe(false);
+  });
+
+  it("close button is visible when dismissable is present", () => {
+    el.setAttribute("dismissable", "");
+    const shadow = el.shadowRoot!;
+    const closeBtn = shadow.querySelector(".close-btn") as HTMLElement;
+    expect(closeBtn).toBeTruthy();
+    expect(el.hasAttribute("dismissable")).toBe(true);
+  });
+
+  // ── ARIA role="alert" ──────────────────────────────────────────────────
+
+  it("has role='alert' on the host element", () => {
+    expect(el.getAttribute("role")).toBe("alert");
+  });
+
+  it("does not override existing role attribute", () => {
+    document.body.innerHTML = "";
+    const custom = document.createElement("ui-alert");
+    custom.setAttribute("role", "status");
+    document.body.appendChild(custom);
+    expect(custom.getAttribute("role")).toBe("status");
+  });
+
+  // ── Close button ARIA ──────────────────────────────────────────────────
+
+  it("close button has aria-label='Dismiss'", () => {
+    const shadow = el.shadowRoot!;
+    const closeBtn = shadow.querySelector(".close-btn") as HTMLElement;
+    expect(closeBtn.getAttribute("aria-label")).toBe("Dismiss");
+  });
+
+  // ── Shadow DOM structure ───────────────────────────────────────────────
+
+  it("has .base element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".base")).toBeTruthy();
+  });
+
+  it("has .top-content element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".top-content")).toBeTruthy();
+  });
+
+  it("has .title element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".title")).toBeTruthy();
+  });
+
+  it("has .close-btn element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".close-btn")).toBeTruthy();
+  });
+
+  it("has .description element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".description")).toBeTruthy();
+  });
+
+  it("has .leading-icon element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".leading-icon")).toBeTruthy();
+  });
+  it("footer is hidden by default", () => {
+    const shadow = el.shadowRoot!;
+    const footer = shadow.querySelector(".footer");
+    expect(footer).toBeTruthy();
+    expect(el.hasAttribute("has-footer")).toBe(false);
+  });
+  it("has .footer element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".footer")).toBeTruthy();
+  });
+
+  // ── Leading icon visibility ────────────────────────────────────────────
+
+  it("leading-icon container is present but hidden by default", () => {
+    const shadow = el.shadowRoot!;
+    const leadingIcon = shadow.querySelector(".leading-icon");
+    expect(leadingIcon).toBeTruthy();
+    expect(el.hasAttribute("leading-icon")).toBe(false);
+  });
+
+  it("leading-icon container becomes visible when attribute is set", () => {
+    el.setAttribute("leading-icon", "");
+    const shadow = el.shadowRoot!;
+    const leadingIcon = shadow.querySelector(".leading-icon");
+    expect(leadingIcon).toBeTruthy();
+    expect(el.hasAttribute("leading-icon")).toBe(true);
+  });
+
+  // ── Property accessors ────────────────────────────────────────────────
+
+  it("exposes all typed property accessors", () => {
+    const component = el as unknown as {
+      size: string;
+      emphasis: string;
+      status: string;
+      dismissable: boolean;
+      leadingIcon: boolean;
+    };
+
+    component.size = "l";
+    expect(component.size).toBe("l");
+
+    component.emphasis = "subtle";
+    expect(component.emphasis).toBe("subtle");
+
+    component.status = "error";
+    expect(component.status).toBe("error");
+
+    component.dismissable = true;
+    expect(component.dismissable).toBe(true);
+
+    component.leadingIcon = true;
+    expect(component.leadingIcon).toBe(true);
+  });
+});

--- a/packages/ui-components/src/components/ui-alert.ts
+++ b/packages/ui-components/src/components/ui-alert.ts
@@ -1,0 +1,590 @@
+import { semanticVar } from "@maneki/foundation";
+
+// ─── Type-safe property unions ───────────────────────────────────────────────
+
+export type AlertSize = "s" | "m" | "l";
+export type AlertEmphasis = "bold" | "subtle";
+export type AlertStatus =
+  | "none"
+  | "information"
+  | "success"
+  | "error"
+  | "warning";
+
+import { ICON_CLOSE } from "../assets/icons.js";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+// Bold surfaces
+const SURF_NONE_BOLD = semanticVar("statusSurface", "noneBold");
+const SURF_INFO_BOLD = semanticVar("statusSurface", "informationBold");
+const SURF_SUCCESS_BOLD = semanticVar("statusSurface", "successBold");
+const SURF_ERROR_BOLD = semanticVar("statusSurface", "errorBold");
+const SURF_WARNING_BOLD = semanticVar("statusSurface", "warningBold");
+
+// Bold text
+const TEXT_NONE_BOLD = semanticVar("statusText", "noneBoldText");
+const TEXT_INFO_BOLD = semanticVar("statusText", "informationBoldText");
+const TEXT_SUCCESS_BOLD = semanticVar("statusText", "successBoldText");
+const TEXT_ERROR_BOLD = semanticVar("statusText", "errorBoldText");
+const TEXT_WARNING_BOLD = semanticVar("statusText", "warningBoldText");
+
+// Bold icon
+const ICON_NONE_BOLD = semanticVar("statusIcon", "noneBoldIcon");
+const ICON_INFO_BOLD = semanticVar("statusIcon", "informationBoldIcon");
+const ICON_SUCCESS_BOLD = semanticVar("statusIcon", "successBoldIcon");
+const ICON_ERROR_BOLD = semanticVar("statusIcon", "errorBoldIcon");
+const ICON_WARNING_BOLD = semanticVar("statusIcon", "warningBoldIcon");
+
+// Subtle surfaces
+const SURF_NONE_SUBTLE = semanticVar("statusSurface", "noneSubtle");
+const SURF_INFO_SUBTLE = semanticVar("statusSurface", "informationSubtle");
+const SURF_SUCCESS_SUBTLE = semanticVar("statusSurface", "successSubtle");
+const SURF_ERROR_SUBTLE = semanticVar("statusSurface", "errorSubtle");
+const SURF_WARNING_SUBTLE = semanticVar("statusSurface", "warningSubtle");
+
+// Subtle text
+const TEXT_NONE_SUBTLE = semanticVar("statusText", "noneSubtleText");
+const TEXT_INFO_SUBTLE = semanticVar("statusText", "informationSubtleText");
+const TEXT_SUCCESS_SUBTLE = semanticVar("statusText", "successSubtleText");
+const TEXT_ERROR_SUBTLE = semanticVar("statusText", "errorSubtleText");
+const TEXT_WARNING_SUBTLE = semanticVar("statusText", "warningSubtleText");
+
+// Subtle icon
+const ICON_NONE_SUBTLE = semanticVar("statusIcon", "noneSubtleIcon");
+const ICON_INFO_SUBTLE = semanticVar("statusIcon", "informationSubtleIcon");
+const ICON_SUCCESS_SUBTLE = semanticVar("statusIcon", "successSubtleIcon");
+const ICON_ERROR_SUBTLE = semanticVar("statusIcon", "errorSubtleIcon");
+const ICON_WARNING_SUBTLE = semanticVar("statusIcon", "warningSubtleIcon");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: block;
+    opacity: 1;
+    transition: opacity 0.2s ease;
+  }
+  :host([dismissed]) {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  /* ── Base ─────────────────────────────────────────────────────────────────── */
+
+  .base {
+    display: flex;
+    flex-direction: column;
+    border-radius: 2px;
+    font-family: "Goldman Sans", sans-serif;
+  }
+
+  /* ── Top content ─────────────────────────────────────────────────────────── */
+
+  .top-content {
+    display: flex;
+    flex-direction: row;
+    gap: 16px;
+    align-items: start;
+  }
+
+  .top-left {
+    display: flex;
+    flex-direction: row;
+    flex: 1;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .top-right {
+    display: flex;
+    flex-direction: row;
+    align-items: start;
+  }
+
+  /* ── Leading icon ────────────────────────────────────────────────────────── */
+
+  .leading-icon {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    line-height: 0;
+    flex-shrink: 0;
+  }
+
+  :host([leading-icon]) .leading-icon {
+    display: inline-flex;
+  }
+
+  .leading-icon ::slotted(*) {
+    width: 100%;
+    height: 100%;
+  }
+
+  /* ── Title ───────────────────────────────────────────────────────────────── */
+
+  .title {
+    flex: 1;
+    font-weight: 400;
+  }
+
+  :host([has-description]) .title {
+    font-weight: 500;
+  }
+
+  /* ── Description ─────────────────────────────────────────────────────────── */
+
+  .description {
+    display: none;
+  }
+
+  :host([has-description]) .description {
+    display: block;
+  }
+
+  :host([has-description]) .base {
+    gap: 12px;
+  }
+
+  /* ── Footer ──────────────────────────────────────────────────────────────── */
+
+  .footer {
+    display: none;
+  }
+
+  :host([has-footer]) .footer {
+    display: block;
+  }
+
+  /* ── Close button ────────────────────────────────────────────────────────── */
+
+  .close-btn {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    color: inherit;
+    line-height: 0;
+  }
+
+  .close-btn svg {
+    width: 100%;
+    height: 100%;
+  }
+
+  :host([dismissable]) .close-btn {
+    display: inline-flex;
+  }
+
+  /* ── Size: m (default) ───────────────────────────────────────────────────── */
+
+  :host .base,
+  :host([size="m"]) .base {
+    padding: 12px;
+  }
+
+  :host .title,
+  :host([size="m"]) .title {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  :host .description,
+  :host([size="m"]) .description {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  :host .leading-icon,
+  :host([size="m"]) .leading-icon {
+    width: 20px;
+    height: 20px;
+  }
+
+  :host .close-btn,
+  :host([size="m"]) .close-btn {
+    width: 20px;
+    height: 20px;
+  }
+
+  /* ── Size: s ─────────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) .base {
+    padding: 8px;
+  }
+
+  :host([size="s"]) .title {
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  :host([size="s"]) .description {
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  :host([size="s"]) .leading-icon {
+    width: 16px;
+    height: 16px;
+  }
+
+  :host([size="s"]) .close-btn {
+    width: 16px;
+    height: 16px;
+  }
+
+  /* ── Size: l ─────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) .base {
+    padding: 16px;
+  }
+
+  :host([size="l"]) .title {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  :host([size="l"]) .description {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  :host([size="l"]) .leading-icon {
+    width: 24px;
+    height: 24px;
+  }
+
+  :host([size="l"]) .close-btn {
+    width: 24px;
+    height: 24px;
+  }
+
+  /* ── Status + Emphasis: bold (default) ───────────────────────────────────── */
+
+  :host .base,
+  :host([status="none"]) .base,
+  :host([status="none"][emphasis="bold"]) .base {
+    background-color: var(--ui-alert-bg, ${SURF_NONE_BOLD});
+    color: var(--ui-alert-text, ${TEXT_NONE_BOLD});
+  }
+
+  :host .leading-icon,
+  :host([status="none"]) .leading-icon,
+  :host([status="none"][emphasis="bold"]) .leading-icon {
+    color: var(--ui-alert-icon, ${ICON_NONE_BOLD});
+  }
+
+  :host([status="information"]) .base,
+  :host([status="information"][emphasis="bold"]) .base {
+    background-color: var(--ui-alert-bg, ${SURF_INFO_BOLD});
+    color: var(--ui-alert-text, ${TEXT_INFO_BOLD});
+  }
+
+  :host([status="information"]) .leading-icon,
+  :host([status="information"][emphasis="bold"]) .leading-icon {
+    color: var(--ui-alert-icon, ${ICON_INFO_BOLD});
+  }
+
+  :host([status="success"]) .base,
+  :host([status="success"][emphasis="bold"]) .base {
+    background-color: var(--ui-alert-bg, ${SURF_SUCCESS_BOLD});
+    color: var(--ui-alert-text, ${TEXT_SUCCESS_BOLD});
+  }
+
+  :host([status="success"]) .leading-icon,
+  :host([status="success"][emphasis="bold"]) .leading-icon {
+    color: var(--ui-alert-icon, ${ICON_SUCCESS_BOLD});
+  }
+
+  :host([status="error"]) .base,
+  :host([status="error"][emphasis="bold"]) .base {
+    background-color: var(--ui-alert-bg, ${SURF_ERROR_BOLD});
+    color: var(--ui-alert-text, ${TEXT_ERROR_BOLD});
+  }
+
+  :host([status="error"]) .leading-icon,
+  :host([status="error"][emphasis="bold"]) .leading-icon {
+    color: var(--ui-alert-icon, ${ICON_ERROR_BOLD});
+  }
+
+  :host([status="warning"]) .base,
+  :host([status="warning"][emphasis="bold"]) .base {
+    background-color: var(--ui-alert-bg, ${SURF_WARNING_BOLD});
+    color: var(--ui-alert-text, ${TEXT_WARNING_BOLD});
+  }
+
+  :host([status="warning"]) .leading-icon,
+  :host([status="warning"][emphasis="bold"]) .leading-icon {
+    color: var(--ui-alert-icon, ${ICON_WARNING_BOLD});
+  }
+
+  /* ── Status + Emphasis: subtle ───────────────────────────────────────────── */
+
+  :host([emphasis="subtle"]) .base,
+  :host([status="none"][emphasis="subtle"]) .base {
+    background-color: var(--ui-alert-bg, ${SURF_NONE_SUBTLE});
+    color: var(--ui-alert-text, ${TEXT_NONE_SUBTLE});
+  }
+
+  :host([emphasis="subtle"]) .leading-icon,
+  :host([status="none"][emphasis="subtle"]) .leading-icon {
+    color: var(--ui-alert-icon, ${ICON_NONE_SUBTLE});
+  }
+
+  :host([status="information"][emphasis="subtle"]) .base {
+    background-color: var(--ui-alert-bg, ${SURF_INFO_SUBTLE});
+    color: var(--ui-alert-text, ${TEXT_INFO_SUBTLE});
+  }
+
+  :host([status="information"][emphasis="subtle"]) .leading-icon {
+    color: var(--ui-alert-icon, ${ICON_INFO_SUBTLE});
+  }
+
+  :host([status="success"][emphasis="subtle"]) .base {
+    background-color: var(--ui-alert-bg, ${SURF_SUCCESS_SUBTLE});
+    color: var(--ui-alert-text, ${TEXT_SUCCESS_SUBTLE});
+  }
+
+  :host([status="success"][emphasis="subtle"]) .leading-icon {
+    color: var(--ui-alert-icon, ${ICON_SUCCESS_SUBTLE});
+  }
+
+  :host([status="error"][emphasis="subtle"]) .base {
+    background-color: var(--ui-alert-bg, ${SURF_ERROR_SUBTLE});
+    color: var(--ui-alert-text, ${TEXT_ERROR_SUBTLE});
+  }
+
+  :host([status="error"][emphasis="subtle"]) .leading-icon {
+    color: var(--ui-alert-icon, ${ICON_ERROR_SUBTLE});
+  }
+
+  :host([status="warning"][emphasis="subtle"]) .base {
+    background-color: var(--ui-alert-bg, ${SURF_WARNING_SUBTLE});
+    color: var(--ui-alert-text, ${TEXT_WARNING_SUBTLE});
+  }
+
+  :host([status="warning"][emphasis="subtle"]) .leading-icon {
+    color: var(--ui-alert-icon, ${ICON_WARNING_SUBTLE});
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export class UiAlert extends HTMLElement {
+  static readonly observedAttributes = [
+    "size",
+    "emphasis",
+    "status",
+    "dismissable",
+    "leading-icon",
+  ];
+
+  private _descriptionSlot: HTMLSlotElement;
+  private _footerSlot: HTMLSlotElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+
+    const style = document.createElement("style");
+    style.textContent = STYLES;
+    shadow.appendChild(style);
+
+    // .base
+    const base = document.createElement("div");
+    base.className = "base";
+
+    // .top-content
+    const topContent = document.createElement("div");
+    topContent.className = "top-content";
+
+    // .top-left
+    const topLeft = document.createElement("div");
+    topLeft.className = "top-left";
+
+    // Leading icon
+    const leadingIcon = document.createElement("span");
+    leadingIcon.className = "leading-icon";
+    const iconSlot = document.createElement("slot");
+    iconSlot.name = "icon";
+    leadingIcon.appendChild(iconSlot);
+    topLeft.appendChild(leadingIcon);
+
+    // Title (default slot)
+    const title = document.createElement("span");
+    title.className = "title";
+    const titleSlot = document.createElement("slot");
+    title.appendChild(titleSlot);
+    topLeft.appendChild(title);
+
+    topContent.appendChild(topLeft);
+
+    // .top-right
+    const topRight = document.createElement("div");
+    topRight.className = "top-right";
+
+    // Action slot
+    const actionSlot = document.createElement("slot");
+    actionSlot.name = "action";
+    topRight.appendChild(actionSlot);
+
+    // Close button
+    const closeBtn = document.createElement("button");
+    closeBtn.className = "close-btn";
+    closeBtn.setAttribute("aria-label", "Dismiss");
+    closeBtn.innerHTML = ICON_CLOSE;
+    closeBtn.addEventListener("click", () => this._dismiss());
+    topRight.appendChild(closeBtn);
+
+    topContent.appendChild(topRight);
+    base.appendChild(topContent);
+
+    // Description slot
+    const description = document.createElement("div");
+    description.className = "description";
+    const descriptionSlot = document.createElement("slot");
+    descriptionSlot.name = "description";
+    description.appendChild(descriptionSlot);
+    base.appendChild(description);
+
+    // Footer slot
+    const footer = document.createElement("div");
+    footer.className = "footer";
+    const footerSlot = document.createElement("slot");
+    footerSlot.name = "footer";
+    footer.appendChild(footerSlot);
+    base.appendChild(footer);
+
+    shadow.appendChild(base);
+
+    this._descriptionSlot = descriptionSlot;
+    this._footerSlot = footerSlot;
+
+    // Listen for slotchange to toggle has-description attribute
+    descriptionSlot.addEventListener("slotchange", () =>
+      this._syncDescription(),
+    );
+
+    // Listen for slotchange to toggle has-footer attribute
+    footerSlot.addEventListener("slotchange", () =>
+      this._syncFooter(),
+    );
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("role")) {
+      this.setAttribute("role", "alert");
+    }
+    this._syncDescription();
+    this._syncFooter();
+  }
+
+  attributeChangedCallback(
+    _name: string,
+    _oldValue: string | null,
+    _newValue: string | null,
+  ): void {
+    // All styling is handled via :host([attr]) CSS selectors — no JS sync needed
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): AlertSize {
+    return (this.getAttribute("size") as AlertSize) ?? "m";
+  }
+
+  set size(value: AlertSize) {
+    this.setAttribute("size", value);
+  }
+
+  get emphasis(): AlertEmphasis {
+    return (this.getAttribute("emphasis") as AlertEmphasis) ?? "bold";
+  }
+
+  set emphasis(value: AlertEmphasis) {
+    this.setAttribute("emphasis", value);
+  }
+
+  get status(): AlertStatus {
+    return (this.getAttribute("status") as AlertStatus) ?? "none";
+  }
+
+  set status(value: AlertStatus) {
+    this.setAttribute("status", value);
+  }
+
+  get dismissable(): boolean {
+    return this.hasAttribute("dismissable");
+  }
+
+  set dismissable(value: boolean) {
+    if (value) {
+      this.setAttribute("dismissable", "");
+    } else {
+      this.removeAttribute("dismissable");
+    }
+  }
+
+  get leadingIcon(): boolean {
+    return this.hasAttribute("leading-icon");
+  }
+
+  set leadingIcon(value: boolean) {
+    if (value) {
+      this.setAttribute("leading-icon", "");
+    } else {
+      this.removeAttribute("leading-icon");
+    }
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private _dismiss(): void {
+    const event = new CustomEvent("dismiss", {
+      bubbles: true,
+      composed: true,
+      cancelable: true,
+    });
+    const dispatched = this.dispatchEvent(event);
+    if (dispatched && !event.defaultPrevented) {
+      this.setAttribute("dismissed", "");
+      this.addEventListener(
+        "transitionend",
+        () => {
+          this.remove();
+        },
+        { once: true },
+      );
+    }
+  }
+
+  private _syncDescription(): void {
+    const nodes = this._descriptionSlot.assignedNodes({ flatten: true });
+    if (nodes.length > 0) {
+      this.setAttribute("has-description", "");
+    } else {
+      this.removeAttribute("has-description");
+    }
+  }
+
+  private _syncFooter(): void {
+    const nodes = this._footerSlot.assignedNodes({ flatten: true });
+    if (nodes.length > 0) {
+      this.setAttribute("has-footer", "");
+    } else {
+      this.removeAttribute("has-footer");
+    }
+  }
+}
+
+customElements.define("ui-alert", UiAlert);

--- a/packages/ui-components/src/components/ui-button.ts
+++ b/packages/ui-components/src/components/ui-button.ts
@@ -9,13 +9,7 @@ export type ButtonShape = "basic" | "rounded";
 export type ButtonIcon = "text-only" | "leading-icon" | "trailing-icon" | "icon-only";
 export type ButtonStatus = "none" | "error" | "loading" | "success";
 
-// ─── SVG status icons (20×20 viewBox, scalable via CSS font-size) ────────────
-
-const ICON_ERROR = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="5" y1="5" x2="15" y2="15"/><line x1="15" y1="5" x2="5" y2="15"/></svg>`;
-
-const ICON_SUCCESS = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 10 8 14 16 6"/></svg>`;
-
-const ICON_LOADING = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M10 2a8 8 0 0 1 8 8"/></svg>`;
+import { ICON_ERROR, ICON_SUCCESS, ICON_LOADING } from "../assets/icons.js";
 
 // ─── Token constants ─────────────────────────────────────────────────────────
 

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -15,3 +15,9 @@ export type {
   AccordionStatus,
 } from "./components/ui-accordion-item.js";
 export { UiAccordionGroup } from "./components/ui-accordion-group.js";
+export { UiAlert } from "./components/ui-alert.js";
+export type {
+  AlertSize,
+  AlertEmphasis,
+  AlertStatus,
+} from "./components/ui-alert.js";

--- a/packages/ui-components/src/stories/ui-alert.stories.ts
+++ b/packages/ui-components/src/stories/ui-alert.stories.ts
@@ -1,0 +1,162 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-alert.js";
+
+const meta: Meta = {
+  title: "Components/Alert",
+  component: "ui-alert",
+  argTypes: {
+    size: { control: { type: "select" }, options: ["s", "m", "l"] },
+    emphasis: { control: { type: "select" }, options: ["bold", "subtle"] },
+    status: {
+      control: { type: "select" },
+      options: ["none", "information", "success", "error", "warning"],
+    },
+    dismissable: { control: "boolean" },
+  },
+  args: {
+    size: "m",
+    emphasis: "bold",
+    status: "none",
+    dismissable: false,
+  },
+  render: (args) => html`
+    <ui-alert
+      size=${args.size}
+      emphasis=${args.emphasis}
+      status=${args.status}
+      ?dismissable=${args.dismissable}
+    >
+      This is an alert message
+    </ui-alert>
+  `,
+};
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => html`
+    <ui-alert>This is an alert message</ui-alert>
+  `,
+};
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 16px;">
+      <ui-alert size="s">Small alert</ui-alert>
+      <ui-alert size="m">Medium alert</ui-alert>
+      <ui-alert size="l">Large alert</ui-alert>
+    </div>
+  `,
+};
+
+export const SubtleEmphasis: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 16px;">
+      <ui-alert status="none" emphasis="subtle">None subtle</ui-alert>
+      <ui-alert status="information" emphasis="subtle"
+        >Information subtle</ui-alert
+      >
+      <ui-alert status="success" emphasis="subtle">Success subtle</ui-alert>
+      <ui-alert status="error" emphasis="subtle">Error subtle</ui-alert>
+      <ui-alert status="warning" emphasis="subtle">Warning subtle</ui-alert>
+    </div>
+  `,
+};
+
+export const BoldEmphasis: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 16px;">
+      <ui-alert status="none" emphasis="bold">None bold</ui-alert>
+      <ui-alert status="information" emphasis="bold"
+        >Information bold</ui-alert
+      >
+      <ui-alert status="success" emphasis="bold">Success bold</ui-alert>
+      <ui-alert status="error" emphasis="bold">Error bold</ui-alert>
+      <ui-alert status="warning" emphasis="bold">Warning bold</ui-alert>
+    </div>
+  `,
+};
+
+export const WithDescription: Story = {
+  render: () => html`
+    <ui-alert status="information">
+      Alert Title
+      <span slot="description"
+        >This is a longer description that provides more context about the
+        alert.</span
+      >
+    </ui-alert>
+  `,
+};
+
+export const WithLeadingIcon: Story = {
+  render: () => html`
+    <ui-alert status="information" leading-icon>
+      <svg slot="icon" viewBox="0 0 20 20" width="100%" height="100%">
+        <circle cx="10" cy="10" r="8" fill="currentColor" />
+      </svg>
+      Alert with leading icon
+    </ui-alert>
+  `,
+};
+
+export const Dismissable: Story = {
+  render: () => html`
+    <ui-alert status="information" dismissable>
+      This alert can be dismissed
+    </ui-alert>
+  `,
+};
+
+export const AllStatuses: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 16px;">
+      <ui-alert status="none" leading-icon>
+        <svg slot="icon" viewBox="0 0 20 20" width="100%" height="100%">
+          <circle cx="10" cy="10" r="8" fill="currentColor" />
+        </svg>
+        None status
+      </ui-alert>
+      <ui-alert status="information" leading-icon>
+        <svg slot="icon" viewBox="0 0 20 20" width="100%" height="100%">
+          <circle cx="10" cy="10" r="8" fill="currentColor" />
+        </svg>
+        Information status
+      </ui-alert>
+      <ui-alert status="success" leading-icon>
+        <svg slot="icon" viewBox="0 0 20 20" width="100%" height="100%">
+          <circle cx="10" cy="10" r="8" fill="currentColor" />
+        </svg>
+        Success status
+      </ui-alert>
+      <ui-alert status="error" leading-icon>
+        <svg slot="icon" viewBox="0 0 20 20" width="100%" height="100%">
+          <circle cx="10" cy="10" r="8" fill="currentColor" />
+        </svg>
+        Error status
+      </ui-alert>
+      <ui-alert status="warning" leading-icon>
+        <svg slot="icon" viewBox="0 0 20 20" width="100%" height="100%">
+          <circle cx="10" cy="10" r="8" fill="currentColor" />
+        </svg>
+        Warning status
+      </ui-alert>
+    </div>
+  `,
+};
+
+export const WithFooterButton: Story = {
+  render: () => html`
+    <ui-alert status="none" leading-icon dismissable>
+      <svg slot="icon" viewBox="0 0 20 20" width="100%" height="100%">
+        <circle cx="10" cy="10" r="8" fill="currentColor" />
+      </svg>
+      Alert Title
+      <span slot="description">Description text explaining the alert in more detail.</span>
+      <div slot="footer">
+        <button style="background: rgba(255,255,255,0.15); border: none; border-radius: 2px; padding: 6px 12px 6px 8px; color: inherit; cursor: pointer; font-family: Goldman Sans, sans-serif; font-size: 14px; font-weight: 500;">Refresh</button>
+      </div>
+    </ui-alert>
+  `,
+};


### PR DESCRIPTION
## Summary
- Add `<ui-alert>` Web Component with full Figma spec: 3 sizes (s/m/l), 2 emphases (bold/subtle), 5 statuses (none/information/success/error/warning)
- Supports dismissable close button, leading icon slot, description slot, and action slot
- All colors via type-safe `semanticVar()` foundation tokens — zero hardcoded hex values
- 36 unit tests, 8 Storybook stories, `tsc --noEmit` clean
- Visually verified against Figma: all status×emphasis color combos match spec