### PR TITLE
feat(ui-components): add avatar component

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ maneki-monorepo/
 ├── packages/
 │   ├── grid-layout/         # <grid-layout> Web Component library (@maneki/grid-layout)
 │   ├── ui-components/       # UI components + Storybook (@maneki/ui-components)
-│   │                        # button, button-group, accordion-item, accordion-group, alert
+│   │                        # button, button-group, accordion-item, accordion-group, alert, avatar
 │   └── foundation/          # Design tokens: colors, semantic, typography, spacing, elevation, breakpoints (@maneki/foundation)
 └── apps/                    # (empty — future apps)
 ```

--- a/packages/ui-components/AGENTS.md
+++ b/packages/ui-components/AGENTS.md
@@ -8,6 +8,7 @@ Web Component library for the Maneki design system. Shadow DOM, CSS custom prope
 - `<ui-accordion-item>` — expandable panel: 3 sizes, 2 emphases, 4 statuses, smooth CSS transition
 - `<ui-accordion-group>` — wrapper with size/emphasis propagation + exclusive mode
 - `<ui-alert>` — dismissable alert/toast: 3 sizes, 2 emphases, 5 statuses, footer slot
+- `<ui-avatar>` — avatar component: 5 sizes, 3 types (text/icon/image), 2 emphases, 2 shapes, 5 statuses, 14 colors
 
 ## STRUCTURE
 ```
@@ -18,13 +19,14 @@ ui-components/
 ├── src/
 │   ├── index.ts             # Barrel export + custom element registration
 │   ├── assets/
-│   │   └── icons.ts         # Shared SVG icon constants (ICON_CLOSE, ICON_CHEVRON, etc.)
+│   │   └── icons.ts         # Shared SVG icon constants (ICON_CLOSE, ICON_CHEVRON, ICON_USER, etc.)
 │   ├── components/
 │   │   ├── ui-button.ts
 │   │   ├── ui-button-group.ts
 │   │   ├── ui-accordion-item.ts
 │   │   ├── ui-accordion-group.ts
 │   │   ├── ui-alert.ts
+│   │   ├── ui-avatar.ts
 │   │   └── *.test.ts        # Co-located tests
 │   └── stories/
 │       └── *.stories.ts     # CSF3 + lit html
@@ -70,7 +72,7 @@ SVG icons are centralized in `src/assets/icons.ts`:
 import { ICON_CLOSE, ICON_CHEVRON } from '../assets/icons.js';
 ```
 
-All icons use `currentColor` for stroke/fill so they inherit the parent's `color`. Available: `ICON_CLOSE`, `ICON_CHEVRON`, `ICON_ERROR`, `ICON_SUCCESS`, `ICON_WARNING`, `ICON_LOADING`.
+All icons use `currentColor` for stroke/fill so they inherit the parent's `color`. Available: `ICON_CLOSE`, `ICON_CHEVRON`, `ICON_ERROR`, `ICON_SUCCESS`, `ICON_WARNING`, `ICON_LOADING`, `ICON_USER`.
 
 ## TYPE SAFETY
 Exported union types cover every attribute:
@@ -109,7 +111,7 @@ Property accessors use these types. Invalid values are compile errors.
 ```bash
 moon run ui-components:storybook       # Dev server on port 6006
 moon run ui-components:storybook-build  # Static build
-moon run ui-components:test            # vitest --run (129 tests)
+moon run ui-components:test            # vitest --run (179 tests)
 moon run ui-components:build           # vite build + tsc --emitDeclarationOnly
 moon run ui-components:chromatic       # Publish to Chromatic
 ```

--- a/packages/ui-components/src/assets/icons.ts
+++ b/packages/ui-components/src/assets/icons.ts
@@ -20,3 +20,6 @@ export const ICON_WARNING = `<svg viewBox="0 0 20 20" fill="none" xmlns="http://
 
 /** Loading spinner arc icon. */
 export const ICON_LOADING = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M10 2a8 8 0 0 1 8 8"/></svg>`;
+
+/** User silhouette icon (avatar default). */
+export const ICON_USER = `<svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></svg>`;

--- a/packages/ui-components/src/components/ui-avatar.test.ts
+++ b/packages/ui-components/src/components/ui-avatar.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "./ui-avatar.js";
+
+describe("ui-avatar", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-avatar");
+    document.body.appendChild(el);
+  });
+
+  // ── Registration ─────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-avatar")).toBeDefined();
+  });
+
+  // ── Default attributes ───────────────────────────────────────────────────
+
+  it("defaults size to 'm'", () => {
+    expect((el as unknown as { size: string }).size).toBe("m");
+  });
+
+  it("defaults type to 'text'", () => {
+    expect((el as unknown as { type: string }).type).toBe("text");
+  });
+
+  it("defaults emphasis to 'bold'", () => {
+    expect((el as unknown as { emphasis: string }).emphasis).toBe("bold");
+  });
+
+  it("defaults shape to 'circle'", () => {
+    expect((el as unknown as { shape: string }).shape).toBe("circle");
+  });
+
+  it("defaults status to 'none'", () => {
+    expect((el as unknown as { status: string }).status).toBe("none");
+  });
+
+  it("defaults color to 'none'", () => {
+    expect((el as unknown as { color: string }).color).toBe("none");
+  });
+
+  // ── Size attribute ──────────────────────────────────────────────────────
+
+  it("reflects size='xs' to attribute", () => {
+    (el as unknown as { size: string }).size = "xs";
+    expect(el.getAttribute("size")).toBe("xs");
+  });
+
+  it("reflects size='s' to attribute", () => {
+    (el as unknown as { size: string }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("reflects size='m' to attribute", () => {
+    (el as unknown as { size: string }).size = "m";
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("reflects size='l' to attribute", () => {
+    (el as unknown as { size: string }).size = "l";
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  it("reflects size='xl' to attribute", () => {
+    (el as unknown as { size: string }).size = "xl";
+    expect(el.getAttribute("size")).toBe("xl");
+  });
+
+  // ── Type attribute ──────────────────────────────────────────────────────
+
+  it("reflects type='text' to attribute", () => {
+    (el as unknown as { type: string }).type = "text";
+    expect(el.getAttribute("type")).toBe("text");
+  });
+
+  it("reflects type='icon' to attribute", () => {
+    (el as unknown as { type: string }).type = "icon";
+    expect(el.getAttribute("type")).toBe("icon");
+  });
+
+  it("reflects type='image' to attribute", () => {
+    (el as unknown as { type: string }).type = "image";
+    expect(el.getAttribute("type")).toBe("image");
+  });
+
+  // ── Emphasis attribute ──────────────────────────────────────────────────
+
+  it("reflects emphasis='bold' to attribute", () => {
+    (el as unknown as { emphasis: string }).emphasis = "bold";
+    expect(el.getAttribute("emphasis")).toBe("bold");
+  });
+
+  it("reflects emphasis='subtle' to attribute", () => {
+    (el as unknown as { emphasis: string }).emphasis = "subtle";
+    expect(el.getAttribute("emphasis")).toBe("subtle");
+  });
+
+  // ── Shape attribute ─────────────────────────────────────────────────────
+
+  it("reflects shape='circle' to attribute", () => {
+    (el as unknown as { shape: string }).shape = "circle";
+    expect(el.getAttribute("shape")).toBe("circle");
+  });
+
+  it("reflects shape='square' to attribute", () => {
+    (el as unknown as { shape: string }).shape = "square";
+    expect(el.getAttribute("shape")).toBe("square");
+  });
+
+  // ── Status attribute ────────────────────────────────────────────────────
+
+  it("reflects status='none' to attribute", () => {
+    (el as unknown as { status: string }).status = "none";
+    expect(el.getAttribute("status")).toBe("none");
+  });
+
+  it("reflects status='error' to attribute", () => {
+    (el as unknown as { status: string }).status = "error";
+    expect(el.getAttribute("status")).toBe("error");
+  });
+
+  it("reflects status='warning' to attribute", () => {
+    (el as unknown as { status: string }).status = "warning";
+    expect(el.getAttribute("status")).toBe("warning");
+  });
+
+  it("reflects status='success' to attribute", () => {
+    (el as unknown as { status: string }).status = "success";
+    expect(el.getAttribute("status")).toBe("success");
+  });
+
+  it("reflects status='information' to attribute", () => {
+    (el as unknown as { status: string }).status = "information";
+    expect(el.getAttribute("status")).toBe("information");
+  });
+
+  // ── Color attribute ─────────────────────────────────────────────────────
+
+  it("reflects color='none' to attribute", () => {
+    (el as unknown as { color: string }).color = "none";
+    expect(el.getAttribute("color")).toBe("none");
+  });
+
+  it("reflects color='gray' to attribute", () => {
+    (el as unknown as { color: string }).color = "gray";
+    expect(el.getAttribute("color")).toBe("gray");
+  });
+
+  it("reflects color='red' to attribute", () => {
+    (el as unknown as { color: string }).color = "red";
+    expect(el.getAttribute("color")).toBe("red");
+  });
+
+  it("reflects color='orange' to attribute", () => {
+    (el as unknown as { color: string }).color = "orange";
+    expect(el.getAttribute("color")).toBe("orange");
+  });
+
+  it("reflects color='yellow' to attribute", () => {
+    (el as unknown as { color: string }).color = "yellow";
+    expect(el.getAttribute("color")).toBe("yellow");
+  });
+
+  it("reflects color='green' to attribute", () => {
+    (el as unknown as { color: string }).color = "green";
+    expect(el.getAttribute("color")).toBe("green");
+  });
+
+  it("reflects color='blue' to attribute", () => {
+    (el as unknown as { color: string }).color = "blue";
+    expect(el.getAttribute("color")).toBe("blue");
+  });
+
+  it("reflects color='lime' to attribute", () => {
+    (el as unknown as { color: string }).color = "lime";
+    expect(el.getAttribute("color")).toBe("lime");
+  });
+
+  it("reflects color='teal' to attribute", () => {
+    (el as unknown as { color: string }).color = "teal";
+    expect(el.getAttribute("color")).toBe("teal");
+  });
+
+  it("reflects color='turquoise' to attribute", () => {
+    (el as unknown as { color: string }).color = "turquoise";
+    expect(el.getAttribute("color")).toBe("turquoise");
+  });
+
+  it("reflects color='aqua' to attribute", () => {
+    (el as unknown as { color: string }).color = "aqua";
+    expect(el.getAttribute("color")).toBe("aqua");
+  });
+
+  it("reflects color='ultramarine' to attribute", () => {
+    (el as unknown as { color: string }).color = "ultramarine";
+    expect(el.getAttribute("color")).toBe("ultramarine");
+  });
+
+  it("reflects color='purple' to attribute", () => {
+    (el as unknown as { color: string }).color = "purple";
+    expect(el.getAttribute("color")).toBe("purple");
+  });
+
+  it("reflects color='pink' to attribute", () => {
+    (el as unknown as { color: string }).color = "pink";
+    expect(el.getAttribute("color")).toBe("pink");
+  });
+
+  // ── ARIA role="img" ─────────────────────────────────────────────────────
+
+  it("has role='img' on the host element", () => {
+    expect(el.getAttribute("role")).toBe("img");
+  });
+
+  it("does not override existing role attribute", () => {
+    document.body.innerHTML = "";
+    const custom = document.createElement("ui-avatar");
+    custom.setAttribute("role", "presentation");
+    document.body.appendChild(custom);
+    expect(custom.getAttribute("role")).toBe("presentation");
+  });
+
+  // ── Shadow DOM structure ───────────────────────────────────────────────
+
+  it("has .base element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".base")).toBeTruthy();
+  });
+
+  it("has .text element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".text")).toBeTruthy();
+  });
+
+  it("has .icon element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".icon")).toBeTruthy();
+  });
+
+  it("has .image element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".image")).toBeTruthy();
+  });
+
+  it("has default icon slot in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    const iconSlot = shadow.querySelector('slot[name="icon"]');
+    expect(iconSlot).toBeTruthy();
+  });
+
+  it("has image slot in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    const imageSlot = shadow.querySelector('slot[name="image"]');
+    expect(imageSlot).toBeTruthy();
+  });
+
+  it("has default (text) slot in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    const defaultSlot = shadow.querySelector("slot:not([name])");
+    expect(defaultSlot).toBeTruthy();
+  });
+
+  // ── Default icon for type=icon ─────────────────────────────────────────
+
+  it("shows default user icon when type=icon and no icon slotted", () => {
+    el.setAttribute("type", "icon");
+    const shadow = el.shadowRoot!;
+    const defaultIcon = shadow.querySelector(".default-icon");
+    expect(defaultIcon).toBeTruthy();
+    expect(defaultIcon!.querySelector("svg")).toBeTruthy();
+  });
+
+  // ── Property accessors ────────────────────────────────────────────────
+
+  it("exposes all typed property accessors", () => {
+    const component = el as unknown as {
+      size: string;
+      type: string;
+      emphasis: string;
+      shape: string;
+      status: string;
+      color: string;
+    };
+
+    component.size = "l";
+    expect(component.size).toBe("l");
+
+    component.type = "icon";
+    expect(component.type).toBe("icon");
+
+    component.emphasis = "subtle";
+    expect(component.emphasis).toBe("subtle");
+
+    component.shape = "square";
+    expect(component.shape).toBe("square");
+
+    component.status = "error";
+    expect(component.status).toBe("error");
+
+    component.color = "blue";
+    expect(component.color).toBe("blue");
+  });
+
+  // ── observedAttributes ────────────────────────────────────────────────
+
+  it("observes size, type, emphasis, shape, status, color attributes", () => {
+    const observed = (
+      customElements.get("ui-avatar") as unknown as {
+        observedAttributes: string[];
+      }
+    ).observedAttributes;
+    expect(observed).toContain("size");
+    expect(observed).toContain("type");
+    expect(observed).toContain("emphasis");
+    expect(observed).toContain("shape");
+    expect(observed).toContain("status");
+    expect(observed).toContain("color");
+  });
+});

--- a/packages/ui-components/src/components/ui-avatar.ts
+++ b/packages/ui-components/src/components/ui-avatar.ts
@@ -1,0 +1,511 @@
+import { colorVar } from "@maneki/foundation";
+import { ICON_USER } from "../assets/icons.js";
+
+// ─── Type-safe property unions ───────────────────────────────────────────────
+
+export type AvatarSize = "xs" | "s" | "m" | "l" | "xl";
+export type AvatarType = "text" | "icon" | "image";
+export type AvatarEmphasis = "bold" | "subtle";
+export type AvatarShape = "circle" | "square";
+export type AvatarStatus =
+  | "none"
+  | "error"
+  | "warning"
+  | "success"
+  | "information";
+export type AvatarColor =
+  | "none"
+  | "gray"
+  | "red"
+  | "orange"
+  | "yellow"
+  | "green"
+  | "blue"
+  | "lime"
+  | "teal"
+  | "turquoise"
+  | "aqua"
+  | "ultramarine"
+  | "purple"
+  | "pink";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const GRAY_60 = colorVar("gray", 60);
+const GRAY_20 = colorVar("gray", 20);
+const RED_60 = colorVar("red", 60);
+const ORANGE_60 = colorVar("orange", 60);
+const YELLOW_30 = colorVar("yellow", 30);
+const GREEN_60 = colorVar("green", 60);
+const BLUE_60 = colorVar("blue", 60);
+const LIME_60 = colorVar("lime", 60);
+const TEAL_60 = colorVar("teal", 60);
+const TURQUOISE_60 = colorVar("turquoise", 60);
+const AQUA_60 = colorVar("aqua", 60);
+const ULTRAMARINE_60 = colorVar("ultramarine", 60);
+const PURPLE_60 = colorVar("purple", 60);
+const PINK_60 = colorVar("pink", 60);
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: inline-flex;
+  }
+
+  /* ── Base ─────────────────────────────────────────────────────────────────── */
+
+  .base {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    font-family: "Goldman Sans", sans-serif;
+    font-weight: 500;
+    color: #ffffff;
+  }
+
+  /* ── Type visibility ─────────────────────────────────────────────────────── */
+
+  .text,
+  .icon,
+  .image {
+    display: none;
+    align-items: center;
+    justify-content: center;
+  }
+
+  :host .text,
+  :host([type="text"]) .text {
+    display: inline-flex;
+  }
+  :host .icon,
+  :host([type="text"]) .icon,
+  :host([type="text"]) .image {
+    display: none;
+  }
+
+  :host([type="icon"]) .icon {
+    display: inline-flex;
+  }
+  :host([type="icon"]) .text,
+  :host([type="icon"]) .image {
+    display: none;
+  }
+
+  :host([type="image"]) .image {
+    display: inline-flex;
+  }
+  :host([type="image"]) .text,
+  :host([type="image"]) .icon {
+    display: none;
+  }
+
+  .text {
+    line-height: 1;
+    white-space: nowrap;
+    user-select: none;
+  }
+
+  .icon {
+    line-height: 0;
+  }
+
+  .icon svg,
+  .icon ::slotted(*) {
+    width: 100%;
+    height: 100%;
+  }
+
+  .image {
+    width: 100%;
+    height: 100%;
+  }
+
+  .image ::slotted(*) {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  /* ── Shape ────────────────────────────────────────────────────────────────── */
+
+  :host .base,
+  :host([shape="circle"]) .base {
+    border-radius: 999px;
+  }
+
+  :host([shape="square"]) .base {
+    border-radius: 2px;
+  }
+
+  /* ── Size: m (default) ───────────────────────────────────────────────────── */
+
+  :host .base,
+  :host([size="m"]) .base {
+    width: var(--ui-avatar-size, 32px);
+    height: var(--ui-avatar-size, 32px);
+  }
+
+  :host .text,
+  :host([size="m"]) .text {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  :host .icon,
+  :host([size="m"]) .icon {
+    width: 24px;
+    height: 24px;
+  }
+
+  /* ── Size: xs ────────────────────────────────────────────────────────────── */
+
+  :host([size="xs"]) .base {
+    width: var(--ui-avatar-size, 16px);
+    height: var(--ui-avatar-size, 16px);
+  }
+
+  :host([size="xs"]) .text {
+    font-size: 8px;
+    line-height: 16px;
+  }
+
+  :host([size="xs"]) .icon {
+    width: 12px;
+    height: 12px;
+  }
+
+  /* ── Size: s ─────────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) .base {
+    width: var(--ui-avatar-size, 24px);
+    height: var(--ui-avatar-size, 24px);
+  }
+
+  :host([size="s"]) .text {
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  :host([size="s"]) .icon {
+    width: 18px;
+    height: 18px;
+  }
+
+  /* ── Size: l ─────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) .base {
+    width: var(--ui-avatar-size, 40px);
+    height: var(--ui-avatar-size, 40px);
+  }
+
+  :host([size="l"]) .text {
+    font-size: 20px;
+    line-height: 28px;
+  }
+
+  :host([size="l"]) .icon {
+    width: 30px;
+    height: 30px;
+  }
+
+  /* ── Size: xl ────────────────────────────────────────────────────────────── */
+
+  :host([size="xl"]) .base {
+    width: var(--ui-avatar-size, 48px);
+    height: var(--ui-avatar-size, 48px);
+  }
+
+  :host([size="xl"]) .text {
+    font-size: 24px;
+    line-height: 32px;
+  }
+
+  :host([size="xl"]) .icon {
+    width: 36px;
+    height: 36px;
+  }
+
+  /* ── Emphasis: bold (default) + color: none (default) ────────────────────── */
+
+  :host .base,
+  :host([emphasis="bold"]) .base,
+  :host([color="none"]) .base,
+  :host([color="none"][emphasis="bold"]) .base {
+    background-color: var(--ui-avatar-bg, ${GRAY_60});
+    color: var(--ui-avatar-text, #ffffff);
+  }
+
+  /* ── Bold color variants ─────────────────────────────────────────────────── */
+
+  :host([color="gray"]) .base,
+  :host([color="gray"][emphasis="bold"]) .base {
+    background-color: var(--ui-avatar-bg, ${GRAY_60});
+  }
+
+  :host([color="red"]) .base,
+  :host([color="red"][emphasis="bold"]) .base {
+    background-color: var(--ui-avatar-bg, ${RED_60});
+  }
+
+  :host([color="orange"]) .base,
+  :host([color="orange"][emphasis="bold"]) .base {
+    background-color: var(--ui-avatar-bg, ${ORANGE_60});
+  }
+
+  :host([color="yellow"]) .base,
+  :host([color="yellow"][emphasis="bold"]) .base {
+    background-color: var(--ui-avatar-bg, ${YELLOW_30});
+  }
+
+  :host([color="green"]) .base,
+  :host([color="green"][emphasis="bold"]) .base {
+    background-color: var(--ui-avatar-bg, ${GREEN_60});
+  }
+
+  :host([color="blue"]) .base,
+  :host([color="blue"][emphasis="bold"]) .base {
+    background-color: var(--ui-avatar-bg, ${BLUE_60});
+  }
+
+  :host([color="lime"]) .base,
+  :host([color="lime"][emphasis="bold"]) .base {
+    background-color: var(--ui-avatar-bg, ${LIME_60});
+  }
+
+  :host([color="teal"]) .base,
+  :host([color="teal"][emphasis="bold"]) .base {
+    background-color: var(--ui-avatar-bg, ${TEAL_60});
+  }
+
+  :host([color="turquoise"]) .base,
+  :host([color="turquoise"][emphasis="bold"]) .base {
+    background-color: var(--ui-avatar-bg, ${TURQUOISE_60});
+  }
+
+  :host([color="aqua"]) .base,
+  :host([color="aqua"][emphasis="bold"]) .base {
+    background-color: var(--ui-avatar-bg, ${AQUA_60});
+  }
+
+  :host([color="ultramarine"]) .base,
+  :host([color="ultramarine"][emphasis="bold"]) .base {
+    background-color: var(--ui-avatar-bg, ${ULTRAMARINE_60});
+  }
+
+  :host([color="purple"]) .base,
+  :host([color="purple"][emphasis="bold"]) .base {
+    background-color: var(--ui-avatar-bg, ${PURPLE_60});
+  }
+
+  :host([color="pink"]) .base,
+  :host([color="pink"][emphasis="bold"]) .base {
+    background-color: var(--ui-avatar-bg, ${PINK_60});
+  }
+
+  /* ── Status overrides (bold) ─────────────────────────────────────────────── */
+
+  :host([status="error"]) .base,
+  :host([status="error"][emphasis="bold"]) .base {
+    background-color: var(--ui-avatar-bg, ${RED_60});
+    color: var(--ui-avatar-text, #ffffff);
+  }
+
+  :host([status="warning"]) .base,
+  :host([status="warning"][emphasis="bold"]) .base {
+    background-color: var(--ui-avatar-bg, ${YELLOW_30});
+    color: var(--ui-avatar-text, #ffffff);
+  }
+
+  :host([status="success"]) .base,
+  :host([status="success"][emphasis="bold"]) .base {
+    background-color: var(--ui-avatar-bg, ${GREEN_60});
+    color: var(--ui-avatar-text, #ffffff);
+  }
+
+  :host([status="information"]) .base,
+  :host([status="information"][emphasis="bold"]) .base {
+    background-color: var(--ui-avatar-bg, ${BLUE_60});
+    color: var(--ui-avatar-text, #ffffff);
+  }
+
+  /* ── Emphasis: subtle ────────────────────────────────────────────────────── */
+
+  :host([emphasis="subtle"]) .base {
+    background-color: var(--ui-avatar-bg, ${GRAY_20});
+    color: var(--ui-avatar-text, ${GRAY_60});
+  }
+
+  /* ── Status overrides (subtle) ───────────────────────────────────────────── */
+
+  :host([status="error"][emphasis="subtle"]) .base {
+    background-color: var(--ui-avatar-bg, ${GRAY_20});
+    color: var(--ui-avatar-text, ${GRAY_60});
+  }
+
+  :host([status="warning"][emphasis="subtle"]) .base {
+    background-color: var(--ui-avatar-bg, ${GRAY_20});
+    color: var(--ui-avatar-text, ${GRAY_60});
+  }
+
+  :host([status="success"][emphasis="subtle"]) .base {
+    background-color: var(--ui-avatar-bg, ${GRAY_20});
+    color: var(--ui-avatar-text, ${GRAY_60});
+  }
+
+  :host([status="information"][emphasis="subtle"]) .base {
+    background-color: var(--ui-avatar-bg, ${GRAY_20});
+    color: var(--ui-avatar-text, ${GRAY_60});
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export class UiAvatar extends HTMLElement {
+  static readonly observedAttributes = [
+    "size",
+    "type",
+    "emphasis",
+    "shape",
+    "status",
+    "color",
+  ];
+
+  private _iconSlot: HTMLSlotElement;
+  private _defaultIcon: HTMLSpanElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+
+    const style = document.createElement("style");
+    style.textContent = STYLES;
+    shadow.appendChild(style);
+
+    // .base
+    const base = document.createElement("div");
+    base.className = "base";
+
+    // .text (default slot)
+    const text = document.createElement("span");
+    text.className = "text";
+    const textSlot = document.createElement("slot");
+    text.appendChild(textSlot);
+    base.appendChild(text);
+
+    // .icon (named slot + default SVG)
+    const icon = document.createElement("span");
+    icon.className = "icon";
+
+    const defaultIcon = document.createElement("span");
+    defaultIcon.className = "default-icon";
+    defaultIcon.innerHTML = ICON_USER;
+    icon.appendChild(defaultIcon);
+
+    const iconSlot = document.createElement("slot");
+    iconSlot.name = "icon";
+    icon.appendChild(iconSlot);
+    base.appendChild(icon);
+
+    // .image (named slot)
+    const image = document.createElement("span");
+    image.className = "image";
+    const imageSlot = document.createElement("slot");
+    imageSlot.name = "image";
+    image.appendChild(imageSlot);
+    base.appendChild(image);
+
+    shadow.appendChild(base);
+
+    this._iconSlot = iconSlot;
+    this._defaultIcon = defaultIcon;
+
+    // Listen for slotchange to toggle default icon visibility
+    iconSlot.addEventListener("slotchange", () => this._syncIconSlot());
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("role")) {
+      this.setAttribute("role", "img");
+    }
+    this._syncIconSlot();
+  }
+
+  attributeChangedCallback(
+    _name: string,
+    _oldValue: string | null,
+    _newValue: string | null,
+  ): void {
+    // All styling is handled via :host([attr]) CSS selectors — no JS sync needed
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): AvatarSize {
+    return (this.getAttribute("size") as AvatarSize) ?? "m";
+  }
+
+  set size(value: AvatarSize) {
+    this.setAttribute("size", value);
+  }
+
+  get type(): AvatarType {
+    return (this.getAttribute("type") as AvatarType) ?? "text";
+  }
+
+  set type(value: AvatarType) {
+    this.setAttribute("type", value);
+  }
+
+  get emphasis(): AvatarEmphasis {
+    return (this.getAttribute("emphasis") as AvatarEmphasis) ?? "bold";
+  }
+
+  set emphasis(value: AvatarEmphasis) {
+    this.setAttribute("emphasis", value);
+  }
+
+  get shape(): AvatarShape {
+    return (this.getAttribute("shape") as AvatarShape) ?? "circle";
+  }
+
+  set shape(value: AvatarShape) {
+    this.setAttribute("shape", value);
+  }
+
+  get status(): AvatarStatus {
+    return (this.getAttribute("status") as AvatarStatus) ?? "none";
+  }
+
+  set status(value: AvatarStatus) {
+    this.setAttribute("status", value);
+  }
+
+  get color(): AvatarColor {
+    return (this.getAttribute("color") as AvatarColor) ?? "none";
+  }
+
+  set color(value: AvatarColor) {
+    this.setAttribute("color", value);
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private _syncIconSlot(): void {
+    const nodes = this._iconSlot.assignedNodes({ flatten: true });
+    if (nodes.length > 0) {
+      this._defaultIcon.style.display = "none";
+    } else {
+      this._defaultIcon.style.display = "";
+    }
+  }
+}
+
+customElements.define("ui-avatar", UiAvatar);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -21,3 +21,12 @@ export type {
   AlertEmphasis,
   AlertStatus,
 } from "./components/ui-alert.js";
+export { UiAvatar } from "./components/ui-avatar.js";
+export type {
+  AvatarSize,
+  AvatarType,
+  AvatarEmphasis,
+  AvatarShape,
+  AvatarStatus,
+  AvatarColor,
+} from "./components/ui-avatar.js";

--- a/packages/ui-components/src/stories/ui-avatar.stories.ts
+++ b/packages/ui-components/src/stories/ui-avatar.stories.ts
@@ -1,0 +1,194 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-avatar.js";
+
+const meta: Meta = {
+  title: "Components/Avatar",
+  component: "ui-avatar",
+  argTypes: {
+    size: {
+      control: { type: "select" },
+      options: ["xs", "s", "m", "l", "xl"],
+    },
+    type: { control: { type: "select" }, options: ["text", "icon", "image"] },
+    emphasis: { control: { type: "select" }, options: ["bold", "subtle"] },
+    shape: { control: { type: "select" }, options: ["circle", "square"] },
+    status: {
+      control: { type: "select" },
+      options: ["none", "error", "warning", "success", "information"],
+    },
+    color: {
+      control: { type: "select" },
+      options: [
+        "none",
+        "gray",
+        "red",
+        "orange",
+        "yellow",
+        "green",
+        "blue",
+        "lime",
+        "teal",
+        "turquoise",
+        "aqua",
+        "ultramarine",
+        "purple",
+        "pink",
+      ],
+    },
+  },
+  args: {
+    size: "m",
+    type: "text",
+    emphasis: "bold",
+    shape: "circle",
+    status: "none",
+    color: "none",
+  },
+  render: (args) => html`
+    <ui-avatar
+      size=${args.size}
+      type=${args.type}
+      emphasis=${args.emphasis}
+      shape=${args.shape}
+      status=${args.status}
+      color=${args.color}
+    >
+      GS
+    </ui-avatar>
+  `,
+};
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => html` <ui-avatar>GS</ui-avatar> `,
+};
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; align-items: center; gap: 12px;">
+      <ui-avatar size="xs">G</ui-avatar>
+      <ui-avatar size="s">GS</ui-avatar>
+      <ui-avatar size="m">GS</ui-avatar>
+      <ui-avatar size="l">GS</ui-avatar>
+      <ui-avatar size="xl">GS</ui-avatar>
+    </div>
+  `,
+};
+
+export const TextType: Story = {
+  render: () => html`
+    <div style="display: flex; align-items: center; gap: 12px;">
+      <ui-avatar type="text" color="blue">AB</ui-avatar>
+      <ui-avatar type="text" color="red">CD</ui-avatar>
+      <ui-avatar type="text" color="green">EF</ui-avatar>
+      <ui-avatar type="text" color="purple">GH</ui-avatar>
+      <ui-avatar type="text" color="orange">IJ</ui-avatar>
+    </div>
+  `,
+};
+
+export const IconType: Story = {
+  render: () => html`
+    <div style="display: flex; align-items: center; gap: 12px;">
+      <ui-avatar type="icon" size="xs"></ui-avatar>
+      <ui-avatar type="icon" size="s"></ui-avatar>
+      <ui-avatar type="icon" size="m"></ui-avatar>
+      <ui-avatar type="icon" size="l"></ui-avatar>
+      <ui-avatar type="icon" size="xl"></ui-avatar>
+    </div>
+  `,
+};
+
+export const ImageType: Story = {
+  render: () => html`
+    <div style="display: flex; align-items: center; gap: 12px;">
+      <ui-avatar type="image" size="s">
+        <img
+          slot="image"
+          src="https://i.pravatar.cc/48?img=1"
+          alt="User avatar"
+        />
+      </ui-avatar>
+      <ui-avatar type="image" size="m">
+        <img
+          slot="image"
+          src="https://i.pravatar.cc/48?img=2"
+          alt="User avatar"
+        />
+      </ui-avatar>
+      <ui-avatar type="image" size="l">
+        <img
+          slot="image"
+          src="https://i.pravatar.cc/48?img=3"
+          alt="User avatar"
+        />
+      </ui-avatar>
+      <ui-avatar type="image" size="xl">
+        <img
+          slot="image"
+          src="https://i.pravatar.cc/48?img=4"
+          alt="User avatar"
+        />
+      </ui-avatar>
+    </div>
+  `,
+};
+
+export const CircleVsSquare: Story = {
+  render: () => html`
+    <div style="display: flex; align-items: center; gap: 16px;">
+      <ui-avatar shape="circle" color="blue">GS</ui-avatar>
+      <ui-avatar shape="square" color="blue">GS</ui-avatar>
+      <ui-avatar shape="circle" type="icon" color="green"></ui-avatar>
+      <ui-avatar shape="square" type="icon" color="green"></ui-avatar>
+    </div>
+  `,
+};
+
+export const BoldVsSubtle: Story = {
+  render: () => html`
+    <div style="display: flex; align-items: center; gap: 16px;">
+      <ui-avatar emphasis="bold" color="blue">GS</ui-avatar>
+      <ui-avatar emphasis="subtle" color="blue">GS</ui-avatar>
+      <ui-avatar emphasis="bold" type="icon" color="red"></ui-avatar>
+      <ui-avatar emphasis="subtle" type="icon" color="red"></ui-avatar>
+    </div>
+  `,
+};
+
+export const ColorVariants: Story = {
+  render: () => html`
+    <div
+      style="display: grid; grid-template-columns: repeat(7, auto); gap: 8px; align-items: center;"
+    >
+      <ui-avatar color="none">GS</ui-avatar>
+      <ui-avatar color="gray">GS</ui-avatar>
+      <ui-avatar color="red">GS</ui-avatar>
+      <ui-avatar color="orange">GS</ui-avatar>
+      <ui-avatar color="yellow">GS</ui-avatar>
+      <ui-avatar color="green">GS</ui-avatar>
+      <ui-avatar color="blue">GS</ui-avatar>
+      <ui-avatar color="lime">GS</ui-avatar>
+      <ui-avatar color="teal">GS</ui-avatar>
+      <ui-avatar color="turquoise">GS</ui-avatar>
+      <ui-avatar color="aqua">GS</ui-avatar>
+      <ui-avatar color="ultramarine">GS</ui-avatar>
+      <ui-avatar color="purple">GS</ui-avatar>
+      <ui-avatar color="pink">GS</ui-avatar>
+    </div>
+  `,
+};
+
+export const StatusVariants: Story = {
+  render: () => html`
+    <div style="display: flex; align-items: center; gap: 12px;">
+      <ui-avatar status="none">GS</ui-avatar>
+      <ui-avatar status="error">GS</ui-avatar>
+      <ui-avatar status="warning">GS</ui-avatar>
+      <ui-avatar status="success">GS</ui-avatar>
+      <ui-avatar status="information">GS</ui-avatar>
+    </div>
+  `,
+};


### PR DESCRIPTION
## Summary

- Add `<ui-avatar>` Web Component with full Figma spec: 5 sizes (xs/s/m/l/xl), 3 types (text/icon/image), 2 emphases (bold/subtle), 2 shapes (circle/square), 5 statuses, 14 color variants
- All colors use type-safe foundation tokens via `colorVar()` — no hardcoded hex values
- Default user icon (ICON_USER) shown when type="icon" with no slotted content, with slotchange detection
- 50 unit tests, 9 Storybook stories, tsc clean, 179/179 tests passing
- Updated AGENTS.md docs in both root and ui-components package