### PR TITLE
fix(foundation): sort spacing story by pixel value instead of alphabetically

### DIFF
--- a/packages/foundation/src/stories/spacing.stories.ts
+++ b/packages/foundation/src/stories/spacing.stories.ts
@@ -17,7 +17,7 @@ export const Scale: Story = {
   render: () => {
     injectAllTokens();
 
-    const steps = Object.entries(spacing) as [string, number][];
+    const steps = (Object.entries(spacing) as [string, number][]).sort((a, b) => a[1] - b[1]);
 
     return html`
       <style>


### PR DESCRIPTION
## Summary
- Spacing story was rendering steps in JS object enumeration order (integer keys first, then string keys), resulting in a jumbled display: `0, 1, 2, 3, ..., 10, 1px, 0.25, 0.5, 0.75, 1.5, 2.5`
- Fixed by sorting entries by pixel value ascending: `0, 1px, 0.25 (2px), 0.5 (4px), 0.75 (6px), 1 (8px), ..., 10 (80px)`