### PR TITLE
refactor(ui-components): migrate to Constructable Stylesheets

### DIFF
--- a/packages/ui-components/src/components/ui-accordion-item.ts
+++ b/packages/ui-components/src/components/ui-accordion-item.ts
@@ -329,6 +329,9 @@ const STYLES = /* css */ `
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiAccordionItem extends HTMLElement {
   static readonly observedAttributes = [
     "size",
@@ -355,9 +358,7 @@ export class UiAccordionItem extends HTMLElement {
     this._headerId = `${uid}_header`;
     this._contentId = `${uid}_content`;
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // Separator
     const separator = document.createElement("div");

--- a/packages/ui-components/src/components/ui-alert.ts
+++ b/packages/ui-components/src/components/ui-alert.ts
@@ -380,6 +380,9 @@ const STYLES = /* css */ `
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiAlert extends HTMLElement {
   static readonly observedAttributes = [
     "size",
@@ -396,9 +399,7 @@ export class UiAlert extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // .base
     const base = document.createElement("div");

--- a/packages/ui-components/src/components/ui-avatar.ts
+++ b/packages/ui-components/src/components/ui-avatar.ts
@@ -370,6 +370,9 @@ const STYLES = /* css */ `
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiAvatar extends HTMLElement {
   static readonly observedAttributes = [
     "size",
@@ -388,9 +391,7 @@ export class UiAvatar extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // .base
     const base = document.createElement("div");

--- a/packages/ui-components/src/components/ui-badge.test.ts
+++ b/packages/ui-components/src/components/ui-badge.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import "./ui-badge.js";
+import { STYLES } from "./ui-badge.js";
 
 describe("ui-badge", () => {
   let el: HTMLElement;
@@ -211,7 +212,7 @@ describe("ui-badge", () => {
 
   it("has a <style> element in shadow DOM", () => {
     const shadow = el.shadowRoot!;
-    expect(shadow.querySelector("style")).toBeTruthy();
+    expect(shadow.adoptedStyleSheets.length).toBeGreaterThan(0);
   });
 
   // ── Property accessors ────────────────────────────────────────────────
@@ -354,46 +355,40 @@ describe("ui-badge", () => {
 
   it("is an inline-flex element via :host", () => {
     const shadow = el.shadowRoot!;
-    const style = shadow.querySelector("style");
-    expect(style!.textContent).toContain("display: inline-flex");
+    const styles = shadow.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
+    expect(styles).toContain("display: inline-flex");
   });
 
   // ── CSS contains expected token references ────────────────────────────
 
   it("CSS contains --ui-badge-bg custom property", () => {
-    const shadow = el.shadowRoot!;
-    const style = shadow.querySelector("style");
-    expect(style!.textContent).toContain("--ui-badge-bg");
+    expect(STYLES).toContain("--ui-badge-bg");
   });
 
   it("CSS contains --ui-badge-color custom property", () => {
-    const shadow = el.shadowRoot!;
-    const style = shadow.querySelector("style");
-    expect(style!.textContent).toContain("--ui-badge-color");
+    expect(STYLES).toContain("--ui-badge-color");
   });
 
   it("CSS contains --ui-badge-border custom property", () => {
-    const shadow = el.shadowRoot!;
-    const style = shadow.querySelector("style");
-    expect(style!.textContent).toContain("--ui-badge-border");
+    expect(STYLES).toContain("--ui-badge-border");
   });
 
   it("CSS contains text-transform: uppercase", () => {
     const shadow = el.shadowRoot!;
-    const style = shadow.querySelector("style");
-    expect(style!.textContent).toContain("text-transform: uppercase");
+    const styles = shadow.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
+    expect(styles).toContain("text-transform: uppercase");
   });
 
   it("CSS contains font-weight: 500", () => {
     const shadow = el.shadowRoot!;
-    const style = shadow.querySelector("style");
-    expect(style!.textContent).toContain("font-weight: 500");
+    const styles = shadow.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
+    expect(styles).toContain("font-weight: 500");
   });
 
   it("CSS contains white-space: nowrap", () => {
     const shadow = el.shadowRoot!;
-    const style = shadow.querySelector("style");
-    expect(style!.textContent).toContain("white-space: nowrap");
+    const styles = shadow.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
+    expect(styles).toContain("white-space: nowrap");
   });
 
   // ── Multiple instances ────────────────────────────────────────────────

--- a/packages/ui-components/src/components/ui-badge.ts
+++ b/packages/ui-components/src/components/ui-badge.ts
@@ -49,7 +49,7 @@ const BORDER_MODERATE = semanticVar("border", "moderate");
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
 
-const STYLES = /* css */ `
+export const STYLES = /* css */ `
   *,
   *::before,
   *::after {
@@ -245,6 +245,9 @@ const STYLES = /* css */ `
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiBadge extends HTMLElement {
   static readonly observedAttributes = [
     "size",
@@ -258,9 +261,7 @@ export class UiBadge extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // .base
     const base = document.createElement("span");

--- a/packages/ui-components/src/components/ui-breadcrumb-group.ts
+++ b/packages/ui-components/src/components/ui-breadcrumb-group.ts
@@ -48,6 +48,9 @@ const STYLES = /* css */ `
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiBreadcrumbGroup extends HTMLElement {
   static readonly observedAttributes = ["size", "aria-label"];
 
@@ -57,9 +60,7 @@ export class UiBreadcrumbGroup extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // <nav aria-label="Breadcrumb">
     const nav = document.createElement("nav");

--- a/packages/ui-components/src/components/ui-breadcrumb-item.ts
+++ b/packages/ui-components/src/components/ui-breadcrumb-item.ts
@@ -157,6 +157,9 @@ const STYLES = /* css */ `
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiBreadcrumbItem extends HTMLElement {
   static readonly observedAttributes = ["size", "href", "disabled"];
 
@@ -169,9 +172,7 @@ export class UiBreadcrumbItem extends HTMLElement {
     const shadow = this.attachShadow({ mode: "open" });
 
     // role="listitem" only when inside a breadcrumb-group (role="list" parent)
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // .base
     this._base = document.createElement("span");

--- a/packages/ui-components/src/components/ui-button.ts
+++ b/packages/ui-components/src/components/ui-button.ts
@@ -422,6 +422,9 @@ const STYLES = /* css */ `
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiButton extends HTMLElement {
   static readonly observedAttributes = [
     "action",
@@ -441,9 +444,7 @@ export class UiButton extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     const button = document.createElement("button");
     button.setAttribute("part", "button");

--- a/packages/ui-components/src/components/ui-card.ts
+++ b/packages/ui-components/src/components/ui-card.ts
@@ -127,6 +127,9 @@ const STYLES = /* css */ `
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiCard extends HTMLElement {
   static readonly observedAttributes = ["size", "elevation", "bordered"];
 
@@ -136,9 +139,7 @@ export class UiCard extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // .base
     const base = document.createElement("div");

--- a/packages/ui-components/src/components/ui-checkbox-group.test.ts
+++ b/packages/ui-components/src/components/ui-checkbox-group.test.ts
@@ -134,40 +134,40 @@ describe("UiCheckboxGroup", () => {
 
   describe("CSS layout", () => {
     it("should have display: flex on host", () => {
-      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      const styles = group.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
       expect(styles).toContain(":host {");
       expect(styles).toContain("display: flex;");
     });
 
     it("should have flex-direction: column for vertical orientation", () => {
-      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      const styles = group.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
       expect(styles).toContain("flex-direction: column;");
     });
 
     it("should have flex-direction: row for horizontal orientation", () => {
-      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      const styles = group.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
       expect(styles).toContain("flex-direction: row;");
     });
   });
 
   describe("gap values", () => {
     it("should have correct gap for size='s' (8px)", () => {
-      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      const styles = group.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
       expect(styles).toContain(':host([size="s"]) .group');
     });
 
     it("should have correct gap for size='m' (12px)", () => {
-      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      const styles = group.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
       expect(styles).toContain(':host([size="m"]) .group');
     });
 
     it("should have correct gap for size='l' (20px)", () => {
-      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      const styles = group.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
       expect(styles).toContain(':host([size="l"]) .group');
     });
 
     it("should have horizontal gap (24px) for horizontal orientation", () => {
-      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      const styles = group.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
       expect(styles).toContain(':host([orientation="horizontal"]) .group');
     });
   });

--- a/packages/ui-components/src/components/ui-checkbox-group.ts
+++ b/packages/ui-components/src/components/ui-checkbox-group.ts
@@ -67,6 +67,9 @@ const STYLES = /* css */ `
 
 const PROPAGATED_ATTRS = ["size"] as const;
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiCheckboxGroup extends HTMLElement {
   static readonly observedAttributes = ["size", "orientation", "aria-labelledby"];
 
@@ -75,9 +78,7 @@ export class UiCheckboxGroup extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     const group = document.createElement("div");
     group.className = "group";

--- a/packages/ui-components/src/components/ui-checkbox-item.ts
+++ b/packages/ui-components/src/components/ui-checkbox-item.ts
@@ -295,6 +295,9 @@ const STYLES = /* css */ `
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiCheckboxItem extends HTMLElement {
   static readonly observedAttributes = [
     "size",
@@ -309,9 +312,7 @@ export class UiCheckboxItem extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // .base
     const base = document.createElement("div");

--- a/packages/ui-components/src/components/ui-dropdown-heading.ts
+++ b/packages/ui-components/src/components/ui-dropdown-heading.ts
@@ -58,6 +58,9 @@ const STYLES = /* css */ `
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiDropdownHeading extends HTMLElement {
   static readonly observedAttributes = ["size"];
 
@@ -65,9 +68,7 @@ export class UiDropdownHeading extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     const heading = document.createElement("div");
     heading.className = "heading";

--- a/packages/ui-components/src/components/ui-dropdown-item.ts
+++ b/packages/ui-components/src/components/ui-dropdown-item.ts
@@ -15,6 +15,9 @@ export type DropdownItemLeading = "icon" | "checkbox" | "radio" | "avatar";
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiDropdownItem extends HTMLElement {
   static readonly observedAttributes = [
     "size", "disabled", "selected", "value",
@@ -35,9 +38,7 @@ export class UiDropdownItem extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     const button = document.createElement("button");
     button.className = "item";

--- a/packages/ui-components/src/components/ui-dropdown-separator.ts
+++ b/packages/ui-components/src/components/ui-dropdown-separator.ts
@@ -27,14 +27,15 @@ const STYLES = /* css */ `
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiDropdownSeparator extends HTMLElement {
   constructor() {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     const line = document.createElement("div");
     line.className = "line";

--- a/packages/ui-components/src/components/ui-dropdown-split.test.ts
+++ b/packages/ui-components/src/components/ui-dropdown-split.test.ts
@@ -771,7 +771,7 @@ describe("UiDropdownSplit — chevron", () => {
   });
 
   it("should have chevron rotation styles when open", () => {
-    const styles = el.shadowRoot!.querySelector("style")!.textContent!;
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
     expect(styles).toContain(":host([open]) .chevron");
     expect(styles).toContain("rotate(180deg)");
   });
@@ -792,51 +792,51 @@ describe("UiDropdownSplit — styles", () => {
   });
 
   it("should include hover styles for left button", () => {
-    const styles = el.shadowRoot!.querySelector("style")!.textContent!;
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
     expect(styles).toContain(".left:hover");
   });
 
   it("should include hover styles for right button", () => {
-    const styles = el.shadowRoot!.querySelector("style")!.textContent!;
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
     expect(styles).toContain(".right:hover");
   });
 
   it("should include active styles", () => {
-    const styles = el.shadowRoot!.querySelector("style")!.textContent!;
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
     expect(styles).toContain(".left:active");
     expect(styles).toContain(".right:active");
   });
 
   it("should include focus-visible styles", () => {
-    const styles = el.shadowRoot!.querySelector("style")!.textContent!;
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
     expect(styles).toContain(".left:focus-visible");
     expect(styles).toContain(".right:focus-visible");
   });
 
   it("should include reduced motion media query", () => {
-    const styles = el.shadowRoot!.querySelector("style")!.textContent!;
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
     expect(styles).toContain("prefers-reduced-motion: reduce");
   });
 
   it("should include menu panel styles", () => {
-    const styles = el.shadowRoot!.querySelector("style")!.textContent!;
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
     expect(styles).toContain(".menu");
     expect(styles).toContain("min-width: 240px");
   });
 
   it("should include divider styles", () => {
-    const styles = el.shadowRoot!.querySelector("style")!.textContent!;
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
     expect(styles).toContain(".divider");
     expect(styles).toContain(".divider-inner");
   });
 
   it("should include disabled styles", () => {
-    const styles = el.shadowRoot!.querySelector("style")!.textContent!;
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
     expect(styles).toContain(":host([disabled])");
   });
 
   it("should include subtle/minimal hover override", () => {
-    const styles = el.shadowRoot!.querySelector("style")!.textContent!;
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
     expect(styles).toContain(':host([emphasis="subtle"]) .left:hover');
     expect(styles).toContain(':host([emphasis="minimal"]) .right:hover');
   });

--- a/packages/ui-components/src/components/ui-dropdown-split.ts
+++ b/packages/ui-components/src/components/ui-dropdown-split.ts
@@ -22,6 +22,9 @@ const DROPDOWN_SPLIT_SIZE_TO_ITEM_SIZE: Record<DropdownSplitSize, "s" | "m" | "l
 
 const PROPAGATED_CHILD_TAGS = ["UI-DROPDOWN-ITEM", "UI-DROPDOWN-HEADING"];
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiDropdownSplit extends HTMLElement {
   static readonly observedAttributes = [
     "size",
@@ -46,9 +49,7 @@ export class UiDropdownSplit extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // ── Base container ──
     const base = document.createElement("div");

--- a/packages/ui-components/src/components/ui-dropdown.test.ts
+++ b/packages/ui-components/src/components/ui-dropdown.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import "./ui-dropdown.js";
+import { STYLES as DROPDOWN_STYLES } from "./ui-dropdown.js";
 import "./ui-dropdown-item.js";
+import { STYLES as ITEM_STYLES } from "./ui-dropdown-item.styles.js";
 import "./ui-dropdown-heading.js";
 import "./ui-dropdown-separator.js";
 
@@ -60,7 +62,7 @@ describe("UiDropdownHeading", () => {
   });
 
   it("should have uppercase text-transform in styles", () => {
-    const styles = el.shadowRoot!.querySelector("style")!.textContent!;
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
     expect(styles).toContain("text-transform: uppercase");
   });
 
@@ -184,7 +186,7 @@ describe("UiDropdownItem", () => {
   });
 
   it("should have hover background style", () => {
-    const styles = el.shadowRoot!.querySelector("style")!.textContent!;
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
     expect(styles).toContain(".item:hover");
   });
   it("should default selected to false", () => {
@@ -201,8 +203,7 @@ describe("UiDropdownItem", () => {
   it("should apply selected styling when selected", () => {
     el.setAttribute("selected", "");
     expect(el.hasAttribute("selected")).toBe(true);
-    const styles = el.shadowRoot!.querySelector("style")!.textContent!;
-    expect(styles).toContain("--ui-dd-item-selected-color");
+    expect(ITEM_STYLES).toContain("--ui-dd-item-selected-color");
   });
 
   it("should include selected state in select event detail", () => {
@@ -336,13 +337,10 @@ describe("UiDropdownItem", () => {
   });
 
   it("should have selected color style in CSS", () => {
-    const styles = el.shadowRoot!.querySelector("style")!.textContent!;
-    expect(styles).toContain("--ui-dd-item-selected-color");
+    expect(ITEM_STYLES).toContain("--ui-dd-item-selected-color");
   });
-
   it("should have disabled color style in CSS", () => {
-    const styles = el.shadowRoot!.querySelector("style")!.textContent!;
-    expect(styles).toContain("--ui-dd-item-disabled-color");
+    expect(ITEM_STYLES).toContain("--ui-dd-item-disabled-color");
   });
 
   // ── Submenu behavior ────────────────────────────────────────────────────

--- a/packages/ui-components/src/components/ui-dropdown.ts
+++ b/packages/ui-components/src/components/ui-dropdown.ts
@@ -21,7 +21,7 @@ const SP_2 = spaceVar("2");     // 16px
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
 
-const STYLES = /* css */ `
+export const STYLES = /* css */ `
   *,
   *::before,
   *::after {
@@ -120,6 +120,9 @@ const DROPDOWN_SIZE_TO_ITEM_SIZE: Record<DropdownSize, "s" | "m" | "l"> = {
 
 const PROPAGATED_CHILD_TAGS = ["UI-DROPDOWN-ITEM", "UI-DROPDOWN-HEADING"];
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiDropdown extends HTMLElement {
   static readonly observedAttributes = [
     "size",
@@ -141,9 +144,7 @@ export class UiDropdown extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // Trigger button (reuse ui-button)
     const trigger = document.createElement("ui-button");

--- a/packages/ui-components/src/components/ui-file-upload.ts
+++ b/packages/ui-components/src/components/ui-file-upload.ts
@@ -191,6 +191,9 @@ const STYLES = /* css */ `
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiFileUpload extends HTMLElement {
   static readonly observedAttributes = [
     "size",
@@ -212,9 +215,7 @@ export class UiFileUpload extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // Hidden file input
     this._hiddenInput = document.createElement("input");

--- a/packages/ui-components/src/components/ui-image.ts
+++ b/packages/ui-components/src/components/ui-image.ts
@@ -83,6 +83,9 @@ const STYLES = /* css */ `
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiImage extends HTMLElement {
   static readonly observedAttributes = ["src", "alt", "ratio", "fit"];
 
@@ -94,9 +97,7 @@ export class UiImage extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // .container
     const container = document.createElement("div");

--- a/packages/ui-components/src/components/ui-input-group.test.ts
+++ b/packages/ui-components/src/components/ui-input-group.test.ts
@@ -180,13 +180,13 @@ describe("ui-input-group", () => {
   // ── Styles ───────────────────────────────────────────────────────────────
 
   it("contains size CSS rules in styles", () => {
-    const styles = el.shadowRoot!.querySelector("style")!.textContent!;
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
     expect(styles).toContain(':host([size="s"])');
     expect(styles).toContain(':host([size="l"])');
   });
 
   it("contains ::slotted(ui-input) rule to remove border", () => {
-    const styles = el.shadowRoot!.querySelector("style")!.textContent!;
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
     expect(styles).toContain("::slotted(ui-input)");
   });
 

--- a/packages/ui-components/src/components/ui-input-group.ts
+++ b/packages/ui-components/src/components/ui-input-group.ts
@@ -140,6 +140,9 @@ const STYLES = /* css */ `
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiInputGroup extends HTMLElement {
   static readonly observedAttributes = ["size", "aria-labelledby"];
 
@@ -152,9 +155,7 @@ export class UiInputGroup extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // ── Wrapper ───────────────────────────────────────────────────────
     const wrapper = document.createElement("div");

--- a/packages/ui-components/src/components/ui-input.test.ts
+++ b/packages/ui-components/src/components/ui-input.test.ts
@@ -672,7 +672,7 @@ describe("ui-input", () => {
   });
 
   it("password toggle is hidden by default via CSS", () => {
-    const styles = el.shadowRoot!.querySelector("style")!.textContent!;
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
     expect(styles).toContain(".password-toggle");
     expect(styles).toContain(":host([type=\"password\"]) .password-toggle");
   });

--- a/packages/ui-components/src/components/ui-input.ts
+++ b/packages/ui-components/src/components/ui-input.ts
@@ -10,6 +10,9 @@ export type InputStatus = "none" | "warning" | "error" | "success" | "loading";
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiInput extends HTMLElement {
   static readonly observedAttributes = [
     "size",
@@ -42,9 +45,7 @@ export class UiInput extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // ── Label row ──────────────────────────────────────────────────────
     const labelRow = document.createElement("div");

--- a/packages/ui-components/src/components/ui-label.test.ts
+++ b/packages/ui-components/src/components/ui-label.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import "./ui-label.js";
+import { STYLES } from "./ui-label.js";
 
 describe("ui-label", () => {
   let el: HTMLElement;
@@ -153,51 +154,49 @@ describe("ui-label", () => {
   // ── CSS custom property overrides ────────────────────────────────────────
 
   it("supports --ui-label-color override", () => {
-    // Verify the CSS contains the override var
-    const style = el.shadowRoot!.querySelector("style");
-    expect(style!.textContent).toContain("--ui-label-color");
+    expect(STYLES).toContain("--ui-label-color");
   });
 
   // ── Size CSS variables ───────────────────────────────────────────────────
 
   it("size s sets 12px font-size via CSS var", () => {
-    const style = el.shadowRoot!.querySelector("style");
-    expect(style!.textContent).toContain(":host([size=\"s\"])");
-    expect(style!.textContent).toContain("--_font-size: 12px");
-    expect(style!.textContent).toContain("--_line-height: 16px");
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
+    expect(styles).toContain(":host([size=\"s\"])");
+    expect(styles).toContain("--_font-size: 12px");
+    expect(styles).toContain("--_line-height: 16px");
   });
 
   it("size m sets 14px font-size via CSS var", () => {
-    const style = el.shadowRoot!.querySelector("style");
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
     // m is the default, defined on :host
-    expect(style!.textContent).toContain("--_font-size: 14px");
-    expect(style!.textContent).toContain("--_line-height: 20px");
+    expect(styles).toContain("--_font-size: 14px");
+    expect(styles).toContain("--_line-height: 20px");
   });
 
   it("size l sets 16px font-size via CSS var", () => {
-    const style = el.shadowRoot!.querySelector("style");
-    expect(style!.textContent).toContain(":host([size=\"l\"])");
-    expect(style!.textContent).toContain("--_font-size: 16px");
-    expect(style!.textContent).toContain("--_line-height: 24px");
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
+    expect(styles).toContain(":host([size=\"l\"])");
+    expect(styles).toContain("--_font-size: 16px");
+    expect(styles).toContain("--_line-height: 24px");
   });
 
   // ── Emphasis CSS variables ───────────────────────────────────────────────
 
   it("bold emphasis sets font-weight 500", () => {
-    const style = el.shadowRoot!.querySelector("style");
-    expect(style!.textContent).toContain("--_font-weight: 500");
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
+    expect(styles).toContain("--_font-weight: 500");
   });
 
   it("subtle emphasis sets font-weight 400", () => {
-    const style = el.shadowRoot!.querySelector("style");
-    expect(style!.textContent).toContain(":host([emphasis=\"subtle\"])");
-    expect(style!.textContent).toContain("--_font-weight: 400");
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
+    expect(styles).toContain(":host([emphasis=\"subtle\"])");
+    expect(styles).toContain("--_font-weight: 400");
   });
 
   // ── Display ──────────────────────────────────────────────────────────────
 
   it("host displays as inline-flex", () => {
-    const style = el.shadowRoot!.querySelector("style");
-    expect(style!.textContent).toContain("display: inline-flex");
+    const styles = el.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
+    expect(styles).toContain("display: inline-flex");
   });
 });

--- a/packages/ui-components/src/components/ui-label.ts
+++ b/packages/ui-components/src/components/ui-label.ts
@@ -13,7 +13,7 @@ const STATUS_ERROR = semanticVar("statusGeneral", "error");
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
 
-const STYLES = /* css */ `
+export const STYLES = /* css */ `
   *,
   *::before,
   *::after {
@@ -92,6 +92,9 @@ const STYLES = /* css */ `
 
 const OBSERVED = ["size", "emphasis", "disabled", "required"] as const;
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 class UiLabel extends HTMLElement {
   static observedAttributes = [...OBSERVED];
 
@@ -102,9 +105,7 @@ class UiLabel extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     this._textEl = document.createElement("span");
     this._textEl.className = "text";

--- a/packages/ui-components/src/components/ui-link.ts
+++ b/packages/ui-components/src/components/ui-link.ts
@@ -175,6 +175,9 @@ const OBSERVED = [
   "disabled",
 ] as const;
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 class UiLink extends HTMLElement {
   static observedAttributes = [...OBSERVED];
 
@@ -189,9 +192,7 @@ class UiLink extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // Start with <span> — will swap to <a> when href is set
     this._linkEl = document.createElement("span");

--- a/packages/ui-components/src/components/ui-menu.test.ts
+++ b/packages/ui-components/src/components/ui-menu.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import "./ui-menu.js";
+import { STYLES as MENU_STYLES } from "./ui-menu.js";
 import "./ui-dropdown-item.js";
 import "./ui-dropdown-heading.js";
 import "./ui-dropdown-separator.js";
@@ -329,11 +330,10 @@ describe("UiMenu", () => {
   // ── CSS custom properties ───────────────────────────────────────────────
 
   it("should include menu styling in shadow DOM", () => {
-    const styles = el.shadowRoot!.querySelector("style")!.textContent!;
-    expect(styles).toContain("--ui-menu-bg");
-    expect(styles).toContain("--ui-menu-shadow");
-    expect(styles).toContain("--ui-menu-radius");
-    expect(styles).toContain("--ui-menu-min-width");
+    expect(MENU_STYLES).toContain("--ui-menu-bg");
+    expect(MENU_STYLES).toContain("--ui-menu-shadow");
+    expect(MENU_STYLES).toContain("--ui-menu-radius");
+    expect(MENU_STYLES).toContain("--ui-menu-min-width");
   });
 
 });

--- a/packages/ui-components/src/components/ui-menu.ts
+++ b/packages/ui-components/src/components/ui-menu.ts
@@ -12,7 +12,7 @@ const SP_05 = spaceVar("0.5"); // 4px
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
 
-const STYLES = /* css */ `
+export const STYLES = /* css */ `
   *,
   *::before,
   *::after {
@@ -55,6 +55,9 @@ const PROPAGATED_CHILD_TAGS = ["UI-DROPDOWN-ITEM", "UI-DROPDOWN-HEADING"];
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiMenu extends HTMLElement {
   static readonly observedAttributes = [
     "open",
@@ -67,9 +70,7 @@ export class UiMenu extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     const slot = document.createElement("slot");
     shadow.appendChild(slot);

--- a/packages/ui-components/src/components/ui-modal.ts
+++ b/packages/ui-components/src/components/ui-modal.ts
@@ -308,6 +308,9 @@ const STYLES = /* css */ `
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiModal extends HTMLElement {
   static readonly observedAttributes = [
     "size",
@@ -327,9 +330,7 @@ export class UiModal extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // Backdrop
     const backdrop = document.createElement("div");

--- a/packages/ui-components/src/components/ui-radio-group.test.ts
+++ b/packages/ui-components/src/components/ui-radio-group.test.ts
@@ -134,40 +134,40 @@ describe("UiRadioGroup", () => {
 
   describe("CSS layout", () => {
     it("should have display: flex on host", () => {
-      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      const styles = group.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
       expect(styles).toContain(":host {");
       expect(styles).toContain("display: flex;");
     });
 
     it("should have flex-direction: column for vertical orientation", () => {
-      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      const styles = group.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
       expect(styles).toContain("flex-direction: column;");
     });
 
     it("should have flex-direction: row for horizontal orientation", () => {
-      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      const styles = group.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
       expect(styles).toContain("flex-direction: row;");
     });
   });
 
   describe("gap values", () => {
     it("should have correct gap for size='s' (8px)", () => {
-      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      const styles = group.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
       expect(styles).toContain(':host([size="s"]) .group');
     });
 
     it("should have correct gap for size='m' (12px)", () => {
-      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      const styles = group.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
       expect(styles).toContain(':host([size="m"]) .group');
     });
 
     it("should have correct gap for size='l' (20px)", () => {
-      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      const styles = group.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
       expect(styles).toContain(':host([size="l"]) .group');
     });
 
     it("should have horizontal gap (24px) for horizontal orientation", () => {
-      const styles = group.shadowRoot!.querySelector("style")!.textContent!;
+      const styles = group.shadowRoot!.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
       expect(styles).toContain(':host([orientation="horizontal"]) .group');
     });
   });

--- a/packages/ui-components/src/components/ui-radio-group.ts
+++ b/packages/ui-components/src/components/ui-radio-group.ts
@@ -67,6 +67,9 @@ const STYLES = /* css */ `
 
 const PROPAGATED_ATTRS = ["size"] as const;
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiRadioGroup extends HTMLElement {
   static readonly observedAttributes = ["size", "orientation", "aria-labelledby"];
 
@@ -75,9 +78,7 @@ export class UiRadioGroup extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     const group = document.createElement("div");
     group.className = "group";

--- a/packages/ui-components/src/components/ui-radio-item.ts
+++ b/packages/ui-components/src/components/ui-radio-item.ts
@@ -263,6 +263,9 @@ const STYLES = /* css */ `
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiRadioItem extends HTMLElement {
   static readonly observedAttributes = [
     "size",
@@ -276,9 +279,7 @@ export class UiRadioItem extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // .base
     const base = document.createElement("div");

--- a/packages/ui-components/src/components/ui-select.ts
+++ b/packages/ui-components/src/components/ui-select.ts
@@ -8,6 +8,9 @@ export type SelectStatus = "none" | "warning" | "error" | "success" | "loading";
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiSelect extends HTMLElement {
   static readonly observedAttributes = [
     "size",
@@ -44,9 +47,7 @@ export class UiSelect extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // ── Label row ──────────────────────────────────────────────────────
     const labelRow = document.createElement("div");

--- a/packages/ui-components/src/components/ui-side-panel-menu-item.ts
+++ b/packages/ui-components/src/components/ui-side-panel-menu-item.ts
@@ -251,6 +251,9 @@ const STYLES = /* css */ `
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiSidePanelMenuItem extends HTMLElement {
   static readonly observedAttributes = [
     "level",
@@ -271,9 +274,7 @@ export class UiSidePanelMenuItem extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // Row (the clickable item)
     const row = document.createElement("div");

--- a/packages/ui-components/src/components/ui-side-panel-menu.ts
+++ b/packages/ui-components/src/components/ui-side-panel-menu.ts
@@ -11,6 +11,9 @@ const MOBILE_MAX_WIDTH = standardBreakpoints.s.maxWidth;
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
 export class UiSidePanelMenu extends HTMLElement {
   static readonly observedAttributes = ["state", "overlay", "title", "mobile"];
 
@@ -30,9 +33,7 @@ export class UiSidePanelMenu extends HTMLElement {
     super();
     const shadow = this.attachShadow({ mode: "open" });
 
-    const style = document.createElement("style");
-    style.textContent = STYLES;
-    shadow.appendChild(style);
+    shadow.adoptedStyleSheets = [sheet];
 
     // Container
     const container = document.createElement("div");


### PR DESCRIPTION
## Summary

- Replace per-instance `<style>` element injection with shared `CSSStyleSheet` via `adoptedStyleSheets` across all 28 components
- Single stylesheet parsed once at module level (`new CSSStyleSheet()` + `replaceSync(STYLES)`) and shared across all instances
- Update tests that queried `querySelector("style")` to use `adoptedStyleSheets` or raw `STYLES` constant
- All 1157 tests pass, types clean