### PR TITLE
feat: side-panel-menu mobile responsive + material-symbols migration

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,19 @@
 import type { Preview } from "@storybook/web-components";
 import { injectAllTokens } from "@maneki/foundation";
 import "material-symbols/outlined.css";
+import "@fontsource-variable/inter";
+import interLatinWoff2 from "@fontsource-variable/inter/files/inter-latin-wght-normal.woff2?url";
+import interLatinExtWoff2 from "@fontsource-variable/inter/files/inter-latin-ext-wght-normal.woff2?url";
+
+// @fontsource-variable/inter registers as "Inter Variable" — alias to "Inter"
+// so components using font-family: 'Inter' pick up the variable font
+for (const src of [interLatinWoff2, interLatinExtWoff2]) {
+  const face = new FontFace("Inter", `url(${src}) format('woff2')`, {
+    weight: "100 900",
+    style: "normal",
+  });
+  face.load().then((f) => document.fonts.add(f));
+}
 
 // Inject foundation design tokens as CSS custom properties on :root
 injectAllTokens();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@fontsource-variable/inter": "^5.2.8",
         "@storybook/web-components": "^10.2.16",
         "@storybook/web-components-vite": "^10.2.16",
         "chromatic": "^15.2.0",
@@ -460,6 +461,16 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@fontsource-variable/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-kOfP2D+ykbcX/P3IFnokOhVRNoTozo5/JxhAIVYLpea/UBmCQ/YWPBfWIDuBImXX/15KH+eKh4xpEUyS2sQQGQ==",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "storybook:build": "storybook build -o storybook-static"
   },
   "devDependencies": {
+    "@fontsource-variable/inter": "^5.2.8",
     "@storybook/web-components": "^10.2.16",
     "@storybook/web-components-vite": "^10.2.16",
     "chromatic": "^15.2.0",

--- a/packages/foundation/AGENTS.md
+++ b/packages/foundation/AGENTS.md
@@ -66,7 +66,7 @@ var() helpers — colorVar(), semanticVar(), elevationVar(), typeVar(), spaceVar
 - **Figma is source of truth.** All values extracted from "Foundation UI Kit (Community)".
 - **Semantic tokens reference palette.** `SemanticValue` is either a hex string, rgba string, or `PaletteRef` (`{ family, step }`).
 - **`resolveSemanticValue()`** resolves `PaletteRef` → hex at CSS generation time (not runtime).
-- **Typography uses two font families.** "Goldman Sans" (primary), "Roboto Mono" (code).
+- **Typography uses two font families.** "Inter" (primary), "Roboto Mono" (code).
 - **Spacing base unit is 8px.** 17 steps: 0 (0px), 1px (1px), 0.25 (2px), 0.5 (4px), 0.75 (6px), 1 (8px) through 10 (80px). CSS property names use hyphens instead of dots (e.g., `--fd-space-0-75` not `--fd-space-0.75`).
 - **`toKebab()` helper** converts camelCase keys to kebab-case for CSS property names.
 - **`injectAllTokens()`** is idempotent — checks for existing `<style id="maneki-foundation-all">` before injecting.

--- a/packages/foundation/README.md
+++ b/packages/foundation/README.md
@@ -61,7 +61,7 @@ elevationVar("03");                           // "var(--fd-elevation-03)"
 
 ### Typography
 
-Groups: display (xl/lg/md), heading (01–07), body (01–03), ui (01–02), caption (01), badge (01), code (01–02). Font families: Goldman Sans (primary), Roboto Mono (code).
+Groups: display (xl/lg/md), heading (01–07), body (01–03), ui (01–02), caption (01), badge (01), code (01–02). Font families: Inter (primary), Roboto Mono (code).
 
 ```ts
 import { typeVar, typography } from '@maneki/foundation';

--- a/packages/foundation/src/colors.ts
+++ b/packages/foundation/src/colors.ts
@@ -1,5 +1,5 @@
 /**
- * Foundation color tokens extracted from the Goldman Sachs Design System (Community).
+ * Foundation color tokens extracted from the Maneki Design System.
  * 13 color families × 10 steps (10–100), plus Gray 110.
  */
 

--- a/packages/foundation/src/typography.ts
+++ b/packages/foundation/src/typography.ts
@@ -3,7 +3,7 @@
  * of the Foundation UI Kit (Community) Figma file.
  *
  * Three sections: Display Headings, Component/Layout Headings, Body/Supporting.
- * Two font families: "Goldman Sans" (primary) and "Roboto Mono" (code).
+ * Two font families: "Inter" (primary) and "Roboto Mono" (code).
  */
 
 // ---------------------------------------------------------------------------
@@ -23,7 +23,7 @@ export interface TypeToken {
 // ---------------------------------------------------------------------------
 
 export const fontFamilies = {
-  primary: "'Goldman Sans', sans-serif",
+  primary: "'Inter', sans-serif",
   code: "'Roboto Mono', monospace",
 } as const;
 
@@ -38,7 +38,7 @@ export const fontWeights = {
 } as const;
 
 // ---------------------------------------------------------------------------
-// Display Headings — Goldman Sans Light, large marketing/content headings
+// Display Headings — Inter Light, large marketing/content headings
 // ---------------------------------------------------------------------------
 
 export const display = {
@@ -66,7 +66,7 @@ export const display = {
 } as const satisfies Record<string, TypeToken>;
 
 // ---------------------------------------------------------------------------
-// Component & Layout Headings — Goldman Sans Medium
+// Component & Layout Headings — Inter Medium
 // ---------------------------------------------------------------------------
 
 export const heading = {
@@ -122,7 +122,7 @@ export const heading = {
 } as const satisfies Record<string, TypeToken>;
 
 // ---------------------------------------------------------------------------
-// Body — Goldman Sans Regular
+// Body — Inter Regular
 // ---------------------------------------------------------------------------
 
 export const body = {

--- a/packages/ui-components/src/components/ui-accordion-item.ts
+++ b/packages/ui-components/src/components/ui-accordion-item.ts
@@ -54,7 +54,7 @@ const STYLES = /* css */ `
     width: 100%;
     padding: 0;
     margin: 0;
-    font-family: "Goldman Sans", sans-serif;
+    font-family: "Inter", sans-serif;
     color: var(--ui-acc-label-color, ${TEXT_PRIMARY});
     transition: background 0.15s ease;
   }
@@ -164,7 +164,7 @@ const STYLES = /* css */ `
     grid-template-rows: 0fr;
     transition: grid-template-rows 0.2s ease;
     color: var(--ui-acc-content-color, ${TEXT_PRIMARY});
-    font-family: "Goldman Sans", sans-serif;
+    font-family: "Inter", sans-serif;
     font-weight: 400;
   }
   :host([expanded]) .content {

--- a/packages/ui-components/src/components/ui-alert.ts
+++ b/packages/ui-components/src/components/ui-alert.ts
@@ -82,7 +82,7 @@ const STYLES = /* css */ `
     display: flex;
     flex-direction: column;
     border-radius: 2px;
-    font-family: "Goldman Sans", sans-serif;
+    font-family: "Inter", sans-serif;
   }
 
   /* ── Top content ─────────────────────────────────────────────────────────── */

--- a/packages/ui-components/src/components/ui-avatar.ts
+++ b/packages/ui-components/src/components/ui-avatar.ts
@@ -66,7 +66,7 @@ const STYLES = /* css */ `
     align-items: center;
     justify-content: center;
     overflow: hidden;
-    font-family: "Goldman Sans", sans-serif;
+    font-family: "Inter", sans-serif;
     font-weight: 500;
     color: #ffffff;
   }

--- a/packages/ui-components/src/components/ui-badge.ts
+++ b/packages/ui-components/src/components/ui-badge.ts
@@ -66,7 +66,7 @@ const STYLES = /* css */ `
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-family: "Goldman Sans", sans-serif;
+    font-family: "Inter", sans-serif;
     font-weight: 500;
     text-transform: uppercase;
     white-space: nowrap;

--- a/packages/ui-components/src/components/ui-breadcrumb-item.ts
+++ b/packages/ui-components/src/components/ui-breadcrumb-item.ts
@@ -27,7 +27,7 @@ const STYLES = /* css */ `
   :host {
     display: inline-flex;
     align-items: center;
-    font-family: "Goldman Sans", sans-serif;
+    font-family: "Inter", sans-serif;
   }
 
   .base {

--- a/packages/ui-components/src/components/ui-button.ts
+++ b/packages/ui-components/src/components/ui-button.ts
@@ -53,7 +53,7 @@ const STYLES = /* css */ `
     cursor: pointer;
     user-select: none;
     -webkit-user-select: none;
-    font-family: var(--ui-btn-font-family, "Goldman Sans", sans-serif);
+    font-family: var(--ui-btn-font-family, "Inter", sans-serif);
     font-weight: var(--ui-btn-font-weight, 500);
     transition:
       background var(--ui-btn-transition-duration, 0.15s) ease,

--- a/packages/ui-components/src/components/ui-card.ts
+++ b/packages/ui-components/src/components/ui-card.ts
@@ -33,7 +33,7 @@ const STYLES = /* css */ `
 
   :host {
     display: block;
-    font-family: "Goldman Sans", sans-serif;
+    font-family: "Inter", sans-serif;
   }
 
   /* ── Base ─────────────────────────────────────────────────────────────────── */

--- a/packages/ui-components/src/components/ui-checkbox-item.ts
+++ b/packages/ui-components/src/components/ui-checkbox-item.ts
@@ -108,7 +108,7 @@ const STYLES = /* css */ `
 
   .label {
     display: none;
-    font-family: "Goldman Sans", sans-serif;
+    font-family: "Inter", sans-serif;
     font-weight: 400;
     color: var(--ui-cb-label-color, ${TEXT_PRIMARY});
   }

--- a/packages/ui-components/src/components/ui-dropdown-heading.ts
+++ b/packages/ui-components/src/components/ui-dropdown-heading.ts
@@ -21,7 +21,7 @@ const STYLES = /* css */ `
   }
 
   .heading {
-    font-family: var(--ui-dd-heading-font-family, "Goldman Sans", sans-serif);
+    font-family: var(--ui-dd-heading-font-family, "Inter", sans-serif);
     font-weight: var(--ui-dd-heading-font-weight, 500);
     color: var(--ui-dd-heading-color, ${GRAY_60});
     text-transform: uppercase;

--- a/packages/ui-components/src/components/ui-dropdown-item.ts
+++ b/packages/ui-components/src/components/ui-dropdown-item.ts
@@ -31,7 +31,7 @@ const STYLES = /* css */ `
     border: none;
     background-color: transparent;
     cursor: pointer;
-    font-family: var(--ui-dd-item-font-family, "Goldman Sans", sans-serif);
+    font-family: var(--ui-dd-item-font-family, "Inter", sans-serif);
     font-weight: var(--ui-dd-item-font-weight, 400);
     color: var(--ui-dd-item-color, ${TEXT_PRIMARY});
     text-align: start;

--- a/packages/ui-components/src/components/ui-dropdown-split.ts
+++ b/packages/ui-components/src/components/ui-dropdown-split.ts
@@ -75,7 +75,7 @@ const STYLES = /* css */ `
     background-color: transparent;
     background-image: none;
     color: inherit;
-    font-family: var(--ui-dds-font-family, "Goldman Sans", sans-serif);
+    font-family: var(--ui-dds-font-family, "Inter", sans-serif);
     font-weight: var(--ui-dds-font-weight, 500);
     transition:
       background-image 0.15s ease,

--- a/packages/ui-components/src/components/ui-modal.ts
+++ b/packages/ui-components/src/components/ui-modal.ts
@@ -63,7 +63,7 @@ const STYLES = /* css */ `
     background-color: var(--ui-modal-bg, ${SURFACE_PRIMARY});
     box-shadow: var(--ui-modal-shadow, ${ELEVATION_06});
     border-radius: 2px;
-    font-family: "Goldman Sans", sans-serif;
+    font-family: "Inter", sans-serif;
     color: ${TEXT_PRIMARY};
     width: var(--ui-modal-width, 441px);
     opacity: 0;

--- a/packages/ui-components/src/components/ui-side-panel-menu-item.ts
+++ b/packages/ui-components/src/components/ui-side-panel-menu-item.ts
@@ -40,7 +40,7 @@ const STYLES = /* css */ `
     border: none;
     margin: 0;
     background-color: var(--ui-spmi-bg, ${SURFACE_SECONDARY});
-    font-family: "Goldman Sans", sans-serif;
+    font-family: "Inter", sans-serif;
     font-size: 14px;
     font-weight: 500;
     line-height: 20px;

--- a/packages/ui-components/src/components/ui-side-panel-menu.ts
+++ b/packages/ui-components/src/components/ui-side-panel-menu.ts
@@ -34,7 +34,7 @@ const STYLES = /* css */ `
     width: 300px;
     height: 100%;
     background-color: var(--ui-spm-bg, ${SURFACE_SECONDARY});
-    font-family: "Goldman Sans", sans-serif;
+    font-family: "Inter", sans-serif;
     position: relative;
     transition: width 0.2s ease;
   }
@@ -170,7 +170,7 @@ const STYLES = /* css */ `
     box-shadow: var(--ui-spm-flyout-shadow, ${ELEVATION_03});
     flex-direction: column;
     z-index: 10;
-    font-family: "Goldman Sans", sans-serif;
+    font-family: "Inter", sans-serif;
   }
 
   .flyout[open] {
@@ -388,6 +388,10 @@ export class UiSidePanelMenu extends HTMLElement {
     for (const item of items) {
       if (isCollapsed) {
         item.setAttribute("type", "icon-only");
+        // Collapse any expanded parents — collapsed mode uses flyout instead
+        if (item.hasAttribute("expanded")) {
+          item.removeAttribute("expanded");
+        }
       } else {
         item.removeAttribute("type");
       }

--- a/packages/ui-components/src/stories/ui-accordion-item.stories.ts
+++ b/packages/ui-components/src/stories/ui-accordion-item.stories.ts
@@ -68,7 +68,7 @@ export const BoldEmphasis: Story = {
 export const WithLeadingIcon: Story = {
   render: () => html`
     <ui-accordion-item leading-icon expanded>
-      <svg slot="icon" viewBox="0 0 20 20" width="100%" height="100%"><circle cx="10" cy="10" r="8" fill="currentColor"/></svg>
+      <span slot="icon" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">info</span>
       <span slot="label">With Leading Icon</span>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </ui-accordion-item>

--- a/packages/ui-components/src/stories/ui-alert.stories.ts
+++ b/packages/ui-components/src/stories/ui-alert.stories.ts
@@ -94,9 +94,7 @@ export const WithDescription: Story = {
 export const WithLeadingIcon: Story = {
   render: () => html`
     <ui-alert status="information" leading-icon>
-      <svg slot="icon" viewBox="0 0 20 20" width="100%" height="100%">
-        <circle cx="10" cy="10" r="8" fill="currentColor" />
-      </svg>
+      <span slot="icon" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">info</span>
       Alert with leading icon
     </ui-alert>
   `,
@@ -114,33 +112,23 @@ export const AllStatuses: Story = {
   render: () => html`
     <div style="display: flex; flex-direction: column; gap: 16px;">
       <ui-alert status="none" leading-icon>
-        <svg slot="icon" viewBox="0 0 20 20" width="100%" height="100%">
-          <circle cx="10" cy="10" r="8" fill="currentColor" />
-        </svg>
+        <span slot="icon" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">notifications</span>
         None status
       </ui-alert>
       <ui-alert status="information" leading-icon>
-        <svg slot="icon" viewBox="0 0 20 20" width="100%" height="100%">
-          <circle cx="10" cy="10" r="8" fill="currentColor" />
-        </svg>
+        <span slot="icon" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">info</span>
         Information status
       </ui-alert>
       <ui-alert status="success" leading-icon>
-        <svg slot="icon" viewBox="0 0 20 20" width="100%" height="100%">
-          <circle cx="10" cy="10" r="8" fill="currentColor" />
-        </svg>
+        <span slot="icon" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">check_circle</span>
         Success status
       </ui-alert>
       <ui-alert status="error" leading-icon>
-        <svg slot="icon" viewBox="0 0 20 20" width="100%" height="100%">
-          <circle cx="10" cy="10" r="8" fill="currentColor" />
-        </svg>
+        <span slot="icon" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">error</span>
         Error status
       </ui-alert>
       <ui-alert status="warning" leading-icon>
-        <svg slot="icon" viewBox="0 0 20 20" width="100%" height="100%">
-          <circle cx="10" cy="10" r="8" fill="currentColor" />
-        </svg>
+        <span slot="icon" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">warning</span>
         Warning status
       </ui-alert>
     </div>
@@ -150,9 +138,7 @@ export const AllStatuses: Story = {
 export const WithFooterButton: Story = {
   render: () => html`
     <ui-alert status="none" leading-icon dismissable>
-      <svg slot="icon" viewBox="0 0 20 20" width="100%" height="100%">
-        <circle cx="10" cy="10" r="8" fill="currentColor" />
-      </svg>
+      <span slot="icon" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">notifications</span>
       Alert Title
       <span slot="description">Description text explaining the alert in more detail.</span>
       <div slot="footer">

--- a/packages/ui-components/src/stories/ui-button.stories.ts
+++ b/packages/ui-components/src/stories/ui-button.stories.ts
@@ -108,15 +108,15 @@ export const WithIcons: Story = {
   render: () => html`
     <div style="display: flex; gap: 12px; align-items: center;">
       <ui-button icon="leading-icon">
-        <svg slot="icon-start" width="20" height="20" viewBox="0 0 20 20" fill="currentColor"><circle cx="10" cy="10" r="4"/></svg>
+        <span slot="icon-start" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">add_circle</span>
         Leading
       </ui-button>
       <ui-button icon="trailing-icon">
         Trailing
-        <svg slot="icon-end" width="20" height="20" viewBox="0 0 20 20" fill="currentColor"><circle cx="10" cy="10" r="4"/></svg>
+        <span slot="icon-end" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">add_circle</span>
       </ui-button>
       <ui-button icon="icon-only">
-        <svg slot="icon-start" width="20" height="20" viewBox="0 0 20 20" fill="currentColor"><circle cx="10" cy="10" r="4"/></svg>
+        <span slot="icon-start" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">add_circle</span>
       </ui-button>
     </div>
   `,

--- a/packages/ui-components/src/stories/ui-card.stories.ts
+++ b/packages/ui-components/src/stories/ui-card.stories.ts
@@ -177,17 +177,7 @@ export const ArticleCard: Story = {
         style="display: flex; justify-content: space-between; align-items: center; padding: 0 16px 16px;"
       >
         <span style="font-size: 12px; color: #6b7b8a;">5 min read</span>
-        <svg
-          viewBox="0 0 20 20"
-          width="20"
-          height="20"
-          style="color: #6b7b8a;"
-        >
-          <path
-            d="M15 6.67a3.33 3.33 0 0 0-2.36.98L8.91 9.28a3.33 3.33 0 0 0 0 1.44l3.73 1.63A3.33 3.33 0 1 0 15 13.33a3.3 3.3 0 0 0-.55.05L10.72 11.75a3.33 3.33 0 0 0 0-3.5l3.73-1.63A3.3 3.3 0 0 0 15 6.67Z"
-            fill="currentColor"
-          />
-        </svg>
+        <span class="material-symbols-outlined" style="font-size: 20px; color: #6b7b8a;">share</span>
       </div>
     </ui-card>
   `,

--- a/packages/ui-components/src/stories/ui-dropdown-split.stories.ts
+++ b/packages/ui-components/src/stories/ui-dropdown-split.stories.ts
@@ -155,26 +155,18 @@ export const WithIcons: Story = {
   render: () => html`
     <div style="display: flex; gap: 12px; align-items: flex-start;">
       <ui-dropdown-split icon="leading-icon" label="Download">
-        <svg slot="icon-start" width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M10 3v10M6 9l4 4 4-4M4 15h12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
+        <span slot="icon-start" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">download</span>
         <ui-dropdown-item>Download as PDF</ui-dropdown-item>
         <ui-dropdown-item>Download as CSV</ui-dropdown-item>
         <ui-dropdown-item>Download as XLSX</ui-dropdown-item>
       </ui-dropdown-split>
       <ui-dropdown-split icon="trailing-icon" label="Export">
-        <svg slot="icon-end" width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M10 3v10M6 9l4 4 4-4M4 15h12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
+        <span slot="icon-end" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">upload</span>
         <ui-dropdown-item>Export JSON</ui-dropdown-item>
         <ui-dropdown-item>Export XML</ui-dropdown-item>
       </ui-dropdown-split>
       <ui-dropdown-split icon="icon-only">
-        <svg slot="icon-start" width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <circle cx="10" cy="4" r="1.5" fill="currentColor"/>
-          <circle cx="10" cy="10" r="1.5" fill="currentColor"/>
-          <circle cx="10" cy="16" r="1.5" fill="currentColor"/>
-        </svg>
+        <span slot="icon-start" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">more_vert</span>
         <ui-dropdown-item>Edit</ui-dropdown-item>
         <ui-dropdown-item>Delete</ui-dropdown-item>
       </ui-dropdown-split>

--- a/packages/ui-components/src/stories/ui-side-panel-menu.stories.ts
+++ b/packages/ui-components/src/stories/ui-side-panel-menu.stories.ts
@@ -5,7 +5,7 @@ import "../components/ui-side-panel-menu-item.js";
 
 // Material Symbols icon helper (font loaded in .storybook/preview.ts)
 const icon = (name: string) =>
-  html`<span slot="icon" class="material-symbols-outlined" style="font-size: 20px;">${name}</span>`;
+  html`<span slot="icon" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">${name}</span>`;
 
 const meta: Meta = {
   title: "Components/Side Panel Menu",
@@ -28,7 +28,7 @@ const meta: Meta = {
       <div style="height: 500px; display: flex;">
         ${story()}
         <div style="flex: 1; padding: 24px; background: #fff;">
-          <p style="margin: 0; color: #1c2b36; font-family: Goldman Sans, sans-serif;">
+          <p style="margin: 0; color: #1c2b36; font-family: Inter, sans-serif;">
             Main content area
           </p>
         </div>
@@ -269,7 +269,7 @@ export const Mobile: Story = {
       <div style="height: 500px; display: flex; position: relative;">
         ${story()}
         <div style="flex: 1; padding: 24px; background: #fff;">
-          <p style="margin: 0; color: #1c2b36; font-family: Goldman Sans, sans-serif;">
+          <p style="margin: 0; color: #1c2b36; font-family: Inter, sans-serif;">
             Main content area — resize below 768px to see mobile behavior
           </p>
         </div>


### PR DESCRIPTION
## Summary

- Add mobile responsive behavior to `<ui-side-panel-menu>`: auto-collapse on viewports ≤767px via `matchMedia` with foundation breakpoints, full-width overlay when expanded on mobile
- Fix cross-browser icon rendering: use `::slotted(svg)` instead of `.leading-icon svg` for Safari/Edge mobile compatibility
- Install `material-symbols` as root devDependency, import in Storybook preview
- Migrate all inline SVG icons to Material Symbols font across all 6 story files (side-panel-menu, accordion-item, button, card, dropdown-split, alert)
- Update Chromatic URL to library view in AGENTS.md and README.md
- Add Mobile story + 6 new tests for responsive behavior (707 total passing)