### PR TITLE
feat: add ui-checkbox-item and ui-checkbox-group components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ maneki-monorepo/
 ├── packages/
 │   ├── grid-layout/         # <grid-layout> Web Component library (@maneki/grid-layout)
 │   ├── ui-components/       # UI components + Storybook (@maneki/ui-components)
-│   │                        # button, button-group, accordion-item, accordion-group, alert, avatar, breadcrumb-item, breadcrumb-group, card
+│   │                        # button, button-group, accordion-item, accordion-group, alert, avatar, breadcrumb-item, breadcrumb-group, card, checkbox-item, checkbox-group
 │   └── foundation/          # Design tokens: colors, semantic, typography, spacing, elevation, breakpoints (@maneki/foundation)
 └── apps/                    # (empty — future apps)
 ```

--- a/packages/ui-components/AGENTS.md
+++ b/packages/ui-components/AGENTS.md
@@ -12,6 +12,8 @@ Web Component library for the Maneki design system. Shadow DOM, CSS custom prope
 - `<ui-breadcrumb-item>` — breadcrumb link item: 3 sizes, 7 states (enabled/hover/focus/active/visited/disabled/current), chevron separator
 - `<ui-breadcrumb-group>` — breadcrumb nav wrapper with size propagation
 - `<ui-card>` — slot-based card container: 3 sizes (s/m/l), 4 elevations (00/01/02/04), bordered variant, image/default/footer slots
+- `<ui-checkbox-item>` — checkbox component: 3 sizes (s/m/l), 3 check states (unchecked/checked/indeterminate), 3 label positions (none/right/left), 5 states (enabled/hover/focus/disabled/error)
+- `<ui-checkbox-group>` — checkbox group wrapper: 3 sizes (s/m/l), 2 orientations (vertical/horizontal), size propagation to children
 
 ## STRUCTURE
 ```
@@ -33,6 +35,8 @@ ui-components/
 │   │   ├── ui-card.ts
 │   │   ├── ui-breadcrumb-item.ts
 │   │   ├── ui-breadcrumb-group.ts
+│   │   ├── ui-checkbox-item.ts
+│   │   ├── ui-checkbox-group.ts
 │   │   └── *.test.ts        # Co-located tests
 │   └── stories/
 │       └── *.stories.ts     # CSF3 + lit html

--- a/packages/ui-components/src/assets/icons.ts
+++ b/packages/ui-components/src/assets/icons.ts
@@ -26,3 +26,6 @@ export const ICON_USER = `<svg viewBox="0 0 24 24" fill="currentColor" xmlns="ht
 
 /** Chevron-right arrow (breadcrumb separator). */
 export const ICON_CHEVRON_RIGHT = `<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7.5 5L12.5 10L7.5 15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`;
+
+/** Checkmark icon (checkbox checked state). */
+export const ICON_CHECK = `<svg viewBox="0 0 10 8" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9.03.97a.75.75 0 0 1 0 1.06l-5 5a.75.75 0 0 1-1.06 0l-2-2a.75.75 0 0 1 1.06-1.06L3.5 5.44 7.97.97a.75.75 0 0 1 1.06 0z" fill="currentColor"/></svg>`;

--- a/packages/ui-components/src/components/ui-checkbox-group.test.ts
+++ b/packages/ui-components/src/components/ui-checkbox-group.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "../components/ui-checkbox-group.js";
+import "../components/ui-checkbox-item.js";
+
+describe("UiCheckboxGroup", () => {
+  let group: HTMLElement;
+
+  beforeEach(() => {
+    group = document.createElement("ui-checkbox-group");
+    document.body.appendChild(group);
+  });
+
+  afterEach(() => {
+    group.remove();
+  });
+
+  describe("rendering", () => {
+    it("should render with shadow DOM", () => {
+      expect(group.shadowRoot).toBeTruthy();
+    });
+
+    it("should have role='group' on container", () => {
+      const groupEl = group.shadowRoot!.querySelector(".group");
+      expect(groupEl?.getAttribute("role")).toBe("group");
+    });
+
+    it("should have part='group' on container", () => {
+      const groupEl = group.shadowRoot!.querySelector(".group");
+      expect(groupEl?.getAttribute("part")).toBe("group");
+    });
+
+    it("should render slot for children", () => {
+      const slot = group.shadowRoot!.querySelector("slot");
+      expect(slot).toBeTruthy();
+    });
+  });
+
+  describe("default attributes", () => {
+    it("should default to size='m'", () => {
+      expect(group.getAttribute("size")).toBeNull();
+      expect((group as any).size).toBe("m");
+    });
+
+    it("should default to orientation='vertical'", () => {
+      expect(group.getAttribute("orientation")).toBeNull();
+      expect((group as any).orientation).toBe("vertical");
+    });
+  });
+
+  describe("size propagation", () => {
+    it("should propagate size to checkbox children", () => {
+      const checkbox1 = document.createElement("ui-checkbox-item");
+      const checkbox2 = document.createElement("ui-checkbox-item");
+      group.appendChild(checkbox1);
+      group.appendChild(checkbox2);
+
+      group.setAttribute("size", "l");
+
+      expect(checkbox1.getAttribute("size")).toBe("l");
+      expect(checkbox2.getAttribute("size")).toBe("l");
+    });
+
+    it("should propagate size to dynamically added children", () => {
+      group.setAttribute("size", "s");
+
+      const checkbox = document.createElement("ui-checkbox-item");
+      group.appendChild(checkbox);
+
+      // Wait for slotchange event
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          expect(checkbox.getAttribute("size")).toBe("s");
+          resolve(undefined);
+        }, 0);
+      });
+    });
+
+    it("should update size on existing children when size changes", () => {
+      const checkbox = document.createElement("ui-checkbox-item");
+      group.appendChild(checkbox);
+
+      group.setAttribute("size", "m");
+      expect(checkbox.getAttribute("size")).toBe("m");
+
+      group.setAttribute("size", "l");
+      expect(checkbox.getAttribute("size")).toBe("l");
+    });
+
+    it("should support all size values: s, m, l", () => {
+      const checkbox = document.createElement("ui-checkbox-item");
+      group.appendChild(checkbox);
+
+      const sizes: Array<"s" | "m" | "l"> = ["s", "m", "l"];
+      for (const size of sizes) {
+        group.setAttribute("size", size);
+        expect(checkbox.getAttribute("size")).toBe(size);
+      }
+    });
+  });
+
+  describe("orientation attribute", () => {
+    it("should accept orientation='vertical'", () => {
+      group.setAttribute("orientation", "vertical");
+      expect(group.getAttribute("orientation")).toBe("vertical");
+    });
+
+    it("should accept orientation='horizontal'", () => {
+      group.setAttribute("orientation", "horizontal");
+      expect(group.getAttribute("orientation")).toBe("horizontal");
+    });
+  });
+
+  describe("property accessors", () => {
+    it("should get/set size property", () => {
+      (group as any).size = "l";
+      expect(group.getAttribute("size")).toBe("l");
+      expect((group as any).size).toBe("l");
+    });
+
+    it("should get/set orientation property", () => {
+      (group as any).orientation = "horizontal";
+      expect(group.getAttribute("orientation")).toBe("horizontal");
+      expect((group as any).orientation).toBe("horizontal");
+    });
+
+    it("should default size to 'm' when not set", () => {
+      expect((group as any).size).toBe("m");
+    });
+
+    it("should default orientation to 'vertical' when not set", () => {
+      expect((group as any).orientation).toBe("vertical");
+    });
+  });
+
+  describe("CSS layout", () => {
+    it("should have display: flex on host", () => {
+      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      expect(styles).toContain(":host {");
+      expect(styles).toContain("display: flex;");
+    });
+
+    it("should have flex-direction: column for vertical orientation", () => {
+      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      expect(styles).toContain("flex-direction: column;");
+    });
+
+    it("should have flex-direction: row for horizontal orientation", () => {
+      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      expect(styles).toContain("flex-direction: row;");
+    });
+  });
+
+  describe("gap values", () => {
+    it("should have correct gap for size='s' (8px)", () => {
+      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      expect(styles).toContain(':host([size="s"]) .group');
+    });
+
+    it("should have correct gap for size='m' (12px)", () => {
+      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      expect(styles).toContain(':host([size="m"]) .group');
+    });
+
+    it("should have correct gap for size='l' (20px)", () => {
+      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      expect(styles).toContain(':host([size="l"]) .group');
+    });
+
+    it("should have horizontal gap (24px) for horizontal orientation", () => {
+      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      expect(styles).toContain(':host([orientation="horizontal"]) .group');
+    });
+  });
+
+  describe("non-checkbox children", () => {
+    it("should only propagate to UI-CHECKBOX-ITEM elements", () => {
+      const checkbox = document.createElement("ui-checkbox-item");
+      const div = document.createElement("div");
+      group.appendChild(checkbox);
+      group.appendChild(div);
+
+      group.setAttribute("size", "l");
+
+      expect(checkbox.getAttribute("size")).toBe("l");
+      expect(div.getAttribute("size")).toBeNull();
+    });
+  });
+});

--- a/packages/ui-components/src/components/ui-checkbox-group.ts
+++ b/packages/ui-components/src/components/ui-checkbox-group.ts
@@ -1,0 +1,149 @@
+import { spaceVar } from "@maneki/foundation";
+import type { CheckboxSize } from "./ui-checkbox-item.js";
+
+// ─── Type-safe property unions ───────────────────────────────────────────────
+
+export type CheckboxGroupSize = CheckboxSize;
+export type CheckboxGroupOrientation = "vertical" | "horizontal";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const SP_1 = spaceVar("1");     // 8px
+const SP_1_5 = spaceVar("1.5"); // 12px
+const SP_2_5 = spaceVar("2.5"); // 20px
+const SP_3 = spaceVar("3");     // 24px
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: flex;
+  }
+
+  /* ── Vertical (default) ──────────────────────────────────────────────────── */
+
+  :host .group,
+  :host([orientation="vertical"]) .group {
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* ── Horizontal ──────────────────────────────────────────────────────────── */
+
+  :host([orientation="horizontal"]) .group {
+    display: flex;
+    flex-direction: row;
+  }
+
+  /* ── Gaps: vertical by size ──────────────────────────────────────────────── */
+
+  :host .group,
+  :host([size="m"]) .group {
+    gap: var(--ui-cbg-gap, ${SP_1_5});
+  }
+
+  :host([size="s"]) .group {
+    gap: var(--ui-cbg-gap, ${SP_1});
+  }
+
+  :host([size="l"]) .group {
+    gap: var(--ui-cbg-gap, ${SP_2_5});
+  }
+
+  /* ── Gaps: horizontal override (same for all sizes) ────────────────────── */
+
+  :host([orientation="horizontal"]) .group {
+    gap: var(--ui-cbg-gap, ${SP_3});
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const PROPAGATED_ATTRS = ["size"] as const;
+
+export class UiCheckboxGroup extends HTMLElement {
+  static readonly observedAttributes = ["size", "orientation"];
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+
+    const style = document.createElement("style");
+    style.textContent = STYLES;
+    shadow.appendChild(style);
+
+    const group = document.createElement("div");
+    group.className = "group";
+    group.setAttribute("role", "group");
+    group.setAttribute("part", "group");
+
+    const slot = document.createElement("slot");
+    group.appendChild(slot);
+
+    shadow.appendChild(group);
+
+    // Listen for slotchange to propagate attributes to new children
+    slot.addEventListener("slotchange", () => this._propagateAttributes());
+  }
+
+  connectedCallback(): void {
+    this._propagateAttributes();
+  }
+
+  attributeChangedCallback(
+    _name: string,
+    _oldValue: string | null,
+    _newValue: string | null,
+  ): void {
+    this._propagateAttributes();
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): CheckboxGroupSize {
+    return (this.getAttribute("size") as CheckboxGroupSize) ?? "m";
+  }
+
+  set size(value: CheckboxGroupSize) {
+    this.setAttribute("size", value);
+  }
+
+  get orientation(): CheckboxGroupOrientation {
+    return (this.getAttribute("orientation") as CheckboxGroupOrientation) ?? "vertical";
+  }
+
+  set orientation(value: CheckboxGroupOrientation) {
+    this.setAttribute("orientation", value);
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private _getChildItems(): Element[] {
+    const slot = this.shadowRoot!.querySelector("slot")!;
+    return slot
+      .assignedElements({ flatten: true })
+      .filter((el) => el.tagName === "UI-CHECKBOX-ITEM");
+  }
+
+  private _propagateAttributes(): void {
+    const items = this._getChildItems();
+    for (const attr of PROPAGATED_ATTRS) {
+      const value = this.getAttribute(attr);
+      for (const item of items) {
+        if (value) {
+          item.setAttribute(attr, value);
+        } else {
+          item.removeAttribute(attr);
+        }
+      }
+    }
+  }
+}
+
+customElements.define("ui-checkbox-group", UiCheckboxGroup);

--- a/packages/ui-components/src/components/ui-checkbox-item.test.ts
+++ b/packages/ui-components/src/components/ui-checkbox-item.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "./ui-checkbox-item.js";
+
+describe("ui-checkbox-item", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-checkbox-item");
+    document.body.appendChild(el);
+  });
+
+  // ── Registration ─────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-checkbox-item")).toBeDefined();
+  });
+
+  // ── Default attributes ───────────────────────────────────────────────────
+
+  it("defaults size to 'm'", () => {
+    expect((el as unknown as { size: string }).size).toBe("m");
+  });
+
+  it("defaults label to 'none'", () => {
+    expect((el as unknown as { label: string }).label).toBe("none");
+  });
+
+  it("defaults checked to false", () => {
+    expect((el as unknown as { checked: boolean }).checked).toBe(false);
+  });
+
+  it("defaults indeterminate to false", () => {
+    expect((el as unknown as { indeterminate: boolean }).indeterminate).toBe(
+      false,
+    );
+  });
+
+  it("defaults disabled to false", () => {
+    expect((el as unknown as { disabled: boolean }).disabled).toBe(false);
+  });
+
+  it("defaults error to false", () => {
+    expect((el as unknown as { error: boolean }).error).toBe(false);
+  });
+
+  // ── Size attribute ──────────────────────────────────────────────────────
+
+  it("reflects size='s' to attribute", () => {
+    (el as unknown as { size: string }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("reflects size='m' to attribute", () => {
+    (el as unknown as { size: string }).size = "m";
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("reflects size='l' to attribute", () => {
+    (el as unknown as { size: string }).size = "l";
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  // ── Label attribute ─────────────────────────────────────────────────────
+
+  it("reflects label='none' to attribute", () => {
+    (el as unknown as { label: string }).label = "none";
+    expect(el.getAttribute("label")).toBe("none");
+  });
+
+  it("reflects label='right' to attribute", () => {
+    (el as unknown as { label: string }).label = "right";
+    expect(el.getAttribute("label")).toBe("right");
+  });
+
+  it("reflects label='left' to attribute", () => {
+    (el as unknown as { label: string }).label = "left";
+    expect(el.getAttribute("label")).toBe("left");
+  });
+
+  // ── Boolean attributes ──────────────────────────────────────────────────
+
+  it("sets checked attribute when property is true", () => {
+    (el as unknown as { checked: boolean }).checked = true;
+    expect(el.hasAttribute("checked")).toBe(true);
+  });
+
+  it("removes checked attribute when property is false", () => {
+    (el as unknown as { checked: boolean }).checked = true;
+    (el as unknown as { checked: boolean }).checked = false;
+    expect(el.hasAttribute("checked")).toBe(false);
+  });
+
+  it("sets indeterminate attribute when property is true", () => {
+    (el as unknown as { indeterminate: boolean }).indeterminate = true;
+    expect(el.hasAttribute("indeterminate")).toBe(true);
+  });
+
+  it("removes indeterminate attribute when property is false", () => {
+    (el as unknown as { indeterminate: boolean }).indeterminate = true;
+    (el as unknown as { indeterminate: boolean }).indeterminate = false;
+    expect(el.hasAttribute("indeterminate")).toBe(false);
+  });
+
+  it("sets disabled attribute when property is true", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    expect(el.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("removes disabled attribute when property is false", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    (el as unknown as { disabled: boolean }).disabled = false;
+    expect(el.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("sets error attribute when property is true", () => {
+    (el as unknown as { error: boolean }).error = true;
+    expect(el.hasAttribute("error")).toBe(true);
+  });
+
+  it("removes error attribute when property is false", () => {
+    (el as unknown as { error: boolean }).error = true;
+    (el as unknown as { error: boolean }).error = false;
+    expect(el.hasAttribute("error")).toBe(false);
+  });
+
+  // ── Shadow DOM structure ───────────────────────────────────────────────
+
+  it("has .base element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".base")).toBeTruthy();
+  });
+
+  it("has .outer element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".outer")).toBeTruthy();
+  });
+
+  it("has .checkbox element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".checkbox")).toBeTruthy();
+  });
+
+  it("has .label element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".label")).toBeTruthy();
+  });
+
+  it("has default slot in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    const slots = shadow.querySelectorAll("slot");
+    const defaultSlot = Array.from(slots).find((s) => !s.name);
+    expect(defaultSlot).toBeTruthy();
+  });
+
+  it("has .check-icon element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".check-icon")).toBeTruthy();
+  });
+
+  it("has .indeterminate-icon element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".indeterminate-icon")).toBeTruthy();
+  });
+
+  // ── Accessibility ──────────────────────────────────────────────────────
+
+  it("sets role='checkbox' on connected", () => {
+    expect(el.getAttribute("role")).toBe("checkbox");
+  });
+
+  it("sets tabindex='0' on connected", () => {
+    expect(el.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("sets aria-checked='false' by default", () => {
+    expect(el.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("sets aria-checked='true' when checked", () => {
+    (el as unknown as { checked: boolean }).checked = true;
+    expect(el.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("sets aria-checked='mixed' when indeterminate", () => {
+    (el as unknown as { indeterminate: boolean }).indeterminate = true;
+    expect(el.getAttribute("aria-checked")).toBe("mixed");
+  });
+
+  // ── Toggle behavior ────────────────────────────────────────────────────
+
+  it("toggles checked on click", () => {
+    el.click();
+    expect((el as unknown as { checked: boolean }).checked).toBe(true);
+    el.click();
+    expect((el as unknown as { checked: boolean }).checked).toBe(false);
+  });
+
+  it("does not toggle when disabled", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    el.click();
+    expect((el as unknown as { checked: boolean }).checked).toBe(false);
+  });
+
+  it("clears indeterminate and sets checked on click", () => {
+    (el as unknown as { indeterminate: boolean }).indeterminate = true;
+    el.click();
+    expect((el as unknown as { indeterminate: boolean }).indeterminate).toBe(
+      false,
+    );
+    expect((el as unknown as { checked: boolean }).checked).toBe(true);
+  });
+
+  // ── Change event ───────────────────────────────────────────────────────
+
+  it("dispatches change event on toggle", () => {
+    let fired = false;
+    el.addEventListener("change", () => {
+      fired = true;
+    });
+    el.click();
+    expect(fired).toBe(true);
+  });
+
+  it("change event bubbles and is composed", () => {
+    let event: Event | null = null;
+    el.addEventListener("change", (e) => {
+      event = e;
+    });
+    el.click();
+    expect(event).toBeTruthy();
+    expect(event!.bubbles).toBe(true);
+    expect(event!.composed).toBe(true);
+  });
+
+  // ── Keyboard interaction ───────────────────────────────────────────────
+
+  it("toggles on Space key", () => {
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: " " }));
+    expect((el as unknown as { checked: boolean }).checked).toBe(true);
+  });
+
+  it("toggles on Enter key", () => {
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    expect((el as unknown as { checked: boolean }).checked).toBe(true);
+  });
+
+  it("does not toggle on other keys", () => {
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "a" }));
+    expect((el as unknown as { checked: boolean }).checked).toBe(false);
+  });
+
+  // ── Property accessors ────────────────────────────────────────────────
+
+  it("exposes all typed property accessors", () => {
+    const component = el as unknown as {
+      size: string;
+      label: string;
+      checked: boolean;
+      indeterminate: boolean;
+      disabled: boolean;
+      error: boolean;
+    };
+
+    component.size = "l";
+    expect(component.size).toBe("l");
+
+    component.label = "right";
+    expect(component.label).toBe("right");
+
+    component.checked = true;
+    expect(component.checked).toBe(true);
+
+    component.indeterminate = true;
+    expect(component.indeterminate).toBe(true);
+
+    component.disabled = true;
+    expect(component.disabled).toBe(true);
+
+    component.error = true;
+    expect(component.error).toBe(true);
+  });
+});

--- a/packages/ui-components/src/components/ui-checkbox-item.ts
+++ b/packages/ui-components/src/components/ui-checkbox-item.ts
@@ -1,0 +1,480 @@
+import { colorVar, semanticVar, spaceVar } from "@maneki/foundation";
+import { ICON_CHECK } from "../assets/icons.js";
+
+// ─── Type-safe property unions ───────────────────────────────────────────────
+
+export type CheckboxSize = "s" | "m" | "l";
+export type CheckboxLabel = "none" | "right" | "left";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const BORDER_MODERATE = semanticVar("border", "moderate");
+const GRAY_50 = colorVar("gray", 50);
+const BLUE_60 = colorVar("blue", 60);
+const ERROR_BOLD = semanticVar("statusSurface", "errorBold");
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const SP_075 = spaceVar("0.75");
+const SP_1 = spaceVar("1");
+
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: inline-flex;
+    outline: none;
+  }
+
+  /* ── Base ─────────────────────────────────────────────────────────────────── */
+
+  .base {
+    display: inline-flex;
+    align-items: center;
+    cursor: pointer;
+    user-select: none;
+    -webkit-user-select: none;
+  }
+
+  /* ── Outer box (hit area + focus ring) ───────────────────────────────────── */
+
+  .outer {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    border: 1px solid transparent;
+    border-radius: 2px;
+  }
+
+  /* ── Inner box (visible checkbox square) ─────────────────────────────────── */
+
+  .checkbox {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--ui-cb-border, ${BORDER_MODERATE});
+    border-radius: 2px;
+    background-color: var(--ui-cb-bg, #ffffff);
+    color: #ffffff;
+    transition:
+      background-color 0.15s ease,
+      border-color 0.15s ease;
+  }
+
+  .checkbox svg {
+    width: 100%;
+    height: 100%;
+  }
+
+  /* ── Check / indeterminate icons ─────────────────────────────────────────── */
+
+  .check-icon,
+  .indeterminate-icon {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    line-height: 0;
+  }
+
+  :host([checked]) .check-icon {
+    display: inline-flex;
+  }
+
+  :host([indeterminate]) .check-icon {
+    display: none;
+  }
+
+  :host([indeterminate]) .indeterminate-icon {
+    display: inline-flex;
+  }
+
+  .indeterminate-bar {
+    display: block;
+    background-color: #ffffff;
+    border-radius: 1px;
+    height: 1.5px;
+  }
+
+  /* ── Label slot ──────────────────────────────────────────────────────────── */
+
+  .label {
+    display: none;
+    font-family: "Goldman Sans", sans-serif;
+    font-weight: 400;
+    color: var(--ui-cb-label-color, ${TEXT_PRIMARY});
+  }
+
+  :host([label="right"]) .label {
+    display: inline;
+    order: 1;
+  }
+
+  :host([label="left"]) .label {
+    display: inline;
+    order: -1;
+  }
+
+  :host([label="right"]) .outer {
+    order: 0;
+  }
+
+  :host([label="left"]) .outer {
+    order: 0;
+  }
+
+  /* ── Size: m (default) ───────────────────────────────────────────────────── */
+
+  :host .outer,
+  :host([size="m"]) .outer {
+    width: var(--ui-cb-outer-size, 18px);
+    height: var(--ui-cb-outer-size, 18px);
+  }
+
+  :host .checkbox,
+  :host([size="m"]) .checkbox {
+    width: var(--ui-cb-inner-size, 14px);
+    height: var(--ui-cb-inner-size, 14px);
+  }
+
+  :host .base,
+  :host([size="m"]) .base {
+    gap: var(--ui-cb-gap, ${SP_1});
+  }
+
+  :host .label,
+  :host([size="m"]) .label {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  :host .indeterminate-bar,
+  :host([size="m"]) .indeterminate-bar {
+    width: 8px;
+  }
+
+  :host .check-icon,
+  :host([size="m"]) .check-icon {
+    width: 10px;
+    height: 10px;
+  }
+
+  /* ── Size: s ─────────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) .outer {
+    width: var(--ui-cb-outer-size, 16px);
+    height: var(--ui-cb-outer-size, 16px);
+  }
+
+  :host([size="s"]) .checkbox {
+    width: var(--ui-cb-inner-size, 12px);
+    height: var(--ui-cb-inner-size, 12px);
+  }
+
+  :host([size="s"]) .base {
+    gap: var(--ui-cb-gap, ${SP_075});
+  }
+
+  :host([size="s"]) .label {
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  :host([size="s"]) .indeterminate-bar {
+    width: 7px;
+  }
+
+  :host([size="s"]) .check-icon {
+    width: 8px;
+    height: 8px;
+  }
+
+  /* ── Size: l ─────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) .outer {
+    width: var(--ui-cb-outer-size, 20px);
+    height: var(--ui-cb-outer-size, 20px);
+  }
+
+  :host([size="l"]) .checkbox {
+    width: var(--ui-cb-inner-size, 16px);
+    height: var(--ui-cb-inner-size, 16px);
+  }
+
+  :host([size="l"]) .base {
+    gap: var(--ui-cb-gap, ${SP_1});
+  }
+
+  :host([size="l"]) .label {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  :host([size="l"]) .indeterminate-bar {
+    width: 9px;
+  }
+
+  :host([size="l"]) .check-icon {
+    width: 12px;
+    height: 12px;
+  }
+
+  /* ── Checked / Indeterminate fill ────────────────────────────────────────── */
+
+  :host([checked]) .checkbox,
+  :host([indeterminate]) .checkbox {
+    background-color: var(--ui-cb-checked-bg, ${BLUE_60});
+    border-color: var(--ui-cb-checked-bg, ${BLUE_60});
+  }
+
+  /* ── Hover ───────────────────────────────────────────────────────────────── */
+
+  :host(:hover) .checkbox {
+    border-color: var(--ui-cb-hover-border, ${GRAY_50});
+  }
+
+  :host([checked]:hover) .checkbox,
+  :host([indeterminate]:hover) .checkbox {
+    border-color: var(--ui-cb-checked-bg, ${BLUE_60});
+  }
+
+  /* ── Focus ───────────────────────────────────────────────────────────────── */
+
+  :host(:focus-visible) .outer {
+    border-color: var(--ui-cb-focus-border, ${BLUE_60});
+  }
+
+  /* ── Disabled ────────────────────────────────────────────────────────────── */
+
+  :host([disabled]) {
+    pointer-events: none;
+  }
+
+  :host([disabled]) .base {
+    opacity: 0.4;
+  }
+
+  :host([disabled]) .label {
+    opacity: 0.5;
+  }
+
+  /* ── Error ───────────────────────────────────────────────────────────────── */
+
+  :host([error]) .checkbox {
+    border-color: var(--ui-cb-error-border, ${ERROR_BOLD});
+  }
+
+  :host([error][checked]) .checkbox,
+  :host([error][indeterminate]) .checkbox {
+    border-color: var(--ui-cb-checked-bg, ${BLUE_60});
+  }
+
+  /* ── Reduced motion ──────────────────────────────────────────────────────── */
+
+  @media (prefers-reduced-motion: reduce) {
+    .checkbox {
+      transition-duration: 0.01ms !important;
+    }
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export class UiCheckboxItem extends HTMLElement {
+  static readonly observedAttributes = [
+    "size",
+    "label",
+    "checked",
+    "indeterminate",
+    "disabled",
+    "error",
+  ];
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+
+    const style = document.createElement("style");
+    style.textContent = STYLES;
+    shadow.appendChild(style);
+
+    // .base
+    const base = document.createElement("div");
+    base.className = "base";
+
+    // .outer (hit area + focus ring)
+    const outer = document.createElement("div");
+    outer.className = "outer";
+
+    // .checkbox (visible square)
+    const checkbox = document.createElement("div");
+    checkbox.className = "checkbox";
+
+    // Check icon
+    const checkIcon = document.createElement("span");
+    checkIcon.className = "check-icon";
+    checkIcon.innerHTML = ICON_CHECK;
+    checkbox.appendChild(checkIcon);
+
+    // Indeterminate icon
+    const indeterminateIcon = document.createElement("span");
+    indeterminateIcon.className = "indeterminate-icon";
+    const indeterminateBar = document.createElement("span");
+    indeterminateBar.className = "indeterminate-bar";
+    indeterminateIcon.appendChild(indeterminateBar);
+    checkbox.appendChild(indeterminateIcon);
+
+    outer.appendChild(checkbox);
+    base.appendChild(outer);
+
+    // Label slot
+    const label = document.createElement("span");
+    label.className = "label";
+    const slot = document.createElement("slot");
+    label.appendChild(slot);
+    base.appendChild(label);
+
+    shadow.appendChild(base);
+
+    // Event listeners
+    this.addEventListener("click", this._handleClick.bind(this));
+    this.addEventListener("keydown", this._handleKeydown.bind(this));
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("role")) {
+      this.setAttribute("role", "checkbox");
+    }
+    if (!this.hasAttribute("tabindex")) {
+      this.setAttribute("tabindex", "0");
+    }
+    this._syncAriaChecked();
+  }
+
+  attributeChangedCallback(
+    name: string,
+    _oldValue: string | null,
+    _newValue: string | null,
+  ): void {
+    if (name === "checked" || name === "indeterminate") {
+      this._syncAriaChecked();
+    }
+    if (name === "disabled") {
+      this.setAttribute(
+        "aria-disabled",
+        this.disabled ? "true" : "false",
+      );
+    }
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): CheckboxSize {
+    return (this.getAttribute("size") as CheckboxSize) ?? "m";
+  }
+
+  set size(value: CheckboxSize) {
+    this.setAttribute("size", value);
+  }
+
+  get label(): CheckboxLabel {
+    return (this.getAttribute("label") as CheckboxLabel) ?? "none";
+  }
+
+  set label(value: CheckboxLabel) {
+    this.setAttribute("label", value);
+  }
+
+  get checked(): boolean {
+    return this.hasAttribute("checked");
+  }
+
+  set checked(value: boolean) {
+    if (value) {
+      this.setAttribute("checked", "");
+    } else {
+      this.removeAttribute("checked");
+    }
+  }
+
+  get indeterminate(): boolean {
+    return this.hasAttribute("indeterminate");
+  }
+
+  set indeterminate(value: boolean) {
+    if (value) {
+      this.setAttribute("indeterminate", "");
+    } else {
+      this.removeAttribute("indeterminate");
+    }
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute("disabled");
+  }
+
+  set disabled(value: boolean) {
+    if (value) {
+      this.setAttribute("disabled", "");
+    } else {
+      this.removeAttribute("disabled");
+    }
+  }
+
+  get error(): boolean {
+    return this.hasAttribute("error");
+  }
+
+  set error(value: boolean) {
+    if (value) {
+      this.setAttribute("error", "");
+    } else {
+      this.removeAttribute("error");
+    }
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private _handleClick(): void {
+    if (this.disabled) return;
+    this._toggle();
+  }
+
+  private _handleKeydown(e: KeyboardEvent): void {
+    if (this.disabled) return;
+    if (e.key === " " || e.key === "Enter") {
+      e.preventDefault();
+      this._toggle();
+    }
+  }
+
+  private _toggle(): void {
+    if (this.indeterminate) {
+      this.indeterminate = false;
+      this.checked = true;
+    } else {
+      this.checked = !this.checked;
+    }
+    this.dispatchEvent(
+      new CustomEvent("change", { bubbles: true, composed: true }),
+    );
+  }
+
+  private _syncAriaChecked(): void {
+    if (this.indeterminate) {
+      this.setAttribute("aria-checked", "mixed");
+    } else {
+      this.setAttribute("aria-checked", this.checked ? "true" : "false");
+    }
+  }
+}
+
+customElements.define("ui-checkbox-item", UiCheckboxItem);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -35,3 +35,7 @@ export type { BreadcrumbSize } from "./components/ui-breadcrumb-item.js";
 export { UiBreadcrumbGroup } from "./components/ui-breadcrumb-group.js";
 export { UiCard } from "./components/ui-card.js";
 export type { CardSize, CardElevation } from "./components/ui-card.js";
+export { UiCheckboxItem } from "./components/ui-checkbox-item.js";
+export type { CheckboxSize, CheckboxLabel } from "./components/ui-checkbox-item.js";
+export { UiCheckboxGroup } from "./components/ui-checkbox-group.js";
+export type { CheckboxGroupOrientation } from "./components/ui-checkbox-group.js";

--- a/packages/ui-components/src/stories/ui-checkbox-item.stories.ts
+++ b/packages/ui-components/src/stories/ui-checkbox-item.stories.ts
@@ -1,0 +1,167 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-checkbox-item.js";
+import "../components/ui-checkbox-group.js";
+
+const meta: Meta = {
+  title: "Components/CheckboxItem",
+  component: "ui-checkbox-item",
+  argTypes: {
+    size: { control: { type: "select" }, options: ["s", "m", "l"] },
+    label: {
+      control: { type: "select" },
+      options: ["none", "right", "left"],
+    },
+    checked: { control: "boolean" },
+    indeterminate: { control: "boolean" },
+    disabled: { control: "boolean" },
+    error: { control: "boolean" },
+  },
+  args: {
+    size: "m",
+    label: "right",
+    checked: false,
+    indeterminate: false,
+    disabled: false,
+    error: false,
+  },
+  render: (args) => html`
+    <ui-checkbox-item
+      size=${args.size}
+      label=${args.label}
+      ?checked=${args.checked}
+      ?indeterminate=${args.indeterminate}
+      ?disabled=${args.disabled}
+      ?error=${args.error}
+    >
+      Checkbox label
+    </ui-checkbox-item>
+  `,
+};
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => html`
+    <ui-checkbox-item label="right">Default checkbox</ui-checkbox-item>
+  `,
+};
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 24px; align-items: center;">
+      <ui-checkbox-item size="s" label="right">Small</ui-checkbox-item>
+      <ui-checkbox-item size="m" label="right">Medium</ui-checkbox-item>
+      <ui-checkbox-item size="l" label="right">Large</ui-checkbox-item>
+    </div>
+  `,
+};
+
+export const CheckStates: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 24px; align-items: center;">
+      <ui-checkbox-item label="right">Unchecked</ui-checkbox-item>
+      <ui-checkbox-item checked label="right">Checked</ui-checkbox-item>
+      <ui-checkbox-item indeterminate label="right"
+        >Indeterminate</ui-checkbox-item
+      >
+    </div>
+  `,
+};
+
+export const LabelPositions: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 24px; align-items: center;">
+      <ui-checkbox-item checked>No label</ui-checkbox-item>
+      <ui-checkbox-item checked label="right"
+        >Label right</ui-checkbox-item
+      >
+      <ui-checkbox-item checked label="left">Label left</ui-checkbox-item>
+    </div>
+  `,
+};
+
+export const States: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 24px; align-items: center;">
+      <ui-checkbox-item label="right">Enabled</ui-checkbox-item>
+      <ui-checkbox-item disabled label="right">Disabled</ui-checkbox-item>
+      <ui-checkbox-item disabled checked label="right"
+        >Disabled checked</ui-checkbox-item
+      >
+      <ui-checkbox-item error label="right">Error</ui-checkbox-item>
+      <ui-checkbox-item error checked label="right"
+        >Error checked</ui-checkbox-item
+      >
+    </div>
+  `,
+};
+
+export const WithLabel: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 12px;">
+      <ui-checkbox-item size="s" label="right"
+        >I agree to the terms and conditions</ui-checkbox-item
+      >
+      <ui-checkbox-item size="m" label="right"
+        >Subscribe to newsletter</ui-checkbox-item
+      >
+      <ui-checkbox-item size="l" label="right"
+        >Remember my preferences</ui-checkbox-item
+      >
+    </div>
+  `,
+};
+
+export const GroupVertical: Story = {
+  render: () => html`
+    <ui-checkbox-group size="m" orientation="vertical">
+      <ui-checkbox-item label="right">Option 1</ui-checkbox-item>
+      <ui-checkbox-item label="right">Option 2</ui-checkbox-item>
+      <ui-checkbox-item label="right">Option 3</ui-checkbox-item>
+      <ui-checkbox-item label="right">Option 4</ui-checkbox-item>
+    </ui-checkbox-group>
+  `,
+};
+
+export const GroupHorizontal: Story = {
+  render: () => html`
+    <ui-checkbox-group size="m" orientation="horizontal">
+      <ui-checkbox-item label="right">Option 1</ui-checkbox-item>
+      <ui-checkbox-item label="right">Option 2</ui-checkbox-item>
+      <ui-checkbox-item label="right">Option 3</ui-checkbox-item>
+      <ui-checkbox-item label="right">Option 4</ui-checkbox-item>
+    </ui-checkbox-group>
+  `,
+};
+
+export const GroupSizes: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 32px;">
+      <div>
+        <p style="margin: 0 0 8px 0; font-size: 12px; font-weight: 600;">Size: S</p>
+        <ui-checkbox-group size="s" orientation="vertical">
+          <ui-checkbox-item label="right">Option 1</ui-checkbox-item>
+          <ui-checkbox-item label="right">Option 2</ui-checkbox-item>
+          <ui-checkbox-item label="right">Option 3</ui-checkbox-item>
+        </ui-checkbox-group>
+      </div>
+      <div>
+        <p style="margin: 0 0 8px 0; font-size: 12px; font-weight: 600;">Size: M</p>
+        <ui-checkbox-group size="m" orientation="vertical">
+          <ui-checkbox-item label="right">Option 1</ui-checkbox-item>
+          <ui-checkbox-item label="right">Option 2</ui-checkbox-item>
+          <ui-checkbox-item label="right">Option 3</ui-checkbox-item>
+        </ui-checkbox-group>
+      </div>
+      <div>
+        <p style="margin: 0 0 8px 0; font-size: 12px; font-weight: 600;">Size: L</p>
+        <ui-checkbox-group size="l" orientation="vertical">
+          <ui-checkbox-item label="right">Option 1</ui-checkbox-item>
+          <ui-checkbox-item label="right">Option 2</ui-checkbox-item>
+          <ui-checkbox-item label="right">Option 3</ui-checkbox-item>
+        </ui-checkbox-group>
+      </div>
+    </div>
+  `,
+};


### PR DESCRIPTION
## Summary

- Add `<ui-checkbox-item>` Web Component: 3 sizes (s/m/l), 3 check states (unchecked/checked/indeterminate), 3 label positions (none/right/left), 5 interaction states (enabled/hover/focus/disabled/error)
- Add `<ui-checkbox-group>` Web Component: wrapper with size propagation, 2 orientations (vertical/horizontal), size-dependent gaps (S=8px, M=12px, L=20px, horizontal=24px)
- 66 unit tests (42 checkbox-item + 24 checkbox-group), 9 Storybook stories (6 + 3)
- Uses foundation tokens via type-safe helpers (`colorVar`, `semanticVar`, `spaceVar`)
- Updated AGENTS.md docs (root + ui-components)

## Files Changed

- `packages/ui-components/src/components/ui-checkbox-item.ts` — checkbox item component
- `packages/ui-components/src/components/ui-checkbox-item.test.ts` — 42 tests
- `packages/ui-components/src/components/ui-checkbox-group.ts` — checkbox group wrapper
- `packages/ui-components/src/components/ui-checkbox-group.test.ts` — 24 tests
- `packages/ui-components/src/stories/ui-checkbox-item.stories.ts` — 9 stories (item + group)
- `packages/ui-components/src/index.ts` — barrel exports + element registration
- `AGENTS.md` — added checkbox-item + checkbox-group to component list
- `packages/ui-components/AGENTS.md` — added checkbox components to overview + structure