### PR TITLE
feat(ui-components): add ui-label component and refactor ui-input to use it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ maneki-monorepo/
 ├── packages/
 │   ├── grid-layout/         # <grid-layout> Web Component library (@maneki/grid-layout)
 │   ├── ui-components/       # UI components + Storybook (@maneki/ui-components)
-│   │                        # Primitives: badge, image, button, avatar, alert
+│   │                        # Primitives: badge, image, button, avatar, alert, label
 │   │                        # Form Controls: checkbox-item/group, radio-item/group, input, input-group, file-upload
 │   │                        # Containers: card, button-group
 │   │                        # Navigation: breadcrumb-item/group, side-panel-menu/item

--- a/packages/ui-components/AGENTS.md
+++ b/packages/ui-components/AGENTS.md
@@ -9,6 +9,7 @@ Web Component library for the Maneki design system. Shadow DOM, CSS custom prope
 - `<ui-button>` — full Figma spec: 5 actions, 3 emphases, 4 sizes, 2 shapes, 4 icon modes, 3 statuses
 - `<ui-avatar>` — avatar component: 5 sizes, 3 types (text/icon/image), 2 emphases, 2 shapes, 5 statuses, 14 colors
 - `<ui-alert>` — dismissable alert/toast: 3 sizes, 2 emphases, 5 statuses, footer slot
+- `<ui-label>` — form field label: 3 sizes (s/m/l), 2 emphases (bold/subtle), disabled state, required indicator
 
 **Form Controls:**
 - `<ui-checkbox-item>` — checkbox component: 3 sizes (s/m/l), 3 check states (unchecked/checked/indeterminate), 3 label positions (none/right/left), 5 states (enabled/hover/focus/disabled/error)
@@ -61,6 +62,7 @@ ui-components/
 │   │   ├── ui-button-group.ts
 │   │   ├── ui-avatar.ts
 │   │   ├── ui-alert.ts
+│   │   ├── ui-label.ts
 │   │   ├── ui-checkbox-item.ts
 │   │   ├── ui-checkbox-group.ts
 │   │   ├── ui-radio-item.ts

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -37,6 +37,7 @@ npm install @maneki/ui-components
 | `<ui-button>` | 5 actions, 3 emphases, 4 sizes, 2 shapes, 4 icon modes, 3 statuses |
 | `<ui-avatar>` | 5 sizes, 3 types (text/icon/image), 2 emphases, 2 shapes, 14 colors |
 | `<ui-alert>` | Dismissable alert: 3 sizes, 2 emphases, 5 statuses, footer slot |
+| `<ui-label>` | Form field label: 3 sizes, 2 emphases, disabled, required indicator |
 | | **Form Controls** |
 | `<ui-checkbox-item>` | 3 sizes, 3 check states, 3 label positions, 5 states |
 | `<ui-checkbox-group>` | Group wrapper: 2 orientations, size propagation |

--- a/packages/ui-components/src/components/ui-input.test.ts
+++ b/packages/ui-components/src/components/ui-input.test.ts
@@ -200,7 +200,7 @@ describe("ui-input", () => {
   it("sets label attribute and shows label text", () => {
     (el as unknown as { label: string }).label = "Email";
     expect(el.getAttribute("label")).toBe("Email");
-    const labelEl = el.shadowRoot!.querySelector(".label-text");
+    const labelEl = el.shadowRoot!.querySelector("ui-label[emphasis='bold']");
     expect(labelEl!.textContent).toBe("Email");
   });
 
@@ -215,7 +215,7 @@ describe("ui-input", () => {
   it("sets secondary-label attribute", () => {
     (el as unknown as { secondaryLabel: string }).secondaryLabel = "Optional";
     expect(el.getAttribute("secondary-label")).toBe("Optional");
-    const secEl = el.shadowRoot!.querySelector(".secondary-label-text");
+    const secEl = el.shadowRoot!.querySelector("ui-label[emphasis='subtle']");
     expect(secEl!.textContent).toBe("Optional");
   });
 

--- a/packages/ui-components/src/components/ui-input.ts
+++ b/packages/ui-components/src/components/ui-input.ts
@@ -1,4 +1,5 @@
 import { semanticVar, spaceVar } from "@maneki/foundation";
+import "./ui-label.js";
 
 // ─── Type-safe property unions ───────────────────────────────────────────────
 
@@ -78,14 +79,8 @@ const STYLES = /* css */ `
     display: flex;
   }
 
-  .label-text {
-    font-weight: 500;
-    color: var(--ui-input-label-color, ${TEXT_SECONDARY});
-  }
-
-  .secondary-label-text {
-    font-weight: 400;
-    color: var(--ui-input-label-color, ${TEXT_SECONDARY});
+  .label-row ui-label {
+    display: inline;
   }
 
   /* ── Input container ───────────────────────────────────────────────────── */
@@ -323,8 +318,6 @@ const STYLES = /* css */ `
     --_input-font-size: 14px;
     --_input-line-height: 20px;
     --_status-icon-size: 18px;
-    --_label-font-size: 14px;
-    --_label-line-height: 20px;
     --_clear-size: 16px;
     --_numeric-width: 24px;
   }
@@ -337,8 +330,6 @@ const STYLES = /* css */ `
     --_input-font-size: 12px;
     --_input-line-height: 16px;
     --_status-icon-size: 14px;
-    --_label-font-size: 12px;
-    --_label-line-height: 16px;
     --_clear-size: 12px;
     --_numeric-width: 20px;
   }
@@ -351,8 +342,6 @@ const STYLES = /* css */ `
     --_input-font-size: 16px;
     --_input-line-height: 24px;
     --_status-icon-size: 20px;
-    --_label-font-size: 14px;
-    --_label-line-height: 20px;
     --_clear-size: 18px;
     --_numeric-width: 28px;
   }
@@ -369,11 +358,6 @@ const STYLES = /* css */ `
     line-height: var(--_input-line-height);
   }
 
-  .label-text,
-  .secondary-label-text {
-    font-size: var(--_label-font-size);
-    line-height: var(--_label-line-height);
-  }
 
   .status-icon {
     width: var(--_status-icon-size);
@@ -456,10 +440,6 @@ const STYLES = /* css */ `
     color: ${DISABLED_TEXT};
   }
 
-  :host([disabled]) .label-text,
-  :host([disabled]) .secondary-label-text {
-    color: ${DISABLED_TEXT};
-  }
 
   :host([disabled]) .supportive-text {
     color: ${DISABLED_TEXT};
@@ -494,10 +474,6 @@ const STYLES = /* css */ `
     color: ${TEXT_SECONDARY};
   }
 
-  :host([readonly]) .label-text,
-  :host([readonly]) .secondary-label-text {
-    color: ${TEXT_SECONDARY};
-  }
 
   /* ── Reduced motion ────────────────────────────────────────────────────── */
 
@@ -545,8 +521,8 @@ export class UiInput extends HTMLElement {
   private _passwordToggleEl: HTMLButtonElement;
   private _passwordIconEl: HTMLSpanElement;
   private _passwordVisible: boolean;
-  private _labelTextEl: HTMLSpanElement;
-  private _secondaryLabelEl: HTMLSpanElement;
+  private _labelTextEl: HTMLElement;
+  private _secondaryLabelEl: HTMLElement;
   private _supportiveTextEl: HTMLSpanElement;
   private _supportiveId: string;
 
@@ -562,12 +538,12 @@ export class UiInput extends HTMLElement {
     const labelRow = document.createElement("div");
     labelRow.className = "label-row";
 
-    this._labelTextEl = document.createElement("span");
-    this._labelTextEl.className = "label-text";
+    this._labelTextEl = document.createElement("ui-label");
+    this._labelTextEl.setAttribute("emphasis", "bold");
     labelRow.appendChild(this._labelTextEl);
 
-    this._secondaryLabelEl = document.createElement("span");
-    this._secondaryLabelEl.className = "secondary-label-text";
+    this._secondaryLabelEl = document.createElement("ui-label");
+    this._secondaryLabelEl.setAttribute("emphasis", "subtle");
     labelRow.appendChild(this._secondaryLabelEl);
 
     shadow.appendChild(labelRow);
@@ -709,6 +685,7 @@ export class UiInput extends HTMLElement {
         break;
       case "disabled":
         this._syncDisabled();
+        this._syncLabels();
         this._syncAria();
         break;
       case "readonly":
@@ -717,6 +694,9 @@ export class UiInput extends HTMLElement {
         break;
       case "type":
         this._syncInputType();
+        break;
+      case "size":
+        this._syncLabels();
         break;
       case "status":
       case "error":
@@ -922,6 +902,17 @@ export class UiInput extends HTMLElement {
   private _syncLabels(): void {
     this._labelTextEl.textContent = this.label;
     this._secondaryLabelEl.textContent = this.secondaryLabel;
+    // Sync size and disabled to ui-label children
+    const size = this.getAttribute("size") || "m";
+    this._labelTextEl.setAttribute("size", size);
+    this._secondaryLabelEl.setAttribute("size", size);
+    if (this.disabled) {
+      this._labelTextEl.setAttribute("disabled", "");
+      this._secondaryLabelEl.setAttribute("disabled", "");
+    } else {
+      this._labelTextEl.removeAttribute("disabled");
+      this._secondaryLabelEl.removeAttribute("disabled");
+    }
   }
 
   private _syncSupportive(): void {

--- a/packages/ui-components/src/components/ui-label.test.ts
+++ b/packages/ui-components/src/components/ui-label.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "./ui-label.js";
+
+describe("ui-label", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-label");
+    document.body.appendChild(el);
+  });
+
+  // ── Registration ─────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-label")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).toBeTruthy();
+  });
+
+  // ── Default attributes ───────────────────────────────────────────────────
+
+  it("defaults size to 'm'", () => {
+    expect((el as unknown as { size: string }).size).toBe("m");
+  });
+
+  it("defaults emphasis to 'bold'", () => {
+    expect((el as unknown as { emphasis: string }).emphasis).toBe("bold");
+  });
+
+  it("defaults disabled to false", () => {
+    expect((el as unknown as { disabled: boolean }).disabled).toBe(false);
+  });
+
+  it("defaults required to false", () => {
+    expect((el as unknown as { required: boolean }).required).toBe(false);
+  });
+
+  // ── Size attribute ───────────────────────────────────────────────────────
+
+  it("reflects size='s' attribute", () => {
+    el.setAttribute("size", "s");
+    expect((el as unknown as { size: string }).size).toBe("s");
+  });
+
+  it("reflects size='m' attribute", () => {
+    el.setAttribute("size", "m");
+    expect((el as unknown as { size: string }).size).toBe("m");
+  });
+
+  it("reflects size='l' attribute", () => {
+    el.setAttribute("size", "l");
+    expect((el as unknown as { size: string }).size).toBe("l");
+  });
+
+  it("sets size via property", () => {
+    (el as unknown as { size: string }).size = "l";
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  // ── Emphasis attribute ───────────────────────────────────────────────────
+
+  it("reflects emphasis='bold' attribute", () => {
+    el.setAttribute("emphasis", "bold");
+    expect((el as unknown as { emphasis: string }).emphasis).toBe("bold");
+  });
+
+  it("reflects emphasis='subtle' attribute", () => {
+    el.setAttribute("emphasis", "subtle");
+    expect((el as unknown as { emphasis: string }).emphasis).toBe("subtle");
+  });
+
+  it("sets emphasis via property", () => {
+    (el as unknown as { emphasis: string }).emphasis = "subtle";
+    expect(el.getAttribute("emphasis")).toBe("subtle");
+  });
+
+  // ── Disabled attribute ───────────────────────────────────────────────────
+
+  it("reflects disabled attribute", () => {
+    el.setAttribute("disabled", "");
+    expect((el as unknown as { disabled: boolean }).disabled).toBe(true);
+  });
+
+  it("sets disabled via property", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    expect(el.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("removes disabled via property", () => {
+    el.setAttribute("disabled", "");
+    (el as unknown as { disabled: boolean }).disabled = false;
+    expect(el.hasAttribute("disabled")).toBe(false);
+  });
+
+  // ── Required attribute ───────────────────────────────────────────────────
+
+  it("reflects required attribute", () => {
+    el.setAttribute("required", "");
+    expect((el as unknown as { required: boolean }).required).toBe(true);
+  });
+
+  it("sets required via property", () => {
+    (el as unknown as { required: boolean }).required = true;
+    expect(el.hasAttribute("required")).toBe(true);
+  });
+
+  it("removes required via property", () => {
+    el.setAttribute("required", "");
+    (el as unknown as { required: boolean }).required = false;
+    expect(el.hasAttribute("required")).toBe(false);
+  });
+
+  // ── Shadow DOM structure ─────────────────────────────────────────────────
+
+  it("renders a text span with slot", () => {
+    const textEl = el.shadowRoot!.querySelector(".text");
+    expect(textEl).toBeTruthy();
+    const slot = textEl!.querySelector("slot");
+    expect(slot).toBeTruthy();
+  });
+
+  it("renders a required indicator", () => {
+    const reqEl = el.shadowRoot!.querySelector(".required");
+    expect(reqEl).toBeTruthy();
+    expect(reqEl!.textContent).toBe("*");
+  });
+
+  it("hides required indicator by default", () => {
+    const reqEl = el.shadowRoot!.querySelector(".required") as HTMLElement;
+    const style = getComputedStyle(reqEl);
+    // Without [required] attr, CSS rule `:host(:not([required])) .required` hides it
+    expect(el.hasAttribute("required")).toBe(false);
+  });
+
+  it("required indicator has aria-hidden", () => {
+    const reqEl = el.shadowRoot!.querySelector(".required");
+    expect(reqEl!.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  // ── Slotted content ──────────────────────────────────────────────────────
+
+  it("renders slotted text content", () => {
+    el.textContent = "Username";
+    const slot = el.shadowRoot!.querySelector("slot") as HTMLSlotElement;
+    const assigned = slot.assignedNodes();
+    expect(assigned.length).toBe(1);
+    expect(assigned[0].textContent).toBe("Username");
+  });
+
+  // ── CSS custom property overrides ────────────────────────────────────────
+
+  it("supports --ui-label-color override", () => {
+    // Verify the CSS contains the override var
+    const style = el.shadowRoot!.querySelector("style");
+    expect(style!.textContent).toContain("--ui-label-color");
+  });
+
+  // ── Size CSS variables ───────────────────────────────────────────────────
+
+  it("size s sets 12px font-size via CSS var", () => {
+    const style = el.shadowRoot!.querySelector("style");
+    expect(style!.textContent).toContain(":host([size=\"s\"])");
+    expect(style!.textContent).toContain("--_font-size: 12px");
+    expect(style!.textContent).toContain("--_line-height: 16px");
+  });
+
+  it("size m sets 14px font-size via CSS var", () => {
+    const style = el.shadowRoot!.querySelector("style");
+    // m is the default, defined on :host
+    expect(style!.textContent).toContain("--_font-size: 14px");
+    expect(style!.textContent).toContain("--_line-height: 20px");
+  });
+
+  it("size l sets 16px font-size via CSS var", () => {
+    const style = el.shadowRoot!.querySelector("style");
+    expect(style!.textContent).toContain(":host([size=\"l\"])");
+    expect(style!.textContent).toContain("--_font-size: 16px");
+    expect(style!.textContent).toContain("--_line-height: 24px");
+  });
+
+  // ── Emphasis CSS variables ───────────────────────────────────────────────
+
+  it("bold emphasis sets font-weight 500", () => {
+    const style = el.shadowRoot!.querySelector("style");
+    expect(style!.textContent).toContain("--_font-weight: 500");
+  });
+
+  it("subtle emphasis sets font-weight 400", () => {
+    const style = el.shadowRoot!.querySelector("style");
+    expect(style!.textContent).toContain(":host([emphasis=\"subtle\"])");
+    expect(style!.textContent).toContain("--_font-weight: 400");
+  });
+
+  // ── Display ──────────────────────────────────────────────────────────────
+
+  it("host displays as inline-flex", () => {
+    const style = el.shadowRoot!.querySelector("style");
+    expect(style!.textContent).toContain("display: inline-flex");
+  });
+});

--- a/packages/ui-components/src/components/ui-label.ts
+++ b/packages/ui-components/src/components/ui-label.ts
@@ -1,0 +1,155 @@
+import { semanticVar } from "@maneki/foundation";
+
+// ─── Type-safe property unions ───────────────────────────────────────────────
+
+export type LabelSize = "s" | "m" | "l";
+export type LabelEmphasis = "bold" | "subtle";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const TEXT_SECONDARY = semanticVar("text", "secondary");
+const DISABLED_TEXT = semanticVar("stateDisabled", "text");
+const STATUS_ERROR = semanticVar("statusGeneral", "error");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: inline-flex;
+    align-items: baseline;
+    font-family: "Inter", sans-serif;
+    color: var(--ui-label-color, ${TEXT_SECONDARY});
+  }
+
+  .text {
+    font-size: var(--_font-size);
+    line-height: var(--_line-height);
+    font-weight: var(--_font-weight);
+  }
+
+  .required {
+    color: ${STATUS_ERROR};
+    font-size: var(--_font-size);
+    line-height: var(--_line-height);
+    margin-left: 2px;
+  }
+
+  :host(:not([required])) .required {
+    display: none;
+  }
+
+  /* ── Emphasis ─────────────────────────────────────────────────────────────── */
+
+  :host,
+  :host([emphasis="bold"]) {
+    --_font-weight: 500;
+  }
+
+  :host([emphasis="subtle"]) {
+    --_font-weight: 400;
+  }
+
+  /* ── Size: m (default) ───────────────────────────────────────────────────── */
+
+  :host,
+  :host([size="m"]) {
+    --_font-size: 14px;
+    --_line-height: 20px;
+  }
+
+  /* ── Size: s ─────────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) {
+    --_font-size: 12px;
+    --_line-height: 16px;
+  }
+
+  /* ── Size: l ─────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) {
+    --_font-size: 16px;
+    --_line-height: 24px;
+  }
+
+  /* ── Disabled ────────────────────────────────────────────────────────────── */
+
+  :host([disabled]) {
+    color: var(--ui-label-color, ${DISABLED_TEXT});
+  }
+
+  :host([disabled]) .required {
+    color: ${DISABLED_TEXT};
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const OBSERVED = ["size", "emphasis", "disabled", "required"] as const;
+
+class UiLabel extends HTMLElement {
+  static observedAttributes = [...OBSERVED];
+
+  private _textEl: HTMLSpanElement;
+  private _requiredEl: HTMLSpanElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+
+    const style = document.createElement("style");
+    style.textContent = STYLES;
+    shadow.appendChild(style);
+
+    this._textEl = document.createElement("span");
+    this._textEl.className = "text";
+    const slot = document.createElement("slot");
+    this._textEl.appendChild(slot);
+    shadow.appendChild(this._textEl);
+
+    this._requiredEl = document.createElement("span");
+    this._requiredEl.className = "required";
+    this._requiredEl.setAttribute("aria-hidden", "true");
+    this._requiredEl.textContent = "*";
+    shadow.appendChild(this._requiredEl);
+  }
+
+  // ── Attribute accessors ──────────────────────────────────────────────────
+
+  get size(): LabelSize {
+    return (this.getAttribute("size") as LabelSize) ?? "m";
+  }
+  set size(v: LabelSize) {
+    this.setAttribute("size", v);
+  }
+
+  get emphasis(): LabelEmphasis {
+    return (this.getAttribute("emphasis") as LabelEmphasis) ?? "bold";
+  }
+  set emphasis(v: LabelEmphasis) {
+    this.setAttribute("emphasis", v);
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute("disabled");
+  }
+  set disabled(v: boolean) {
+    v ? this.setAttribute("disabled", "") : this.removeAttribute("disabled");
+  }
+
+  get required(): boolean {
+    return this.hasAttribute("required");
+  }
+  set required(v: boolean) {
+    v ? this.setAttribute("required", "") : this.removeAttribute("required");
+  }
+}
+
+customElements.define("ui-label", UiLabel);
+
+export { UiLabel };

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -31,6 +31,8 @@ export type {
 
 // ─── Form Controls ──────────────────────────────────────────────────────────
 
+export { UiLabel } from "./components/ui-label.js";
+export type { LabelSize, LabelEmphasis } from "./components/ui-label.js";
 export { UiCheckboxItem } from "./components/ui-checkbox-item.js";
 export type { CheckboxSize, CheckboxLabel } from "./components/ui-checkbox-item.js";
 export { UiCheckboxGroup } from "./components/ui-checkbox-group.js";

--- a/packages/ui-components/src/stories/ui-label.stories.ts
+++ b/packages/ui-components/src/stories/ui-label.stories.ts
@@ -1,0 +1,143 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-label.js";
+
+const meta: Meta = {
+  title: "Components/Label",
+  component: "ui-label",
+  argTypes: {
+    size: { control: { type: "select" }, options: ["s", "m", "l"] },
+    emphasis: { control: { type: "select" }, options: ["bold", "subtle"] },
+    disabled: { control: "boolean" },
+    required: { control: "boolean" },
+    text: { control: "text" },
+  },
+  args: {
+    size: "m",
+    emphasis: "bold",
+    disabled: false,
+    required: false,
+    text: "Label",
+  },
+  render: (args) => html`
+    <ui-label
+      size=${args.size}
+      emphasis=${args.emphasis}
+      ?disabled=${args.disabled}
+      ?required=${args.required}
+    >${args.text}</ui-label>
+  `,
+};
+export default meta;
+
+type Story = StoryObj;
+
+// ── Variants (all sizes × emphases) ─────────────────────────────────────────
+
+export const Variants: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 24px;">
+      <div>
+        <h3 style="margin: 0 0 12px; font-size: 14px; color: #5b7282;">Bold (default)</h3>
+        <div style="display: flex; align-items: baseline; gap: 32px;">
+          <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+            <span style="font-size: 11px; color: #9fb1bd;">S</span>
+            <ui-label size="s">Label</ui-label>
+          </div>
+          <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+            <span style="font-size: 11px; color: #9fb1bd;">M</span>
+            <ui-label size="m">Label</ui-label>
+          </div>
+          <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+            <span style="font-size: 11px; color: #9fb1bd;">L</span>
+            <ui-label size="l">Label</ui-label>
+          </div>
+        </div>
+      </div>
+      <div>
+        <h3 style="margin: 0 0 12px; font-size: 14px; color: #5b7282;">Subtle</h3>
+        <div style="display: flex; align-items: baseline; gap: 32px;">
+          <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+            <span style="font-size: 11px; color: #9fb1bd;">S</span>
+            <ui-label size="s" emphasis="subtle">Label</ui-label>
+          </div>
+          <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+            <span style="font-size: 11px; color: #9fb1bd;">M</span>
+            <ui-label size="m" emphasis="subtle">Label</ui-label>
+          </div>
+          <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+            <span style="font-size: 11px; color: #9fb1bd;">L</span>
+            <ui-label size="l" emphasis="subtle">Label</ui-label>
+          </div>
+        </div>
+      </div>
+    </div>
+  `,
+};
+
+// ── States ───────────────────────────────────────────────────────────────────
+
+export const States: Story = {
+  render: () => html`
+    <div style="display: flex; align-items: baseline; gap: 32px;">
+      <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+        <span style="font-size: 11px; color: #9fb1bd;">Enabled</span>
+        <ui-label>Label</ui-label>
+      </div>
+      <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+        <span style="font-size: 11px; color: #9fb1bd;">Disabled</span>
+        <ui-label disabled>Label</ui-label>
+      </div>
+    </div>
+  `,
+};
+
+// ── Required ─────────────────────────────────────────────────────────────────
+
+export const Required: Story = {
+  render: () => html`
+    <div style="display: flex; align-items: baseline; gap: 32px;">
+      <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+        <span style="font-size: 11px; color: #9fb1bd;">Not required</span>
+        <ui-label>Username</ui-label>
+      </div>
+      <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+        <span style="font-size: 11px; color: #9fb1bd;">Required</span>
+        <ui-label required>Username</ui-label>
+      </div>
+      <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+        <span style="font-size: 11px; color: #9fb1bd;">Required + Disabled</span>
+        <ui-label required disabled>Username</ui-label>
+      </div>
+    </div>
+  `,
+};
+
+// ── Emphasis ─────────────────────────────────────────────────────────────────
+
+export const Emphasis: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 16px;">
+      <div style="display: flex; align-items: baseline; gap: 32px;">
+        <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+          <span style="font-size: 11px; color: #9fb1bd;">Bold</span>
+          <ui-label emphasis="bold">Label</ui-label>
+        </div>
+        <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+          <span style="font-size: 11px; color: #9fb1bd;">Subtle</span>
+          <ui-label emphasis="subtle">Label</ui-label>
+        </div>
+      </div>
+      <div style="display: flex; align-items: baseline; gap: 32px;">
+        <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+          <span style="font-size: 11px; color: #9fb1bd;">Bold + Disabled</span>
+          <ui-label emphasis="bold" disabled>Label</ui-label>
+        </div>
+        <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+          <span style="font-size: 11px; color: #9fb1bd;">Subtle + Disabled</span>
+          <ui-label emphasis="subtle" disabled>Label</ui-label>
+        </div>
+      </div>
+    </div>
+  `,
+};


### PR DESCRIPTION
## Summary

- New `<ui-label>` component: form field label with 3 sizes (s/m/l), 2 emphases (bold/subtle), disabled state, and required indicator (`*`)
- Refactored `<ui-input>` to use `<ui-label>` internally for its label-text and secondary-label-text, replacing manual span rendering
- Fixed L size label typography: 14px/20px → 16px/24px to match Figma spec (ui-label uses correct values)
- 31 new tests for ui-label, 1074 total tests passing across 25 files
- 4 Storybook stories: Variants, States, Required, Emphasis

## Changes

- `packages/ui-components/src/components/ui-label.ts` — new component
- `packages/ui-components/src/components/ui-label.test.ts` — 31 tests
- `packages/ui-components/src/stories/ui-label.stories.ts` — 4 stories
- `packages/ui-components/src/components/ui-input.ts` — refactored to use `<ui-label>` for label rendering, removed redundant label CSS
- `packages/ui-components/src/components/ui-input.test.ts` — updated selectors for ui-label
- `packages/ui-components/src/index.ts` — registered ui-label export
- `AGENTS.md`, `packages/ui-components/AGENTS.md`, `packages/ui-components/README.md` — docs updated