### PR TITLE
feat(ui-components): add breadcrumbs component

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ maneki-monorepo/
 ├── packages/
 │   ├── grid-layout/         # <grid-layout> Web Component library (@maneki/grid-layout)
 │   ├── ui-components/       # UI components + Storybook (@maneki/ui-components)
-│   │                        # button, button-group, accordion-item, accordion-group, alert, avatar
+│   │                        # button, button-group, accordion-item, accordion-group, alert, avatar, breadcrumb-item, breadcrumb-group
 │   └── foundation/          # Design tokens: colors, semantic, typography, spacing, elevation, breakpoints (@maneki/foundation)
 └── apps/                    # (empty — future apps)
 ```
@@ -48,6 +48,7 @@ maneki-monorepo/
 - **Don't mutate layouts externally** — always use property setters on components
 - **Don't inherit Web Components** — use composition (see responsive-grid-layout pattern)
 - **Branch per component** — every new component gets its own branch (`feat/ui-*`). Never implement directly on `main`.
+- **Fetch + rebase before branching** — always `jj git fetch` and branch off latest `main` before starting a new component. Prevents merge conflicts from stale base.
 - **Visual Figma verification** — compare Storybook rendering against Figma before marking a component done. Use browser tools to screenshot and verify.
 
 ## COMMANDS

--- a/packages/ui-components/AGENTS.md
+++ b/packages/ui-components/AGENTS.md
@@ -9,6 +9,8 @@ Web Component library for the Maneki design system. Shadow DOM, CSS custom prope
 - `<ui-accordion-group>` — wrapper with size/emphasis propagation + exclusive mode
 - `<ui-alert>` — dismissable alert/toast: 3 sizes, 2 emphases, 5 statuses, footer slot
 - `<ui-avatar>` — avatar component: 5 sizes, 3 types (text/icon/image), 2 emphases, 2 shapes, 5 statuses, 14 colors
+- `<ui-breadcrumb-item>` — breadcrumb link item: 3 sizes, 7 states (enabled/hover/focus/active/visited/disabled/current), chevron separator
+- `<ui-breadcrumb-group>` — breadcrumb nav wrapper with size propagation
 
 ## STRUCTURE
 ```
@@ -72,7 +74,7 @@ SVG icons are centralized in `src/assets/icons.ts`:
 import { ICON_CLOSE, ICON_CHEVRON } from '../assets/icons.js';
 ```
 
-All icons use `currentColor` for stroke/fill so they inherit the parent's `color`. Available: `ICON_CLOSE`, `ICON_CHEVRON`, `ICON_ERROR`, `ICON_SUCCESS`, `ICON_WARNING`, `ICON_LOADING`, `ICON_USER`.
+All icons use `currentColor` for stroke/fill so they inherit the parent's `color`. Available: `ICON_CLOSE`, `ICON_CHEVRON`, `ICON_CHEVRON_RIGHT`, `ICON_ERROR`, `ICON_SUCCESS`, `ICON_WARNING`, `ICON_LOADING`, `ICON_USER`.
 
 ## TYPE SAFETY
 Exported union types cover every attribute:
@@ -111,7 +113,7 @@ Property accessors use these types. Invalid values are compile errors.
 ```bash
 moon run ui-components:storybook       # Dev server on port 6006
 moon run ui-components:storybook-build  # Static build
-moon run ui-components:test            # vitest --run (179 tests)
+moon run ui-components:test            # vitest --run (208 tests)
 moon run ui-components:build           # vite build + tsc --emitDeclarationOnly
 moon run ui-components:chromatic       # Publish to Chromatic
 ```

--- a/packages/ui-components/src/assets/icons.ts
+++ b/packages/ui-components/src/assets/icons.ts
@@ -23,3 +23,6 @@ export const ICON_LOADING = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 
 
 /** User silhouette icon (avatar default). */
 export const ICON_USER = `<svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></svg>`;
+
+/** Chevron-right arrow (breadcrumb separator). */
+export const ICON_CHEVRON_RIGHT = `<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7.5 5L12.5 10L7.5 15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`;

--- a/packages/ui-components/src/components/ui-breadcrumb-group.test.ts
+++ b/packages/ui-components/src/components/ui-breadcrumb-group.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "./ui-breadcrumb-item.js";
+import "./ui-breadcrumb-group.js";
+
+describe("ui-breadcrumb-group", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-breadcrumb-group");
+    document.body.appendChild(el);
+  });
+
+  // ── Registration ─────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-breadcrumb-group")).toBeDefined();
+  });
+
+  // ── Default attributes ───────────────────────────────────────────────────
+
+  it("defaults size to 'm'", () => {
+    expect((el as unknown as { size: string }).size).toBe("m");
+  });
+
+  // ── Size attribute ──────────────────────────────────────────────────────
+
+  it("reflects size='s' to attribute", () => {
+    (el as unknown as { size: string }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("reflects size='m' to attribute", () => {
+    (el as unknown as { size: string }).size = "m";
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("reflects size='l' to attribute", () => {
+    (el as unknown as { size: string }).size = "l";
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  // ── Shadow DOM structure ───────────────────────────────────────────────
+
+  it("has nav element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector("nav")).toBeTruthy();
+  });
+
+  it("has ol.list element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    const ol = shadow.querySelector("ol.list");
+    expect(ol).toBeTruthy();
+  });
+
+  it("nav has aria-label='Breadcrumb'", () => {
+    const shadow = el.shadowRoot!;
+    const nav = shadow.querySelector("nav");
+    expect(nav!.getAttribute("aria-label")).toBe("Breadcrumb");
+  });
+
+  // ── Size propagation ──────────────────────────────────────────────────
+
+  it("propagates size to child breadcrumb items", () => {
+    const item1 = document.createElement("ui-breadcrumb-item");
+    const item2 = document.createElement("ui-breadcrumb-item");
+    item1.setAttribute("href", "/a");
+    el.appendChild(item1);
+    el.appendChild(item2);
+
+    (el as unknown as { size: string }).size = "l";
+
+    // Trigger slotchange manually since happy-dom may not fire it
+    const slot = el.shadowRoot!.querySelector("slot")!;
+    slot.dispatchEvent(new Event("slotchange"));
+
+    expect(item1.getAttribute("size")).toBe("l");
+    expect(item2.getAttribute("size")).toBe("l");
+  });
+});

--- a/packages/ui-components/src/components/ui-breadcrumb-group.ts
+++ b/packages/ui-components/src/components/ui-breadcrumb-group.ts
@@ -1,0 +1,122 @@
+import type { BreadcrumbSize } from "./ui-breadcrumb-item.js";
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: block;
+  }
+
+  nav {
+    display: block;
+  }
+
+  .list {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  /* ── Gap: m (default) ──────────────────────────────────────────────────── */
+
+  :host .list,
+  :host([size="m"]) .list {
+    gap: 8px;
+  }
+
+  /* ── Gap: s ─────────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) .list {
+    gap: 4px;
+  }
+
+  /* ── Gap: l ─────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) .list {
+    gap: 8px;
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export class UiBreadcrumbGroup extends HTMLElement {
+  static readonly observedAttributes = ["size"];
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+
+    const style = document.createElement("style");
+    style.textContent = STYLES;
+    shadow.appendChild(style);
+
+    // <nav aria-label="Breadcrumb">
+    const nav = document.createElement("nav");
+    nav.setAttribute("aria-label", "Breadcrumb");
+
+    // <ol class="list" part="list">
+    const ol = document.createElement("ol");
+    ol.className = "list";
+    ol.setAttribute("part", "list");
+
+    const slot = document.createElement("slot");
+    ol.appendChild(slot);
+
+    nav.appendChild(ol);
+    shadow.appendChild(nav);
+
+    // Listen for slotchange to propagate size to new children
+    slot.addEventListener("slotchange", () => this._propagateSize());
+  }
+
+  connectedCallback(): void {
+    this._propagateSize();
+  }
+
+  attributeChangedCallback(
+    _name: string,
+    _oldValue: string | null,
+    _newValue: string | null,
+  ): void {
+    this._propagateSize();
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): BreadcrumbSize {
+    return (this.getAttribute("size") as BreadcrumbSize) ?? "m";
+  }
+
+  set size(value: BreadcrumbSize) {
+    this.setAttribute("size", value);
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private _propagateSize(): void {
+    const slot = this.shadowRoot!.querySelector("slot")!;
+    const items = slot
+      .assignedElements({ flatten: true })
+      .filter((el) => el.tagName === "UI-BREADCRUMB-ITEM");
+
+    const sizeValue = this.getAttribute("size");
+    for (const item of items) {
+      if (sizeValue) {
+        item.setAttribute("size", sizeValue);
+      } else {
+        item.removeAttribute("size");
+      }
+    }
+  }
+}
+
+customElements.define("ui-breadcrumb-group", UiBreadcrumbGroup);

--- a/packages/ui-components/src/components/ui-breadcrumb-item.test.ts
+++ b/packages/ui-components/src/components/ui-breadcrumb-item.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "./ui-breadcrumb-item.js";
+
+describe("ui-breadcrumb-item", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-breadcrumb-item");
+    document.body.appendChild(el);
+  });
+
+  // ── Registration ─────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-breadcrumb-item")).toBeDefined();
+  });
+
+  // ── Default attributes ───────────────────────────────────────────────────
+
+  it("defaults size to 'm'", () => {
+    expect((el as unknown as { size: string }).size).toBe("m");
+  });
+
+  // ── Size attribute ──────────────────────────────────────────────────────
+
+  it("reflects size='s' to attribute", () => {
+    (el as unknown as { size: string }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("reflects size='m' to attribute", () => {
+    (el as unknown as { size: string }).size = "m";
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("reflects size='l' to attribute", () => {
+    (el as unknown as { size: string }).size = "l";
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  // ── href attribute ──────────────────────────────────────────────────────
+
+  it("reflects href to attribute", () => {
+    (el as unknown as { href: string | null }).href = "/home";
+    expect(el.getAttribute("href")).toBe("/home");
+  });
+
+  it("removes href attribute when set to null", () => {
+    (el as unknown as { href: string | null }).href = "/home";
+    (el as unknown as { href: string | null }).href = null;
+    expect(el.hasAttribute("href")).toBe(false);
+  });
+
+  // ── disabled attribute ──────────────────────────────────────────────────
+
+  it("sets disabled attribute when property is true", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    expect(el.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("removes disabled attribute when property is false", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    (el as unknown as { disabled: boolean }).disabled = false;
+    expect(el.hasAttribute("disabled")).toBe(false);
+  });
+
+  // ── Shadow DOM structure ───────────────────────────────────────────────
+
+  it("has .base element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".base")).toBeTruthy();
+  });
+
+  it("has .link element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".link")).toBeTruthy();
+  });
+
+  it("has .separator element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".separator")).toBeTruthy();
+  });
+
+  // ── Link element type based on href ───────────────────────────────────
+
+  it("renders <a> element when href is set", () => {
+    el.setAttribute("href", "/home");
+    const shadow = el.shadowRoot!;
+    const link = shadow.querySelector(".link");
+    expect(link).toBeTruthy();
+    expect(link!.tagName).toBe("A");
+    expect(link!.getAttribute("href")).toBe("/home");
+  });
+
+  it("renders <span> with class 'current' when href is absent", () => {
+    const shadow = el.shadowRoot!;
+    const link = shadow.querySelector(".link");
+    expect(link).toBeTruthy();
+    expect(link!.tagName).toBe("SPAN");
+    expect(link!.classList.contains("current")).toBe(true);
+  });
+
+  // ── Separator visibility ──────────────────────────────────────────────
+
+  it("hides separator when href is absent", () => {
+    const shadow = el.shadowRoot!;
+    const separator = shadow.querySelector(".separator");
+    expect(separator).toBeTruthy();
+    expect(separator!.classList.contains("hidden")).toBe(true);
+  });
+
+  it("shows separator when href is set", () => {
+    el.setAttribute("href", "/home");
+    const shadow = el.shadowRoot!;
+    const separator = shadow.querySelector(".separator");
+    expect(separator).toBeTruthy();
+    expect(separator!.classList.contains("hidden")).toBe(false);
+  });
+
+  // ── aria-current ──────────────────────────────────────────────────────
+
+  it("sets aria-current='page' when no href", () => {
+    expect(el.getAttribute("aria-current")).toBe("page");
+  });
+
+  it("removes aria-current when href is set", () => {
+    el.setAttribute("href", "/home");
+    expect(el.hasAttribute("aria-current")).toBe(false);
+  });
+
+  // ── Disabled pointer events ───────────────────────────────────────────
+
+  it("disabled attribute is present when disabled", () => {
+    el.setAttribute("disabled", "");
+    expect(el.hasAttribute("disabled")).toBe(true);
+  });
+
+  // ── Property accessors ────────────────────────────────────────────────
+
+  it("exposes all typed property accessors", () => {
+    const component = el as unknown as {
+      size: string;
+      href: string | null;
+      disabled: boolean;
+    };
+
+    component.size = "l";
+    expect(component.size).toBe("l");
+
+    component.href = "/test";
+    expect(component.href).toBe("/test");
+
+    component.disabled = true;
+    expect(component.disabled).toBe(true);
+
+    component.href = null;
+    expect(component.href).toBeNull();
+
+    component.disabled = false;
+    expect(component.disabled).toBe(false);
+  });
+});

--- a/packages/ui-components/src/components/ui-breadcrumb-item.ts
+++ b/packages/ui-components/src/components/ui-breadcrumb-item.ts
@@ -1,0 +1,295 @@
+import { colorVar, semanticVar } from "@maneki/foundation";
+import { ICON_CHEVRON_RIGHT } from "../assets/icons.js";
+
+// ─── Type-safe property unions ───────────────────────────────────────────────
+
+export type BreadcrumbSize = "s" | "m" | "l";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const BLUE_60 = colorVar("blue", 60);
+const BLUE_70 = colorVar("blue", 70);
+const BLUE_80 = colorVar("blue", 80);
+const PURPLE_60 = colorVar("purple", 60);
+const TEXT_DISABLED = semanticVar("text", "tertiary");
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const ICON_PRIMARY = semanticVar("icon", "primary");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: inline-flex;
+    align-items: center;
+    font-family: "Goldman Sans", sans-serif;
+  }
+
+  .base {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  /* ── Link ──────────────────────────────────────────────────────────────── */
+
+  .link {
+    color: var(--ui-bc-link-color, ${BLUE_60});
+    text-decoration: none;
+    cursor: pointer;
+    font-family: inherit;
+    font-weight: 400;
+  }
+
+  .link:hover {
+    color: var(--ui-bc-link-hover, ${BLUE_70});
+  }
+
+  .link:active {
+    color: var(--ui-bc-link-active, ${BLUE_80});
+  }
+
+  .link:focus-visible {
+    color: var(--ui-bc-link-focus, ${BLUE_60});
+    text-decoration: underline;
+    outline: none;
+  }
+
+  .link:visited {
+    color: var(--ui-bc-link-visited, ${PURPLE_60});
+  }
+
+  /* ── Disabled ──────────────────────────────────────────────────────────── */
+
+  :host([disabled]) .link {
+    color: var(--ui-bc-link-disabled, ${TEXT_DISABLED});
+    opacity: 0.5;
+    pointer-events: none;
+    cursor: default;
+  }
+
+  /* ── Current (no href) ─────────────────────────────────────────────────── */
+
+  .link.current {
+    color: var(--ui-bc-current-color, ${TEXT_PRIMARY});
+    cursor: default;
+  }
+
+  /* ── Separator ─────────────────────────────────────────────────────────── */
+
+  .separator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--ui-bc-separator-color, ${ICON_PRIMARY});
+    line-height: 0;
+  }
+
+  .separator svg {
+    width: 100%;
+    height: 100%;
+  }
+
+  .separator.hidden {
+    display: none;
+  }
+
+  /* ── Size: m (default) ─────────────────────────────────────────────────── */
+
+  :host .link,
+  :host([size="m"]) .link {
+    font-size: 14px;
+    line-height: 20px;
+    padding-left: 2px;
+    padding-right: 2px;
+  }
+
+  :host .separator,
+  :host([size="m"]) .separator {
+    width: 16px;
+    height: 16px;
+  }
+
+  :host .base,
+  :host([size="m"]) .base {
+    gap: 4px;
+  }
+
+  /* ── Size: s ────────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) .link {
+    font-size: 12px;
+    line-height: 16px;
+    padding-left: 2px;
+    padding-right: 2px;
+  }
+
+  :host([size="s"]) .separator {
+    width: 16px;
+    height: 16px;
+  }
+
+  :host([size="s"]) .base {
+    gap: 2px;
+  }
+
+  /* ── Size: l ────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) .link {
+    font-size: 16px;
+    line-height: 24px;
+    padding-left: 2px;
+    padding-right: 2px;
+  }
+
+  :host([size="l"]) .separator {
+    width: 18px;
+    height: 18px;
+  }
+
+  :host([size="l"]) .base {
+    gap: 4px;
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export class UiBreadcrumbItem extends HTMLElement {
+  static readonly observedAttributes = ["size", "href", "disabled"];
+
+  private _base: HTMLSpanElement;
+  private _linkEl: HTMLAnchorElement | HTMLSpanElement;
+  private _separator: HTMLSpanElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+
+    const style = document.createElement("style");
+    style.textContent = STYLES;
+    shadow.appendChild(style);
+
+    // .base
+    this._base = document.createElement("span");
+    this._base.className = "base";
+
+    // Initial link element (default: span for current page)
+    this._linkEl = document.createElement("span");
+    this._linkEl.className = "link current";
+    const slot = document.createElement("slot");
+    this._linkEl.appendChild(slot);
+    this._base.appendChild(this._linkEl);
+
+    // Separator
+    this._separator = document.createElement("span");
+    this._separator.className = "separator hidden";
+    this._separator.setAttribute("aria-hidden", "true");
+    this._separator.innerHTML = ICON_CHEVRON_RIGHT;
+    this._base.appendChild(this._separator);
+
+    shadow.appendChild(this._base);
+  }
+
+  connectedCallback(): void {
+    this._syncLink();
+  }
+
+  attributeChangedCallback(
+    name: string,
+    _oldValue: string | null,
+    _newValue: string | null,
+  ): void {
+    if (name === "href") {
+      this._syncLink();
+    }
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): BreadcrumbSize {
+    return (this.getAttribute("size") as BreadcrumbSize) ?? "m";
+  }
+
+  set size(value: BreadcrumbSize) {
+    this.setAttribute("size", value);
+  }
+
+  get href(): string | null {
+    return this.getAttribute("href");
+  }
+
+  set href(value: string | null) {
+    if (value) {
+      this.setAttribute("href", value);
+    } else {
+      this.removeAttribute("href");
+    }
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute("disabled");
+  }
+
+  set disabled(value: boolean) {
+    if (value) {
+      this.setAttribute("disabled", "");
+    } else {
+      this.removeAttribute("disabled");
+    }
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private _syncLink(): void {
+    const hrefValue = this.getAttribute("href");
+    const hasHref = hrefValue !== null;
+
+    // Swap between <a> and <span> based on href presence
+    const needsAnchor = hasHref;
+    const isCurrentlyAnchor = this._linkEl.tagName === "A";
+
+    if (needsAnchor !== isCurrentlyAnchor) {
+      const newEl = needsAnchor
+        ? document.createElement("a")
+        : document.createElement("span");
+
+      newEl.className = needsAnchor ? "link" : "link current";
+      if (needsAnchor) {
+        (newEl as HTMLAnchorElement).setAttribute("href", hrefValue!);
+        newEl.setAttribute("part", "link");
+      }
+
+      // Move slot to new element
+      const slot = this._linkEl.querySelector("slot");
+      if (slot) {
+        newEl.appendChild(slot);
+      }
+
+      this._base.replaceChild(newEl, this._linkEl);
+      this._linkEl = newEl;
+    } else if (needsAnchor) {
+      // Just update href value
+      (this._linkEl as HTMLAnchorElement).setAttribute("href", hrefValue!);
+    }
+
+    // Toggle separator visibility
+    if (hasHref) {
+      this._separator.classList.remove("hidden");
+    } else {
+      this._separator.classList.add("hidden");
+    }
+
+    // Toggle aria-current
+    if (hasHref) {
+      this.removeAttribute("aria-current");
+    } else {
+      this.setAttribute("aria-current", "page");
+    }
+  }
+}
+
+customElements.define("ui-breadcrumb-item", UiBreadcrumbItem);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -30,3 +30,6 @@ export type {
   AvatarStatus,
   AvatarColor,
 } from "./components/ui-avatar.js";
+export { UiBreadcrumbItem } from "./components/ui-breadcrumb-item.js";
+export type { BreadcrumbSize } from "./components/ui-breadcrumb-item.js";
+export { UiBreadcrumbGroup } from "./components/ui-breadcrumb-group.js";

--- a/packages/ui-components/src/stories/ui-breadcrumb-group.stories.ts
+++ b/packages/ui-components/src/stories/ui-breadcrumb-group.stories.ts
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-breadcrumb-item.js";
+import "../components/ui-breadcrumb-group.js";
+
+const meta: Meta = {
+  title: "Components/Breadcrumb Group",
+  component: "ui-breadcrumb-group",
+  argTypes: {
+    size: { control: { type: "select" }, options: ["s", "m", "l"] },
+  },
+  args: {
+    size: "m",
+  },
+  render: (args) => html`
+    <ui-breadcrumb-group size=${args.size}>
+      <ui-breadcrumb-item href="/home">Home</ui-breadcrumb-item>
+      <ui-breadcrumb-item href="/products">Products</ui-breadcrumb-item>
+      <ui-breadcrumb-item href="/products/shoes">Shoes</ui-breadcrumb-item>
+      <ui-breadcrumb-item>Running Shoes</ui-breadcrumb-item>
+    </ui-breadcrumb-group>
+  `,
+};
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => html`
+    <ui-breadcrumb-group>
+      <ui-breadcrumb-item href="/home">Home</ui-breadcrumb-item>
+      <ui-breadcrumb-item href="/products">Products</ui-breadcrumb-item>
+      <ui-breadcrumb-item href="/products/shoes">Shoes</ui-breadcrumb-item>
+      <ui-breadcrumb-item>Running Shoes</ui-breadcrumb-item>
+    </ui-breadcrumb-group>
+  `,
+};
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 24px;">
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Size: s</div>
+        <ui-breadcrumb-group size="s">
+          <ui-breadcrumb-item href="/home">Home</ui-breadcrumb-item>
+          <ui-breadcrumb-item href="/docs">Docs</ui-breadcrumb-item>
+          <ui-breadcrumb-item>Current</ui-breadcrumb-item>
+        </ui-breadcrumb-group>
+      </div>
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Size: m</div>
+        <ui-breadcrumb-group size="m">
+          <ui-breadcrumb-item href="/home">Home</ui-breadcrumb-item>
+          <ui-breadcrumb-item href="/docs">Docs</ui-breadcrumb-item>
+          <ui-breadcrumb-item>Current</ui-breadcrumb-item>
+        </ui-breadcrumb-group>
+      </div>
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Size: l</div>
+        <ui-breadcrumb-group size="l">
+          <ui-breadcrumb-item href="/home">Home</ui-breadcrumb-item>
+          <ui-breadcrumb-item href="/docs">Docs</ui-breadcrumb-item>
+          <ui-breadcrumb-item>Current</ui-breadcrumb-item>
+        </ui-breadcrumb-group>
+      </div>
+    </div>
+  `,
+};
+
+export const WithManyItems: Story = {
+  render: () => html`
+    <ui-breadcrumb-group>
+      <ui-breadcrumb-item href="/home">Home</ui-breadcrumb-item>
+      <ui-breadcrumb-item href="/products">Products</ui-breadcrumb-item>
+      <ui-breadcrumb-item href="/products/clothing">Clothing</ui-breadcrumb-item>
+      <ui-breadcrumb-item href="/products/clothing/mens">Men's</ui-breadcrumb-item>
+      <ui-breadcrumb-item href="/products/clothing/mens/shirts">Shirts</ui-breadcrumb-item>
+      <ui-breadcrumb-item>Oxford Button-Down</ui-breadcrumb-item>
+    </ui-breadcrumb-group>
+  `,
+};

--- a/packages/ui-components/src/stories/ui-breadcrumb-item.stories.ts
+++ b/packages/ui-components/src/stories/ui-breadcrumb-item.stories.ts
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-breadcrumb-item.js";
+
+const meta: Meta = {
+  title: "Components/Breadcrumb Item",
+  component: "ui-breadcrumb-item",
+  argTypes: {
+    size: { control: { type: "select" }, options: ["s", "m", "l"] },
+    href: { control: "text" },
+    disabled: { control: "boolean" },
+  },
+  args: {
+    size: "m",
+    href: "/home",
+    disabled: false,
+  },
+  render: (args) => html`
+    <ui-breadcrumb-item
+      size=${args.size}
+      href=${args.href || nothing}
+      ?disabled=${args.disabled}
+    >
+      Home
+    </ui-breadcrumb-item>
+  `,
+};
+export default meta;
+type Story = StoryObj;
+
+import { nothing } from "lit";
+
+export const Default: Story = {
+  render: () => html`
+    <ui-breadcrumb-item href="/home">Home</ui-breadcrumb-item>
+  `,
+};
+
+export const Current: Story = {
+  render: () => html`
+    <ui-breadcrumb-item>Current Page</ui-breadcrumb-item>
+  `,
+};
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 16px;">
+      <ui-breadcrumb-item size="s" href="/home">Small</ui-breadcrumb-item>
+      <ui-breadcrumb-item size="m" href="/home">Medium</ui-breadcrumb-item>
+      <ui-breadcrumb-item size="l" href="/home">Large</ui-breadcrumb-item>
+    </div>
+  `,
+};
+
+export const Disabled: Story = {
+  render: () => html`
+    <ui-breadcrumb-item href="/home" disabled>Disabled Link</ui-breadcrumb-item>
+  `,
+};
+
+export const AllStates: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 16px;">
+      <ui-breadcrumb-item href="/home">Enabled</ui-breadcrumb-item>
+      <ui-breadcrumb-item href="/visited-page">Visited (browser-dependent)</ui-breadcrumb-item>
+      <ui-breadcrumb-item href="/home" disabled>Disabled</ui-breadcrumb-item>
+      <ui-breadcrumb-item>Current Page</ui-breadcrumb-item>
+    </div>
+  `,
+};


### PR DESCRIPTION
## Summary

- Add `<ui-breadcrumb-item>` component — link item with chevron-right separator, 3 sizes (s/m/l), 7 states (enabled/hover/focus/active/visited/disabled/current), `<a>`↔`<span>` swap based on `href`, `aria-current="page"` for current item
- Add `<ui-breadcrumb-group>` component — `<nav>` + `<ol>` wrapper with size propagation to children via slotchange
- Add `ICON_CHEVRON_RIGHT` and `ICON_USER` to shared icons
- 29 new tests (20 item + 9 group), 158 total passing
- 8 new stories across both components
- Updated barrel exports and AGENTS.md docs