### PR TITLE
feat: add root-level Storybook aggregating all packages

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,12 +4,14 @@ on:
   push:
     branches: [main]
     paths:
+      - '.storybook/**'
       - 'packages/ui-components/**'
       - 'packages/foundation/**'
       - '.github/workflows/chromatic.yml'
   pull_request:
     branches: [main]
     paths:
+      - '.storybook/**'
       - 'packages/ui-components/**'
       - 'packages/foundation/**'
       - '.github/workflows/chromatic.yml'
@@ -37,5 +39,4 @@ jobs:
         uses: chromaui/action@latest
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          workingDir: packages/ui-components
           buildScriptName: storybook:build

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,14 @@
+import type { StorybookConfig } from "@storybook/web-components-vite";
+
+const config: StorybookConfig = {
+  stories: [
+    "../packages/foundation/src/**/*.stories.ts",
+    "../packages/ui-components/src/**/*.stories.ts",
+  ],
+  framework: {
+    name: "@storybook/web-components-vite",
+    options: {},
+  },
+};
+
+export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,18 @@
+import type { Preview } from "@storybook/web-components";
+import { injectAllTokens } from "@maneki/foundation";
+
+// Inject foundation design tokens as CSS custom properties on :root
+injectAllTokens();
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,10 @@ maneki-monorepo/
 ├── .moon/
 │   ├── workspace.yml        # projects: apps/*, packages/*
 │   └── toolchains.yml       # npm package manager
-├── package.json             # npm workspaces root (required by npm, not Moon)
+├── .storybook/              # Root Storybook config (aggregates all packages)
+│   ├── main.ts              # stories from foundation + ui-components
+│   └── preview.ts           # injects tokens + registers components
+├── package.json             # npm workspaces root + Storybook scripts
 ├── packages/
 │   ├── grid-layout/         # <grid-layout> Web Component library (@maneki/grid-layout)
 │   ├── ui-components/       # UI components + Storybook (@maneki/ui-components)
@@ -30,6 +33,7 @@ maneki-monorepo/
 | Design tokens (colors, spacing, type) | `packages/foundation/` | Extracted from Figma |
 | UI components + Storybook | `packages/ui-components/` | Web Components with stories |
 | Grid layout library | `packages/grid-layout/` | Has its own detailed AGENTS.md |
+| Storybook (all packages) | `.storybook/` | Root-level, aggregates foundation + ui-components |
 
 ## CONVENTIONS
 - **Zero runtime deps** (except `ui-components` → `@maneki/foundation`). Grid-layout and foundation have zero production dependencies.
@@ -61,6 +65,10 @@ moon run <pkg>:build         # Build a specific package
 moon run <pkg>:test          # Test a specific package
 moon check --all             # Run all tasks across all packages
 
+# Root Storybook (all packages)
+npm run storybook            # Dev server on port 6006
+npm run storybook:build      # Static build → storybook-static/
+
 # Per-package (run from package dir)
 npx vitest --run             # Unit tests
 npx tsc --noEmit             # Type check
@@ -69,8 +77,8 @@ npx vite build               # Build
 
 ## NOTES
 - Git repo: `maneki-technology/monorepo` on GitHub
-- CI/CD: Chromatic for Storybook visual review (`.github/workflows/chromatic.yml`)
+- CI/CD: Chromatic for Storybook visual review (`.github/workflows/chromatic.yml`). Storybook: https://www.chromatic.com/builds?appId=69ac56bb2124263f2f04fadc
 - `apps/` directory exists but is empty — reserved for future consumer apps
-- Root `package.json` exists solely for npm workspaces — Moon handles task orchestration
+- Root `package.json` has Storybook scripts (`storybook`, `storybook:build`) and devDependencies for the root-level Storybook
 - Node pinned at 22 because Storybook 10 requires Node 20.19+
 - LSP diagnostics unavailable (no global typescript-language-server) — use `npx tsc --noEmit` instead

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Design system monorepo with Web Components and design tokens extracted from Figm
 maneki-monorepo/
 ├── .prototools              # node 22.16.0, moon 2.0.4
 ├── .moon/                   # Moon workspace + toolchain config
-├── package.json             # npm workspaces root
+├── .storybook/              # Root Storybook config (aggregates all packages)
+├── package.json             # npm workspaces root + Storybook scripts
 ├── packages/
 │   ├── foundation/          # Design tokens (@maneki/foundation)
 │   ├── ui-components/       # Web Components + Storybook (@maneki/ui-components)
@@ -35,7 +36,7 @@ maneki-monorepo/
 | Package | npm name | Description |
 |---|---|---|
 | `foundation` | `@maneki/foundation` | Design tokens: 131 colors, semantic tokens, typography, spacing, elevation, responsive breakpoints |
-| `ui-components` | `@maneki/ui-components` | Web Components (`<ui-button>`) with Storybook 10 |
+| `ui-components` | `@maneki/ui-components` | 19 Web Components (button, accordion, alert, avatar, breadcrumb, card, checkbox, dropdown, modal, badge) with Storybook 10 |
 | `grid-layout` | `@maneki/grid-layout` | Zero-dep drag/resize grid layout (220 tests) |
 
 ---
@@ -56,6 +57,10 @@ moon check --all
 moon run foundation:test
 moon run ui-components:test
 moon run grid-layout:test
+
+# Storybook (all packages)
+npm run storybook            # Dev server on port 6006
+npm run storybook:build      # Static build → storybook-static/
 ```
 
 ---
@@ -64,10 +69,14 @@ moon run grid-layout:test
 
 - Zero runtime dependencies (except ui-components depends on foundation)
 - Web Components with Shadow DOM
-- CSS custom properties, prefixed per package: `--fd-*`, `--grid-*`
+- CSS custom properties, prefixed per package: `--fd-*`, `--ui-*`, `--grid-*`
 - TypeScript strict mode, ES2022 target
 - Tests co-located: `foo.ts` → `foo.test.ts`
 - Moon tasks in kebab-case: `build`, `test`, `test-watch`, `dev`, `storybook`
+
+## Storybook
+
+Published to Chromatic: https://www.chromatic.com/builds?appId=69ac56bb2124263f2f04fadc
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,14 @@
       "workspaces": [
         "apps/*",
         "packages/*"
-      ]
+      ],
+      "devDependencies": {
+        "@storybook/web-components": "^10.2.16",
+        "@storybook/web-components-vite": "^10.2.16",
+        "chromatic": "^15.2.0",
+        "lit": "^3.3.2",
+        "storybook": "^10.2.16"
+      }
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
@@ -561,7 +568,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.59.0",
@@ -575,7 +583,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.59.0",
@@ -589,7 +598,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.59.0",
@@ -603,7 +613,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.59.0",
@@ -617,7 +628,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.59.0",
@@ -631,7 +643,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.59.0",
@@ -645,7 +658,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.59.0",
@@ -659,7 +673,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.59.0",
@@ -673,7 +688,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.59.0",
@@ -687,7 +703,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.59.0",
@@ -701,7 +718,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.59.0",
@@ -715,7 +733,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.59.0",
@@ -729,7 +748,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.59.0",
@@ -743,7 +763,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.59.0",
@@ -757,7 +778,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.59.0",
@@ -771,7 +793,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.59.0",
@@ -785,7 +808,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.59.0",
@@ -799,7 +823,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.59.0",
@@ -813,7 +838,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.59.0",
@@ -827,7 +853,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.59.0",
@@ -841,7 +868,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.59.0",
@@ -855,7 +883,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.59.0",
@@ -869,7 +898,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.59.0",
@@ -883,7 +913,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.59.0",
@@ -897,7 +928,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@storybook/builder-vite": {
       "version": "10.2.16",
@@ -2361,6 +2393,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -4,5 +4,16 @@
   "workspaces": [
     "apps/*",
     "packages/*"
-  ]
+  ],
+  "scripts": {
+    "storybook": "storybook dev -p 6006",
+    "storybook:build": "storybook build -o storybook-static"
+  },
+  "devDependencies": {
+    "@storybook/web-components": "^10.2.16",
+    "@storybook/web-components-vite": "^10.2.16",
+    "chromatic": "^15.2.0",
+    "lit": "^3.3.2",
+    "storybook": "^10.2.16"
+  }
 }

--- a/packages/foundation/.storybook/main.ts
+++ b/packages/foundation/.storybook/main.ts
@@ -1,0 +1,11 @@
+import type { StorybookConfig } from "@storybook/web-components-vite";
+
+const config: StorybookConfig = {
+  stories: ["../src/**/*.stories.ts"],
+  framework: {
+    name: "@storybook/web-components-vite",
+    options: {},
+  },
+};
+
+export default config;

--- a/packages/foundation/.storybook/preview.ts
+++ b/packages/foundation/.storybook/preview.ts
@@ -1,0 +1,18 @@
+import type { Preview } from "@storybook/web-components";
+import { injectAllTokens } from "../src/index.js";
+
+// Inject all foundation tokens so stories can reference CSS custom properties
+injectAllTokens();
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/packages/foundation/AGENTS.md
+++ b/packages/foundation/AGENTS.md
@@ -6,6 +6,9 @@ Design tokens extracted from the "Foundation UI Kit (Community)" Figma file. Gen
 ## STRUCTURE
 ```
 foundation/
+├── .storybook/
+│   ├── main.ts              # @storybook/web-components-vite
+│   └── preview.ts           # imports injectAllTokens()
 └── src/
     ├── index.ts              # Barrel export (all modules)
     ├── colors.ts             # 131 palette tokens (13 families × 10 steps + gray-110)
@@ -15,7 +18,13 @@ foundation/
     ├── breakpoints.ts        # 3 density variants (compact/standard/spacious) × 7 breakpoints + helpers
     ├── tokens.ts             # CSS custom property generators + var() helpers
     ├── tokens.test.ts        # 28 tests
-    └── breakpoints.test.ts   # 27 tests
+    ├── breakpoints.test.ts   # 27 tests
+    └── stories/
+        ├── colors.stories.ts           # Color palette grid (13 families × 10-11 steps)
+        ├── semantic-tokens.stories.ts  # Surface, border, text, icon, global, status
+        ├── typography.stories.ts       # All 7 typography groups with live samples
+        ├── spacing.stories.ts          # Visual spacing scale (17 steps)
+        └── elevation.stories.ts        # Elevation levels with box-shadow samples
 ```
 
 ## WHERE TO LOOK
@@ -68,3 +77,11 @@ var() helpers — colorVar(), semanticVar(), elevationVar(), typeVar(), spaceVar
 - **Don't hardcode color values in components** — use `colorVar()` / `semanticVar()` helpers
 - **Don't add tokens not in Figma** — this is a faithful extraction, not a creative exercise
 - **Don't forget to update `injectAllTokens()`** when adding a new token category
+
+## COMMANDS
+```bash
+moon run foundation:storybook       # Dev server on port 6007
+moon run foundation:storybook-build  # Static build
+moon run foundation:test            # vitest --run (55 tests)
+moon run foundation:build           # vite build + tsc --emitDeclarationOnly
+```

--- a/packages/foundation/moon.yml
+++ b/packages/foundation/moon.yml
@@ -24,3 +24,15 @@ tasks:
     inputs:
       - 'src/**/*'
     preset: 'server'
+
+  storybook:
+    command: 'storybook dev -p 6007'
+    preset: 'server'
+
+  storybook-build:
+    command: 'storybook build -o storybook-static'
+    inputs:
+      - 'src/**/*'
+      - '.storybook/**/*'
+    outputs:
+      - 'storybook-static'

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -12,10 +12,16 @@
   "scripts": {
     "build": "vite build && tsc --emitDeclarationOnly",
     "test": "vitest --run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "storybook": "storybook dev -p 6007",
+    "storybook:build": "storybook build -o storybook-static"
   },
   "devDependencies": {
+    "@storybook/web-components": "^10.2.16",
+    "@storybook/web-components-vite": "^10.2.16",
     "happy-dom": "^17.6.1",
+    "lit": "^3.3.2",
+    "storybook": "^10.2.16",
     "typescript": "^5.4.0",
     "vite": "^5.4.0",
     "vitest": "^3.2.4"

--- a/packages/foundation/src/stories/colors.stories.ts
+++ b/packages/foundation/src/stories/colors.stories.ts
@@ -1,0 +1,123 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import { colors } from "../colors.js";
+import { injectAllTokens } from "../tokens.js";
+
+const meta: Meta = {
+  title: "Foundation/Colors",
+};
+export default meta;
+type Story = StoryObj;
+
+export const Palette: Story = {
+  render: () => {
+    injectAllTokens();
+
+    const families = Object.keys(colors) as (keyof typeof colors)[];
+    const allSteps = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110];
+
+    return html`
+      <style>
+        .color-grid {
+          font-family: system-ui, sans-serif;
+          font-size: 11px;
+          color: #1c2b36;
+        }
+        .color-grid table {
+          border-collapse: collapse;
+          width: 100%;
+        }
+        .color-grid th {
+          padding: 6px 8px;
+          text-align: center;
+          font-weight: 500;
+          color: #5b7282;
+          font-size: 11px;
+          letter-spacing: 0.03em;
+        }
+        .color-grid th:first-child {
+          text-align: left;
+          min-width: 100px;
+        }
+        .color-grid td {
+          padding: 4px;
+          text-align: center;
+          vertical-align: top;
+        }
+        .color-grid td:first-child {
+          text-align: left;
+          font-weight: 500;
+          font-size: 12px;
+          padding-top: 14px;
+          text-transform: capitalize;
+        }
+        .swatch {
+          width: 48px;
+          height: 48px;
+          border-radius: 6px;
+          margin: 0 auto 4px;
+          border: 1px solid rgba(0,0,0,0.06);
+          transition: transform 0.15s ease;
+          cursor: default;
+        }
+        .swatch:hover {
+          transform: scale(1.12);
+        }
+        .swatch-label {
+          font-size: 10px;
+          color: #7a909e;
+          line-height: 1.3;
+        }
+        .swatch-var {
+          font-size: 9px;
+          color: #9fb1bd;
+          font-family: monospace;
+          display: none;
+        }
+        td:hover .swatch-var {
+          display: block;
+        }
+        .empty-cell {
+          width: 48px;
+          height: 48px;
+        }
+      </style>
+      <div class="color-grid">
+        <table>
+          <thead>
+            <tr>
+              <th></th>
+              ${allSteps.map((s) => html`<th>${s}</th>`)}
+            </tr>
+          </thead>
+          <tbody>
+            ${families.map((family) => {
+              const steps = colors[family] as Record<number, string>;
+              return html`
+                <tr>
+                  <td>${family}</td>
+                  ${allSteps.map((step) => {
+                    const hex = steps[step];
+                    if (!hex) {
+                      return html`<td><div class="empty-cell"></div></td>`;
+                    }
+                    return html`
+                      <td>
+                        <div
+                          class="swatch"
+                          style="background-color: ${hex};"
+                        ></div>
+                        <div class="swatch-label">${hex}</div>
+                        <div class="swatch-var">--fd-color-${family}-${step}</div>
+                      </td>
+                    `;
+                  })}
+                </tr>
+              `;
+            })}
+          </tbody>
+        </table>
+      </div>
+    `;
+  },
+};

--- a/packages/foundation/src/stories/elevation.stories.ts
+++ b/packages/foundation/src/stories/elevation.stories.ts
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import { elevation } from "../semantic-tokens.js";
+import { injectAllTokens } from "../tokens.js";
+
+const meta: Meta = {
+  title: "Foundation/Elevation",
+};
+export default meta;
+type Story = StoryObj;
+
+export const Levels: Story = {
+  render: () => {
+    injectAllTokens();
+
+    const levels = Object.entries(elevation) as [
+      string,
+      { boxShadow: string },
+    ][];
+
+    return html`
+      <style>
+        .elevation-container {
+          font-family: system-ui, sans-serif;
+          color: #1c2b36;
+          padding: 32px;
+          background: #f2f5f7;
+          border-radius: 12px;
+        }
+        .elevation-grid {
+          display: grid;
+          grid-template-columns: repeat(3, 1fr);
+          gap: 32px;
+        }
+        .elevation-card {
+          background: #ffffff;
+          border-radius: 10px;
+          padding: 24px;
+          min-height: 120px;
+          display: flex;
+          flex-direction: column;
+          justify-content: space-between;
+          transition: transform 0.2s ease;
+        }
+        .elevation-card:hover {
+          transform: translateY(-2px);
+        }
+        .elevation-level {
+          font-size: 20px;
+          font-weight: 600;
+          color: #1c2b36;
+          margin-bottom: 8px;
+        }
+        .elevation-var {
+          font-size: 11px;
+          font-family: monospace;
+          color: #5b7282;
+          margin-bottom: 12px;
+        }
+        .elevation-shadow {
+          font-size: 10px;
+          font-family: monospace;
+          color: #9fb1bd;
+          line-height: 1.5;
+          word-break: break-all;
+        }
+      </style>
+      <div class="elevation-container">
+        <div class="elevation-grid">
+          ${levels.map(
+            ([level, token]) => html`
+              <div
+                class="elevation-card"
+                style="box-shadow: ${token.boxShadow};"
+              >
+                <div>
+                  <div class="elevation-level">${level}</div>
+                  <div class="elevation-var">--fd-elevation-${level}</div>
+                </div>
+                <div class="elevation-shadow">${token.boxShadow}</div>
+              </div>
+            `,
+          )}
+        </div>
+      </div>
+    `;
+  },
+};

--- a/packages/foundation/src/stories/semantic-tokens.stories.ts
+++ b/packages/foundation/src/stories/semantic-tokens.stories.ts
@@ -1,0 +1,307 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html, nothing } from "lit";
+import {
+  surface,
+  border,
+  text,
+  icon,
+  global,
+  statusSurface,
+  statusText,
+  statusIcon,
+  statusGeneral,
+  resolveSemanticValue,
+  type SemanticValue,
+} from "../semantic-tokens.js";
+import { injectAllTokens } from "../tokens.js";
+
+const meta: Meta = {
+  title: "Foundation/Semantic Tokens",
+};
+export default meta;
+type Story = StoryObj;
+
+function toKebab(s: string): string {
+  return s.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
+}
+
+function renderColorSwatch(
+  name: string,
+  cssVar: string,
+  value: SemanticValue,
+  mode: "surface" | "border" | "text" | "icon",
+) {
+  const resolved = resolveSemanticValue(value);
+  const isLight =
+    resolved === "#ffffff" || resolved === "rgba(28, 43, 54, 0.8)";
+
+  if (mode === "surface") {
+    return html`
+      <div class="token-row">
+        <div
+          class="surface-swatch"
+          style="background-color: ${resolved}; ${isLight ? "border: 1px solid #dce3e8;" : ""}"
+        ></div>
+        <div class="token-info">
+          <div class="token-name">${name}</div>
+          <code class="token-var">${cssVar}</code>
+          <div class="token-value">${resolved}</div>
+        </div>
+      </div>
+    `;
+  }
+
+  if (mode === "border") {
+    return html`
+      <div class="token-row">
+        <div
+          class="border-swatch"
+          style="border: 2px solid ${resolved};"
+        ></div>
+        <div class="token-info">
+          <div class="token-name">${name}</div>
+          <code class="token-var">${cssVar}</code>
+          <div class="token-value">${resolved}</div>
+        </div>
+      </div>
+    `;
+  }
+
+  // text or icon
+  return html`
+    <div class="token-row">
+      <div class="text-swatch" style="color: ${resolved};">
+        ${mode === "icon" ? "★" : "Aa"}
+      </div>
+      <div class="token-info">
+        <div class="token-name">${name}</div>
+        <code class="token-var">${cssVar}</code>
+        <div class="token-value">${resolved}</div>
+      </div>
+    </div>
+  `;
+}
+
+function renderGroup(
+  tokens: Record<string, SemanticValue>,
+  prefix: string,
+  mode: "surface" | "border" | "text" | "icon",
+) {
+  return html`
+    <div class="token-grid">
+      ${Object.entries(tokens).map(([name, value]) => {
+        const cssVar = `--fd-${prefix}-${toKebab(name)}`;
+        return renderColorSwatch(name, cssVar, value, mode);
+      })}
+    </div>
+  `;
+}
+
+const sharedStyles = html`
+  <style>
+    .semantic-container {
+      font-family: system-ui, sans-serif;
+      color: #1c2b36;
+    }
+    .section-title {
+      font-size: 14px;
+      font-weight: 600;
+      margin: 0 0 16px;
+      color: #1c2b36;
+      letter-spacing: 0.02em;
+    }
+    .token-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 12px;
+      margin-bottom: 32px;
+    }
+    .token-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 8px;
+      border-radius: 8px;
+      background: #f8f9fa;
+    }
+    .surface-swatch {
+      width: 44px;
+      height: 44px;
+      border-radius: 6px;
+      flex-shrink: 0;
+    }
+    .border-swatch {
+      width: 44px;
+      height: 44px;
+      border-radius: 6px;
+      flex-shrink: 0;
+      background: #ffffff;
+    }
+    .text-swatch {
+      width: 44px;
+      height: 44px;
+      border-radius: 6px;
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 20px;
+      font-weight: 600;
+      background: #ffffff;
+      border: 1px solid #dce3e8;
+    }
+    .token-info {
+      min-width: 0;
+    }
+    .token-name {
+      font-size: 12px;
+      font-weight: 500;
+      margin-bottom: 2px;
+    }
+    .token-var {
+      font-size: 10px;
+      color: #5b7282;
+      display: block;
+      margin-bottom: 1px;
+    }
+    .token-value {
+      font-size: 10px;
+      color: #9fb1bd;
+      font-family: monospace;
+    }
+    .status-section {
+      margin-bottom: 24px;
+    }
+    .status-label {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: #7a909e;
+      margin-bottom: 8px;
+    }
+  </style>
+`;
+
+export const Surface: Story = {
+  render: () => {
+    injectAllTokens();
+    return html`
+      ${sharedStyles}
+      <div class="semantic-container">
+        <p class="section-title">Surface</p>
+        ${renderGroup(surface, "surface", "surface")}
+      </div>
+    `;
+  },
+};
+
+export const Border: Story = {
+  render: () => {
+    injectAllTokens();
+    return html`
+      ${sharedStyles}
+      <div class="semantic-container">
+        <p class="section-title">Border</p>
+        ${renderGroup(border, "border", "border")}
+      </div>
+    `;
+  },
+};
+
+export const Text: Story = {
+  render: () => {
+    injectAllTokens();
+    return html`
+      ${sharedStyles}
+      <div class="semantic-container">
+        <p class="section-title">Text</p>
+        ${renderGroup(text, "text", "text")}
+      </div>
+    `;
+  },
+};
+
+export const Icon: Story = {
+  render: () => {
+    injectAllTokens();
+    return html`
+      ${sharedStyles}
+      <div class="semantic-container">
+        <p class="section-title">Icon</p>
+        ${renderGroup(icon, "icon", "icon")}
+      </div>
+    `;
+  },
+};
+
+export const Global: Story = {
+  render: () => {
+    injectAllTokens();
+    return html`
+      ${sharedStyles}
+      <div class="semantic-container">
+        <p class="section-title">Global</p>
+        ${renderGroup(global, "global", "surface")}
+      </div>
+    `;
+  },
+};
+
+export const Status: Story = {
+  render: () => {
+    injectAllTokens();
+
+    const renderStatusGroup = (
+      label: string,
+      tokens: Record<string, SemanticValue>,
+      prefix: string,
+      mode: "surface" | "border" | "text" | "icon",
+    ) => {
+      const bold: Record<string, SemanticValue> = {};
+      const subtle: Record<string, SemanticValue> = {};
+      const other: Record<string, SemanticValue> = {};
+
+      for (const [k, v] of Object.entries(tokens)) {
+        const kl = k.toLowerCase();
+        if (kl.includes("bold")) bold[k] = v;
+        else if (kl.includes("subtle")) subtle[k] = v;
+        else other[k] = v;
+      }
+
+      return html`
+        <div class="status-section">
+          <p class="section-title">${label}</p>
+          ${Object.keys(other).length > 0
+            ? html`
+                <div class="status-label">Base</div>
+                ${renderGroup(other, prefix, mode)}
+              `
+            : nothing}
+          ${Object.keys(bold).length > 0
+            ? html`
+                <div class="status-label">Bold</div>
+                ${renderGroup(bold, prefix, mode)}
+              `
+            : nothing}
+          ${Object.keys(subtle).length > 0
+            ? html`
+                <div class="status-label">Subtle</div>
+                ${renderGroup(subtle, prefix, mode)}
+              `
+            : nothing}
+        </div>
+      `;
+    };
+
+    return html`
+      ${sharedStyles}
+      <div class="semantic-container">
+        ${renderStatusGroup("Status — General", statusGeneral, "status-general", "surface")}
+        ${renderStatusGroup("Status — Surface", statusSurface, "status-surface", "surface")}
+        ${renderStatusGroup("Status — Text", statusText, "status-text", "text")}
+        ${renderStatusGroup("Status — Icon", statusIcon, "status-icon", "icon")}
+      </div>
+    `;
+  },
+};

--- a/packages/foundation/src/stories/spacing.stories.ts
+++ b/packages/foundation/src/stories/spacing.stories.ts
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import { spacing } from "../spacing.js";
+import { injectAllTokens } from "../tokens.js";
+
+const meta: Meta = {
+  title: "Foundation/Spacing",
+};
+export default meta;
+type Story = StoryObj;
+
+function spaceKey(step: string): string {
+  return step.replace(/\./g, "-");
+}
+
+export const Scale: Story = {
+  render: () => {
+    injectAllTokens();
+
+    const steps = Object.entries(spacing) as [string, number][];
+
+    return html`
+      <style>
+        .spacing-container {
+          font-family: system-ui, sans-serif;
+          color: #1c2b36;
+          max-width: 720px;
+        }
+        .spacing-row {
+          display: flex;
+          align-items: center;
+          gap: 16px;
+          padding: 6px 0;
+        }
+        .spacing-label {
+          font-size: 12px;
+          font-weight: 500;
+          min-width: 48px;
+          text-align: right;
+          color: #3e5463;
+        }
+        .spacing-bar-track {
+          flex: 1;
+          position: relative;
+          height: 24px;
+          background: #f2f5f7;
+          border-radius: 4px;
+          overflow: hidden;
+        }
+        .spacing-bar {
+          height: 100%;
+          background: #186ade;
+          border-radius: 4px;
+          min-width: 1px;
+          transition: width 0.3s ease;
+        }
+        .spacing-value {
+          font-size: 11px;
+          color: #7a909e;
+          min-width: 56px;
+          font-family: monospace;
+        }
+        .spacing-var {
+          font-size: 10px;
+          color: #9fb1bd;
+          font-family: monospace;
+          min-width: 130px;
+        }
+      </style>
+      <div class="spacing-container">
+        ${steps.map(
+          ([step, value]) => html`
+            <div class="spacing-row">
+              <span class="spacing-label">${step}</span>
+              <div class="spacing-bar-track">
+                <div
+                  class="spacing-bar"
+                  style="width: ${Math.min((value / 80) * 100, 100)}%;"
+                ></div>
+              </div>
+              <span class="spacing-value">${value}px</span>
+              <span class="spacing-var">--fd-space-${spaceKey(step)}</span>
+            </div>
+          `,
+        )}
+      </div>
+    `;
+  },
+};

--- a/packages/foundation/src/stories/typography.stories.ts
+++ b/packages/foundation/src/stories/typography.stories.ts
@@ -1,0 +1,127 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import { typography, type TypeToken } from "../typography.js";
+import { injectAllTokens } from "../tokens.js";
+
+const meta: Meta = {
+  title: "Foundation/Typography",
+};
+export default meta;
+type Story = StoryObj;
+
+const groupLabels: Record<string, string> = {
+  display: "Display",
+  heading: "Heading",
+  body: "Body",
+  ui: "UI",
+  caption: "Caption",
+  badge: "Badge",
+  code: "Code",
+};
+
+export const TypeScale: Story = {
+  render: () => {
+    injectAllTokens();
+
+    const groups = Object.entries(typography) as [
+      string,
+      Record<string, TypeToken>,
+    ][];
+
+    return html`
+      <style>
+        .type-container {
+          font-family: system-ui, sans-serif;
+          color: #1c2b36;
+        }
+        .type-group {
+          margin-bottom: 40px;
+        }
+        .group-header {
+          font-size: 11px;
+          font-weight: 600;
+          text-transform: uppercase;
+          letter-spacing: 0.08em;
+          color: #7a909e;
+          margin: 0 0 16px;
+          padding-bottom: 8px;
+          border-bottom: 1px solid #dce3e8;
+        }
+        .type-row {
+          display: grid;
+          grid-template-columns: 1fr 280px;
+          align-items: baseline;
+          gap: 24px;
+          padding: 12px 0;
+          border-bottom: 1px solid #f2f5f7;
+        }
+        .type-sample {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+        .type-meta {
+          display: flex;
+          gap: 16px;
+          align-items: baseline;
+          font-size: 11px;
+          color: #7a909e;
+          flex-shrink: 0;
+        }
+        .meta-key {
+          font-weight: 500;
+          color: #3e5463;
+          min-width: 70px;
+        }
+        .meta-detail {
+          font-family: monospace;
+          font-size: 10px;
+          color: #9fb1bd;
+        }
+        .meta-usage {
+          font-size: 10px;
+          color: #9fb1bd;
+          margin-top: 4px;
+          font-style: italic;
+        }
+      </style>
+      <div class="type-container">
+        ${groups.map(
+          ([group, tokens]) => html`
+            <div class="type-group">
+              <p class="group-header">${groupLabels[group] ?? group}</p>
+              ${Object.entries(tokens).map(([key, token]) => {
+                const t = token as TypeToken;
+                return html`
+                  <div class="type-row">
+                    <div
+                      class="type-sample"
+                      style="
+                        font-family: ${t.fontFamily};
+                        font-size: ${t.fontSize}px;
+                        line-height: ${t.lineHeight}px;
+                        font-weight: ${t.fontWeight};
+                      "
+                    >
+                      The quick brown fox jumps
+                    </div>
+                    <div>
+                      <div class="type-meta">
+                        <span class="meta-key">${group}/${key}</span>
+                        <span class="meta-detail"
+                          >${t.fontSize}px / ${t.lineHeight}px ·
+                          ${t.fontWeight}</span
+                        >
+                      </div>
+                      <div class="meta-usage">${t.usage}</div>
+                    </div>
+                  </div>
+                `;
+              })}
+            </div>
+          `,
+        )}
+      </div>
+    `;
+  },
+};


### PR DESCRIPTION
## Summary
- Add root-level Storybook that aggregates stories from both `foundation` and `ui-components` packages
- Foundation token stories: Colors palette, Semantic tokens, Typography, Spacing, Elevation
- Foundation gets its own `.storybook/` config + moon tasks (`storybook` on port 6007, `storybook-build`)
- Root `.storybook/` config pulls stories from `packages/foundation/src/**/*.stories.ts` and `packages/ui-components/src/**/*.stories.ts`
- Root `package.json` gets Storybook scripts + devDependencies
- Chromatic workflow updated to use root Storybook (removes `workingDir: packages/ui-components`), adds `.storybook/**` to path triggers
- Supersedes PR #18 (`feat/foundation-storybook`)