### PR TITLE
refactor(stories): replace inline <button> with <ui-button> in card and alert stories

### DIFF
--- a/packages/ui-components/src/stories/ui-alert.stories.ts
+++ b/packages/ui-components/src/stories/ui-alert.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/web-components";
 import { html } from "lit";
 import "../components/ui-alert.js";
+import "../components/ui-button.js";
 
 const meta: Meta = {
   title: "Components/Alert",
@@ -155,7 +156,7 @@ export const WithFooterButton: Story = {
       Alert Title
       <span slot="description">Description text explaining the alert in more detail.</span>
       <div slot="footer">
-        <button style="background: rgba(255,255,255,0.15); border: none; border-radius: 2px; padding: 6px 12px 6px 8px; color: inherit; cursor: pointer; font-family: Goldman Sans, sans-serif; font-size: 14px; font-weight: 500;">Refresh</button>
+        <ui-button action="contrast" emphasis="subtle" size="s">Refresh</ui-button>
       </div>
     </ui-alert>
   `,

--- a/packages/ui-components/src/stories/ui-card.stories.ts
+++ b/packages/ui-components/src/stories/ui-card.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/web-components";
 import { html } from "lit";
 import "../components/ui-card.js";
+import "../components/ui-button.js";
 
 const meta: Meta = {
   title: "Components/Card",
@@ -129,16 +130,8 @@ export const WithFooter: Story = {
       <h3 style="margin: 0; font-size: 16px; font-weight: 500;">Card Title</h3>
       <p style="margin: 0; font-size: 14px;">Card body content goes here.</p>
       <div slot="footer" style="display: flex; gap: 8px; padding: 0 16px 16px;">
-        <button
-          style="background-color: #186ade; border: none; border-radius: 2px; padding: 8px 16px; color: #fff; cursor: pointer; font-family: Goldman Sans, sans-serif; font-size: 14px; font-weight: 500;"
-        >
-          Confirm
-        </button>
-        <button
-          style="background-color: transparent; border: 1px solid #c1ccd6; border-radius: 2px; padding: 8px 16px; color: #1c2b36; cursor: pointer; font-family: Goldman Sans, sans-serif; font-size: 14px; font-weight: 500;"
-        >
-          Cancel
-        </button>
+        <ui-button action="primary" emphasis="bold" size="s">Confirm</ui-button>
+        <ui-button action="secondary" emphasis="subtle" size="s">Cancel</ui-button>
       </div>
     </ui-card>
   `,
@@ -159,11 +152,7 @@ export const ImageCard: Story = {
         button.
       </p>
       <div slot="footer" style="padding: 0 16px 16px;">
-        <button
-          style="background-color: #186ade; border: none; border-radius: 2px; padding: 8px 16px; color: #fff; cursor: pointer; font-family: Goldman Sans, sans-serif; font-size: 14px; font-weight: 500;"
-        >
-          Read More
-        </button>
+        <ui-button action="primary" emphasis="bold" size="s">Read More</ui-button>
       </div>
     </ui-card>
   `,


### PR DESCRIPTION
## Summary

- Replace inline `<button>` elements with `<ui-button>` in card stories (WithFooter, ImageCard) and alert story (WithFooterButton)
- Applies the new "reuse existing primitives" SOP from #9

No logic changes — stories now consume our own design system components instead of duplicating button markup with inline styles.