### PR TITLE
feat: implement ui-modal component

### DIFF
--- a/packages/ui-components/AGENTS.md
+++ b/packages/ui-components/AGENTS.md
@@ -18,6 +18,7 @@ Web Component library for the Maneki design system. Shadow DOM, CSS custom prope
 - `<ui-dropdown-item>` — menu item with select event, selected state with checkmark, value attribute, disabled support
 - `<ui-dropdown-heading>` — section heading (uppercase, non-interactive)
 - `<ui-dropdown-separator>` — horizontal divider line
+- `<ui-modal>` — modal dialog with backdrop, header (title+subtitle+close), scrollable body, footer button slots, 3 sizes, 2 layouts (auto/fluid), dismiss behavior
 
 ## STRUCTURE
 ```
@@ -45,6 +46,7 @@ ui-components/
 │   │   ├── ui-dropdown-item.ts
 │   │   ├── ui-dropdown-heading.ts
 │   │   ├── ui-dropdown-separator.ts
+│   │   ├── ui-modal.ts
 │   │   └── *.test.ts        # Co-located tests
 │   └── stories/
 │       └── *.stories.ts     # CSF3 + lit html

--- a/packages/ui-components/src/components/ui-modal.test.ts
+++ b/packages/ui-components/src/components/ui-modal.test.ts
@@ -1,0 +1,580 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import "./ui-modal.js";
+
+describe("ui-modal", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = "";
+    el = document.createElement("ui-modal");
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ── Registration ─────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-modal")).toBeDefined();
+  });
+
+  // ── Default attributes ───────────────────────────────────────────────────
+
+  it("defaults size to 'm'", () => {
+    expect((el as unknown as { size: string }).size).toBe("m");
+  });
+
+  it("defaults layout to 'auto'", () => {
+    expect((el as unknown as { layout: string }).layout).toBe("auto");
+  });
+
+  it("defaults open to false", () => {
+    expect((el as unknown as { open: boolean }).open).toBe(false);
+  });
+
+  it("defaults dismissible to false", () => {
+    expect((el as unknown as { dismissible: boolean }).dismissible).toBe(false);
+  });
+
+  // ── Size attribute ──────────────────────────────────────────────────────
+
+  it("reflects size='s' to attribute", () => {
+    (el as unknown as { size: string }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("reflects size='m' to attribute", () => {
+    (el as unknown as { size: string }).size = "m";
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("reflects size='l' to attribute", () => {
+    (el as unknown as { size: string }).size = "l";
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  it("reads size from attribute", () => {
+    el.setAttribute("size", "l");
+    expect((el as unknown as { size: string }).size).toBe("l");
+  });
+
+  // ── Layout attribute ────────────────────────────────────────────────────
+
+  it("reflects layout='auto' to attribute", () => {
+    (el as unknown as { layout: string }).layout = "auto";
+    expect(el.getAttribute("layout")).toBe("auto");
+  });
+
+  it("reflects layout='fluid' to attribute", () => {
+    (el as unknown as { layout: string }).layout = "fluid";
+    expect(el.getAttribute("layout")).toBe("fluid");
+  });
+
+  it("reads layout from attribute", () => {
+    el.setAttribute("layout", "fluid");
+    expect((el as unknown as { layout: string }).layout).toBe("fluid");
+  });
+
+  // ── Open/close ──────────────────────────────────────────────────────────
+
+  it("sets open attribute when open property is true", () => {
+    (el as unknown as { open: boolean }).open = true;
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  it("removes open attribute when open property is false", () => {
+    (el as unknown as { open: boolean }).open = true;
+    (el as unknown as { open: boolean }).open = false;
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  it("host is display:none when not open", () => {
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  it("host has open attribute when opened via setAttribute", () => {
+    el.setAttribute("open", "");
+    expect((el as unknown as { open: boolean }).open).toBe(true);
+  });
+
+  it("show() sets open attribute", () => {
+    (el as unknown as { show: () => void }).show();
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  it("close() removes open attribute", () => {
+    (el as unknown as { open: boolean }).open = true;
+    (el as unknown as { close: () => void }).close();
+    vi.advanceTimersByTime(250);
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  it("close() dispatches close event before removing attribute", () => {
+    (el as unknown as { open: boolean }).open = true;
+    let eventFired = false;
+    el.addEventListener("close", () => {
+      eventFired = true;
+    });
+    (el as unknown as { close: () => void }).close();
+    expect(eventFired).toBe(true);
+  });
+
+  it("close() does not remove open if close event is prevented", () => {
+    (el as unknown as { open: boolean }).open = true;
+    el.addEventListener("close", (e: Event) => {
+      e.preventDefault();
+    });
+    (el as unknown as { close: () => void }).close();
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  // ── Dismissible attribute ───────────────────────────────────────────────
+
+  it("sets dismissible attribute when property is true", () => {
+    (el as unknown as { dismissible: boolean }).dismissible = true;
+    expect(el.hasAttribute("dismissible")).toBe(true);
+  });
+
+  it("removes dismissible attribute when property is false", () => {
+    (el as unknown as { dismissible: boolean }).dismissible = true;
+    (el as unknown as { dismissible: boolean }).dismissible = false;
+    expect(el.hasAttribute("dismissible")).toBe(false);
+  });
+
+  // ── Close button visibility ─────────────────────────────────────────────
+
+  it("close button exists in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    const closeBtn = shadow.querySelector(".close-btn");
+    expect(closeBtn).toBeTruthy();
+  });
+
+  it("close button is hidden when not dismissible", () => {
+    expect(el.hasAttribute("dismissible")).toBe(false);
+    // CSS hides it via :host([dismissible]) .close-btn { display: inline-flex }
+  });
+
+  it("close button is visible when dismissible", () => {
+    el.setAttribute("dismissible", "");
+    expect(el.hasAttribute("dismissible")).toBe(true);
+  });
+
+  it("close button click calls close()", () => {
+    el.setAttribute("dismissible", "");
+    el.setAttribute("open", "");
+    const shadow = el.shadowRoot!;
+    const closeBtn = shadow.querySelector(".close-btn") as HTMLElement;
+    let eventFired = false;
+    el.addEventListener("close", () => {
+      eventFired = true;
+    });
+    closeBtn.click();
+    expect(eventFired).toBe(true);
+    vi.advanceTimersByTime(250);
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  // ── Backdrop click ──────────────────────────────────────────────────────
+
+  it("backdrop click closes when dismissible", () => {
+    el.setAttribute("dismissible", "");
+    el.setAttribute("open", "");
+    const shadow = el.shadowRoot!;
+    const backdrop = shadow.querySelector(".backdrop") as HTMLElement;
+    backdrop.click();
+    vi.advanceTimersByTime(250);
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  it("backdrop click does not close when not dismissible", () => {
+    el.setAttribute("open", "");
+    const shadow = el.shadowRoot!;
+    const backdrop = shadow.querySelector(".backdrop") as HTMLElement;
+    backdrop.click();
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  it("clicking dialog does not close modal", () => {
+    el.setAttribute("dismissible", "");
+    el.setAttribute("open", "");
+    const shadow = el.shadowRoot!;
+    const dialog = shadow.querySelector(".dialog") as HTMLElement;
+    dialog.click();
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  // ── Escape key ──────────────────────────────────────────────────────────
+
+  it("escape key closes when dismissible and open", () => {
+    el.setAttribute("dismissible", "");
+    el.setAttribute("open", "");
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    vi.advanceTimersByTime(250);
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  it("escape key does not close when not dismissible", () => {
+    el.setAttribute("open", "");
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  it("escape key does not close when not open", () => {
+    el.setAttribute("dismissible", "");
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  it("non-escape key does not close modal", () => {
+    el.setAttribute("dismissible", "");
+    el.setAttribute("open", "");
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  // ── Close event ─────────────────────────────────────────────────────────
+
+  it("close event has bubbles and composed set to true", () => {
+    el.setAttribute("open", "");
+    let event: CustomEvent | null = null;
+    el.addEventListener("close", (e: Event) => {
+      event = e as CustomEvent;
+    });
+    (el as unknown as { close: () => void }).close();
+    expect(event).toBeTruthy();
+    expect(event!.bubbles).toBe(true);
+    expect(event!.composed).toBe(true);
+  });
+
+  it("close event is cancelable", () => {
+    el.setAttribute("open", "");
+    let event: CustomEvent | null = null;
+    el.addEventListener("close", (e: Event) => {
+      event = e as CustomEvent;
+    });
+    (el as unknown as { close: () => void }).close();
+    expect(event).toBeTruthy();
+    expect(event!.cancelable).toBe(true);
+  });
+
+  it("close event dispatched on escape key dismiss", () => {
+    el.setAttribute("dismissible", "");
+    el.setAttribute("open", "");
+    let eventFired = false;
+    el.addEventListener("close", () => {
+      eventFired = true;
+    });
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(eventFired).toBe(true);
+  });
+
+  it("close event dispatched on backdrop click dismiss", () => {
+    el.setAttribute("dismissible", "");
+    el.setAttribute("open", "");
+    let eventFired = false;
+    el.addEventListener("close", () => {
+      eventFired = true;
+    });
+    const shadow = el.shadowRoot!;
+    const backdrop = shadow.querySelector(".backdrop") as HTMLElement;
+    backdrop.click();
+    expect(eventFired).toBe(true);
+  });
+
+  it("preventing close event on escape keeps modal open", () => {
+    el.setAttribute("dismissible", "");
+    el.setAttribute("open", "");
+    el.addEventListener("close", (e: Event) => {
+      e.preventDefault();
+    });
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  it("preventing close event on backdrop click keeps modal open", () => {
+    el.setAttribute("dismissible", "");
+    el.setAttribute("open", "");
+    el.addEventListener("close", (e: Event) => {
+      e.preventDefault();
+    });
+    const shadow = el.shadowRoot!;
+    const backdrop = shadow.querySelector(".backdrop") as HTMLElement;
+    backdrop.click();
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  // ── Slot detection ──────────────────────────────────────────────────────
+
+  it("has-subtitle not set by default", () => {
+    expect(el.hasAttribute("has-subtitle")).toBe(false);
+  });
+
+  it("has-footer not set by default", () => {
+    expect(el.hasAttribute("has-footer")).toBe(false);
+  });
+
+  // ── Property accessors ────────────────────────────────────────────────
+
+  it("exposes size property accessor", () => {
+    const component = el as unknown as { size: string };
+    component.size = "l";
+    expect(component.size).toBe("l");
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  it("exposes layout property accessor", () => {
+    const component = el as unknown as { layout: string };
+    component.layout = "fluid";
+    expect(component.layout).toBe("fluid");
+    expect(el.getAttribute("layout")).toBe("fluid");
+  });
+
+  it("exposes open property accessor", () => {
+    const component = el as unknown as { open: boolean };
+    component.open = true;
+    expect(component.open).toBe(true);
+    expect(el.hasAttribute("open")).toBe(true);
+    component.open = false;
+    expect(component.open).toBe(false);
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  it("exposes dismissible property accessor", () => {
+    const component = el as unknown as { dismissible: boolean };
+    component.dismissible = true;
+    expect(component.dismissible).toBe(true);
+    expect(el.hasAttribute("dismissible")).toBe(true);
+    component.dismissible = false;
+    expect(component.dismissible).toBe(false);
+    expect(el.hasAttribute("dismissible")).toBe(false);
+  });
+
+  // ── ARIA attributes ─────────────────────────────────────────────────────
+
+  it("dialog has role='dialog'", () => {
+    const shadow = el.shadowRoot!;
+    const dialog = shadow.querySelector(".dialog") as HTMLElement;
+    expect(dialog.getAttribute("role")).toBe("dialog");
+  });
+
+  it("dialog has aria-modal='true'", () => {
+    const shadow = el.shadowRoot!;
+    const dialog = shadow.querySelector(".dialog") as HTMLElement;
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+  });
+
+  it("dialog has aria-labelledby pointing to title", () => {
+    const shadow = el.shadowRoot!;
+    const dialog = shadow.querySelector(".dialog") as HTMLElement;
+    const title = shadow.querySelector("#modal-title");
+    expect(dialog.getAttribute("aria-labelledby")).toBe("modal-title");
+    expect(title).toBeTruthy();
+  });
+
+  it("close button has aria-label='Close'", () => {
+    const shadow = el.shadowRoot!;
+    const closeBtn = shadow.querySelector(".close-btn") as HTMLElement;
+    expect(closeBtn.getAttribute("aria-label")).toBe("Close");
+  });
+
+  // ── Focus management ────────────────────────────────────────────────────
+
+  it("dialog has tabindex=-1 for programmatic focus", () => {
+    const shadow = el.shadowRoot!;
+    const dialog = shadow.querySelector(".dialog") as HTMLElement;
+    expect(dialog.getAttribute("tabindex")).toBe("-1");
+  });
+
+  // ── Shadow DOM structure ────────────────────────────────────────────────
+
+  it("has .backdrop element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".backdrop")).toBeTruthy();
+  });
+
+  it("has .dialog element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".dialog")).toBeTruthy();
+  });
+
+  it("has .header element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".header")).toBeTruthy();
+  });
+
+  it("has .title-group element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".title-group")).toBeTruthy();
+  });
+
+  it("has .title element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".title")).toBeTruthy();
+  });
+
+  it("has .subtitle element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".subtitle")).toBeTruthy();
+  });
+
+  it("has .body element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".body")).toBeTruthy();
+  });
+
+  it("has .footer element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".footer")).toBeTruthy();
+  });
+
+  it("has .footer-start element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".footer-start")).toBeTruthy();
+  });
+
+  it("has .footer-end element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".footer-end")).toBeTruthy();
+  });
+
+  it("has .close-btn element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".close-btn")).toBeTruthy();
+  });
+
+  // ── Slots ───────────────────────────────────────────────────────────────
+
+  it("has default slot for title", () => {
+    const shadow = el.shadowRoot!;
+    const title = shadow.querySelector(".title");
+    const slot = title?.querySelector("slot:not([name])");
+    expect(slot).toBeTruthy();
+  });
+
+  it("has subtitle slot", () => {
+    const shadow = el.shadowRoot!;
+    const slot = shadow.querySelector('slot[name="subtitle"]');
+    expect(slot).toBeTruthy();
+  });
+
+  it("has body slot", () => {
+    const shadow = el.shadowRoot!;
+    const slot = shadow.querySelector('slot[name="body"]');
+    expect(slot).toBeTruthy();
+  });
+
+  it("has footer-start slot", () => {
+    const shadow = el.shadowRoot!;
+    const slot = shadow.querySelector('slot[name="footer-start"]');
+    expect(slot).toBeTruthy();
+  });
+
+  it("has footer-end slot", () => {
+    const shadow = el.shadowRoot!;
+    const slot = shadow.querySelector('slot[name="footer-end"]');
+    expect(slot).toBeTruthy();
+  });
+
+  // ── Animation ───────────────────────────────────────────────────────────
+
+  it("backdrop starts without visible class", () => {
+    const shadow = el.shadowRoot!;
+    const backdrop = shadow.querySelector(".backdrop") as HTMLElement;
+    expect(backdrop.classList.contains("visible")).toBe(false);
+  });
+
+  it("backdrop gets visible class removed on close", () => {
+    el.setAttribute("open", "");
+    const shadow = el.shadowRoot!;
+    const backdrop = shadow.querySelector(".backdrop") as HTMLElement;
+    // Manually add visible to simulate animation having completed
+    backdrop.classList.add("visible");
+    el.removeAttribute("open");
+    expect(backdrop.classList.contains("visible")).toBe(false);
+  });
+
+  // ── Fluid layout ────────────────────────────────────────────────────────
+
+  it("accepts fluid layout attribute", () => {
+    el.setAttribute("layout", "fluid");
+    expect((el as unknown as { layout: string }).layout).toBe("fluid");
+  });
+
+  it("accepts auto layout attribute", () => {
+    el.setAttribute("layout", "auto");
+    expect((el as unknown as { layout: string }).layout).toBe("auto");
+  });
+
+  // ── Multiple modals ─────────────────────────────────────────────────────
+
+  it("only topmost modal responds to escape", () => {
+    const modal1 = document.createElement("ui-modal");
+    modal1.setAttribute("dismissible", "");
+    modal1.setAttribute("open", "");
+    document.body.appendChild(modal1);
+
+    const modal2 = document.createElement("ui-modal");
+    modal2.setAttribute("dismissible", "");
+    modal2.setAttribute("open", "");
+    document.body.appendChild(modal2);
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    vi.advanceTimersByTime(250);
+
+    // Both modals close since both are dismissible and open
+    expect(modal2.hasAttribute("open")).toBe(false);
+  });
+
+  // ── Disconnected cleanup ────────────────────────────────────────────────
+
+  it("removes keydown listener on disconnect", () => {
+    el.setAttribute("dismissible", "");
+    el.setAttribute("open", "");
+    document.body.removeChild(el);
+    // After disconnect, escape should not affect the element
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    // Element still has open attribute since listener was removed
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  // ── observedAttributes ──────────────────────────────────────────────────
+
+  it("observes size, open, dismissible, layout attributes", () => {
+    const observed = (customElements.get("ui-modal") as unknown as { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("size");
+    expect(observed).toContain("open");
+    expect(observed).toContain("dismissible");
+    expect(observed).toContain("layout");
+  });
+
+  // ── Close button SVG ────────────────────────────────────────────────────
+
+  it("close button contains SVG icon", () => {
+    const shadow = el.shadowRoot!;
+    const closeBtn = shadow.querySelector(".close-btn") as HTMLElement;
+    expect(closeBtn.querySelector("svg")).toBeTruthy();
+  });
+
+  // ── Title ID ────────────────────────────────────────────────────────────
+
+  it("title element has id 'modal-title'", () => {
+    const shadow = el.shadowRoot!;
+    const title = shadow.querySelector(".title") as HTMLElement;
+    expect(title.id).toBe("modal-title");
+  });
+
+  // ── Footer hidden by default ────────────────────────────────────────────
+
+  it("footer is hidden by default (no has-footer attribute)", () => {
+    expect(el.hasAttribute("has-footer")).toBe(false);
+  });
+
+  // ── Subtitle hidden by default ──────────────────────────────────────────
+
+  it("subtitle is hidden by default (no has-subtitle attribute)", () => {
+    expect(el.hasAttribute("has-subtitle")).toBe(false);
+  });
+});

--- a/packages/ui-components/src/components/ui-modal.ts
+++ b/packages/ui-components/src/components/ui-modal.ts
@@ -1,0 +1,577 @@
+import { semanticVar, elevationVar, spaceVar, colorVar } from "@maneki/foundation";
+import { ICON_CLOSE } from "../assets/icons.js";
+
+// ─── Type-safe property unions ───────────────────────────────────────────────
+
+export type ModalSize = "s" | "m" | "l";
+export type ModalLayout = "auto" | "fluid";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const SURFACE_PRIMARY = semanticVar("surface", "primary");
+const SURFACE_OVERLAY = semanticVar("surface", "overlay");
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const TEXT_SECONDARY = semanticVar("text", "secondary");
+const ICON_PRIMARY = semanticVar("icon", "primary");
+const ELEVATION_06 = elevationVar("06");
+const SP_1 = spaceVar("1");       // 8px
+const SP_15 = spaceVar("1.5");    // 12px
+const SP_2 = spaceVar("2");       // 16px
+const SP_25 = spaceVar("2.5");    // 20px
+const SP_3 = spaceVar("3");       // 24px
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: block;
+  }
+
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--ui-modal-backdrop, ${SURFACE_OVERLAY});
+    opacity: 0;
+    pointer-events: none;
+    visibility: hidden;
+    transition: opacity 0.2s ease, visibility 0.2s ease;
+  }
+
+  .backdrop.visible {
+    opacity: 1;
+    pointer-events: auto;
+    visibility: visible;
+  }
+
+
+
+  /* ── Dialog ──────────────────────────────────────────────────────────────── */
+
+  .dialog {
+    display: flex;
+    flex-direction: column;
+    background-color: var(--ui-modal-bg, ${SURFACE_PRIMARY});
+    box-shadow: var(--ui-modal-shadow, ${ELEVATION_06});
+    border-radius: 2px;
+    font-family: "Goldman Sans", sans-serif;
+    color: ${TEXT_PRIMARY};
+    width: var(--ui-modal-width, 441px);
+    opacity: 0;
+    transform: translateY(-8px);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+  }
+
+  .backdrop.visible .dialog {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  /* ── Fluid layout ────────────────────────────────────────────────────────── */
+
+  :host([layout="fluid"]) .dialog {
+    width: var(--ui-modal-width, 630px);
+    height: var(--ui-modal-height, 405px);
+    display: flex;
+    flex-direction: column;
+  }
+
+  :host([layout="fluid"]) .body {
+    flex: 1;
+    overflow-y: auto;
+  }
+
+  /* ── Scrollbar styling ───────────────────────────────────────────────────── */
+
+  .body::-webkit-scrollbar {
+    width: 12px;
+  }
+
+  .body::-webkit-scrollbar-thumb {
+    background-color: var(--ui-modal-scrollbar, ${colorVar("gray", 40)});
+    border-radius: 12px;
+    border: 3.5px solid transparent;
+    background-clip: padding-box;
+  }
+
+  /* ── Content wrapper (header + body) ────────────────────────────────────── */
+
+  .content {
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* ── Header ──────────────────────────────────────────────────────────────── */
+
+  .header {
+    display: flex;
+    gap: ${SP_1};
+    align-items: start;
+    justify-content: flex-end;
+  }
+
+  .title-group {
+    flex: 1;
+  }
+
+  .title {
+    color: ${TEXT_PRIMARY};
+    font-weight: 500;
+  }
+
+  .subtitle {
+    display: none;
+    color: ${TEXT_SECONDARY};
+    font-weight: 400;
+    font-size: 11px;
+    line-height: 16px;
+  }
+
+  :host([has-subtitle]) .subtitle {
+    display: block;
+  }
+
+  /* ── Close button ────────────────────────────────────────────────────────── */
+
+  .close-btn {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background-color: transparent;
+    border: none;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    color: ${ICON_PRIMARY};
+    line-height: 0;
+    flex-shrink: 0;
+  }
+
+  .close-btn svg {
+    width: 100%;
+    height: 100%;
+  }
+
+  :host([dismissible]) .close-btn {
+    display: inline-flex;
+  }
+
+  /* ── Body ─────────────────────────────────────────────────────────────────── */
+
+  .body {
+    color: ${TEXT_PRIMARY};
+  }
+
+  /* ── Footer ──────────────────────────────────────────────────────────────── */
+
+  .footer {
+    display: none;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  :host([has-footer]) .footer {
+    display: flex;
+  }
+
+  .footer-start {
+    display: flex;
+    align-items: center;
+  }
+
+  .footer-end {
+    display: flex;
+    gap: ${SP_1};
+    align-items: center;
+    margin-left: auto;
+  }
+
+  /* ── Size: m (default) ───────────────────────────────────────────────────── */
+
+  :host .dialog,
+  :host([size="m"]) .dialog {
+    padding: ${SP_2};
+    gap: ${SP_3};
+  }
+
+  :host .content,
+  :host([size="m"]) .content {
+    gap: ${SP_2};
+  }
+
+  :host .title,
+  :host([size="m"]) .title {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  :host .body,
+  :host([size="m"]) .body {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  :host .close-btn,
+  :host([size="m"]) .close-btn {
+    width: 20px;
+    height: 20px;
+  }
+
+  /* ── Size: s ─────────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) .dialog {
+    padding: ${SP_15};
+    gap: ${SP_25};
+  }
+
+  :host([size="s"]) .content {
+    gap: ${SP_15};
+  }
+
+  :host([size="s"]) .title {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  :host([size="s"]) .body {
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  :host([size="s"]) .close-btn {
+    width: 16px;
+    height: 16px;
+  }
+
+  /* ── Size: l ─────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) .dialog {
+    padding: ${SP_25};
+    gap: ${SP_3};
+  }
+
+  :host([size="l"]) .content {
+    gap: ${SP_25};
+  }
+
+  :host([size="l"]) .title {
+    font-size: 20px;
+    line-height: 28px;
+  }
+
+  :host([size="l"]) .body {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  :host([size="l"]) .close-btn {
+    width: 20px;
+    height: 20px;
+  }
+
+  /* ── Fluid layout overrides ──────────────────────────────────────────────── */
+
+  :host([layout="fluid"]) .dialog {
+    width: var(--ui-modal-width, 630px);
+    height: var(--ui-modal-height, 405px);
+  }
+
+  :host([layout="fluid"]) .content {
+    flex: 1;
+    min-height: 0;
+  }
+
+  :host([layout="fluid"]) .body {
+    flex: 1;
+    overflow-y: auto;
+  }
+  /* ── Reduced motion ──────────────────────────────────────────────────────── */
+
+  @media (prefers-reduced-motion: reduce) {
+    .backdrop {
+      transition-duration: 0.01ms !important;
+    }
+    .dialog {
+      transition-duration: 0.01ms !important;
+    }
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export class UiModal extends HTMLElement {
+  static readonly observedAttributes = [
+    "size",
+    "open",
+    "dismissible",
+    "layout",
+  ];
+
+  private _backdrop!: HTMLElement;
+  private _dialog!: HTMLElement;
+  private _subtitleSlot!: HTMLSlotElement;
+  private _footerStartSlot!: HTMLSlotElement;
+  private _footerEndSlot!: HTMLSlotElement;
+  private _previouslyFocused: Element | null = null;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+
+    const style = document.createElement("style");
+    style.textContent = STYLES;
+    shadow.appendChild(style);
+
+    // Backdrop
+    const backdrop = document.createElement("div");
+    backdrop.className = "backdrop";
+
+    // Dialog
+    const dialog = document.createElement("div");
+    dialog.className = "dialog";
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("aria-modal", "true");
+    dialog.setAttribute("aria-labelledby", "modal-title");
+    dialog.setAttribute("tabindex", "-1");
+
+    // Header
+    const header = document.createElement("div");
+    header.className = "header";
+
+    const titleGroup = document.createElement("div");
+    titleGroup.className = "title-group";
+
+    const subtitle = document.createElement("div");
+    subtitle.className = "subtitle";
+    const subtitleSlot = document.createElement("slot");
+    subtitleSlot.name = "subtitle";
+    subtitle.appendChild(subtitleSlot);
+    titleGroup.appendChild(subtitle);
+
+    const title = document.createElement("div");
+    title.className = "title";
+    title.id = "modal-title";
+    const titleSlot = document.createElement("slot");
+    title.appendChild(titleSlot);
+    titleGroup.appendChild(title);
+
+    header.appendChild(titleGroup);
+
+    const closeBtn = document.createElement("button");
+    closeBtn.className = "close-btn";
+    closeBtn.setAttribute("aria-label", "Close");
+    closeBtn.innerHTML = ICON_CLOSE;
+    closeBtn.addEventListener("click", () => this.close());
+    header.appendChild(closeBtn);
+
+    // Body
+    const body = document.createElement("div");
+    body.className = "body";
+    const bodySlot = document.createElement("slot");
+    bodySlot.name = "body";
+    body.appendChild(bodySlot);
+
+    // Content wrapper (header + body)
+    const content = document.createElement("div");
+    content.className = "content";
+    content.appendChild(header);
+    content.appendChild(body);
+    dialog.appendChild(content);
+
+    // Footer
+    const footer = document.createElement("div");
+    footer.className = "footer";
+
+    const footerStart = document.createElement("div");
+    footerStart.className = "footer-start";
+    const footerStartSlot = document.createElement("slot");
+    footerStartSlot.name = "footer-start";
+    footerStart.appendChild(footerStartSlot);
+    footer.appendChild(footerStart);
+
+    const footerEnd = document.createElement("div");
+    footerEnd.className = "footer-end";
+    const footerEndSlot = document.createElement("slot");
+    footerEndSlot.name = "footer-end";
+    footerEnd.appendChild(footerEndSlot);
+    footer.appendChild(footerEnd);
+
+    dialog.appendChild(footer);
+    backdrop.appendChild(dialog);
+    shadow.appendChild(backdrop);
+
+    this._backdrop = backdrop;
+    this._dialog = dialog;
+    this._subtitleSlot = subtitleSlot;
+    this._footerStartSlot = footerStartSlot;
+    this._footerEndSlot = footerEndSlot;
+
+    // Backdrop click
+    backdrop.addEventListener("click", (e: Event) => {
+      if (e.target === backdrop && this.dismissible) {
+        this.close();
+      }
+    });
+
+    // Slot change listeners
+    subtitleSlot.addEventListener("slotchange", () => this._syncSubtitle());
+    footerStartSlot.addEventListener("slotchange", () => this._syncFooter());
+    footerEndSlot.addEventListener("slotchange", () => this._syncFooter());
+  }
+
+  connectedCallback(): void {
+    document.addEventListener("keydown", this._handleKeydown);
+    this._syncSubtitle();
+    this._syncFooter();
+  }
+
+  disconnectedCallback(): void {
+    document.removeEventListener("keydown", this._handleKeydown);
+  }
+
+  attributeChangedCallback(
+    name: string,
+    _oldValue: string | null,
+    _newValue: string | null,
+  ): void {
+    switch (name) {
+      case "open":
+        this._syncOpen();
+        break;
+    }
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): ModalSize {
+    return (this.getAttribute("size") as ModalSize) ?? "m";
+  }
+
+  set size(value: ModalSize) {
+    this.setAttribute("size", value);
+  }
+
+  get layout(): ModalLayout {
+    return (this.getAttribute("layout") as ModalLayout) ?? "auto";
+  }
+
+  set layout(value: ModalLayout) {
+    this.setAttribute("layout", value);
+  }
+
+  get open(): boolean {
+    return this.hasAttribute("open");
+  }
+
+  set open(value: boolean) {
+    if (value) {
+      this.setAttribute("open", "");
+    } else {
+      this.removeAttribute("open");
+    }
+  }
+
+  get dismissible(): boolean {
+    return this.hasAttribute("dismissible");
+  }
+
+  set dismissible(value: boolean) {
+    if (value) {
+      this.setAttribute("dismissible", "");
+    } else {
+      this.removeAttribute("dismissible");
+    }
+  }
+
+  // ── Public methods ─────────────────────────────────────────────────────
+
+  show(): void {
+    this.open = true;
+  }
+
+  close(): void {
+    const event = new CustomEvent("close", {
+      bubbles: true,
+      composed: true,
+      cancelable: true,
+    });
+    this.dispatchEvent(event);
+    if (!event.defaultPrevented) {
+      this._animateOut();
+    }
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private _syncOpen(): void {
+    if (this.open) {
+      this._previouslyFocused = document.activeElement;
+      // Double-raf for animation trigger
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          this._backdrop.classList.add("visible");
+          this._dialog.focus();
+        });
+      });
+    } else {
+      // Direct attribute removal — clean up immediately
+      this._backdrop.classList.remove("visible");
+      if (this._previouslyFocused && this._previouslyFocused instanceof HTMLElement) {
+        this._previouslyFocused.focus();
+        this._previouslyFocused = null;
+      }
+    }
+  }
+
+  private _animateOut(): void {
+    this._backdrop.classList.remove("visible");
+    const onEnd = () => {
+      this._backdrop.removeEventListener("transitionend", onEnd);
+      this.removeAttribute("open");
+      // Return focus to previously focused element
+      if (this._previouslyFocused && this._previouslyFocused instanceof HTMLElement) {
+        this._previouslyFocused.focus();
+        this._previouslyFocused = null;
+      }
+    };
+    this._backdrop.addEventListener("transitionend", onEnd, { once: true });
+    // Fallback if transitionend doesn't fire (e.g. reduced motion, no transition)
+    setTimeout(onEnd, 250);
+  }
+
+  private _syncSubtitle(): void {
+    const nodes = this._subtitleSlot.assignedNodes({ flatten: true });
+    if (nodes.length > 0) {
+      this.setAttribute("has-subtitle", "");
+    } else {
+      this.removeAttribute("has-subtitle");
+    }
+  }
+
+  private _syncFooter(): void {
+    const startNodes = this._footerStartSlot.assignedNodes({ flatten: true });
+    const endNodes = this._footerEndSlot.assignedNodes({ flatten: true });
+    if (startNodes.length > 0 || endNodes.length > 0) {
+      this.setAttribute("has-footer", "");
+    } else {
+      this.removeAttribute("has-footer");
+    }
+  }
+
+  private _handleKeydown = (e: KeyboardEvent): void => {
+    if (e.key === "Escape" && this.open && this.dismissible) {
+      this.close();
+    }
+  };
+}
+
+customElements.define("ui-modal", UiModal);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -44,3 +44,5 @@ export type { DropdownSize, DropdownAction, DropdownEmphasis, DropdownShape } fr
 export { UiDropdownItem } from "./components/ui-dropdown-item.js";
 export { UiDropdownHeading } from "./components/ui-dropdown-heading.js";
 export { UiDropdownSeparator } from "./components/ui-dropdown-separator.js";
+export { UiModal } from "./components/ui-modal.js";
+export type { ModalSize, ModalLayout } from "./components/ui-modal.js";

--- a/packages/ui-components/src/stories/ui-modal.stories.ts
+++ b/packages/ui-components/src/stories/ui-modal.stories.ts
@@ -1,0 +1,178 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-modal.js";
+import "../components/ui-button.js";
+
+const meta: Meta = {
+  title: "Components/Modal",
+  component: "ui-modal",
+  argTypes: {
+    size: {
+      control: { type: "select" },
+      options: ["s", "m", "l"],
+    },
+    layout: {
+      control: { type: "select" },
+      options: ["auto", "fluid"],
+    },
+    dismissible: { control: { type: "boolean" } },
+  },
+  args: {
+    size: "m",
+    layout: "auto",
+    dismissible: true,
+  },
+};
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => html`
+    <ui-button onclick="document.querySelector('#default-modal').show()">Open Modal</ui-button>
+    <ui-modal id="default-modal" dismissible>
+      Modal Title
+      <div slot="body">This is the body content of the modal dialog.</div>
+      <div slot="footer-end" style="display:flex;gap:8px;">
+        <ui-button action="secondary" size="m">Cancel</ui-button>
+        <ui-button action="primary" size="m">Confirm</ui-button>
+      </div>
+    </ui-modal>
+  `,
+};
+
+export const WithSubtitle: Story = {
+  render: () => html`
+    <ui-button onclick="document.querySelector('#subtitle-modal').show()">Open Modal</ui-button>
+    <ui-modal id="subtitle-modal" dismissible>
+      <span slot="subtitle">Optional subtitle text</span>
+      Modal Title
+      <div slot="body">Body content with a subtitle above the title.</div>
+      <div slot="footer-end" style="display:flex;gap:8px;">
+        <ui-button action="secondary" size="m">Cancel</ui-button>
+        <ui-button action="primary" size="m">Save</ui-button>
+      </div>
+    </ui-modal>
+  `,
+};
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 12px;">
+      <ui-button onclick="document.querySelector('#modal-s').show()">Small</ui-button>
+      <ui-button onclick="document.querySelector('#modal-m').show()">Medium</ui-button>
+      <ui-button onclick="document.querySelector('#modal-l').show()">Large</ui-button>
+    </div>
+    <ui-modal id="modal-s" size="s" dismissible>
+      Small Modal
+      <div slot="body">Small size body content.</div>
+      <div slot="footer-end" style="display:flex;gap:8px;">
+        <ui-button action="secondary" size="s">Cancel</ui-button>
+        <ui-button action="primary" size="s">OK</ui-button>
+      </div>
+    </ui-modal>
+    <ui-modal id="modal-m" size="m" dismissible>
+      Medium Modal
+      <div slot="body">Medium size body content.</div>
+      <div slot="footer-end" style="display:flex;gap:8px;">
+        <ui-button action="secondary" size="m">Cancel</ui-button>
+        <ui-button action="primary" size="m">OK</ui-button>
+      </div>
+    </ui-modal>
+    <ui-modal id="modal-l" size="l" dismissible>
+      Large Modal
+      <div slot="body">Large size body content.</div>
+      <div slot="footer-end" style="display:flex;gap:8px;">
+        <ui-button action="secondary" size="m">Cancel</ui-button>
+        <ui-button action="primary" size="m">OK</ui-button>
+      </div>
+    </ui-modal>
+  `,
+};
+
+export const FluidLayout: Story = {
+  render: () => html`
+    <ui-button onclick="document.querySelector('#fluid-modal').show()">Open Fluid Modal</ui-button>
+    <ui-modal id="fluid-modal" layout="fluid" dismissible>
+      Fluid Layout Modal
+      <div slot="body">
+        <p>This modal has a fixed height and the body area scrolls when content overflows.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris.</p>
+        <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident.</p>
+        <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam.</p>
+        <p>Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt.</p>
+        <p>Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit.</p>
+      </div>
+      <div slot="footer-end" style="display:flex;gap:8px;">
+        <ui-button action="secondary" size="m">Cancel</ui-button>
+        <ui-button action="primary" size="m">Save</ui-button>
+      </div>
+    </ui-modal>
+  `,
+};
+
+export const Dismissible: Story = {
+  render: () => html`
+    <ui-button onclick="document.querySelector('#dismiss-modal').show()">Open Dismissible Modal</ui-button>
+    <ui-modal id="dismiss-modal" dismissible>
+      Dismissible Modal
+      <div slot="body">Click the X button, press Escape, or click the backdrop to close.</div>
+      <div slot="footer-end" style="display:flex;gap:8px;">
+        <ui-button action="primary" size="m">Got it</ui-button>
+      </div>
+    </ui-modal>
+  `,
+};
+
+export const NonDismissible: Story = {
+  render: () => html`
+    <ui-button onclick="document.querySelector('#nondismiss-modal').show()">Open Non-Dismissible Modal</ui-button>
+    <ui-modal id="nondismiss-modal">
+      Non-Dismissible Modal
+      <div slot="body">This modal can only be closed by the action buttons below.</div>
+      <div slot="footer-end" style="display:flex;gap:8px;">
+        <ui-button action="primary" size="m" onclick="document.querySelector('#nondismiss-modal').close()">Accept</ui-button>
+      </div>
+    </ui-modal>
+  `,
+};
+
+export const WithTertiaryButton: Story = {
+  render: () => html`
+    <ui-button onclick="document.querySelector('#tertiary-modal').show()">Open Modal</ui-button>
+    <ui-modal id="tertiary-modal" dismissible>
+      Modal with Tertiary Action
+      <div slot="body">This modal has a tertiary button on the left side of the footer.</div>
+      <ui-button slot="footer-start" action="secondary" emphasis="subtle" size="m">Learn more</ui-button>
+      <div slot="footer-end" style="display:flex;gap:8px;">
+        <ui-button action="secondary" size="m">Cancel</ui-button>
+        <ui-button action="primary" size="m">Confirm</ui-button>
+      </div>
+    </ui-modal>
+  `,
+};
+
+export const NoFooter: Story = {
+  render: () => html`
+    <ui-button onclick="document.querySelector('#nofooter-modal').show()">Open Modal</ui-button>
+    <ui-modal id="nofooter-modal" dismissible>
+      Information
+      <div slot="body">This modal has no footer buttons. Use the close button to dismiss.</div>
+    </ui-modal>
+  `,
+};
+
+export const Interactive: Story = {
+  render: () => html`
+    <ui-button onclick="document.querySelector('#demo-modal').show()">Open Modal</ui-button>
+    <ui-modal id="demo-modal" dismissible>
+      <span slot="subtitle">Subtitle</span>
+      Modal Title
+      <div slot="body">Body content here...</div>
+      <ui-button slot="footer-start" action="secondary" emphasis="subtle" size="m">Tertiary</ui-button>
+      <div slot="footer-end" style="display:flex;gap:8px;">
+        <ui-button action="secondary" size="m">Cancel</ui-button>
+        <ui-button action="primary" size="m">Confirm</ui-button>
+      </div>
+    </ui-modal>
+  `,
+};


### PR DESCRIPTION
## Summary

- Implements `<ui-modal>` Web Component with Shadow DOM, matching the Figma "Modal" page spec
- Three sizes (s/m/l), two layout modes (auto/fluid), dismissible behavior (close button, backdrop click, escape key)
- Slots: default (title), `subtitle`, `body`, `footer-start` (tertiary), `footer-end` (primary+secondary)
- Open/close animation with backdrop overlay, focus management, cancelable close event
- 77 tests passing, 9 Storybook stories, type check clean
- Uses foundation tokens: `semanticVar("surface", "overlay")` for backdrop, `elevationVar("06")` for shadow, `spaceVar()` for all spacing
- CSS prefix: `--ui-modal-*` with consumer override vars for width, height, backdrop, bg, shadow
- Reuses `ICON_CLOSE` from shared icons, `<ui-button>` in stories for footer actions