### PR TITLE
feat: add Storybook stories for grid-layout + wire foundation tokens

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -4,6 +4,7 @@ const config: StorybookConfig = {
   stories: [
     "../packages/foundation/src/**/*.stories.ts",
     "../packages/ui-components/src/**/*.stories.ts",
+    "../packages/grid-layout/src/**/*.stories.ts",
   ],
   framework: {
     name: "@storybook/web-components-vite",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ maneki-monorepo/
 │   ├── workspace.yml        # projects: apps/*, packages/*
 │   └── toolchains.yml       # npm package manager
 ├── .storybook/              # Root Storybook config (aggregates all packages)
-│   ├── main.ts              # stories from foundation + ui-components
+│   ├── main.ts              # stories from foundation + ui-components + grid-layout
 │   └── preview.ts           # injects tokens + registers components
 ├── package.json             # npm workspaces root + Storybook scripts
 ├── packages/
@@ -33,10 +33,10 @@ maneki-monorepo/
 | Design tokens (colors, spacing, type) | `packages/foundation/` | Extracted from Figma |
 | UI components + Storybook | `packages/ui-components/` | Web Components with stories |
 | Grid layout library | `packages/grid-layout/` | Has its own detailed AGENTS.md |
-| Storybook (all packages) | `.storybook/` | Root-level, aggregates foundation + ui-components |
+| Storybook (all packages) | `.storybook/` | Root-level, aggregates foundation + ui-components + grid-layout |
 
 ## CONVENTIONS
-- **Zero runtime deps** (except `ui-components` → `@maneki/foundation`). Grid-layout and foundation have zero production dependencies.
+- **Zero runtime deps** (except `ui-components` and `grid-layout` → `@maneki/foundation`). Foundation has zero production dependencies.
 - **Web Components + Shadow DOM.** All UI is custom elements with `attachShadow({ mode: "open" })`.
 - **CSS custom properties.** Each package has its own prefix: `--grid-*` (grid-layout), `--fd-*` (foundation), `--ui-*` (ui-components).
 - **Package naming.** npm: `@maneki/*` scope (e.g., `@maneki/foundation`, `@maneki/ui-components`, `@maneki/grid-layout`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -2558,7 +2558,11 @@
       "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
+        "@storybook/web-components": "^10.2.16",
+        "@storybook/web-components-vite": "^10.2.16",
         "happy-dom": "^17.6.1",
+        "lit": "^3.3.2",
+        "storybook": "^10.2.16",
         "typescript": "^5.4.0",
         "vite": "^5.4.0",
         "vitest": "^3.2.4"
@@ -2568,6 +2572,9 @@
       "name": "@maneki/grid-layout",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@maneki/foundation": "*"
+      },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "happy-dom": "^17.6.1",

--- a/packages/grid-layout/AGENTS.md
+++ b/packages/grid-layout/AGENTS.md
@@ -9,6 +9,7 @@ Zero-dependency Web Component grid layout library (`<grid-layout>`, `<grid-item>
 ├── src/
 │   ├── core/          # Pure logic engine (no DOM). Types, math, collision, compaction, layout engine, responsive utils
 │   ├── components/    # Web Components with Shadow DOM. grid-item, grid-layout, responsive-grid-layout
+│   ├── stories/       # Storybook stories (basic, compaction, resize-handles, responsive, theming, accessibility)
 │   └── index.ts       # Barrel export — all types, utilities, and components
 ├── e2e/
 │   ├── fixtures.html  # Test fixture page with 8 grid scenarios
@@ -36,7 +37,8 @@ Zero-dependency Web Component grid layout library (`<grid-layout>`, `<grid-item>
 | Accessibility / ARIA | `grid-item.ts` (role, tabindex, aria-grabbed) + `grid-layout.ts` (role, live region, keyboard handlers) |
 
 ## CONVENTIONS
-- **No dependencies.** Zero runtime deps. Only devDeps: typescript, vite, vitest, happy-dom, @playwright/test.
+- **`@maneki/foundation` is a production dependency.** Components import `colorVar`, `semanticVar` from foundation and use them as CSS custom property fallbacks in the nested `var(--grid-*, ${token})` pattern.
+- **Custom element spec compliance.** Never set attributes in constructors — use `connectedCallback` instead. `GridLayoutElement` sets `role="grid"` and `aria-roledescription` in `connectedCallback` with a guard (`if (!this.hasAttribute("role"))`). Violating this causes `NotSupportedError` when elements are created via `document.createElement` during Lit template cloning.
 - **Shadow DOM everywhere.** All three components use `attachShadow({ mode: "open" })`.
 - **CSS custom properties** use `--grid-*` prefix. Defined inline in component style constants, not external CSS.
 - **Lifecycle hooks** are JS property setters (not attributes). Return `false` to cancel/reject.
@@ -73,3 +75,7 @@ npm run test:visual:update  # regenerate baseline snapshots
 - `grid-layout.ts` is the largest file (~923 lines) — contains drag/resize, keyboard nav, external drop, and ARIA logic
 - Keyboard state tracked via `_kbDragActive`, `_kbResizeActive`, `_kbFocusedItemId`, `_kbOldLayout` private fields
 - External drop state tracked via `_isDroppable`, `_droppingItem`, `_externalDragOver`, `_externalPlaceholderItem` private fields
+- Storybook stories in `src/stories/` — 6 files, 16 stories covering basic usage, compaction modes, resize handles, responsive breakpoints, CSS theming (with foundation tokens), and accessibility
+- Stories use `import type` + side-effect `import "../components/grid-layout.js"` pattern — named imports get tree-shaken by Vite if only used as TypeScript type generics
+- Storybook keyboard shortcuts (S, A, D, etc.) can intercept keys before they reach the iframe — click inside the story preview first to give the iframe focus
+- `responsive-grid-layout.ts` `layouts` setter directly applies layout for current breakpoint instead of going through `onWidthChange` — fixes race condition where ResizeObserver fires before `setTimeout(0)` sets layouts

--- a/packages/grid-layout/package.json
+++ b/packages/grid-layout/package.json
@@ -18,6 +18,9 @@
     "test:visual": "playwright test",
     "test:visual:update": "playwright test --update-snapshots"
   },
+  "dependencies": {
+    "@maneki/foundation": "*"
+  },
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "happy-dom": "^17.6.1",

--- a/packages/grid-layout/src/components/grid-item.ts
+++ b/packages/grid-layout/src/components/grid-item.ts
@@ -1,4 +1,10 @@
 import type { ResizeHandleAxis } from "../core/types";
+import { colorVar, semanticVar } from "@maneki/foundation";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const BLUE_60 = colorVar("blue", 60);
+const BORDER_BOLD = semanticVar("border", "bold");
 
 const GRID_ITEM_STYLES = `
 :host {
@@ -11,7 +17,7 @@ const GRID_ITEM_STYLES = `
   contain: layout style;
 }
 :host(:focus-visible) {
-  outline: 2px solid var(--grid-focus-ring-color, #4a90d9);
+  outline: 2px solid var(--grid-focus-ring-color, ${BLUE_60});
   outline-offset: -2px;
   z-index: 2;
 }
@@ -99,8 +105,8 @@ const GRID_ITEM_STYLES = `
   bottom: var(--grid-handle-indicator-offset, 3px);
   width: var(--grid-handle-indicator-size, 5px);
   height: var(--grid-handle-indicator-size, 5px);
-  border-right: 2px solid var(--grid-handle-color, rgba(0, 0, 0, 0.4));
-  border-bottom: 2px solid var(--grid-handle-color, rgba(0, 0, 0, 0.4));
+  border-right: 2px solid var(--grid-handle-color, ${BORDER_BOLD});
+  border-bottom: 2px solid var(--grid-handle-color, ${BORDER_BOLD});
 }
 `;
 

--- a/packages/grid-layout/src/components/grid-layout.ts
+++ b/packages/grid-layout/src/components/grid-layout.ts
@@ -1,3 +1,4 @@
+import { semanticVar } from "@maneki/foundation";
 import type {
   LayoutItem,
   Layout,
@@ -36,6 +37,11 @@ import { moveElement } from "../core/layout-engine";
 import { compact, correctBounds } from "../core/compact";
 import { GridItemElement } from "./grid-item";
 
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+const SURFACE_SECONDARY = semanticVar("surface", "secondary");
+const BORDER_MINIMAL = semanticVar("border", "minimal");
+
 const GRID_LAYOUT_STYLES = `
 :host {
   display: block;
@@ -47,8 +53,8 @@ const GRID_LAYOUT_STYLES = `
 }
 .placeholder {
   position: absolute;
-  background: var(--grid-placeholder-bg, rgba(0, 0, 0, 0.1));
-  border: var(--grid-placeholder-border, 2px dashed rgba(0, 0, 0, 0.3));
+  background: var(--grid-placeholder-bg, ${SURFACE_SECONDARY});
+  border: var(--grid-placeholder-border, 2px dashed ${BORDER_MINIMAL});
   border-radius: var(--grid-placeholder-radius, 4px);
   transition:
     transform var(--grid-placeholder-transition-duration, 0.15s) var(--grid-placeholder-transition-easing, ease),
@@ -169,8 +175,6 @@ export class GridLayoutElement extends HTMLElement {
   constructor() {
     super();
     this._shadow = this.attachShadow({ mode: "open" });
-    this.setAttribute("role", "grid");
-    this.setAttribute("aria-roledescription", "draggable grid");
 
     const style = document.createElement("style");
     style.textContent = GRID_LAYOUT_STYLES;
@@ -289,6 +293,11 @@ export class GridLayoutElement extends HTMLElement {
   // --- Lifecycle ---
 
   connectedCallback(): void {
+    // ARIA roles (must be in connectedCallback, not constructor, per custom element spec)
+    if (!this.hasAttribute("role")) {
+      this.setAttribute("role", "grid");
+      this.setAttribute("aria-roledescription", "draggable grid");
+    }
     this.addEventListener("pointerdown", this._onPointerDown);
     this.addEventListener("keydown", this._onKeyDown);
     this.addEventListener("dragenter", this._onDragEnter);

--- a/packages/grid-layout/src/components/responsive-grid-layout.ts
+++ b/packages/grid-layout/src/components/responsive-grid-layout.ts
@@ -81,7 +81,18 @@ export class ResponsiveGridLayoutElement extends HTMLElement {
   set layouts(value: ResponsiveLayouts) {
     this._layouts = { ...value };
     if (this._mounted && this._currentBreakpoint) {
-      this.onWidthChange(this._containerWidth);
+      // Force-apply layout for current breakpoint (bypass onWidthChange early-return guard)
+      const cols = getColsFromBreakpoint(this._currentBreakpoint, this._cols);
+      const newLayout = findOrGenerateResponsiveLayout(
+        this._layouts,
+        this._breakpoints,
+        this._currentBreakpoint,
+        cols,
+        this._compactType
+      );
+      this._layouts[this._currentBreakpoint] = cloneLayout(newLayout);
+      this.syncInnerGridConfig(cols);
+      this._innerGrid.layout = newLayout;
     }
   }
 

--- a/packages/grid-layout/src/stories/accessibility.stories.ts
+++ b/packages/grid-layout/src/stories/accessibility.stories.ts
@@ -1,0 +1,265 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import type { GridLayoutElement } from "../components/grid-layout.js";
+import "../components/grid-layout.js";
+import "../components/grid-item.js";
+import { colorVar, semanticVar, injectAllTokens } from "@maneki/foundation";
+
+injectAllTokens();
+
+const meta: Meta = {
+  title: "Grid Layout/Accessibility",
+};
+export default meta;
+type Story = StoryObj;
+
+const COLORS = [
+  { bg: colorVar("red", 50), text: "#fff" },
+  { bg: colorVar("blue", 60), text: "#fff" },
+  { bg: colorVar("green", 50), text: "#fff" },
+  { bg: colorVar("purple", 60), text: "#fff" },
+];
+
+export const KeyboardNavigation: Story = {
+  render: () => {
+    setTimeout(() => {
+      const grid = document.querySelector<GridLayoutElement>("grid-layout#a11y-keyboard");
+      if (grid) {
+        grid.gridConfig = { cols: 12, rowHeight: 70, margin: [10, 10], containerPadding: [10, 10] };
+        grid.layout = [
+          { i: "k1", x: 0, y: 0, w: 4, h: 2 },
+          { i: "k2", x: 4, y: 0, w: 4, h: 2 },
+          { i: "k3", x: 8, y: 0, w: 4, h: 2 },
+          { i: "k4", x: 0, y: 2, w: 6, h: 2 },
+        ];
+      }
+    }, 0);
+
+    return html`
+      <style>
+        grid-layout#a11y-keyboard {
+          display: block;
+          width: 100%;
+          min-height: 350px;
+          border-radius: 8px;
+          background: ${semanticVar("surface", "secondary")};
+          --grid-focus-ring-color: ${colorVar("blue", 60)};
+        }
+        grid-item {
+          cursor: grab;
+        }
+        grid-item[dragging] {
+          cursor: grabbing;
+        }
+        .kb-instructions {
+          font-family: system-ui, sans-serif;
+          font-size: 13px;
+          color: ${colorVar("gray", 80)};
+          background: ${colorVar("gray", 10)};
+          border-radius: 8px;
+          padding: 16px 20px;
+          margin-bottom: 16px;
+          line-height: 1.7;
+        }
+        .kb-instructions code {
+          font-family: monospace;
+          font-size: 12px;
+          background: ${colorVar("gray", 20)};
+          padding: 2px 6px;
+          border-radius: 3px;
+          color: ${colorVar("gray", 90)};
+        }
+        .kb-instructions ol {
+          margin: 8px 0 0;
+          padding-left: 20px;
+        }
+        .kb-item {
+          border-radius: 6px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: system-ui, sans-serif;
+          font-size: 1rem;
+          font-weight: 600;
+          height: 100%;
+          box-sizing: border-box;
+          user-select: none;
+        }
+      </style>
+      <div class="kb-instructions">
+        Keyboard navigation flow:
+        <ol>
+          <li><code>Tab</code> to focus a grid item</li>
+          <li><code>Enter</code> or <code>Space</code> to grab it (drag mode)</li>
+          <li><code>Arrow keys</code> to move one cell at a time</li>
+          <li><code>Enter</code> to confirm placement</li>
+          <li><code>Escape</code> to cancel and revert</li>
+        </ol>
+        For resize: press <code>R</code> instead of Enter, then use arrows to grow/shrink.
+      </div>
+      <grid-layout id="a11y-keyboard">
+        ${["k1", "k2", "k3", "k4"].map(
+          (id, i) => html`
+            <grid-item item-id=${id}>
+              <div
+                class="kb-item"
+                style="background:${COLORS[i].bg};border:1px solid ${semanticVar("border", "minimal")};color:${COLORS[i].text}"
+              >
+                ${id}
+              </div>
+            </grid-item>
+          `,
+        )}
+      </grid-layout>
+    `;
+  },
+};
+
+export const AriaRoles: Story = {
+  render: () => {
+    setTimeout(() => {
+      const grid = document.querySelector<GridLayoutElement>("grid-layout#a11y-aria");
+      if (grid) {
+        grid.gridConfig = { cols: 12, rowHeight: 70, margin: [10, 10], containerPadding: [10, 10] };
+        grid.layout = [
+          { i: "a1", x: 0, y: 0, w: 6, h: 2 },
+          { i: "a2", x: 6, y: 0, w: 6, h: 2 },
+          { i: "a3", x: 0, y: 2, w: 4, h: 2, static: true },
+          { i: "a4", x: 4, y: 2, w: 8, h: 2 },
+        ];
+      }
+    }, 0);
+
+    return html`
+      <style>
+        grid-layout#a11y-aria {
+          display: block;
+          width: 100%;
+          min-height: 350px;
+          border-radius: 8px;
+          background: ${semanticVar("surface", "secondary")};
+        }
+        grid-item {
+          cursor: grab;
+        }
+        grid-item[dragging] {
+          cursor: grabbing;
+        }
+        .aria-table {
+          font-family: system-ui, sans-serif;
+          font-size: 13px;
+          border-collapse: collapse;
+          margin-bottom: 16px;
+          width: 100%;
+          max-width: 600px;
+        }
+        .aria-table th,
+        .aria-table td {
+          text-align: left;
+          padding: 6px 12px;
+          border: 1px solid ${semanticVar("border", "minimal")};
+        }
+        .aria-table th {
+          background: ${colorVar("gray", 10)};
+          color: ${colorVar("gray", 80)};
+          font-weight: 600;
+        }
+        .aria-table td {
+          color: ${semanticVar("text", "secondary")};
+        }
+        .aria-table code {
+          font-family: monospace;
+          font-size: 12px;
+          background: ${semanticVar("surface", "secondary")};
+          padding: 1px 4px;
+          border-radius: 2px;
+        }
+        .aria-item {
+          border-radius: 6px;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          font-family: system-ui, sans-serif;
+          height: 100%;
+          box-sizing: border-box;
+          user-select: none;
+          gap: 4px;
+        }
+        .aria-item__role {
+          font-size: 1rem;
+          font-weight: 600;
+        }
+        .aria-item__attr {
+          font-size: 11px;
+          font-family: monospace;
+          opacity: 0.7;
+        }
+      </style>
+      <table class="aria-table">
+        <thead>
+          <tr>
+            <th>Element</th>
+            <th>Role</th>
+            <th>Attributes</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>&lt;grid-layout&gt;</code></td>
+            <td><code>role="grid"</code></td>
+            <td><code>aria-roledescription="draggable grid"</code></td>
+          </tr>
+          <tr>
+            <td><code>&lt;grid-item&gt;</code></td>
+            <td><code>role="gridcell"</code></td>
+            <td><code>tabindex="0"</code>, <code>aria-grabbed="false"</code></td>
+          </tr>
+          <tr>
+            <td>Live region</td>
+            <td>—</td>
+            <td><code>aria-live="polite"</code> (announces drag/resize state)</td>
+          </tr>
+        </tbody>
+      </table>
+      <grid-layout id="a11y-aria">
+        <grid-item item-id="a1">
+          <div
+            class="aria-item"
+            style="background:${COLORS[0].bg};border:1px solid ${semanticVar("border", "minimal")};color:${COLORS[0].text}"
+          >
+            <span class="aria-item__role">gridcell</span>
+            <span class="aria-item__attr">tabindex="0" aria-grabbed</span>
+          </div>
+        </grid-item>
+        <grid-item item-id="a2">
+          <div
+            class="aria-item"
+            style="background:${COLORS[1].bg};border:1px solid ${semanticVar("border", "minimal")};color:${COLORS[1].text}"
+          >
+            <span class="aria-item__role">gridcell</span>
+            <span class="aria-item__attr">tabindex="0" aria-grabbed</span>
+          </div>
+        </grid-item>
+        <grid-item item-id="a3" static>
+          <div
+            class="aria-item"
+            style="background:${semanticVar("surface", "moderate")};border:2px dashed ${semanticVar("border", "subtle")};color:${semanticVar("text", "tertiary")}"
+          >
+            <span class="aria-item__role">gridcell (static)</span>
+            <span class="aria-item__attr">not draggable</span>
+          </div>
+        </grid-item>
+        <grid-item item-id="a4">
+          <div
+            class="aria-item"
+            style="background:${COLORS[3].bg};border:1px solid ${semanticVar("border", "minimal")};color:${COLORS[3].text}"
+          >
+            <span class="aria-item__role">gridcell</span>
+            <span class="aria-item__attr">tabindex="0" aria-grabbed</span>
+          </div>
+        </grid-item>
+      </grid-layout>
+    `;
+  },
+};

--- a/packages/grid-layout/src/stories/basic.stories.ts
+++ b/packages/grid-layout/src/stories/basic.stories.ts
@@ -1,0 +1,269 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import type { GridLayoutElement } from "../components/grid-layout.js";
+import "../components/grid-layout.js";
+import "../components/grid-item.js";
+import { colorVar, semanticVar, injectAllTokens } from "@maneki/foundation";
+
+injectAllTokens();
+
+const meta: Meta = {
+  title: "Grid Layout/Basic",
+};
+export default meta;
+type Story = StoryObj;
+
+const COLORS = [
+  { bg: colorVar("red", 50), text: "#fff" },
+  { bg: colorVar("blue", 60), text: "#fff" },
+  { bg: colorVar("green", 50), text: "#fff" },
+  { bg: colorVar("purple", 60), text: "#fff" },
+  { bg: colorVar("orange", 50), text: "#fff" },
+  { bg: colorVar("teal", 50), text: "#fff" },
+];
+
+export const Default: Story = {
+  render: () => {
+    setTimeout(() => {
+      const grid = document.querySelector<GridLayoutElement>("grid-layout#basic-default");
+      if (grid) {
+        grid.gridConfig = { cols: 12, rowHeight: 80, margin: [10, 10], containerPadding: [10, 10] };
+        grid.layout = [
+          { i: "a", x: 0, y: 0, w: 4, h: 2 },
+          { i: "b", x: 4, y: 0, w: 4, h: 2 },
+          { i: "c", x: 8, y: 0, w: 4, h: 2 },
+          { i: "d", x: 0, y: 2, w: 6, h: 2 },
+          { i: "e", x: 6, y: 2, w: 3, h: 2 },
+          { i: "f", x: 9, y: 2, w: 3, h: 3 },
+        ];
+      }
+    }, 0);
+
+    return html`
+      <style>
+        grid-layout#basic-default {
+          display: block;
+          width: 100%;
+          min-height: 400px;
+          border-radius: 8px;
+          background: ${semanticVar("surface", "secondary")};
+        }
+        grid-item {
+          cursor: grab;
+        }
+        grid-item[dragging] {
+          cursor: grabbing;
+        }
+        .basic-item {
+          border-radius: 6px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: system-ui, sans-serif;
+          font-size: 1rem;
+          font-weight: 600;
+          height: 100%;
+          box-sizing: border-box;
+          user-select: none;
+        }
+      </style>
+      <grid-layout id="basic-default">
+        ${["a", "b", "c", "d", "e", "f"].map(
+          (id, i) => html`
+            <grid-item item-id=${id}>
+              <div
+                class="basic-item"
+                style="background:${COLORS[i].bg};border:1px solid ${semanticVar("border", "minimal")};color:${COLORS[i].text}"
+              >
+                ${id.toUpperCase()}
+              </div>
+            </grid-item>
+          `,
+        )}
+      </grid-layout>
+    `;
+  },
+};
+
+export const StaticItems: Story = {
+  render: () => {
+    setTimeout(() => {
+      const grid = document.querySelector<GridLayoutElement>("grid-layout#basic-static");
+      if (grid) {
+        grid.gridConfig = { cols: 12, rowHeight: 80, margin: [10, 10], containerPadding: [10, 10] };
+        grid.layout = [
+          { i: "s1", x: 0, y: 0, w: 12, h: 1, static: true },
+          { i: "d1", x: 0, y: 1, w: 4, h: 2 },
+          { i: "s2", x: 4, y: 1, w: 4, h: 2, static: true },
+          { i: "d2", x: 8, y: 1, w: 4, h: 2 },
+          { i: "d3", x: 0, y: 3, w: 6, h: 2 },
+          { i: "d4", x: 6, y: 3, w: 6, h: 2 },
+        ];
+      }
+    }, 0);
+
+    return html`
+      <style>
+        grid-layout#basic-static {
+          display: block;
+          width: 100%;
+          min-height: 400px;
+          border-radius: 8px;
+          background: ${semanticVar("surface", "secondary")};
+        }
+        grid-item {
+          cursor: grab;
+        }
+        grid-item[dragging] {
+          cursor: grabbing;
+        }
+        .static-item {
+          border-radius: 6px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: system-ui, sans-serif;
+          font-size: 1rem;
+          font-weight: 600;
+          height: 100%;
+          box-sizing: border-box;
+          user-select: none;
+        }
+        .static-item--locked {
+          background: ${semanticVar("surface", "moderate")};
+          color: ${semanticVar("text", "reversed")};
+          border: 1px solid ${semanticVar("border", "subtle")};
+        }
+        .static-item--free {
+          background: ${COLORS[1].bg};
+          border: 1px solid ${semanticVar("border", "minimal")};
+          color: #fff;
+        }
+      </style>
+      <grid-layout id="basic-static">
+        <grid-item item-id="s1" static>
+          <div class="static-item static-item--locked">Header (static)</div>
+        </grid-item>
+        <grid-item item-id="d1">
+          <div class="static-item static-item--free">Draggable 1</div>
+        </grid-item>
+        <grid-item item-id="s2" static>
+          <div class="static-item static-item--locked">Locked</div>
+        </grid-item>
+        <grid-item item-id="d2">
+          <div class="static-item static-item--free">Draggable 2</div>
+        </grid-item>
+        <grid-item item-id="d3">
+          <div class="static-item static-item--free">Draggable 3</div>
+        </grid-item>
+        <grid-item item-id="d4">
+          <div class="static-item static-item--free">Draggable 4</div>
+        </grid-item>
+      </grid-layout>
+    `;
+  },
+};
+
+export const Constraints: Story = {
+  render: () => {
+    setTimeout(() => {
+      const grid = document.querySelector<GridLayoutElement>("grid-layout#basic-constraints");
+      if (grid) {
+        grid.gridConfig = { cols: 12, rowHeight: 80, margin: [10, 10], containerPadding: [10, 10] };
+        grid.layout = [
+          { i: "c1", x: 0, y: 0, w: 4, h: 2, minW: 2, maxW: 6 },
+          { i: "c2", x: 4, y: 0, w: 4, h: 2, minH: 2, maxH: 4 },
+          { i: "c3", x: 8, y: 0, w: 4, h: 2, minW: 3, maxW: 5, minH: 1, maxH: 3 },
+          { i: "c4", x: 0, y: 2, w: 6, h: 2, minW: 4 },
+          { i: "c5", x: 6, y: 2, w: 6, h: 2, maxW: 8, maxH: 3 },
+        ];
+      }
+    }, 0);
+
+    return html`
+      <style>
+        grid-layout#basic-constraints {
+          display: block;
+          width: 100%;
+          min-height: 400px;
+          border-radius: 8px;
+          background: ${semanticVar("surface", "secondary")};
+        }
+        grid-item {
+          cursor: grab;
+        }
+        grid-item[dragging] {
+          cursor: grabbing;
+        }
+        .constraint-item {
+          border-radius: 6px;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          font-family: system-ui, sans-serif;
+          height: 100%;
+          box-sizing: border-box;
+          user-select: none;
+          gap: 4px;
+        }
+        .constraint-item__id {
+          font-size: 14px;
+          font-weight: 600;
+        }
+        .constraint-item__label {
+          font-size: 11px;
+          font-family: monospace;
+          opacity: 0.7;
+        }
+      </style>
+      <grid-layout id="basic-constraints">
+        <grid-item item-id="c1" min-w="2" max-w="6">
+          <div
+            class="constraint-item"
+            style="background:${COLORS[0].bg};border:1px solid ${semanticVar("border", "minimal")};color:${COLORS[0].text}"
+          >
+            <span class="constraint-item__id">C1</span>
+            <span class="constraint-item__label">w: 2–6</span>
+          </div>
+        </grid-item>
+        <grid-item item-id="c2" min-h="2" max-h="4">
+          <div
+            class="constraint-item"
+            style="background:${COLORS[1].bg};border:1px solid ${semanticVar("border", "minimal")};color:${COLORS[1].text}"
+          >
+            <span class="constraint-item__id">C2</span>
+            <span class="constraint-item__label">h: 2–4</span>
+          </div>
+        </grid-item>
+        <grid-item item-id="c3" min-w="3" max-w="5" min-h="1" max-h="3">
+          <div
+            class="constraint-item"
+            style="background:${COLORS[2].bg};border:1px solid ${semanticVar("border", "minimal")};color:${COLORS[2].text}"
+          >
+            <span class="constraint-item__id">C3</span>
+            <span class="constraint-item__label">w: 3–5, h: 1–3</span>
+          </div>
+        </grid-item>
+        <grid-item item-id="c4" min-w="4">
+          <div
+            class="constraint-item"
+            style="background:${COLORS[3].bg};border:1px solid ${semanticVar("border", "minimal")};color:${COLORS[3].text}"
+          >
+            <span class="constraint-item__id">C4</span>
+            <span class="constraint-item__label">min-w: 4</span>
+          </div>
+        </grid-item>
+        <grid-item item-id="c5" max-w="8" max-h="3">
+          <div
+            class="constraint-item"
+            style="background:${COLORS[4].bg};border:1px solid ${semanticVar("border", "minimal")};color:${COLORS[4].text}"
+          >
+            <span class="constraint-item__id">C5</span>
+            <span class="constraint-item__label">max-w: 8, max-h: 3</span>
+          </div>
+        </grid-item>
+      </grid-layout>
+    `;
+  },
+};

--- a/packages/grid-layout/src/stories/compaction.stories.ts
+++ b/packages/grid-layout/src/stories/compaction.stories.ts
@@ -1,0 +1,255 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import type { GridLayoutElement } from "../components/grid-layout.js";
+import "../components/grid-layout.js";
+import "../components/grid-item.js";
+import { colorVar, semanticVar, injectAllTokens } from "@maneki/foundation";
+
+injectAllTokens();
+
+const meta: Meta = {
+  title: "Grid Layout/Compaction",
+};
+export default meta;
+type Story = StoryObj;
+
+const COLORS = [
+  { bg: colorVar("red", 50), text: "#fff" },
+  { bg: colorVar("blue", 60), text: "#fff" },
+  { bg: colorVar("green", 50), text: "#fff" },
+  { bg: colorVar("purple", 60), text: "#fff" },
+  { bg: colorVar("orange", 50), text: "#fff" },
+  { bg: colorVar("teal", 50), text: "#fff" },
+];
+
+const CONTAINER_STYLE = `
+  display: block;
+  width: 100%;
+  min-height: 400px;
+  border-radius: 8px;
+  background: ${semanticVar("surface", "secondary")};
+`;
+
+const itemStyle = (i: number) =>
+  `background:${COLORS[i % COLORS.length].bg};border:1px solid ${semanticVar("border", "minimal")};color:${COLORS[i % COLORS.length].text}`;
+
+export const Vertical: Story = {
+  render: () => {
+    setTimeout(() => {
+      const grid = document.querySelector<GridLayoutElement>("grid-layout#compact-vertical");
+      if (grid) {
+        grid.gridConfig = { cols: 12, rowHeight: 60, margin: [10, 10], containerPadding: [10, 10] };
+        grid.compactType = "vertical";
+        grid.layout = [
+          { i: "v1", x: 0, y: 0, w: 4, h: 2 },
+          { i: "v2", x: 4, y: 0, w: 4, h: 2 },
+          { i: "v3", x: 0, y: 4, w: 4, h: 2 },
+          { i: "v4", x: 4, y: 6, w: 4, h: 2 },
+          { i: "v5", x: 8, y: 0, w: 4, h: 3 },
+        ];
+      }
+    }, 0);
+
+    return html`
+      <style>
+        grid-layout#compact-vertical { ${CONTAINER_STYLE} }
+        grid-item {
+          cursor: grab;
+        }
+        grid-item[dragging] {
+          cursor: grabbing;
+        }
+        .compact-item {
+          border-radius: 6px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: system-ui, sans-serif;
+          font-size: 1rem;
+          font-weight: 600;
+          height: 100%;
+          box-sizing: border-box;
+          user-select: none;
+        }
+      </style>
+      <p style="font-family:system-ui;font-size:13px;color:${semanticVar("text", "secondary")};margin:0 0 8px">
+        Vertical compaction — items with gaps collapse upward.
+      </p>
+      <grid-layout id="compact-vertical">
+        ${["v1", "v2", "v3", "v4", "v5"].map(
+          (id, i) => html`
+            <grid-item item-id=${id}>
+              <div class="compact-item" style="${itemStyle(i)}">${id}</div>
+            </grid-item>
+          `,
+        )}
+      </grid-layout>
+    `;
+  },
+};
+
+export const Horizontal: Story = {
+  render: () => {
+    setTimeout(() => {
+      const grid = document.querySelector<GridLayoutElement>("grid-layout#compact-horizontal");
+      if (grid) {
+        grid.gridConfig = { cols: 12, rowHeight: 60, margin: [10, 10], containerPadding: [10, 10] };
+        grid.compactType = "horizontal";
+        grid.layout = [
+          { i: "h1", x: 0, y: 0, w: 3, h: 2 },
+          { i: "h2", x: 6, y: 0, w: 3, h: 2 },
+          { i: "h3", x: 0, y: 2, w: 3, h: 2 },
+          { i: "h4", x: 9, y: 2, w: 3, h: 2 },
+          { i: "h5", x: 6, y: 4, w: 3, h: 2 },
+        ];
+      }
+    }, 0);
+
+    return html`
+      <style>
+        grid-layout#compact-horizontal { ${CONTAINER_STYLE} }
+        grid-item {
+          cursor: grab;
+        }
+        grid-item[dragging] {
+          cursor: grabbing;
+        }
+        .compact-item {
+          border-radius: 6px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: system-ui, sans-serif;
+          font-size: 1rem;
+          font-weight: 600;
+          height: 100%;
+          box-sizing: border-box;
+          user-select: none;
+        }
+      </style>
+      <p style="font-family:system-ui;font-size:13px;color:${semanticVar("text", "secondary")};margin:0 0 8px">
+        Horizontal compaction — items collapse leftward.
+      </p>
+      <grid-layout id="compact-horizontal">
+        ${["h1", "h2", "h3", "h4", "h5"].map(
+          (id, i) => html`
+            <grid-item item-id=${id}>
+              <div class="compact-item" style="${itemStyle(i)}">${id}</div>
+            </grid-item>
+          `,
+        )}
+      </grid-layout>
+    `;
+  },
+};
+
+export const NoCompaction: Story = {
+  render: () => {
+    setTimeout(() => {
+      const grid = document.querySelector<GridLayoutElement>("grid-layout#compact-none");
+      if (grid) {
+        grid.gridConfig = { cols: 12, rowHeight: 60, margin: [10, 10], containerPadding: [10, 10] };
+        grid.compactType = null;
+        grid.layout = [
+          { i: "n1", x: 0, y: 0, w: 3, h: 2 },
+          { i: "n2", x: 5, y: 0, w: 3, h: 2 },
+          { i: "n3", x: 0, y: 4, w: 3, h: 2 },
+          { i: "n4", x: 5, y: 4, w: 3, h: 2 },
+          { i: "n5", x: 9, y: 2, w: 3, h: 3 },
+        ];
+      }
+    }, 0);
+
+    return html`
+      <style>
+        grid-layout#compact-none { ${CONTAINER_STYLE} }
+        grid-item {
+          cursor: grab;
+        }
+        grid-item[dragging] {
+          cursor: grabbing;
+        }
+        .compact-item {
+          border-radius: 6px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: system-ui, sans-serif;
+          font-size: 1rem;
+          font-weight: 600;
+          height: 100%;
+          box-sizing: border-box;
+          user-select: none;
+        }
+      </style>
+      <p style="font-family:system-ui;font-size:13px;color:${semanticVar("text", "secondary")};margin:0 0 8px">
+        No compaction — items stay exactly where placed. Gaps remain.
+      </p>
+      <grid-layout id="compact-none">
+        ${["n1", "n2", "n3", "n4", "n5"].map(
+          (id, i) => html`
+            <grid-item item-id=${id}>
+              <div class="compact-item" style="${itemStyle(i)}">${id}</div>
+            </grid-item>
+          `,
+        )}
+      </grid-layout>
+    `;
+  },
+};
+
+export const PreventCollision: Story = {
+  render: () => {
+    setTimeout(() => {
+      const grid = document.querySelector<GridLayoutElement>("grid-layout#compact-collision");
+      if (grid) {
+        grid.gridConfig = { cols: 12, rowHeight: 60, margin: [10, 10], containerPadding: [10, 10] };
+        grid.compactType = null;
+        grid.preventCollision = true;
+        grid.layout = [
+          { i: "p1", x: 0, y: 0, w: 4, h: 2 },
+          { i: "p2", x: 4, y: 0, w: 4, h: 2 },
+          { i: "p3", x: 8, y: 0, w: 4, h: 2 },
+          { i: "p4", x: 2, y: 2, w: 4, h: 2 },
+          { i: "p5", x: 6, y: 2, w: 4, h: 2 },
+        ];
+      }
+    }, 0);
+
+    return html`
+      <style>
+        grid-layout#compact-collision { ${CONTAINER_STYLE} }
+        grid-item {
+          cursor: grab;
+        }
+        grid-item[dragging] {
+          cursor: grabbing;
+        }
+        .compact-item {
+          border-radius: 6px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: system-ui, sans-serif;
+          font-size: 1rem;
+          font-weight: 600;
+          height: 100%;
+          box-sizing: border-box;
+          user-select: none;
+        }
+      </style>
+      <p style="font-family:system-ui;font-size:13px;color:${semanticVar("text", "secondary")};margin:0 0 8px">
+        Prevent collision — items cannot overlap. Try dragging one onto another.
+      </p>
+      <grid-layout id="compact-collision">
+        ${["p1", "p2", "p3", "p4", "p5"].map(
+          (id, i) => html`
+            <grid-item item-id=${id}>
+              <div class="compact-item" style="${itemStyle(i)}">${id}</div>
+            </grid-item>
+          `,
+        )}
+      </grid-layout>
+    `;
+  },
+};

--- a/packages/grid-layout/src/stories/resize-handles.stories.ts
+++ b/packages/grid-layout/src/stories/resize-handles.stories.ts
@@ -1,0 +1,180 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import type { GridLayoutElement } from "../components/grid-layout.js";
+import "../components/grid-layout.js";
+import "../components/grid-item.js";
+import { colorVar, semanticVar, injectAllTokens } from "@maneki/foundation";
+
+injectAllTokens();
+
+const meta: Meta = {
+  title: "Grid Layout/Resize Handles",
+};
+export default meta;
+type Story = StoryObj;
+
+const CONTAINER_STYLE = `
+  display: block;
+  width: 100%;
+  min-height: 400px;
+  border-radius: 8px;
+  background: ${semanticVar("surface", "secondary")};
+`;
+
+export const AllHandles: Story = {
+  render: () => {
+    setTimeout(() => {
+      const grid = document.querySelector<GridLayoutElement>("grid-layout#resize-all");
+      if (grid) {
+        grid.gridConfig = { cols: 12, rowHeight: 60, margin: [10, 10], containerPadding: [10, 10] };
+        grid.resizeConfig = {
+          enabled: true,
+          handles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+        };
+        grid.layout = [
+          { i: "all-handles", x: 3, y: 1, w: 6, h: 4 },
+        ];
+      }
+    }, 0);
+
+    return html`
+      <style>
+        grid-layout#resize-all { ${CONTAINER_STYLE} min-height: 500px; }
+        grid-item {
+          cursor: grab;
+        }
+        grid-item[dragging] {
+          cursor: grabbing;
+        }
+        .resize-demo-item {
+          border-radius: 6px;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          font-family: system-ui, sans-serif;
+          height: 100%;
+          box-sizing: border-box;
+          user-select: none;
+          background: ${colorVar("blue", 60)};
+          border: 1px solid ${semanticVar("border", "minimal")};
+          color: #fff;
+          gap: 8px;
+        }
+        .resize-demo-item__title {
+          font-size: 1rem;
+          font-weight: 700;
+        }
+        .resize-demo-item__hint {
+          font-size: 12px;
+          opacity: 0.7;
+          font-family: monospace;
+        }
+        .handle-legend {
+          display: grid;
+          grid-template-columns: repeat(4, auto);
+          gap: 4px 16px;
+          font-family: monospace;
+          font-size: 12px;
+          color: ${semanticVar("text", "secondary")};
+          margin-bottom: 12px;
+        }
+        .handle-legend span {
+          padding: 2px 6px;
+          background: ${semanticVar("surface", "secondary")};
+          border-radius: 3px;
+        }
+      </style>
+      <div class="handle-legend">
+        <span>nw ↖</span><span>n ↑</span><span>ne ↗</span><span></span>
+        <span>w ←</span><span></span><span>e →</span><span></span>
+        <span>sw ↙</span><span>s ↓</span><span>se ↘</span><span></span>
+      </div>
+      <grid-layout id="resize-all">
+        <grid-item item-id="all-handles">
+          <div class="resize-demo-item">
+            <span class="resize-demo-item__title">All 8 Handles</span>
+            <span class="resize-demo-item__hint">Drag any edge or corner to resize</span>
+          </div>
+        </grid-item>
+      </grid-layout>
+    `;
+  },
+};
+
+export const CornerOnly: Story = {
+  render: () => {
+    setTimeout(() => {
+      const grid = document.querySelector<GridLayoutElement>("grid-layout#resize-corners");
+      if (grid) {
+        grid.gridConfig = { cols: 12, rowHeight: 60, margin: [10, 10], containerPadding: [10, 10] };
+        grid.resizeConfig = {
+          enabled: true,
+          handles: ["se", "sw", "ne", "nw"],
+        };
+        grid.layout = [
+          { i: "corner1", x: 0, y: 0, w: 5, h: 3 },
+          { i: "corner2", x: 6, y: 0, w: 5, h: 3 },
+          { i: "corner3", x: 2, y: 3, w: 8, h: 3 },
+        ];
+      }
+    }, 0);
+
+    const colors = [
+      { bg: colorVar("green", 50), text: "#fff" },
+      { bg: colorVar("purple", 60), text: "#fff" },
+      { bg: colorVar("orange", 50), text: "#fff" },
+    ];
+
+    return html`
+      <style>
+        grid-layout#resize-corners { ${CONTAINER_STYLE} }
+        grid-item {
+          cursor: grab;
+        }
+        grid-item[dragging] {
+          cursor: grabbing;
+        }
+        .corner-item {
+          border-radius: 6px;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+          font-family: system-ui, sans-serif;
+          height: 100%;
+          box-sizing: border-box;
+          user-select: none;
+          gap: 4px;
+        }
+        .corner-item__title {
+          font-size: 1rem;
+          font-weight: 600;
+        }
+        .corner-item__hint {
+          font-size: 11px;
+          font-family: monospace;
+          opacity: 0.7;
+        }
+      </style>
+      <p style="font-family:system-ui;font-size:13px;color:${semanticVar("text", "secondary")};margin:0 0 8px">
+        Corner handles only — se, sw, ne, nw. No edge handles.
+      </p>
+      <grid-layout id="resize-corners">
+        ${["corner1", "corner2", "corner3"].map(
+          (id, i) => html`
+            <grid-item item-id=${id}>
+              <div
+                class="corner-item"
+                style="background:${colors[i].bg};border:1px solid ${semanticVar("border", "minimal")};color:${colors[i].text}"
+              >
+                <span class="corner-item__title">${id}</span>
+                <span class="corner-item__hint">corners only</span>
+              </div>
+            </grid-item>
+          `,
+        )}
+      </grid-layout>
+    `;
+  },
+};

--- a/packages/grid-layout/src/stories/responsive.stories.ts
+++ b/packages/grid-layout/src/stories/responsive.stories.ts
@@ -1,0 +1,241 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import type { GridLayoutElement } from "../components/grid-layout.js";
+import "../components/grid-layout.js";
+import "../components/grid-item.js";
+import type { ResponsiveGridLayoutElement } from "../components/responsive-grid-layout.js";
+import "../components/responsive-grid-layout.js";
+import { colorVar, semanticVar, injectAllTokens } from "@maneki/foundation";
+
+injectAllTokens();
+
+const meta: Meta = {
+  title: "Grid Layout/Responsive",
+};
+export default meta;
+type Story = StoryObj;
+
+const COLORS = [
+  { bg: colorVar("red", 50), text: "#fff" },
+  { bg: colorVar("blue", 60), text: "#fff" },
+  { bg: colorVar("green", 50), text: "#fff" },
+  { bg: colorVar("purple", 60), text: "#fff" },
+  { bg: colorVar("orange", 50), text: "#fff" },
+  { bg: colorVar("teal", 50), text: "#fff" },
+];
+
+const CONTAINER_STYLE = `
+  display: block;
+  width: 100%;
+  min-height: 400px;
+  border-radius: 8px;
+  background: ${semanticVar("surface", "secondary")};
+`;
+
+export const Breakpoints: Story = {
+  render: () => {
+    setTimeout(() => {
+      const rgl = document.querySelector<ResponsiveGridLayoutElement>(
+        "responsive-grid-layout#responsive-bp",
+      );
+      if (rgl) {
+        rgl.gridConfig = { rowHeight: 80, margin: [10, 10], containerPadding: [10, 10] };
+        rgl.layouts = {
+          lg: [
+            { i: "r1", x: 0, y: 0, w: 4, h: 2 },
+            { i: "r2", x: 4, y: 0, w: 4, h: 2 },
+            { i: "r3", x: 8, y: 0, w: 4, h: 2 },
+            { i: "r4", x: 0, y: 2, w: 6, h: 2 },
+            { i: "r5", x: 6, y: 2, w: 6, h: 2 },
+          ],
+          md: [
+            { i: "r1", x: 0, y: 0, w: 5, h: 2 },
+            { i: "r2", x: 5, y: 0, w: 5, h: 2 },
+            { i: "r3", x: 0, y: 2, w: 5, h: 2 },
+            { i: "r4", x: 5, y: 2, w: 5, h: 2 },
+            { i: "r5", x: 0, y: 4, w: 10, h: 2 },
+          ],
+          sm: [
+            { i: "r1", x: 0, y: 0, w: 6, h: 2 },
+            { i: "r2", x: 0, y: 2, w: 6, h: 2 },
+            { i: "r3", x: 0, y: 4, w: 6, h: 2 },
+            { i: "r4", x: 0, y: 6, w: 6, h: 2 },
+            { i: "r5", x: 0, y: 8, w: 6, h: 2 },
+          ],
+          xs: [
+            { i: "r1", x: 0, y: 0, w: 4, h: 2 },
+            { i: "r2", x: 0, y: 2, w: 4, h: 2 },
+            { i: "r3", x: 0, y: 4, w: 4, h: 2 },
+            { i: "r4", x: 0, y: 6, w: 4, h: 2 },
+            { i: "r5", x: 0, y: 8, w: 4, h: 2 },
+          ],
+          xxs: [
+            { i: "r1", x: 0, y: 0, w: 2, h: 2 },
+            { i: "r2", x: 0, y: 2, w: 2, h: 2 },
+            { i: "r3", x: 0, y: 4, w: 2, h: 2 },
+            { i: "r4", x: 0, y: 6, w: 2, h: 2 },
+            { i: "r5", x: 0, y: 8, w: 2, h: 2 },
+          ],
+        };
+
+        const label = document.querySelector("#bp-label");
+        rgl.addEventListener("breakpoint-change", (e: Event) => {
+          const detail = (e as CustomEvent).detail;
+          if (label) {
+            label.textContent = `${detail.breakpoint} (${detail.cols} cols)`;
+          }
+        });
+      }
+    }, 0);
+
+    return html`
+      <style>
+        responsive-grid-layout#responsive-bp { ${CONTAINER_STYLE} }
+        grid-item {
+          cursor: grab;
+        }
+        grid-item[dragging] {
+          cursor: grabbing;
+        }
+        .bp-label {
+          font-family: monospace;
+          font-size: 13px;
+          padding: 6px 12px;
+          background: ${colorVar("gray", 90)};
+          color: ${colorVar("teal", 30)};
+          border-radius: 4px;
+          display: inline-block;
+          margin-bottom: 12px;
+        }
+        .responsive-item {
+          border-radius: 6px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: system-ui, sans-serif;
+          font-size: 1rem;
+          font-weight: 600;
+          height: 100%;
+          box-sizing: border-box;
+          user-select: none;
+        }
+      </style>
+      <p style="font-family:system-ui;font-size:13px;color:${semanticVar("text", "secondary")};margin:0 0 8px">
+        Resize the browser window to see layout changes per breakpoint.
+      </p>
+      <div class="bp-label">Breakpoint: <span id="bp-label">detecting…</span></div>
+      <responsive-grid-layout id="responsive-bp">
+        ${["r1", "r2", "r3", "r4", "r5"].map(
+          (id, i) => html`
+            <grid-item item-id=${id}>
+              <div
+                class="responsive-item"
+                style="background:${COLORS[i].bg};border:1px solid ${semanticVar("border", "minimal")};color:${COLORS[i].text}"
+              >
+                ${id}
+              </div>
+            </grid-item>
+          `,
+        )}
+      </responsive-grid-layout>
+    `;
+  },
+};
+
+export const CustomBreakpoints: Story = {
+  render: () => {
+    setTimeout(() => {
+      const rgl = document.querySelector<ResponsiveGridLayoutElement>(
+        "responsive-grid-layout#responsive-custom",
+      );
+      if (rgl) {
+        rgl.breakpoints = { wide: 1000, medium: 600, narrow: 0 };
+        rgl.cols = { wide: 8, medium: 4, narrow: 2 };
+        rgl.gridConfig = { rowHeight: 80, margin: [12, 12], containerPadding: [10, 10] };
+        rgl.layouts = {
+          wide: [
+            { i: "x1", x: 0, y: 0, w: 4, h: 2 },
+            { i: "x2", x: 4, y: 0, w: 4, h: 2 },
+            { i: "x3", x: 0, y: 2, w: 8, h: 2 },
+          ],
+          medium: [
+            { i: "x1", x: 0, y: 0, w: 4, h: 2 },
+            { i: "x2", x: 0, y: 2, w: 4, h: 2 },
+            { i: "x3", x: 0, y: 4, w: 4, h: 2 },
+          ],
+          narrow: [
+            { i: "x1", x: 0, y: 0, w: 2, h: 2 },
+            { i: "x2", x: 0, y: 2, w: 2, h: 2 },
+            { i: "x3", x: 0, y: 4, w: 2, h: 2 },
+          ],
+        };
+
+        const label = document.querySelector("#custom-bp-label");
+        rgl.addEventListener("breakpoint-change", (e: Event) => {
+          const detail = (e as CustomEvent).detail;
+          if (label) {
+            label.textContent = `${detail.breakpoint} (${detail.cols} cols)`;
+          }
+        });
+      }
+    }, 0);
+
+    const items = [
+      { id: "x1", label: "Panel 1" },
+      { id: "x2", label: "Panel 2" },
+      { id: "x3", label: "Full Width" },
+    ];
+
+    return html`
+      <style>
+        responsive-grid-layout#responsive-custom { ${CONTAINER_STYLE} }
+        grid-item {
+          cursor: grab;
+        }
+        grid-item[dragging] {
+          cursor: grabbing;
+        }
+        .bp-label-custom {
+          font-family: monospace;
+          font-size: 13px;
+          padding: 6px 12px;
+          background: ${colorVar("ultramarine", 80)};
+          color: ${colorVar("purple", 30)};
+          border-radius: 4px;
+          display: inline-block;
+          margin-bottom: 12px;
+        }
+        .custom-bp-item {
+          border-radius: 6px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: system-ui, sans-serif;
+          font-size: 1rem;
+          font-weight: 600;
+          height: 100%;
+          box-sizing: border-box;
+          user-select: none;
+        }
+      </style>
+      <p style="font-family:system-ui;font-size:13px;color:${semanticVar("text", "secondary")};margin:0 0 8px">
+        Custom breakpoints: wide (1000px+), medium (600–999px), narrow (&lt;600px).
+      </p>
+      <div class="bp-label-custom">Breakpoint: <span id="custom-bp-label">detecting…</span></div>
+      <responsive-grid-layout id="responsive-custom">
+        ${items.map(
+          (item, i) => html`
+            <grid-item item-id=${item.id}>
+              <div
+                class="custom-bp-item"
+                style="background:${COLORS[i + 2].bg};border:1px solid ${semanticVar("border", "minimal")};color:${COLORS[i + 2].text}"
+              >
+                ${item.label}
+              </div>
+            </grid-item>
+          `,
+        )}
+      </responsive-grid-layout>
+    `;
+  },
+};

--- a/packages/grid-layout/src/stories/theming.stories.ts
+++ b/packages/grid-layout/src/stories/theming.stories.ts
@@ -1,0 +1,289 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import type { GridLayoutElement } from "../components/grid-layout.js";
+import "../components/grid-layout.js";
+import "../components/grid-item.js";
+import { colorVar, semanticVar, injectAllTokens } from "@maneki/foundation";
+
+injectAllTokens();
+
+const meta: Meta = {
+  title: "Grid Layout/Theming",
+};
+export default meta;
+type Story = StoryObj;
+
+const ITEMS = ["t1", "t2", "t3", "t4", "t5", "t6"];
+
+const LAYOUT = [
+  { i: "t1", x: 0, y: 0, w: 4, h: 2 },
+  { i: "t2", x: 4, y: 0, w: 4, h: 2 },
+  { i: "t3", x: 8, y: 0, w: 4, h: 2 },
+  { i: "t4", x: 0, y: 2, w: 6, h: 2 },
+  { i: "t5", x: 6, y: 2, w: 3, h: 2 },
+  { i: "t6", x: 9, y: 2, w: 3, h: 3 },
+];
+
+function setupGrid(id: string) {
+  setTimeout(() => {
+    const grid = document.querySelector<GridLayoutElement>(`grid-layout#${id}`);
+    if (grid) {
+      grid.gridConfig = { cols: 12, rowHeight: 70, margin: [10, 10], containerPadding: [10, 10] };
+      grid.layout = LAYOUT.map((item) => ({ ...item }));
+    }
+  }, 0);
+}
+
+const COLORS = [
+  { bg: colorVar("red", 50), text: "#fff" },
+  { bg: colorVar("blue", 60), text: "#fff" },
+  { bg: colorVar("green", 50), text: "#fff" },
+  { bg: colorVar("purple", 60), text: "#fff" },
+  { bg: colorVar("orange", 50), text: "#fff" },
+  { bg: colorVar("teal", 50), text: "#fff" },
+];
+
+export const Default: Story = {
+  render: () => {
+    setupGrid("theme-default");
+
+    return html`
+      <style>
+        grid-layout#theme-default {
+          display: block;
+          width: 100%;
+          min-height: 400px;
+          border-radius: 8px;
+          background: ${semanticVar("surface", "secondary")};
+        }
+        grid-item {
+          cursor: grab;
+        }
+        grid-item[dragging] {
+          cursor: grabbing;
+        }
+        .theme-item {
+          border-radius: 6px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: system-ui, sans-serif;
+          font-size: 1rem;
+          font-weight: 600;
+          height: 100%;
+          box-sizing: border-box;
+          user-select: none;
+        }
+      </style>
+      <p style="font-family:system-ui;font-size:13px;color:${semanticVar("text", "secondary")};margin:0 0 8px">
+        Default theme — no custom properties overridden.
+      </p>
+      <grid-layout id="theme-default">
+        ${ITEMS.map(
+          (id, i) => html`
+            <grid-item item-id=${id}>
+              <div
+                class="theme-item"
+                style="background:${COLORS[i].bg};border:1px solid ${semanticVar("border", "minimal")};color:${COLORS[i].text}"
+              >
+                ${id}
+              </div>
+            </grid-item>
+          `,
+        )}
+      </grid-layout>
+    `;
+  },
+};
+
+export const DarkTheme: Story = {
+  render: () => {
+    setupGrid("theme-dark");
+
+    return html`
+      <style>
+        grid-layout#theme-dark {
+          display: block;
+          width: 100%;
+          min-height: 400px;
+          border: 1px solid ${colorVar("gray", 80)};
+          border-radius: 8px;
+          background: ${colorVar("gray", 100)};
+
+          --grid-placeholder-bg: rgba(255, 255, 255, 0.06);
+          --grid-placeholder-border: 2px dashed ${colorVar("gray", 60)};
+          --grid-placeholder-radius: 6px;
+          --grid-handle-color: ${colorVar("gray", 40)};
+          --grid-focus-ring-color: ${colorVar("blue", 40)};
+          --grid-item-active-opacity: 0.85;
+        }
+        grid-item {
+          cursor: grab;
+        }
+        grid-item[dragging] {
+          cursor: grabbing;
+        }
+        .dark-item {
+          border-radius: 6px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: system-ui, sans-serif;
+          font-size: 14px;
+          font-weight: 600;
+          height: 100%;
+          box-sizing: border-box;
+          user-select: none;
+          background: ${colorVar("gray", 90)};
+          border: 1px solid ${colorVar("gray", 70)};
+          color: ${colorVar("gray", 20)};
+        }
+      </style>
+      <p style="font-family:system-ui;font-size:13px;color:${colorVar("gray", 50)};margin:0 0 8px">
+        Dark theme — custom placeholder, handle, and focus ring colors.
+      </p>
+      <grid-layout id="theme-dark">
+        ${ITEMS.map(
+          (id) => html`
+            <grid-item item-id=${id}>
+              <div class="dark-item">${id}</div>
+            </grid-item>
+          `,
+        )}
+      </grid-layout>
+    `;
+  },
+};
+
+export const ColorfulTheme: Story = {
+  render: () => {
+    setupGrid("theme-colorful");
+
+    const neonColors = [
+      { bg: colorVar("red", 60), text: "#fff" },
+      { bg: colorVar("blue", 60), text: "#fff" },
+      { bg: colorVar("purple", 60), text: "#fff" },
+      { bg: colorVar("green", 60), text: "#fff" },
+      { bg: colorVar("pink", 60), text: "#fff" },
+      { bg: colorVar("turquoise", 60), text: "#fff" },
+    ];
+
+    return html`
+      <style>
+        grid-layout#theme-colorful {
+          display: block;
+          width: 100%;
+          min-height: 400px;
+          border: 1px solid ${colorVar("purple", 70)};
+          border-radius: 8px;
+          background: ${colorVar("gray", 100)};
+
+          --grid-placeholder-bg: rgba(204, 29, 146, 0.12);
+          --grid-placeholder-border: 2px dashed ${colorVar("pink", 60)};
+          --grid-placeholder-radius: 8px;
+          --grid-handle-color: ${colorVar("pink", 50)};
+          --grid-focus-ring-color: ${colorVar("turquoise", 40)};
+          --grid-item-active-opacity: 0.9;
+        }
+        grid-item {
+          cursor: grab;
+        }
+        grid-item[dragging] {
+          cursor: grabbing;
+        }
+        .neon-item {
+          border-radius: 8px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: system-ui, sans-serif;
+          font-size: 14px;
+          font-weight: 700;
+          height: 100%;
+          box-sizing: border-box;
+          user-select: none;
+          letter-spacing: 0.5px;
+        }
+      </style>
+      <p style="font-family:system-ui;font-size:13px;color:${colorVar("gray", 50)};margin:0 0 8px">
+        Neon theme — bright placeholder, handles, and focus ring on dark background.
+      </p>
+      <grid-layout id="theme-colorful">
+        ${ITEMS.map(
+          (id, i) => html`
+            <grid-item item-id=${id}>
+              <div
+                class="neon-item"
+                style="background:${neonColors[i].bg};border:1px solid transparent;color:${neonColors[i].text}"
+              >
+                ${id}
+              </div>
+            </grid-item>
+          `,
+        )}
+      </grid-layout>
+    `;
+  },
+};
+
+export const NoAnimation: Story = {
+  render: () => {
+    setupGrid("theme-no-anim");
+
+    const warmColors = [
+      { bg: colorVar("orange", 50), text: "#fff" },
+      { bg: colorVar("yellow", 30), text: colorVar("gray", 100) },
+      { bg: colorVar("orange", 60), text: "#fff" },
+      { bg: colorVar("yellow", 40), text: colorVar("gray", 100) },
+      { bg: colorVar("orange", 40), text: colorVar("gray", 100) },
+      { bg: colorVar("yellow", 50), text: "#fff" },
+    ];
+
+    return html`
+      <style>
+        grid-layout#theme-no-anim {
+          display: block;
+          width: 100%;
+          min-height: 400px;
+          border-radius: 8px;
+          background: ${semanticVar("surface", "secondary")};
+        }
+        grid-item {
+          cursor: grab;
+        }
+        grid-item[dragging] {
+          cursor: grabbing;
+        }
+        .no-anim-item {
+          border-radius: 6px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          font-family: system-ui, sans-serif;
+          font-size: 14px;
+          font-weight: 600;
+          height: 100%;
+          box-sizing: border-box;
+          user-select: none;
+        }
+      </style>
+      <p style="font-family:system-ui;font-size:13px;color:${semanticVar("text", "secondary")};margin:0 0 8px">
+        All transitions disabled via the <code>no-animation</code> attribute. Items snap instantly.
+      </p>
+      <grid-layout id="theme-no-anim" no-animation>
+        ${ITEMS.map(
+          (id, i) => html`
+            <grid-item item-id=${id}>
+              <div
+                class="no-anim-item"
+                style="background:${warmColors[i].bg};border:1px solid ${semanticVar("border", "minimal")};color:${warmColors[i].text}"
+              >
+                ${id}
+              </div>
+            </grid-item>
+          `,
+        )}
+      </grid-layout>
+    `;
+  },
+};


### PR DESCRIPTION
## Summary

- Added 6 Storybook story files (16 stories total) for `@maneki/grid-layout` in `packages/grid-layout/src/stories/`
- Added grid-layout stories glob to root `.storybook/main.ts` so they appear alongside Foundation and Components stories
- Wired `@maneki/foundation` as a production dependency — replaced all hardcoded color fallbacks with type-safe token references
- Updated docs (`AGENTS.md`, `packages/grid-layout/AGENTS.md`)

## Stories

| File | Stories | Demonstrates |
|------|---------|-------------|
| `basic.stories.ts` | Default, StaticItems, Constraints | 12-col grid, static/locked items, min/max constraints |
| `compaction.stories.ts` | Vertical, Horizontal, NoCompaction, PreventCollision | All compaction modes |
| `resize-handles.stories.ts` | AllHandles, CornerOnly | 8-direction and corner-only resize |
| `responsive.stories.ts` | Breakpoints, CustomBreakpoints | Responsive layout with breakpoint label |
| `theming.stories.ts` | Default, DarkTheme, ColorfulTheme, NoAnimation | CSS custom property theming |
| `accessibility.stories.ts` | KeyboardNavigation, AriaRoles | Keyboard nav instructions, ARIA structure |

## Foundation Token Wiring

Replaced hardcoded CSS fallbacks with foundation tokens:

| File | Before | After |
|------|--------|-------|
| `grid-item.ts` | `#4a90d9` (focus ring) | `colorVar("blue", 60)` |
| `grid-item.ts` | `rgba(0,0,0,0.4)` (handle) | `semanticVar("border", "bold")` |
| `grid-layout.ts` | `rgba(0,0,0,0.1)` (placeholder bg) | `semanticVar("surface", "secondary")` |
| `grid-layout.ts` | `rgba(0,0,0,0.3)` (placeholder border) | `semanticVar("border", "minimal")` |

## Verification

- All 220 grid-layout tests pass
- `tsc --noEmit` clean
- Stories verified in root Storybook via Playwright