### PR TITLE
feat: implement ui-badge component

### DIFF
--- a/packages/ui-components/AGENTS.md
+++ b/packages/ui-components/AGENTS.md
@@ -19,6 +19,7 @@ Web Component library for the Maneki design system. Shadow DOM, CSS custom prope
 - `<ui-dropdown-heading>` — section heading (uppercase, non-interactive)
 - `<ui-dropdown-separator>` — horizontal divider line
 - `<ui-modal>` — modal dialog with backdrop, header (title+subtitle+close), scrollable body, footer button slots, 3 sizes, 2 layouts (auto/fluid), dismiss behavior
+- `<ui-badge>` — label/tag with 4 sizes, 3 emphases, 2 shapes, 13 colors, 5 statuses, uppercase text
 
 ## STRUCTURE
 ```
@@ -47,6 +48,7 @@ ui-components/
 │   │   ├── ui-dropdown-heading.ts
 │   │   ├── ui-dropdown-separator.ts
 │   │   ├── ui-modal.ts
+│   │   ├── ui-badge.ts
 │   │   └── *.test.ts        # Co-located tests
 │   └── stories/
 │       └── *.stories.ts     # CSF3 + lit html
@@ -69,7 +71,7 @@ Follow `ui-button.ts` or `ui-alert.ts` as reference implementations:
 3. DOM built imperatively with `document.createElement()` (not innerHTML)
 4. Observed attributes → `attributeChangedCallback`
 5. CSS in `STYLES` template literal with token constants at module level
-6. CSS uses nested var pattern: `var(--ui-btn-bg, ${BLUE_60})` — consumer override → foundation token
+6. CSS uses nested var pattern: `var(--ui-btn-bg, ${BLUE_60})` / `var(--ui-badge-bg, ${GRAY_60})` — consumer override → foundation token
 7. `customElements.define("ui-*", Class)` at module level
 
 ## FOUNDATION TOKEN WIRING

--- a/packages/ui-components/src/components/ui-badge.test.ts
+++ b/packages/ui-components/src/components/ui-badge.test.ts
@@ -1,0 +1,411 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "./ui-badge.js";
+
+describe("ui-badge", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-badge");
+    document.body.appendChild(el);
+  });
+
+  // ── Registration ─────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-badge")).toBeDefined();
+  });
+
+  // ── Default attributes ───────────────────────────────────────────────────
+
+  it("defaults size to 'm'", () => {
+    expect((el as unknown as { size: string }).size).toBe("m");
+  });
+
+  it("defaults emphasis to 'bold'", () => {
+    expect((el as unknown as { emphasis: string }).emphasis).toBe("bold");
+  });
+
+  it("defaults shape to 'square'", () => {
+    expect((el as unknown as { shape: string }).shape).toBe("square");
+  });
+
+  it("defaults color to 'none'", () => {
+    expect((el as unknown as { color: string }).color).toBe("none");
+  });
+
+  it("defaults status to 'none'", () => {
+    expect((el as unknown as { status: string }).status).toBe("none");
+  });
+
+  // ── Size attribute ──────────────────────────────────────────────────────
+
+  it("reflects size='xs' to attribute", () => {
+    (el as unknown as { size: string }).size = "xs";
+    expect(el.getAttribute("size")).toBe("xs");
+  });
+
+  it("reflects size='s' to attribute", () => {
+    (el as unknown as { size: string }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("reflects size='m' to attribute", () => {
+    (el as unknown as { size: string }).size = "m";
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("reflects size='l' to attribute", () => {
+    (el as unknown as { size: string }).size = "l";
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  // ── Emphasis attribute ──────────────────────────────────────────────────
+
+  it("reflects emphasis='bold' to attribute", () => {
+    (el as unknown as { emphasis: string }).emphasis = "bold";
+    expect(el.getAttribute("emphasis")).toBe("bold");
+  });
+
+  it("reflects emphasis='subtle' to attribute", () => {
+    (el as unknown as { emphasis: string }).emphasis = "subtle";
+    expect(el.getAttribute("emphasis")).toBe("subtle");
+  });
+
+  it("reflects emphasis='minimal' to attribute", () => {
+    (el as unknown as { emphasis: string }).emphasis = "minimal";
+    expect(el.getAttribute("emphasis")).toBe("minimal");
+  });
+
+  // ── Shape attribute ─────────────────────────────────────────────────────
+
+  it("reflects shape='square' to attribute", () => {
+    (el as unknown as { shape: string }).shape = "square";
+    expect(el.getAttribute("shape")).toBe("square");
+  });
+
+  it("reflects shape='rounded' to attribute", () => {
+    (el as unknown as { shape: string }).shape = "rounded";
+    expect(el.getAttribute("shape")).toBe("rounded");
+  });
+
+  // ── Color attribute ─────────────────────────────────────────────────────
+
+  it("reflects color='none' to attribute", () => {
+    (el as unknown as { color: string }).color = "none";
+    expect(el.getAttribute("color")).toBe("none");
+  });
+
+  it("reflects color='red' to attribute", () => {
+    (el as unknown as { color: string }).color = "red";
+    expect(el.getAttribute("color")).toBe("red");
+  });
+
+  it("reflects color='yellow' to attribute", () => {
+    (el as unknown as { color: string }).color = "yellow";
+    expect(el.getAttribute("color")).toBe("yellow");
+  });
+
+  it("reflects color='green' to attribute", () => {
+    (el as unknown as { color: string }).color = "green";
+    expect(el.getAttribute("color")).toBe("green");
+  });
+
+  it("reflects color='blue' to attribute", () => {
+    (el as unknown as { color: string }).color = "blue";
+    expect(el.getAttribute("color")).toBe("blue");
+  });
+
+  it("reflects color='lime' to attribute", () => {
+    (el as unknown as { color: string }).color = "lime";
+    expect(el.getAttribute("color")).toBe("lime");
+  });
+
+  it("reflects color='teal' to attribute", () => {
+    (el as unknown as { color: string }).color = "teal";
+    expect(el.getAttribute("color")).toBe("teal");
+  });
+
+  it("reflects color='turquoise' to attribute", () => {
+    (el as unknown as { color: string }).color = "turquoise";
+    expect(el.getAttribute("color")).toBe("turquoise");
+  });
+
+  it("reflects color='aqua' to attribute", () => {
+    (el as unknown as { color: string }).color = "aqua";
+    expect(el.getAttribute("color")).toBe("aqua");
+  });
+
+  it("reflects color='ultramarine' to attribute", () => {
+    (el as unknown as { color: string }).color = "ultramarine";
+    expect(el.getAttribute("color")).toBe("ultramarine");
+  });
+
+  it("reflects color='pink' to attribute", () => {
+    (el as unknown as { color: string }).color = "pink";
+    expect(el.getAttribute("color")).toBe("pink");
+  });
+
+  it("reflects color='purple' to attribute", () => {
+    (el as unknown as { color: string }).color = "purple";
+    expect(el.getAttribute("color")).toBe("purple");
+  });
+
+  it("reflects color='orange' to attribute", () => {
+    (el as unknown as { color: string }).color = "orange";
+    expect(el.getAttribute("color")).toBe("orange");
+  });
+
+  // ── Status attribute ────────────────────────────────────────────────────
+
+  it("reflects status='none' to attribute", () => {
+    (el as unknown as { status: string }).status = "none";
+    expect(el.getAttribute("status")).toBe("none");
+  });
+
+  it("reflects status='error' to attribute", () => {
+    (el as unknown as { status: string }).status = "error";
+    expect(el.getAttribute("status")).toBe("error");
+  });
+
+  it("reflects status='warning' to attribute", () => {
+    (el as unknown as { status: string }).status = "warning";
+    expect(el.getAttribute("status")).toBe("warning");
+  });
+
+  it("reflects status='success' to attribute", () => {
+    (el as unknown as { status: string }).status = "success";
+    expect(el.getAttribute("status")).toBe("success");
+  });
+
+  it("reflects status='information' to attribute", () => {
+    (el as unknown as { status: string }).status = "information";
+    expect(el.getAttribute("status")).toBe("information");
+  });
+
+  // ── Shadow DOM structure ───────────────────────────────────────────────
+
+  it("has .base element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".base")).toBeTruthy();
+  });
+
+  it("has a <span> as .base element", () => {
+    const shadow = el.shadowRoot!;
+    const base = shadow.querySelector(".base");
+    expect(base!.tagName).toBe("SPAN");
+  });
+
+  it("has default slot in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    const defaultSlot = shadow.querySelector("slot:not([name])");
+    expect(defaultSlot).toBeTruthy();
+  });
+
+  it("has slot inside .base element", () => {
+    const shadow = el.shadowRoot!;
+    const base = shadow.querySelector(".base");
+    const slot = base!.querySelector("slot");
+    expect(slot).toBeTruthy();
+  });
+
+  it("has a <style> element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector("style")).toBeTruthy();
+  });
+
+  // ── Property accessors ────────────────────────────────────────────────
+
+  it("exposes size property accessor", () => {
+    const component = el as unknown as { size: string };
+    component.size = "l";
+    expect(component.size).toBe("l");
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  it("exposes emphasis property accessor", () => {
+    const component = el as unknown as { emphasis: string };
+    component.emphasis = "subtle";
+    expect(component.emphasis).toBe("subtle");
+    expect(el.getAttribute("emphasis")).toBe("subtle");
+  });
+
+  it("exposes shape property accessor", () => {
+    const component = el as unknown as { shape: string };
+    component.shape = "rounded";
+    expect(component.shape).toBe("rounded");
+    expect(el.getAttribute("shape")).toBe("rounded");
+  });
+
+  it("exposes color property accessor", () => {
+    const component = el as unknown as { color: string };
+    component.color = "blue";
+    expect(component.color).toBe("blue");
+    expect(el.getAttribute("color")).toBe("blue");
+  });
+
+  it("exposes status property accessor", () => {
+    const component = el as unknown as { status: string };
+    component.status = "error";
+    expect(component.status).toBe("error");
+    expect(el.getAttribute("status")).toBe("error");
+  });
+
+  it("exposes all typed property accessors together", () => {
+    const component = el as unknown as {
+      size: string;
+      emphasis: string;
+      shape: string;
+      color: string;
+      status: string;
+    };
+
+    component.size = "xs";
+    expect(component.size).toBe("xs");
+
+    component.emphasis = "minimal";
+    expect(component.emphasis).toBe("minimal");
+
+    component.shape = "rounded";
+    expect(component.shape).toBe("rounded");
+
+    component.color = "purple";
+    expect(component.color).toBe("purple");
+
+    component.status = "success";
+    expect(component.status).toBe("success");
+  });
+
+  // ── observedAttributes ────────────────────────────────────────────────
+
+  it("observes size attribute", () => {
+    const observed = (
+      customElements.get("ui-badge") as unknown as {
+        observedAttributes: string[];
+      }
+    ).observedAttributes;
+    expect(observed).toContain("size");
+  });
+
+  it("observes emphasis attribute", () => {
+    const observed = (
+      customElements.get("ui-badge") as unknown as {
+        observedAttributes: string[];
+      }
+    ).observedAttributes;
+    expect(observed).toContain("emphasis");
+  });
+
+  it("observes shape attribute", () => {
+    const observed = (
+      customElements.get("ui-badge") as unknown as {
+        observedAttributes: string[];
+      }
+    ).observedAttributes;
+    expect(observed).toContain("shape");
+  });
+
+  it("observes color attribute", () => {
+    const observed = (
+      customElements.get("ui-badge") as unknown as {
+        observedAttributes: string[];
+      }
+    ).observedAttributes;
+    expect(observed).toContain("color");
+  });
+
+  it("observes status attribute", () => {
+    const observed = (
+      customElements.get("ui-badge") as unknown as {
+        observedAttributes: string[];
+      }
+    ).observedAttributes;
+    expect(observed).toContain("status");
+  });
+
+  // ── Attribute via setAttribute ────────────────────────────────────────
+
+  it("reads size from setAttribute", () => {
+    el.setAttribute("size", "xs");
+    expect((el as unknown as { size: string }).size).toBe("xs");
+  });
+
+  it("reads emphasis from setAttribute", () => {
+    el.setAttribute("emphasis", "minimal");
+    expect((el as unknown as { emphasis: string }).emphasis).toBe("minimal");
+  });
+
+  it("reads shape from setAttribute", () => {
+    el.setAttribute("shape", "rounded");
+    expect((el as unknown as { shape: string }).shape).toBe("rounded");
+  });
+
+  it("reads color from setAttribute", () => {
+    el.setAttribute("color", "teal");
+    expect((el as unknown as { color: string }).color).toBe("teal");
+  });
+
+  it("reads status from setAttribute", () => {
+    el.setAttribute("status", "warning");
+    expect((el as unknown as { status: string }).status).toBe("warning");
+  });
+
+  // ── Display ───────────────────────────────────────────────────────────
+
+  it("is an inline-flex element via :host", () => {
+    const shadow = el.shadowRoot!;
+    const style = shadow.querySelector("style");
+    expect(style!.textContent).toContain("display: inline-flex");
+  });
+
+  // ── CSS contains expected token references ────────────────────────────
+
+  it("CSS contains --ui-badge-bg custom property", () => {
+    const shadow = el.shadowRoot!;
+    const style = shadow.querySelector("style");
+    expect(style!.textContent).toContain("--ui-badge-bg");
+  });
+
+  it("CSS contains --ui-badge-color custom property", () => {
+    const shadow = el.shadowRoot!;
+    const style = shadow.querySelector("style");
+    expect(style!.textContent).toContain("--ui-badge-color");
+  });
+
+  it("CSS contains --ui-badge-border custom property", () => {
+    const shadow = el.shadowRoot!;
+    const style = shadow.querySelector("style");
+    expect(style!.textContent).toContain("--ui-badge-border");
+  });
+
+  it("CSS contains text-transform: uppercase", () => {
+    const shadow = el.shadowRoot!;
+    const style = shadow.querySelector("style");
+    expect(style!.textContent).toContain("text-transform: uppercase");
+  });
+
+  it("CSS contains font-weight: 500", () => {
+    const shadow = el.shadowRoot!;
+    const style = shadow.querySelector("style");
+    expect(style!.textContent).toContain("font-weight: 500");
+  });
+
+  it("CSS contains white-space: nowrap", () => {
+    const shadow = el.shadowRoot!;
+    const style = shadow.querySelector("style");
+    expect(style!.textContent).toContain("white-space: nowrap");
+  });
+
+  // ── Multiple instances ────────────────────────────────────────────────
+
+  it("supports multiple independent instances", () => {
+    const el2 = document.createElement("ui-badge");
+    document.body.appendChild(el2);
+
+    (el as unknown as { color: string }).color = "red";
+    (el2 as unknown as { color: string }).color = "blue";
+
+    expect((el as unknown as { color: string }).color).toBe("red");
+    expect((el2 as unknown as { color: string }).color).toBe("blue");
+  });
+});

--- a/packages/ui-components/src/components/ui-badge.ts
+++ b/packages/ui-components/src/components/ui-badge.ts
@@ -1,0 +1,327 @@
+import { colorVar, semanticVar } from "@maneki/foundation";
+
+// ─── Type-safe property unions ───────────────────────────────────────────────
+
+export type BadgeSize = "xs" | "s" | "m" | "l";
+export type BadgeEmphasis = "bold" | "subtle" | "minimal";
+export type BadgeShape = "square" | "rounded";
+export type BadgeColor =
+  | "none"
+  | "red"
+  | "yellow"
+  | "green"
+  | "blue"
+  | "lime"
+  | "teal"
+  | "turquoise"
+  | "aqua"
+  | "ultramarine"
+  | "pink"
+  | "purple"
+  | "orange";
+export type BadgeStatus =
+  | "none"
+  | "error"
+  | "warning"
+  | "success"
+  | "information";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const GRAY_60 = colorVar("gray", 60);
+const RED_60 = colorVar("red", 60);
+const YELLOW_30 = colorVar("yellow", 30);
+const GREEN_60 = colorVar("green", 60);
+const BLUE_60 = colorVar("blue", 60);
+const LIME_60 = colorVar("lime", 60);
+const TEAL_60 = colorVar("teal", 60);
+const TURQUOISE_60 = colorVar("turquoise", 60);
+const AQUA_60 = colorVar("aqua", 60);
+const ULTRAMARINE_60 = colorVar("ultramarine", 60);
+const PINK_60 = colorVar("pink", 60);
+const PURPLE_60 = colorVar("purple", 60);
+const ORANGE_60 = colorVar("orange", 60);
+
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const TEXT_SECONDARY = semanticVar("text", "secondary");
+const SURFACE_TERTIARY = semanticVar("surface", "tertiary");
+const BORDER_MODERATE = semanticVar("border", "moderate");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: inline-flex;
+  }
+
+  /* ── Base ─────────────────────────────────────────────────────────────────── */
+
+  .base {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-family: "Goldman Sans", sans-serif;
+    font-weight: 500;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  /* ── Size: m (default) ───────────────────────────────────────────────────── */
+
+  :host .base,
+  :host([size="m"]) .base {
+    font-size: 12px;
+    line-height: 16px;
+    padding: 2px 8px;
+  }
+
+  /* ── Size: xs ────────────────────────────────────────────────────────────── */
+
+  :host([size="xs"]) .base {
+    font-size: 9px;
+    line-height: 12px;
+    padding: 0 4px;
+  }
+
+  /* ── Size: s ─────────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) .base {
+    font-size: 11px;
+    line-height: 16px;
+    padding: 0 6px;
+  }
+
+  /* ── Size: l ─────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) .base {
+    font-size: 14px;
+    line-height: 20px;
+    padding: 4px 10px;
+  }
+
+  /* ── Shape: square (default) ─────────────────────────────────────────────── */
+
+  :host .base,
+  :host([shape="square"]) .base {
+    border-radius: 2px;
+  }
+
+  /* ── Shape: rounded ──────────────────────────────────────────────────────── */
+
+  :host([shape="rounded"]) .base {
+    border-radius: 20px;
+  }
+
+  /* ── Emphasis: bold (default) + color: none (default) ────────────────────── */
+
+  :host .base,
+  :host([color="none"]) .base,
+  :host([color="none"][emphasis="bold"]) .base {
+    background-color: var(--ui-badge-bg, ${GRAY_60});
+    color: var(--ui-badge-color, #ffffff);
+  }
+
+  /* ── Bold color variants ─────────────────────────────────────────────────── */
+
+  :host([color="red"]) .base,
+  :host([color="red"][emphasis="bold"]) .base {
+    background-color: var(--ui-badge-bg, ${RED_60});
+    color: var(--ui-badge-color, #ffffff);
+  }
+
+  :host([color="yellow"]) .base,
+  :host([color="yellow"][emphasis="bold"]) .base {
+    background-color: var(--ui-badge-bg, ${YELLOW_30});
+    color: var(--ui-badge-color, ${TEXT_PRIMARY});
+  }
+
+  :host([color="green"]) .base,
+  :host([color="green"][emphasis="bold"]) .base {
+    background-color: var(--ui-badge-bg, ${GREEN_60});
+    color: var(--ui-badge-color, #ffffff);
+  }
+
+  :host([color="blue"]) .base,
+  :host([color="blue"][emphasis="bold"]) .base {
+    background-color: var(--ui-badge-bg, ${BLUE_60});
+    color: var(--ui-badge-color, #ffffff);
+  }
+
+  :host([color="lime"]) .base,
+  :host([color="lime"][emphasis="bold"]) .base {
+    background-color: var(--ui-badge-bg, ${LIME_60});
+    color: var(--ui-badge-color, #ffffff);
+  }
+
+  :host([color="teal"]) .base,
+  :host([color="teal"][emphasis="bold"]) .base {
+    background-color: var(--ui-badge-bg, ${TEAL_60});
+    color: var(--ui-badge-color, #ffffff);
+  }
+
+  :host([color="turquoise"]) .base,
+  :host([color="turquoise"][emphasis="bold"]) .base {
+    background-color: var(--ui-badge-bg, ${TURQUOISE_60});
+    color: var(--ui-badge-color, #ffffff);
+  }
+
+  :host([color="aqua"]) .base,
+  :host([color="aqua"][emphasis="bold"]) .base {
+    background-color: var(--ui-badge-bg, ${AQUA_60});
+    color: var(--ui-badge-color, #ffffff);
+  }
+
+  :host([color="ultramarine"]) .base,
+  :host([color="ultramarine"][emphasis="bold"]) .base {
+    background-color: var(--ui-badge-bg, ${ULTRAMARINE_60});
+    color: var(--ui-badge-color, #ffffff);
+  }
+
+  :host([color="pink"]) .base,
+  :host([color="pink"][emphasis="bold"]) .base {
+    background-color: var(--ui-badge-bg, ${PINK_60});
+    color: var(--ui-badge-color, #ffffff);
+  }
+
+  :host([color="purple"]) .base,
+  :host([color="purple"][emphasis="bold"]) .base {
+    background-color: var(--ui-badge-bg, ${PURPLE_60});
+    color: var(--ui-badge-color, #ffffff);
+  }
+
+  :host([color="orange"]) .base,
+  :host([color="orange"][emphasis="bold"]) .base {
+    background-color: var(--ui-badge-bg, ${ORANGE_60});
+    color: var(--ui-badge-color, #ffffff);
+  }
+
+  /* ── Status overrides (bold) ─────────────────────────────────────────────── */
+
+  :host([status="error"]) .base,
+  :host([status="error"][emphasis="bold"]) .base {
+    background-color: var(--ui-badge-bg, ${RED_60});
+    color: var(--ui-badge-color, #ffffff);
+  }
+
+  :host([status="warning"]) .base,
+  :host([status="warning"][emphasis="bold"]) .base {
+    background-color: var(--ui-badge-bg, ${YELLOW_30});
+    color: var(--ui-badge-color, ${TEXT_PRIMARY});
+  }
+
+  :host([status="success"]) .base,
+  :host([status="success"][emphasis="bold"]) .base {
+    background-color: var(--ui-badge-bg, ${GREEN_60});
+    color: var(--ui-badge-color, #ffffff);
+  }
+
+  :host([status="information"]) .base,
+  :host([status="information"][emphasis="bold"]) .base {
+    background-color: var(--ui-badge-bg, ${BLUE_60});
+    color: var(--ui-badge-color, #ffffff);
+  }
+
+  /* ── Emphasis: subtle ────────────────────────────────────────────────────── */
+
+  :host([emphasis="subtle"]) .base {
+    background-color: var(--ui-badge-bg, ${SURFACE_TERTIARY});
+    color: var(--ui-badge-color, ${TEXT_SECONDARY});
+  }
+
+  /* ── Emphasis: minimal ───────────────────────────────────────────────────── */
+
+  :host([emphasis="minimal"]) .base {
+    background-color: var(--ui-badge-bg, transparent);
+    color: var(--ui-badge-color, ${TEXT_SECONDARY});
+    border: 1px solid var(--ui-badge-border, ${BORDER_MODERATE});
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export class UiBadge extends HTMLElement {
+  static readonly observedAttributes = [
+    "size",
+    "emphasis",
+    "shape",
+    "color",
+    "status",
+  ];
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+
+    const style = document.createElement("style");
+    style.textContent = STYLES;
+    shadow.appendChild(style);
+
+    // .base
+    const base = document.createElement("span");
+    base.className = "base";
+
+    // default slot
+    const slot = document.createElement("slot");
+    base.appendChild(slot);
+
+    shadow.appendChild(base);
+  }
+
+  attributeChangedCallback(
+    _name: string,
+    _oldValue: string | null,
+    _newValue: string | null,
+  ): void {
+    // All styling is handled via :host([attr]) CSS selectors — no JS sync needed
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): BadgeSize {
+    return (this.getAttribute("size") as BadgeSize) ?? "m";
+  }
+
+  set size(value: BadgeSize) {
+    this.setAttribute("size", value);
+  }
+
+  get emphasis(): BadgeEmphasis {
+    return (this.getAttribute("emphasis") as BadgeEmphasis) ?? "bold";
+  }
+
+  set emphasis(value: BadgeEmphasis) {
+    this.setAttribute("emphasis", value);
+  }
+
+  get shape(): BadgeShape {
+    return (this.getAttribute("shape") as BadgeShape) ?? "square";
+  }
+
+  set shape(value: BadgeShape) {
+    this.setAttribute("shape", value);
+  }
+
+  get color(): BadgeColor {
+    return (this.getAttribute("color") as BadgeColor) ?? "none";
+  }
+
+  set color(value: BadgeColor) {
+    this.setAttribute("color", value);
+  }
+
+  get status(): BadgeStatus {
+    return (this.getAttribute("status") as BadgeStatus) ?? "none";
+  }
+
+  set status(value: BadgeStatus) {
+    this.setAttribute("status", value);
+  }
+}
+
+customElements.define("ui-badge", UiBadge);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -46,3 +46,5 @@ export { UiDropdownHeading } from "./components/ui-dropdown-heading.js";
 export { UiDropdownSeparator } from "./components/ui-dropdown-separator.js";
 export { UiModal } from "./components/ui-modal.js";
 export type { ModalSize, ModalLayout } from "./components/ui-modal.js";
+export { UiBadge } from "./components/ui-badge.js";
+export type { BadgeSize, BadgeEmphasis, BadgeShape, BadgeColor, BadgeStatus } from "./components/ui-badge.js";

--- a/packages/ui-components/src/stories/ui-badge.stories.ts
+++ b/packages/ui-components/src/stories/ui-badge.stories.ts
@@ -1,0 +1,154 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-badge.js";
+
+const meta: Meta = {
+  title: "Components/Badge",
+  component: "ui-badge",
+  argTypes: {
+    size: {
+      control: { type: "select" },
+      options: ["xs", "s", "m", "l"],
+    },
+    emphasis: {
+      control: { type: "select" },
+      options: ["bold", "subtle", "minimal"],
+    },
+    shape: {
+      control: { type: "select" },
+      options: ["square", "rounded"],
+    },
+    color: {
+      control: { type: "select" },
+      options: [
+        "none",
+        "red",
+        "yellow",
+        "green",
+        "blue",
+        "lime",
+        "teal",
+        "turquoise",
+        "aqua",
+        "ultramarine",
+        "pink",
+        "purple",
+        "orange",
+      ],
+    },
+    status: {
+      control: { type: "select" },
+      options: ["none", "error", "warning", "success", "information"],
+    },
+  },
+  args: {
+    size: "m",
+    emphasis: "bold",
+    shape: "square",
+    color: "none",
+    status: "none",
+  },
+  render: (args) => html`
+    <ui-badge
+      size=${args.size}
+      emphasis=${args.emphasis}
+      shape=${args.shape}
+      color=${args.color}
+      status=${args.status}
+    >
+      Badge
+    </ui-badge>
+  `,
+};
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => html`<ui-badge>Badge</ui-badge>`,
+};
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 8px; align-items: center;">
+      <ui-badge size="xs">Badge</ui-badge>
+      <ui-badge size="s">Badge</ui-badge>
+      <ui-badge size="m">Badge</ui-badge>
+      <ui-badge size="l">Badge</ui-badge>
+    </div>
+  `,
+};
+
+export const AllEmphases: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 8px; align-items: center;">
+      <ui-badge emphasis="bold">Bold</ui-badge>
+      <ui-badge emphasis="subtle">Subtle</ui-badge>
+      <ui-badge emphasis="minimal">Minimal</ui-badge>
+    </div>
+  `,
+};
+
+export const AllShapes: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 8px; align-items: center;">
+      <ui-badge shape="square">Square</ui-badge>
+      <ui-badge shape="rounded">Rounded</ui-badge>
+    </div>
+  `,
+};
+
+export const AllColors: Story = {
+  render: () => html`
+    <div
+      style="display: grid; grid-template-columns: repeat(7, auto); gap: 8px; align-items: center;"
+    >
+      <ui-badge color="none">None</ui-badge>
+      <ui-badge color="red">Red</ui-badge>
+      <ui-badge color="yellow">Yellow</ui-badge>
+      <ui-badge color="green">Green</ui-badge>
+      <ui-badge color="blue">Blue</ui-badge>
+      <ui-badge color="lime">Lime</ui-badge>
+      <ui-badge color="teal">Teal</ui-badge>
+      <ui-badge color="turquoise">Turquoise</ui-badge>
+      <ui-badge color="aqua">Aqua</ui-badge>
+      <ui-badge color="ultramarine">Ultramarine</ui-badge>
+      <ui-badge color="pink">Pink</ui-badge>
+      <ui-badge color="purple">Purple</ui-badge>
+      <ui-badge color="orange">Orange</ui-badge>
+    </div>
+  `,
+};
+
+export const AllStatuses: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 8px; align-items: center;">
+      <ui-badge status="none">None</ui-badge>
+      <ui-badge status="error">Error</ui-badge>
+      <ui-badge status="warning">Warning</ui-badge>
+      <ui-badge status="success">Success</ui-badge>
+      <ui-badge status="information">Information</ui-badge>
+    </div>
+  `,
+};
+
+export const SubtleEmphasis: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 8px; align-items: center;">
+      <ui-badge emphasis="subtle">Default</ui-badge>
+      <ui-badge emphasis="subtle">New</ui-badge>
+      <ui-badge emphasis="subtle">Draft</ui-badge>
+      <ui-badge emphasis="subtle">Pending</ui-badge>
+    </div>
+  `,
+};
+
+export const MinimalEmphasis: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 8px; align-items: center;">
+      <ui-badge emphasis="minimal">Default</ui-badge>
+      <ui-badge emphasis="minimal">New</ui-badge>
+      <ui-badge emphasis="minimal">Draft</ui-badge>
+      <ui-badge emphasis="minimal">Pending</ui-badge>
+    </div>
+  `,
+};


### PR DESCRIPTION
## Summary

- Implements `<ui-badge>` Web Component — a label/tag with 4 sizes (xs/s/m/l), 3 emphases (bold/subtle/minimal), 2 shapes (square/rounded), 13 colors, 5 statuses
- Bold emphasis uses color-specific backgrounds with white text (yellow gets dark text); subtle uses gray bg; minimal uses border-only
- 62 tests passing, 8 Storybook stories, type check clean
- Uses foundation tokens via `colorVar()` and `semanticVar()` for all colors
- CSS prefix: `--ui-badge-*` with consumer override vars for bg, color, border