### PR TITLE
feat(ui-components): add card component

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ maneki-monorepo/
 ├── packages/
 │   ├── grid-layout/         # <grid-layout> Web Component library (@maneki/grid-layout)
 │   ├── ui-components/       # UI components + Storybook (@maneki/ui-components)
-│   │                        # button, button-group, accordion-item, accordion-group, alert, avatar, breadcrumb-item, breadcrumb-group
+│   │                        # button, button-group, accordion-item, accordion-group, alert, avatar, breadcrumb-item, breadcrumb-group, card
 │   └── foundation/          # Design tokens: colors, semantic, typography, spacing, elevation, breakpoints (@maneki/foundation)
 └── apps/                    # (empty — future apps)
 ```

--- a/packages/ui-components/AGENTS.md
+++ b/packages/ui-components/AGENTS.md
@@ -11,6 +11,7 @@ Web Component library for the Maneki design system. Shadow DOM, CSS custom prope
 - `<ui-avatar>` — avatar component: 5 sizes, 3 types (text/icon/image), 2 emphases, 2 shapes, 5 statuses, 14 colors
 - `<ui-breadcrumb-item>` — breadcrumb link item: 3 sizes, 7 states (enabled/hover/focus/active/visited/disabled/current), chevron separator
 - `<ui-breadcrumb-group>` — breadcrumb nav wrapper with size propagation
+- `<ui-card>` — slot-based card container: 3 sizes (s/m/l), 4 elevations (00/01/02/04), bordered variant, image/default/footer slots
 
 ## STRUCTURE
 ```
@@ -29,6 +30,9 @@ ui-components/
 │   │   ├── ui-accordion-group.ts
 │   │   ├── ui-alert.ts
 │   │   ├── ui-avatar.ts
+│   │   ├── ui-card.ts
+│   │   ├── ui-breadcrumb-item.ts
+│   │   ├── ui-breadcrumb-group.ts
 │   │   └── *.test.ts        # Co-located tests
 │   └── stories/
 │       └── *.stories.ts     # CSF3 + lit html
@@ -113,7 +117,7 @@ Property accessors use these types. Invalid values are compile errors.
 ```bash
 moon run ui-components:storybook       # Dev server on port 6006
 moon run ui-components:storybook-build  # Static build
-moon run ui-components:test            # vitest --run (208 tests)
+moon run ui-components:test            # vitest --run (230 tests)
 moon run ui-components:build           # vite build + tsc --emitDeclarationOnly
 moon run ui-components:chromatic       # Publish to Chromatic
 ```

--- a/packages/ui-components/src/components/ui-card.test.ts
+++ b/packages/ui-components/src/components/ui-card.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "./ui-card.js";
+
+describe("ui-card", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-card");
+    document.body.appendChild(el);
+  });
+
+  // ── Registration ─────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-card")).toBeDefined();
+  });
+
+  // ── Default attributes ───────────────────────────────────────────────────
+
+  it("defaults size to 'm'", () => {
+    expect((el as unknown as { size: string }).size).toBe("m");
+  });
+
+  it("defaults elevation to '02'", () => {
+    expect((el as unknown as { elevation: string }).elevation).toBe("02");
+  });
+
+  it("defaults bordered to false", () => {
+    expect((el as unknown as { bordered: boolean }).bordered).toBe(false);
+  });
+
+  // ── Size attribute ──────────────────────────────────────────────────────
+
+  it("reflects size='s' to attribute", () => {
+    (el as unknown as { size: string }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("reflects size='m' to attribute", () => {
+    (el as unknown as { size: string }).size = "m";
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("reflects size='l' to attribute", () => {
+    (el as unknown as { size: string }).size = "l";
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  // ── Elevation attribute ─────────────────────────────────────────────────
+
+  it("reflects elevation='00' to attribute", () => {
+    (el as unknown as { elevation: string }).elevation = "00";
+    expect(el.getAttribute("elevation")).toBe("00");
+  });
+
+  it("reflects elevation='01' to attribute", () => {
+    (el as unknown as { elevation: string }).elevation = "01";
+    expect(el.getAttribute("elevation")).toBe("01");
+  });
+
+  it("reflects elevation='02' to attribute", () => {
+    (el as unknown as { elevation: string }).elevation = "02";
+    expect(el.getAttribute("elevation")).toBe("02");
+  });
+
+  it("reflects elevation='04' to attribute", () => {
+    (el as unknown as { elevation: string }).elevation = "04";
+    expect(el.getAttribute("elevation")).toBe("04");
+  });
+
+  // ── Bordered attribute ──────────────────────────────────────────────────
+
+  it("sets bordered attribute when property is true", () => {
+    (el as unknown as { bordered: boolean }).bordered = true;
+    expect(el.hasAttribute("bordered")).toBe(true);
+  });
+
+  it("removes bordered attribute when property is false", () => {
+    (el as unknown as { bordered: boolean }).bordered = true;
+    (el as unknown as { bordered: boolean }).bordered = false;
+    expect(el.hasAttribute("bordered")).toBe(false);
+  });
+
+  // ── Shadow DOM structure ───────────────────────────────────────────────
+
+  it("has .base element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".base")).toBeTruthy();
+  });
+
+  it("has .content element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".content")).toBeTruthy();
+  });
+
+  it("has image slot in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    const slot = shadow.querySelector('slot[name="image"]');
+    expect(slot).toBeTruthy();
+  });
+
+  it("has default slot in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    const slots = shadow.querySelectorAll("slot");
+    const defaultSlot = Array.from(slots).find((s) => !s.name);
+    expect(defaultSlot).toBeTruthy();
+  });
+
+  it("has footer slot in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    const slot = shadow.querySelector('slot[name="footer"]');
+    expect(slot).toBeTruthy();
+  });
+
+  // ── Footer visibility ─────────────────────────────────────────────────
+
+  it("footer is hidden by default (no has-footer attribute)", () => {
+    const shadow = el.shadowRoot!;
+    const footer = shadow.querySelector(".footer");
+    expect(footer).toBeTruthy();
+    expect(el.hasAttribute("has-footer")).toBe(false);
+  });
+
+  // ── Part attributes ───────────────────────────────────────────────────
+
+  it(".base has part='base'", () => {
+    const shadow = el.shadowRoot!;
+    const base = shadow.querySelector(".base");
+    expect(base!.getAttribute("part")).toBe("base");
+  });
+
+  it(".content has part='content'", () => {
+    const shadow = el.shadowRoot!;
+    const content = shadow.querySelector(".content");
+    expect(content!.getAttribute("part")).toBe("content");
+  });
+
+  // ── Property accessors ────────────────────────────────────────────────
+
+  it("exposes all typed property accessors", () => {
+    const component = el as unknown as {
+      size: string;
+      elevation: string;
+      bordered: boolean;
+    };
+
+    component.size = "l";
+    expect(component.size).toBe("l");
+
+    component.elevation = "04";
+    expect(component.elevation).toBe("04");
+
+    component.bordered = true;
+    expect(component.bordered).toBe(true);
+  });
+});

--- a/packages/ui-components/src/components/ui-card.ts
+++ b/packages/ui-components/src/components/ui-card.ts
@@ -1,0 +1,235 @@
+import { semanticVar, elevationVar, spaceVar } from "@maneki/foundation";
+
+// ─── Type-safe property unions ───────────────────────────────────────────────
+
+export type CardSize = "s" | "m" | "l";
+export type CardElevation = "00" | "01" | "02" | "04";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const SURFACE_PRIMARY = semanticVar("surface", "primary");
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const BORDER_MINIMAL = semanticVar("border", "minimal");
+
+const ELEVATION_00 = elevationVar("00");
+const ELEVATION_01 = elevationVar("01");
+const ELEVATION_02 = elevationVar("02");
+const ELEVATION_04 = elevationVar("04");
+
+const SP_1 = spaceVar("1");
+const SP_1_5 = spaceVar("1.5");
+const SP_2 = spaceVar("2");
+const SP_2_5 = spaceVar("2.5");
+const SP_3 = spaceVar("3");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: block;
+    font-family: "Goldman Sans", sans-serif;
+  }
+
+  /* ── Base ─────────────────────────────────────────────────────────────────── */
+
+  .base {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    border-radius: var(--ui-card-radius, 2px);
+    background-color: var(--ui-card-bg, ${SURFACE_PRIMARY});
+    color: var(--ui-card-color, ${TEXT_PRIMARY});
+    overflow: hidden;
+  }
+
+  /* ── Elevation ───────────────────────────────────────────────────────────── */
+
+  :host .base,
+  :host([elevation="02"]) .base {
+    box-shadow: var(--ui-card-shadow, ${ELEVATION_02});
+  }
+
+  :host([elevation="00"]) .base {
+    box-shadow: var(--ui-card-shadow, ${ELEVATION_00});
+  }
+
+  :host([elevation="01"]) .base {
+    box-shadow: var(--ui-card-shadow, ${ELEVATION_01});
+  }
+
+  :host([elevation="04"]) .base {
+    box-shadow: var(--ui-card-shadow, ${ELEVATION_04});
+  }
+
+  /* ── Bordered ────────────────────────────────────────────────────────────── */
+
+  :host([bordered]) .base {
+    border: 1px solid var(--ui-card-border-color, ${BORDER_MINIMAL});
+  }
+
+  /* ── Image slot ──────────────────────────────────────────────────────────── */
+
+  .image-slot {
+    overflow: hidden;
+    border-radius: var(--ui-card-radius, 2px) var(--ui-card-radius, 2px) 0 0;
+  }
+
+  .image-slot ::slotted(*) {
+    display: block;
+    width: 100%;
+  }
+
+  /* ── Content ─────────────────────────────────────────────────────────────── */
+
+  .content {
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* ── Footer ──────────────────────────────────────────────────────────────── */
+
+  .footer {
+    display: none;
+  }
+
+  :host([has-footer]) .footer {
+    display: block;
+  }
+
+  /* ── Size: m (default) ───────────────────────────────────────────────────── */
+
+  :host .content,
+  :host([size="m"]) .content {
+    padding: ${SP_1_5} ${SP_2} ${SP_2} ${SP_2};
+    gap: ${SP_1_5};
+  }
+
+  /* ── Size: s ─────────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) .content {
+    padding: ${SP_1_5} ${SP_2} ${SP_1_5} ${SP_2};
+    gap: ${SP_1};
+  }
+
+  /* ── Size: l ─────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) .content {
+    padding: ${SP_2_5} ${SP_3} ${SP_3} ${SP_3};
+    gap: ${SP_2_5};
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export class UiCard extends HTMLElement {
+  static readonly observedAttributes = ["size", "elevation", "bordered"];
+
+  private _footerSlot: HTMLSlotElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+
+    const style = document.createElement("style");
+    style.textContent = STYLES;
+    shadow.appendChild(style);
+
+    // .base
+    const base = document.createElement("div");
+    base.className = "base";
+    base.setAttribute("part", "base");
+
+    // Image slot wrapper
+    const imageSlotWrapper = document.createElement("div");
+    imageSlotWrapper.className = "image-slot";
+    const imageSlot = document.createElement("slot");
+    imageSlot.name = "image";
+    imageSlotWrapper.appendChild(imageSlot);
+    base.appendChild(imageSlotWrapper);
+
+    // .content
+    const content = document.createElement("div");
+    content.className = "content";
+    content.setAttribute("part", "content");
+    const defaultSlot = document.createElement("slot");
+    content.appendChild(defaultSlot);
+    base.appendChild(content);
+
+    // .footer
+    const footer = document.createElement("div");
+    footer.className = "footer";
+    footer.setAttribute("part", "footer");
+    const footerSlot = document.createElement("slot");
+    footerSlot.name = "footer";
+    footer.appendChild(footerSlot);
+    base.appendChild(footer);
+
+    shadow.appendChild(base);
+
+    this._footerSlot = footerSlot;
+
+    // Listen for slotchange to toggle has-footer attribute
+    footerSlot.addEventListener("slotchange", () => this._syncFooter());
+  }
+
+  connectedCallback(): void {
+    this._syncFooter();
+  }
+
+  attributeChangedCallback(
+    _name: string,
+    _oldValue: string | null,
+    _newValue: string | null,
+  ): void {
+    // All styling is handled via :host([attr]) CSS selectors — no JS sync needed
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): CardSize {
+    return (this.getAttribute("size") as CardSize) ?? "m";
+  }
+
+  set size(value: CardSize) {
+    this.setAttribute("size", value);
+  }
+
+  get elevation(): CardElevation {
+    return (this.getAttribute("elevation") as CardElevation) ?? "02";
+  }
+
+  set elevation(value: CardElevation) {
+    this.setAttribute("elevation", value);
+  }
+
+  get bordered(): boolean {
+    return this.hasAttribute("bordered");
+  }
+
+  set bordered(value: boolean) {
+    if (value) {
+      this.setAttribute("bordered", "");
+    } else {
+      this.removeAttribute("bordered");
+    }
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private _syncFooter(): void {
+    const nodes = this._footerSlot.assignedNodes({ flatten: true });
+    if (nodes.length > 0) {
+      this.setAttribute("has-footer", "");
+    } else {
+      this.removeAttribute("has-footer");
+    }
+  }
+}
+
+customElements.define("ui-card", UiCard);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -33,3 +33,5 @@ export type {
 export { UiBreadcrumbItem } from "./components/ui-breadcrumb-item.js";
 export type { BreadcrumbSize } from "./components/ui-breadcrumb-item.js";
 export { UiBreadcrumbGroup } from "./components/ui-breadcrumb-group.js";
+export { UiCard } from "./components/ui-card.js";
+export type { CardSize, CardElevation } from "./components/ui-card.js";

--- a/packages/ui-components/src/stories/ui-card.stories.ts
+++ b/packages/ui-components/src/stories/ui-card.stories.ts
@@ -1,0 +1,205 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-card.js";
+
+const meta: Meta = {
+  title: "Components/Card",
+  component: "ui-card",
+  argTypes: {
+    size: { control: { type: "select" }, options: ["s", "m", "l"] },
+    elevation: {
+      control: { type: "select" },
+      options: ["00", "01", "02", "04"],
+    },
+    bordered: { control: "boolean" },
+  },
+  args: {
+    size: "m",
+    elevation: "02",
+    bordered: false,
+  },
+  render: (args) => html`
+    <ui-card
+      size=${args.size}
+      elevation=${args.elevation}
+      ?bordered=${args.bordered}
+    >
+      <h3 style="margin: 0; font-size: 16px; font-weight: 500;">Card Title</h3>
+      <p style="margin: 0; font-size: 14px;">
+        This is a basic card with some body text content.
+      </p>
+    </ui-card>
+  `,
+};
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => html`
+    <ui-card style="max-width: 320px;">
+      <h3 style="margin: 0; font-size: 16px; font-weight: 500;">Card Title</h3>
+      <p style="margin: 0; font-size: 14px;">
+        This is a basic card with some body text content.
+      </p>
+    </ui-card>
+  `,
+};
+
+export const WithImage: Story = {
+  render: () => html`
+    <ui-card style="max-width: 320px;">
+      <div
+        slot="image"
+        style="height: 160px; background-color: #c1ccd6;"
+      ></div>
+      <h3 style="margin: 0; font-size: 16px; font-weight: 500;">Card Title</h3>
+      <p style="margin: 0; font-size: 14px;">
+        Card content below the image area.
+      </p>
+    </ui-card>
+  `,
+};
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 24px; align-items: start;">
+      <ui-card size="s" style="flex: 1;">
+        <h3 style="margin: 0; font-size: 14px; font-weight: 500;">Small</h3>
+        <p style="margin: 0; font-size: 12px;">Size s card content.</p>
+      </ui-card>
+      <ui-card size="m" style="flex: 1;">
+        <h3 style="margin: 0; font-size: 16px; font-weight: 500;">Medium</h3>
+        <p style="margin: 0; font-size: 14px;">Size m card content.</p>
+      </ui-card>
+      <ui-card size="l" style="flex: 1;">
+        <h3 style="margin: 0; font-size: 18px; font-weight: 500;">Large</h3>
+        <p style="margin: 0; font-size: 16px;">Size l card content.</p>
+      </ui-card>
+    </div>
+  `,
+};
+
+export const AllElevations: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 24px; align-items: start;">
+      <ui-card elevation="00" style="flex: 1;">
+        <h3 style="margin: 0; font-size: 16px; font-weight: 500;">
+          Elevation 00
+        </h3>
+        <p style="margin: 0; font-size: 14px;">No shadow.</p>
+      </ui-card>
+      <ui-card elevation="01" style="flex: 1;">
+        <h3 style="margin: 0; font-size: 16px; font-weight: 500;">
+          Elevation 01
+        </h3>
+        <p style="margin: 0; font-size: 14px;">Subtle shadow.</p>
+      </ui-card>
+      <ui-card elevation="02" style="flex: 1;">
+        <h3 style="margin: 0; font-size: 16px; font-weight: 500;">
+          Elevation 02
+        </h3>
+        <p style="margin: 0; font-size: 14px;">Default shadow.</p>
+      </ui-card>
+      <ui-card elevation="04" style="flex: 1;">
+        <h3 style="margin: 0; font-size: 16px; font-weight: 500;">
+          Elevation 04
+        </h3>
+        <p style="margin: 0; font-size: 14px;">Strong shadow.</p>
+      </ui-card>
+    </div>
+  `,
+};
+
+export const Bordered: Story = {
+  render: () => html`
+    <ui-card bordered elevation="00" style="max-width: 320px;">
+      <h3 style="margin: 0; font-size: 16px; font-weight: 500;">
+        Bordered Card
+      </h3>
+      <p style="margin: 0; font-size: 14px;">
+        A card with a border and no elevation shadow.
+      </p>
+    </ui-card>
+  `,
+};
+
+export const WithFooter: Story = {
+  render: () => html`
+    <ui-card style="max-width: 320px;">
+      <h3 style="margin: 0; font-size: 16px; font-weight: 500;">Card Title</h3>
+      <p style="margin: 0; font-size: 14px;">Card body content goes here.</p>
+      <div slot="footer" style="display: flex; gap: 8px; padding: 0 16px 16px;">
+        <button
+          style="background-color: #186ade; border: none; border-radius: 2px; padding: 8px 16px; color: #fff; cursor: pointer; font-family: Goldman Sans, sans-serif; font-size: 14px; font-weight: 500;"
+        >
+          Confirm
+        </button>
+        <button
+          style="background-color: transparent; border: 1px solid #c1ccd6; border-radius: 2px; padding: 8px 16px; color: #1c2b36; cursor: pointer; font-family: Goldman Sans, sans-serif; font-size: 14px; font-weight: 500;"
+        >
+          Cancel
+        </button>
+      </div>
+    </ui-card>
+  `,
+};
+
+export const ImageCard: Story = {
+  render: () => html`
+    <ui-card style="max-width: 320px;">
+      <div
+        slot="image"
+        style="height: 180px; background-color: #c1ccd6;"
+      ></div>
+      <h3 style="margin: 0; font-size: 16px; font-weight: 500;">
+        Featured Article
+      </h3>
+      <p style="margin: 0; font-size: 14px;">
+        A full card example with image, heading, body text, and an action
+        button.
+      </p>
+      <div slot="footer" style="padding: 0 16px 16px;">
+        <button
+          style="background-color: #186ade; border: none; border-radius: 2px; padding: 8px 16px; color: #fff; cursor: pointer; font-family: Goldman Sans, sans-serif; font-size: 14px; font-weight: 500;"
+        >
+          Read More
+        </button>
+      </div>
+    </ui-card>
+  `,
+};
+
+export const ArticleCard: Story = {
+  render: () => html`
+    <ui-card style="max-width: 320px;">
+      <div
+        slot="image"
+        style="height: 160px; background-color: #c1ccd6;"
+      ></div>
+      <h3 style="margin: 0; font-size: 16px; font-weight: 500;">
+        Article Headline
+      </h3>
+      <p style="margin: 0; font-size: 14px;">
+        Brief summary of the article content that gives readers a preview of
+        what to expect.
+      </p>
+      <div
+        slot="footer"
+        style="display: flex; justify-content: space-between; align-items: center; padding: 0 16px 16px;"
+      >
+        <span style="font-size: 12px; color: #6b7b8a;">5 min read</span>
+        <svg
+          viewBox="0 0 20 20"
+          width="20"
+          height="20"
+          style="color: #6b7b8a;"
+        >
+          <path
+            d="M15 6.67a3.33 3.33 0 0 0-2.36.98L8.91 9.28a3.33 3.33 0 0 0 0 1.44l3.73 1.63A3.33 3.33 0 1 0 15 13.33a3.3 3.3 0 0 0-.55.05L10.72 11.75a3.33 3.33 0 0 0 0-3.5l3.73-1.63A3.3 3.3 0 0 0 15 6.67Z"
+            fill="currentColor"
+          />
+        </svg>
+      </div>
+    </ui-card>
+  `,
+};


### PR DESCRIPTION
## Summary

- Add `<ui-card>` Web Component — slot-based card container with 3 sizes (s/m/l), 4 elevation levels (00/01/02/04), bordered variant, and image/default/footer slots
- 22 unit tests covering registration, attributes, shadow DOM structure, footer visibility, and property accessors
- 8 Storybook stories: Default, WithImage, AllSizes, AllElevations, Bordered, WithFooter, ImageCard, ArticleCard
- Update AGENTS.md docs (root + ui-components) to include card in component list

230 tests passing, build clean.