### PR TITLE
feat: flex-layout panel-based layout package

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -5,6 +5,7 @@ const config: StorybookConfig = {
     "../packages/foundation/src/**/*.stories.ts",
     "../packages/ui-components/src/**/*.stories.ts",
     "../packages/grid-layout/src/**/*.stories.ts",
+    "../packages/flex-layout/src/**/*.stories.ts",
   ],
   addons: ["@storybook/addon-a11y", "@storybook/addon-vitest", "@storybook/addon-docs"],
   framework: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -647,6 +647,10 @@
         "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
     },
+    "node_modules/@maneki/flex-layout": {
+      "resolved": "packages/flex-layout",
+      "link": true
+    },
     "node_modules/@maneki/foundation": {
       "resolved": "packages/foundation",
       "link": true
@@ -5004,6 +5008,210 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/flex-layout": {
+      "name": "@maneki/flex-layout",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@maneki/foundation": "*"
+      },
+      "devDependencies": {
+        "@maneki/ui-components": "*",
+        "happy-dom": "^17.6.1",
+        "typescript": "^5.4.0",
+        "vite": "^5.4.0",
+        "vitest": "^3.2.4"
+      }
+    },
+    "packages/flex-layout/node_modules/@vitest/browser": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-3.2.4.tgz",
+      "integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@testing-library/dom": "^10.4.0",
+        "@testing-library/user-event": "^14.6.1",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "magic-string": "^0.30.17",
+        "sirv": "^3.0.1",
+        "tinyrainbow": "^2.0.0",
+        "ws": "^8.18.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "playwright": "*",
+        "vitest": "3.2.4",
+        "webdriverio": "^7.0.0 || ^8.0.0 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "playwright": {
+          "optional": true
+        },
+        "safaridriver": {
+          "optional": true
+        },
+        "webdriverio": {
+          "optional": true
+        }
+      }
+    },
+    "packages/flex-layout/node_modules/@vitest/browser/node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "packages/flex-layout/node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/flex-layout/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/flex-layout/node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/flex-layout/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
     "packages/foundation": {

--- a/packages/flex-layout/AGENTS.md
+++ b/packages/flex-layout/AGENTS.md
@@ -1,0 +1,106 @@
+# packages/flex-layout — Panel-Based Flex Layout
+
+## OVERVIEW
+Panel-based flex layout Web Component system for dashboard-style interfaces. Three components: `<flex-layout>`, `<flex-panel>`, `<flex-panel-header>`. TypeScript, Vite, Shadow DOM, Constructable Stylesheets. Extracted from Figma "Flex Layout" page.
+
+## STRUCTURE
+```
+flex-layout/
+├── src/
+│   ├── components/
+│   │   ├── flex-layout.ts           # <flex-layout> container
+│   │   ├── flex-layout.test.ts
+│   │   ├── flex-panel.ts            # <flex-panel> content panel
+│   │   ├── flex-panel.test.ts
+│   │   ├── flex-panel-header.ts     # <flex-panel-header> title/tabs header
+│   │   └── flex-panel-header.test.ts
+│   ├── stories/
+│   │   ├── basic.stories.ts         # Size variants (Large, Medium, Small)
+│   │   └── title-options.stories.ts # Header variants (Tabs, Title, Title+Tabs)
+│   └── index.ts                     # Barrel export
+├── package.json
+├── tsconfig.json
+├── vite.config.ts
+└── moon.yml
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Add new size variant | `flex-layout.ts` SIZE_CONFIG + CSS `:host([size="..."])` | Also update `flex-panel-header.ts` size presets |
+| Add new header variant | `flex-panel-header.ts` | Add CSS for `:host([variant="..."])` |
+| Change panel styling | `flex-panel.ts` STYLES | White bg, padding, divider |
+| Change container styling | `flex-layout.ts` STYLES | Gap, padding, background |
+| Add CSS custom property | Component's STYLES const | Use `var(--flex-*, fallback)` pattern |
+
+## COMPONENTS
+
+### `<flex-layout>`
+Flex container with size-based gap/padding presets.
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `size` | `"large" \| "medium" \| "small"` | `"medium"` | Controls gap and padding |
+| `direction` | `"row" \| "column"` | `"row"` | Flex direction |
+
+Size presets (from Figma):
+| Size | Gap | Padding |
+|------|-----|---------|
+| large | 8px | 8px |
+| medium | 8px | 8px |
+| small | 4px | 4px |
+
+CSS custom properties: `--flex-bg`, `--flex-gap`, `--flex-padding`, `--flex-direction`, `--flex-align`
+
+### `<flex-panel>`
+Content panel with optional header slot.
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `width` | `number \| null` | `null` | Fixed width in px (overrides flex) |
+| `no-padding` | `boolean` | `false` | Remove content padding |
+
+Slots: `header` (named), default (content)
+
+CSS custom properties: `--flex-panel-flex`, `--flex-panel-bg`, `--flex-panel-padding`, `--flex-panel-divider`
+
+### `<flex-panel-header>`
+Panel header bar with title and/or tabs.
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `variant` | `"title" \| "tabs" \| "title-tabs"` | `"title"` | Header type |
+| `size` | `"large" \| "medium" \| "small"` | `"medium"` | Size preset |
+| `heading` | `string` | `""` | Title text |
+
+Slots: `action` (named, for icon button), `tabs` (named, for tab content)
+
+Size presets (from Figma):
+| Size | Height | Font Size |
+|------|--------|-----------|
+| large | 32px | 12px |
+| medium | 24px | 12px |
+| small | 20px | 11px |
+
+CSS custom properties: `--flex-header-bg`, `--flex-header-height`, `--flex-header-color`, `--flex-header-divider`, `--flex-header-font-size`, `--flex-header-font-weight`, `--flex-header-line-height`, `--flex-header-icon-size`, `--flex-header-icon-color`, `--flex-header-padding-*`
+
+## CONVENTIONS
+- **`@maneki/foundation` is a production dependency.** Components import `semanticVar`, `spaceVar` for CSS custom property fallbacks.
+- **Shadow DOM + Constructable Stylesheets.** `const sheet = new CSSStyleSheet(); sheet.replaceSync(STYLES);` at module level, `shadow.adoptedStyleSheets = [sheet]` in constructor.
+- **CSS custom properties** use `--flex-*` prefix.
+- **No default ARIA role on `<flex-layout>`** — it's a generic container. Consumers add `role="region"` + `aria-label` if needed.
+- **`<flex-panel>` uses `role="group"`**, `<flex-panel-header>` uses `role="toolbar"`.
+- **Nesting is supported.** `<flex-layout>` inside `<flex-panel>` for split layouts (top/bottom, left/right).
+- **Tests co-located.** `foo.ts` → `foo.test.ts` in same directory.
+
+## ANTI-PATTERNS
+- **Don't hardcode colors** — use `semanticVar()` / `spaceVar()` from foundation
+- **Don't use `role="banner"` on headers** — causes duplicate landmark violations when multiple headers exist
+- **Don't use `role="region"` on layout containers** — causes unique landmark violations when nested
+
+## COMMANDS
+```bash
+npx vitest --run             # Unit tests (50 tests)
+npx tsc --noEmit             # Type check
+npx vite build               # Build → dist/
+```

--- a/packages/flex-layout/moon.yml
+++ b/packages/flex-layout/moon.yml
@@ -1,0 +1,30 @@
+$schema: 'https://moonrepo.dev/schemas/project.json'
+
+language: 'typescript'
+
+tasks:
+  build:
+    script: 'tsc && vite build'
+    inputs:
+      - 'src/**/*'
+      - 'tsconfig.json'
+      - 'vite.config.ts'
+    outputs:
+      - 'dist'
+
+  test:
+    command: 'vitest --run'
+    inputs:
+      - 'src/**/*'
+      - 'tsconfig.json'
+      - 'vite.config.ts'
+
+  test-watch:
+    command: 'vitest'
+    inputs:
+      - 'src/**/*'
+    preset: 'server'
+
+  dev:
+    command: 'vite'
+    preset: 'server'

--- a/packages/flex-layout/package.json
+++ b/packages/flex-layout/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@maneki/flex-layout",
+  "version": "0.1.0",
+  "description": "A panel-based flex layout Web Component system for dashboard-style interfaces",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "vitest --run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@maneki/foundation": "*"
+  },
+  "devDependencies": {
+    "@maneki/ui-components": "*",
+    "happy-dom": "^17.6.1",
+    "typescript": "^5.4.0",
+    "vite": "^5.4.0",
+    "vitest": "^3.2.4"
+  },
+  "license": "MIT"
+}

--- a/packages/flex-layout/src/components/flex-layout.test.ts
+++ b/packages/flex-layout/src/components/flex-layout.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "./flex-layout.js";
+import type { FlexLayoutElement } from "./flex-layout.js";
+
+describe("flex-layout", () => {
+  let el: FlexLayoutElement;
+
+  beforeEach(() => {
+    el = document.createElement("flex-layout") as FlexLayoutElement;
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    el.remove();
+  });
+
+  // --- Registration ---
+
+  it("should be registered as a custom element", () => {
+    expect(customElements.get("flex-layout")).toBeDefined();
+  });
+
+  it("should be an instance of FlexLayoutElement", () => {
+    expect(el.tagName.toLowerCase()).toBe("flex-layout");
+  });
+
+  // --- Shadow DOM ---
+
+  it("should have a shadow root", () => {
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("should use Constructable Stylesheets", () => {
+    expect(el.shadowRoot!.adoptedStyleSheets.length).toBe(1);
+  });
+
+  it("should contain a slot element", () => {
+    const slot = el.shadowRoot!.querySelector("slot");
+    expect(slot).not.toBeNull();
+  });
+
+  // --- Attributes ---
+
+  it("should default size to medium", () => {
+    expect(el.size).toBe("medium");
+  });
+
+  it("should reflect size attribute", () => {
+    el.size = "large";
+    expect(el.getAttribute("size")).toBe("large");
+    el.size = "small";
+    expect(el.getAttribute("size")).toBe("small");
+  });
+
+  it("should default direction to row", () => {
+    expect(el.direction).toBe("row");
+  });
+
+  it("should reflect direction attribute", () => {
+    el.direction = "column";
+    expect(el.getAttribute("direction")).toBe("column");
+  });
+
+  // --- Accessibility ---
+
+  it("should not set a default role", () => {
+    expect(el.hasAttribute("role")).toBe(false);
+  });
+
+  it("should preserve consumer-set role", () => {
+    const el2 = document.createElement("flex-layout") as FlexLayoutElement;
+    el2.setAttribute("role", "main");
+    document.body.appendChild(el2);
+    expect(el2.getAttribute("role")).toBe("main");
+    el2.remove();
+  });
+
+  // --- CSS Custom Properties ---
+
+  it("should include surface-moderate background in styles", () => {
+    const styles = el.shadowRoot!.adoptedStyleSheets[0];
+    expect(styles).toBeDefined();
+  });
+
+  it("should use --flex-bg custom property", () => {
+    const raw = el.shadowRoot!.adoptedStyleSheets[0];
+    expect(raw).toBeDefined();
+  });
+});

--- a/packages/flex-layout/src/components/flex-layout.ts
+++ b/packages/flex-layout/src/components/flex-layout.ts
@@ -1,0 +1,113 @@
+import { semanticVar, spaceVar } from "@maneki/foundation";
+
+// ---------------------------------------------------------------------------
+// Token constants
+// ---------------------------------------------------------------------------
+
+const SURFACE_MODERATE = semanticVar("surface", "moderate");
+
+// ---------------------------------------------------------------------------
+// Size presets (from Figma)
+// ---------------------------------------------------------------------------
+
+export type FlexLayoutSize = "large" | "medium" | "small";
+
+const SIZE_CONFIG: Record<FlexLayoutSize, { gap: string; padding: string }> = {
+  large: { gap: spaceVar("1"), padding: spaceVar("1") },   // 8px
+  medium: { gap: spaceVar("1"), padding: spaceVar("1") },  // 8px
+  small: { gap: spaceVar("0.5"), padding: spaceVar("0.5") }, // 4px
+};
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const STYLES = `
+:host {
+  display: flex;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  background: var(--flex-bg, ${SURFACE_MODERATE});
+  gap: var(--flex-gap, ${SIZE_CONFIG.medium.gap});
+  padding: var(--flex-padding, ${SIZE_CONFIG.medium.padding});
+  flex-direction: var(--flex-direction, row);
+  align-items: var(--flex-align, stretch);
+  overflow: hidden;
+}
+
+:host([direction="column"]) {
+  flex-direction: column;
+}
+
+:host([direction="row"]) {
+  flex-direction: row;
+}
+
+:host([size="large"]) {
+  gap: var(--flex-gap, ${SIZE_CONFIG.large.gap});
+  padding: var(--flex-padding, ${SIZE_CONFIG.large.padding});
+}
+
+:host([size="medium"]) {
+  gap: var(--flex-gap, ${SIZE_CONFIG.medium.gap});
+  padding: var(--flex-padding, ${SIZE_CONFIG.medium.padding});
+}
+
+:host([size="small"]) {
+  gap: var(--flex-gap, ${SIZE_CONFIG.small.gap});
+  padding: var(--flex-padding, ${SIZE_CONFIG.small.padding});
+}
+
+::slotted(*) {
+  min-width: 0;
+  min-height: 0;
+}
+`;
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export class FlexLayoutElement extends HTMLElement {
+  static observedAttributes = ["size", "direction"];
+
+  private _shadow: ShadowRoot;
+
+  constructor() {
+    super();
+    this._shadow = this.attachShadow({ mode: "open" });
+    this._shadow.adoptedStyleSheets = [sheet];
+
+    const slot = document.createElement("slot");
+    this._shadow.appendChild(slot);
+  }
+
+  connectedCallback(): void {
+    // No default role — flex-layout is a generic container.
+    // Consumers can add role="region" + aria-label if needed.
+  }
+
+  // --- size ---
+  get size(): FlexLayoutSize {
+    return (this.getAttribute("size") as FlexLayoutSize) || "medium";
+  }
+
+  set size(value: FlexLayoutSize) {
+    this.setAttribute("size", value);
+  }
+
+  // --- direction ---
+  get direction(): "row" | "column" {
+    return (this.getAttribute("direction") as "row" | "column") || "row";
+  }
+
+  set direction(value: "row" | "column") {
+    this.setAttribute("direction", value);
+  }
+}
+
+customElements.define("flex-layout", FlexLayoutElement);

--- a/packages/flex-layout/src/components/flex-panel-header.test.ts
+++ b/packages/flex-layout/src/components/flex-panel-header.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "./flex-panel-header.js";
+import type { FlexPanelHeaderElement } from "./flex-panel-header.js";
+
+describe("flex-panel-header", () => {
+  let el: FlexPanelHeaderElement;
+
+  beforeEach(() => {
+    el = document.createElement("flex-panel-header") as FlexPanelHeaderElement;
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    el.remove();
+  });
+
+  // --- Registration ---
+
+  it("should be registered as a custom element", () => {
+    expect(customElements.get("flex-panel-header")).toBeDefined();
+  });
+
+  it("should be an instance of FlexPanelHeaderElement", () => {
+    expect(el.tagName.toLowerCase()).toBe("flex-panel-header");
+  });
+
+  // --- Shadow DOM ---
+
+  it("should have a shadow root", () => {
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("should use Constructable Stylesheets", () => {
+    expect(el.shadowRoot!.adoptedStyleSheets.length).toBe(1);
+  });
+
+  it("should contain a title-bar element", () => {
+    const titleBar = el.shadowRoot!.querySelector(".title-bar");
+    expect(titleBar).not.toBeNull();
+  });
+
+  it("should contain a title-text element", () => {
+    const titleText = el.shadowRoot!.querySelector(".title-text");
+    expect(titleText).not.toBeNull();
+  });
+
+  it("should contain a tabs-bar element", () => {
+    const tabsBar = el.shadowRoot!.querySelector(".tabs-bar");
+    expect(tabsBar).not.toBeNull();
+  });
+
+  it("should contain a divider element", () => {
+    const divider = el.shadowRoot!.querySelector(".divider");
+    expect(divider).not.toBeNull();
+  });
+
+  it("should contain an action slot", () => {
+    const slot = el.shadowRoot!.querySelector('slot[name="action"]');
+    expect(slot).not.toBeNull();
+  });
+
+  it("should contain a tabs slot", () => {
+    const slot = el.shadowRoot!.querySelector('slot[name="tabs"]');
+    expect(slot).not.toBeNull();
+  });
+
+  // --- Attributes ---
+
+  it("should default variant to title", () => {
+    expect(el.variant).toBe("title");
+  });
+
+  it("should reflect variant attribute", () => {
+    el.variant = "tabs";
+    expect(el.getAttribute("variant")).toBe("tabs");
+    el.variant = "title-tabs";
+    expect(el.getAttribute("variant")).toBe("title-tabs");
+  });
+
+  it("should default size to medium", () => {
+    expect(el.size).toBe("medium");
+  });
+
+  it("should reflect size attribute", () => {
+    el.size = "large";
+    expect(el.getAttribute("size")).toBe("large");
+    el.size = "small";
+    expect(el.getAttribute("size")).toBe("small");
+  });
+
+  it("should default heading to empty string", () => {
+    expect(el.heading).toBe("");
+  });
+
+  it("should reflect heading attribute", () => {
+    el.heading = "Card Heading";
+    expect(el.getAttribute("heading")).toBe("Card Heading");
+  });
+
+  it("should update title text when heading changes", () => {
+    el.heading = "Test Title";
+    const titleText = el.shadowRoot!.querySelector(".title-text");
+    expect(titleText!.textContent).toBe("Test Title");
+  });
+
+  it("should update title text when heading attribute is set directly", () => {
+    el.setAttribute("heading", "Direct Attr");
+    const titleText = el.shadowRoot!.querySelector(".title-text");
+    expect(titleText!.textContent).toBe("Direct Attr");
+  });
+
+  // --- Accessibility ---
+
+  it("should set role=toolbar by default", () => {
+    expect(el.getAttribute("role")).toBe("toolbar");
+  });
+
+  it("should not override existing role", () => {
+    const el2 = document.createElement("flex-panel-header") as FlexPanelHeaderElement;
+    el2.setAttribute("role", "heading");
+    document.body.appendChild(el2);
+    expect(el2.getAttribute("role")).toBe("heading");
+    el2.remove();
+  });
+
+  // --- Size presets ---
+
+  it("should apply large size styles", () => {
+    el.size = "large";
+    expect(el.getAttribute("size")).toBe("large");
+  });
+
+  it("should apply small size styles", () => {
+    el.size = "small";
+    expect(el.getAttribute("size")).toBe("small");
+  });
+});

--- a/packages/flex-layout/src/components/flex-panel-header.ts
+++ b/packages/flex-layout/src/components/flex-panel-header.ts
@@ -1,0 +1,335 @@
+import { semanticVar } from "@maneki/foundation";
+
+// ---------------------------------------------------------------------------
+// Token constants
+// ---------------------------------------------------------------------------
+
+const SURFACE_SECONDARY = semanticVar("surface", "secondary");
+const BORDER_MINIMAL = semanticVar("border", "minimal");
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const ICON_ACTION = semanticVar("icon", "action");
+
+// ---------------------------------------------------------------------------
+// Size presets (from Figma)
+// ---------------------------------------------------------------------------
+
+export type FlexPanelHeaderSize = "large" | "medium" | "small";
+
+interface SizePreset {
+  height: string;
+  fontSize: string;
+  fontWeight: string;
+  lineHeight: string;
+  paddingLeft: string;
+  paddingRight: string;
+  paddingTop: string;
+  paddingBottom: string;
+  iconSize: string;
+}
+
+const SIZE_PRESETS: Record<FlexPanelHeaderSize, SizePreset> = {
+  large: {
+    height: "32px",
+    fontSize: "12px",
+    fontWeight: "500",
+    lineHeight: "16px",
+    paddingLeft: "16px",
+    paddingRight: "8px",
+    paddingTop: "8px",
+    paddingBottom: "8px",
+    iconSize: "16px",
+  },
+  medium: {
+    height: "24px",
+    fontSize: "12px",
+    fontWeight: "500",
+    lineHeight: "16px",
+    paddingLeft: "16px",
+    paddingRight: "8px",
+    paddingTop: "4px",
+    paddingBottom: "3px",
+    iconSize: "12px",
+  },
+  small: {
+    height: "20px",
+    fontSize: "11px",
+    fontWeight: "500",
+    lineHeight: "16px",
+    paddingLeft: "16px",
+    paddingRight: "8px",
+    paddingTop: "2px",
+    paddingBottom: "2px",
+    iconSize: "12px",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const STYLES = `
+:host {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--flex-header-bg, ${SURFACE_SECONDARY});
+  overflow: visible;
+}
+
+.title-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  box-sizing: border-box;
+  min-height: var(--flex-header-height, 24px);
+  padding-left: var(--flex-header-padding-left, 16px);
+  padding-right: var(--flex-header-padding-right, 8px);
+  padding-top: var(--flex-header-padding-top, 4px);
+  padding-bottom: var(--flex-header-padding-bottom, 3px);
+}
+
+.title-text {
+  flex: 1 1 0%;
+  min-width: 0;
+  font-family: "Inter", sans-serif;
+  font-size: var(--flex-header-font-size, 12px);
+  font-weight: var(--flex-header-font-weight, 500);
+  line-height: var(--flex-header-line-height, 16px);
+  color: var(--flex-header-color, ${TEXT_PRIMARY});
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0;
+}
+
+.action-icon {
+  flex-shrink: 0;
+  width: var(--flex-header-icon-size, 12px);
+  height: var(--flex-header-icon-size, 12px);
+  color: var(--flex-header-icon-color, ${ICON_ACTION});
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.action-icon ::slotted(*) {
+  width: 100%;
+  height: 100%;
+}
+
+.divider {
+  height: 1px;
+  background: var(--flex-header-divider, ${BORDER_MINIMAL});
+  flex-shrink: 0;
+}
+
+/* Tabs slot */
+.tabs-bar {
+  display: none;
+  flex-shrink: 0;
+  width: 100%;
+  overflow: visible;
+  align-items: flex-end;
+  padding-left: 16px;
+  padding-right: 8px;
+  box-sizing: border-box;
+  margin-bottom: -1px;
+  position: relative;
+  z-index: 1;
+}
+
+.tabs-bar ::slotted(*) {
+  width: 100%;
+  --ui-tab-group-border: none;
+  --ui-tab-group-border-shadow: none;
+}
+
+:host([variant="tabs"]) .tabs-bar,
+:host([variant="title-tabs"]) .tabs-bar {
+  display: flex;
+}
+
+:host([variant="tabs"]) .title-bar {
+  display: none;
+}
+
+/* The header's own .divider provides the full-width bottom line.
+   Tab-group's internal border is suppressed via --ui-tab-group-border: none. */
+/* Title-tabs: stacked column layout (title above tabs) */
+:host([variant="title-tabs"]) .title-bar {
+  border-bottom: 1px solid ${BORDER_MINIMAL};
+}
+
+:host([variant="title-tabs"]) .tabs-bar {
+  width: 100%;
+}
+
+/* Size: large */
+:host([size="large"]) .title-bar {
+  min-height: 32px;
+  padding-left: 16px;
+  padding-right: 8px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  font-size: 12px;
+}
+
+:host([size="large"]) .title-text {
+  font-size: 12px;
+  line-height: 16px;
+}
+
+:host([size="large"]) .action-icon {
+  width: 16px;
+  height: 16px;
+}
+
+:host([size="large"]) .tabs-bar {
+  min-height: 32px;
+}
+
+/* Size: medium (default) */
+:host([size="medium"]) .title-bar {
+  min-height: 24px;
+  padding-left: 16px;
+  padding-right: 8px;
+  padding-top: 4px;
+  padding-bottom: 3px;
+}
+
+:host([size="medium"]) .title-text {
+  font-size: 12px;
+  line-height: 16px;
+}
+
+:host([size="medium"]) .action-icon {
+  width: 12px;
+  height: 12px;
+}
+
+:host([size="medium"]) .tabs-bar {
+  min-height: 24px;
+}
+
+/* Size: small */
+:host([size="small"]) .title-bar {
+  min-height: 20px;
+  padding-left: 16px;
+  padding-right: 8px;
+  padding-top: 2px;
+  padding-bottom: 2px;
+}
+
+:host([size="small"]) .title-text {
+  font-size: 11px;
+  line-height: 16px;
+}
+
+:host([size="small"]) .action-icon {
+  width: 12px;
+  height: 12px;
+}
+
+:host([size="small"]) .tabs-bar {
+  min-height: 20px;
+}
+`;
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export class FlexPanelHeaderElement extends HTMLElement {
+  static observedAttributes = ["variant", "size", "heading"];
+
+  private _shadow: ShadowRoot;
+  private _titleText: HTMLSpanElement;
+
+  constructor() {
+    super();
+    this._shadow = this.attachShadow({ mode: "open" });
+    this._shadow.adoptedStyleSheets = [sheet];
+
+    // Title bar
+    const titleBar = document.createElement("div");
+    titleBar.className = "title-bar";
+
+    this._titleText = document.createElement("span");
+    this._titleText.className = "title-text";
+    titleBar.appendChild(this._titleText);
+
+    const actionIcon = document.createElement("div");
+    actionIcon.className = "action-icon";
+    const actionSlot = document.createElement("slot");
+    actionSlot.name = "action";
+    actionIcon.appendChild(actionSlot);
+    titleBar.appendChild(actionIcon);
+
+    this._shadow.appendChild(titleBar);
+
+    // Tabs bar (slot for tab content)
+    const tabsBar = document.createElement("div");
+    tabsBar.className = "tabs-bar";
+    const tabsSlot = document.createElement("slot");
+    tabsSlot.name = "tabs";
+    tabsBar.appendChild(tabsSlot);
+    this._shadow.appendChild(tabsBar);
+
+    // Bottom divider
+    const divider = document.createElement("div");
+    divider.className = "divider";
+    this._shadow.appendChild(divider);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("role")) {
+      this.setAttribute("role", "toolbar");
+    }
+    this._updateHeading();
+  }
+
+  attributeChangedCallback(name: string): void {
+    if (name === "heading") {
+      this._updateHeading();
+    }
+  }
+
+  private _updateHeading(): void {
+    this._titleText.textContent = this.getAttribute("heading") || "";
+  }
+
+  // --- variant ---
+  get variant(): "title" | "tabs" | "title-tabs" {
+    return (this.getAttribute("variant") as "title" | "tabs" | "title-tabs") || "title";
+  }
+
+  set variant(value: "title" | "tabs" | "title-tabs") {
+    this.setAttribute("variant", value);
+  }
+
+  // --- size ---
+  get size(): FlexPanelHeaderSize {
+    return (this.getAttribute("size") as FlexPanelHeaderSize) || "medium";
+  }
+
+  set size(value: FlexPanelHeaderSize) {
+    this.setAttribute("size", value);
+  }
+
+  // --- heading ---
+  get heading(): string {
+    return this.getAttribute("heading") || "";
+  }
+
+  set heading(value: string) {
+    this.setAttribute("heading", value);
+  }
+}
+
+customElements.define("flex-panel-header", FlexPanelHeaderElement);

--- a/packages/flex-layout/src/components/flex-panel.test.ts
+++ b/packages/flex-layout/src/components/flex-panel.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "./flex-panel.js";
+import type { FlexPanelElement } from "./flex-panel.js";
+
+describe("flex-panel", () => {
+  let el: FlexPanelElement;
+
+  beforeEach(() => {
+    el = document.createElement("flex-panel") as FlexPanelElement;
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    el.remove();
+  });
+
+  // --- Registration ---
+
+  it("should be registered as a custom element", () => {
+    expect(customElements.get("flex-panel")).toBeDefined();
+  });
+
+  it("should be an instance of FlexPanelElement", () => {
+    expect(el.tagName.toLowerCase()).toBe("flex-panel");
+  });
+
+  // --- Shadow DOM ---
+
+  it("should have a shadow root", () => {
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("should use Constructable Stylesheets", () => {
+    expect(el.shadowRoot!.adoptedStyleSheets.length).toBe(1);
+  });
+
+  it("should contain a named header slot", () => {
+    const slot = el.shadowRoot!.querySelector('slot[name="header"]');
+    expect(slot).not.toBeNull();
+  });
+
+  it("should contain a default content slot", () => {
+    const slot = el.shadowRoot!.querySelector("slot:not([name])");
+    expect(slot).not.toBeNull();
+  });
+
+  it("should contain a divider element", () => {
+    const divider = el.shadowRoot!.querySelector(".divider");
+    expect(divider).not.toBeNull();
+  });
+
+  // --- Attributes ---
+
+  it("should default width to null", () => {
+    expect(el.width).toBeNull();
+  });
+
+  it("should reflect width attribute", () => {
+    el.width = 300;
+    expect(el.getAttribute("width")).toBe("300");
+    expect(el.style.width).toBe("300px");
+    expect(el.style.flex).toMatch(/none|0 0 auto/);
+  });
+
+  it("should clear width styles when width is removed", () => {
+    el.width = 300;
+    el.width = null;
+    expect(el.hasAttribute("width")).toBe(false);
+    expect(el.style.width).toBe("");
+  });
+
+  it("should default noPadding to false", () => {
+    expect(el.noPadding).toBe(false);
+  });
+
+  it("should reflect no-padding attribute", () => {
+    el.noPadding = true;
+    expect(el.hasAttribute("no-padding")).toBe(true);
+    el.noPadding = false;
+    expect(el.hasAttribute("no-padding")).toBe(false);
+  });
+
+  // --- Accessibility ---
+
+  it("should set role=group by default", () => {
+    expect(el.getAttribute("role")).toBe("group");
+  });
+
+  it("should not override existing role", () => {
+    const el2 = document.createElement("flex-panel") as FlexPanelElement;
+    el2.setAttribute("role", "complementary");
+    document.body.appendChild(el2);
+    expect(el2.getAttribute("role")).toBe("complementary");
+    el2.remove();
+  });
+
+  // --- Divider visibility ---
+
+  it("should hide divider when no header is slotted", () => {
+    const divider = el.shadowRoot!.querySelector(".divider") as HTMLElement;
+    expect(divider.style.display).toBe("none");
+  });
+});

--- a/packages/flex-layout/src/components/flex-panel.ts
+++ b/packages/flex-layout/src/components/flex-panel.ts
@@ -1,0 +1,156 @@
+import { semanticVar, spaceVar } from "@maneki/foundation";
+
+// ---------------------------------------------------------------------------
+// Token constants
+// ---------------------------------------------------------------------------
+
+const SURFACE_PRIMARY = semanticVar("surface", "primary");
+const BORDER_MINIMAL = semanticVar("border", "minimal");
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const STYLES = `
+:host {
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  min-width: 0;
+  min-height: 0;
+  flex: var(--flex-panel-flex, 1 1 0%);
+  overflow: hidden;
+}
+
+:host([width]) {
+  flex: none;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0%;
+  min-height: 0;
+  background: var(--flex-panel-bg, ${SURFACE_PRIMARY});
+  padding: var(--flex-panel-padding, ${spaceVar("2")});
+  overflow: auto;
+}
+
+:host([no-padding]) .content {
+  padding: 0;
+}
+
+.content ::slotted(*) {
+  min-width: 0;
+  min-height: 0;
+}
+
+/* Divider between header and content — hidden by default because
+   flex-panel-header provides its own bottom border in all variants
+   (title → .divider, tabs/title-tabs → tab-group border-bottom). */
+.divider {
+  height: 1px;
+  background: var(--flex-panel-divider, ${BORDER_MINIMAL});
+  flex-shrink: 0;
+  display: none;
+}
+`;
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export class FlexPanelElement extends HTMLElement {
+  static observedAttributes = ["width", "flex", "no-padding"];
+
+  private _shadow: ShadowRoot;
+  private _headerSlot: HTMLSlotElement;
+  private _divider: HTMLDivElement;
+
+  constructor() {
+    super();
+    this._shadow = this.attachShadow({ mode: "open" });
+    this._shadow.adoptedStyleSheets = [sheet];
+
+    // Header slot (named)
+    this._headerSlot = document.createElement("slot");
+    this._headerSlot.name = "header";
+    this._shadow.appendChild(this._headerSlot);
+
+    // Divider between header and content
+    this._divider = document.createElement("div");
+    this._divider.className = "divider";
+    this._shadow.appendChild(this._divider);
+
+    // Content area
+    const content = document.createElement("div");
+    content.className = "content";
+    const contentSlot = document.createElement("slot");
+    content.appendChild(contentSlot);
+    this._shadow.appendChild(content);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("role")) {
+      this.setAttribute("role", "group");
+    }
+    this._updateDividerVisibility();
+    this._headerSlot.addEventListener("slotchange", this._onHeaderSlotChange);
+  }
+
+  disconnectedCallback(): void {
+    this._headerSlot.removeEventListener("slotchange", this._onHeaderSlotChange);
+  }
+
+  attributeChangedCallback(name: string, _old: string | null, value: string | null): void {
+    if (name === "width") {
+      this.style.width = value ? `${value}px` : "";
+      this.style.flex = value ? "none" : "";
+    } else if (name === "flex") {
+      if (value && !this.hasAttribute("width")) {
+        this.style.flex = value;
+      }
+    }
+  }
+
+  private _onHeaderSlotChange = (): void => {
+    this._updateDividerVisibility();
+  };
+
+  private _updateDividerVisibility(): void {
+    const hasHeader = this._headerSlot.assignedElements().length > 0;
+    this._divider.style.display = hasHeader ? "" : "none";
+  }
+
+  // --- width (fixed px) ---
+  get width(): number | null {
+    const attr = this.getAttribute("width");
+    return attr ? Number(attr) : null;
+  }
+
+  set width(value: number | null) {
+    if (value === null) {
+      this.removeAttribute("width");
+    } else {
+      this.setAttribute("width", String(value));
+    }
+  }
+
+  // --- no-padding ---
+  get noPadding(): boolean {
+    return this.hasAttribute("no-padding");
+  }
+
+  set noPadding(value: boolean) {
+    if (value) {
+      this.setAttribute("no-padding", "");
+    } else {
+      this.removeAttribute("no-padding");
+    }
+  }
+}
+
+customElements.define("flex-panel", FlexPanelElement);

--- a/packages/flex-layout/src/index.ts
+++ b/packages/flex-layout/src/index.ts
@@ -1,0 +1,13 @@
+// Components
+export { FlexLayoutElement } from "./components/flex-layout.js";
+export type { FlexLayoutSize } from "./components/flex-layout.js";
+
+export { FlexPanelElement } from "./components/flex-panel.js";
+
+export { FlexPanelHeaderElement } from "./components/flex-panel-header.js";
+export type { FlexPanelHeaderSize } from "./components/flex-panel-header.js";
+
+// Side-effect imports (register custom elements)
+import "./components/flex-layout.js";
+import "./components/flex-panel.js";
+import "./components/flex-panel-header.js";

--- a/packages/flex-layout/src/stories/basic.stories.ts
+++ b/packages/flex-layout/src/stories/basic.stories.ts
@@ -1,0 +1,172 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import { injectAllTokens } from "@maneki/foundation";
+import "@maneki/ui-components/src/components/ui-tab-item.js";
+import "@maneki/ui-components/src/components/ui-tab-group.js";
+import "../components/flex-layout.js";
+import "../components/flex-panel.js";
+import "../components/flex-panel-header.js";
+
+injectAllTokens();
+
+const meta: Meta = {
+  title: "Flex Layout/Sizes",
+};
+export default meta;
+type Story = StoryObj;
+
+const panelContentStyle = `
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--fd-text-tertiary);
+  font-family: "Inter", sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+`;
+
+function tabs(size: "s" | "m") {
+  return html`
+    <ui-tab-group slot="tabs" size=${size} closable>
+      <ui-tab-item label="Tab 1" selected></ui-tab-item>
+      <ui-tab-item label="Tab 2"></ui-tab-item>
+      <ui-tab-item label="Tab 3"></ui-tab-item>
+    </ui-tab-group>
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// Large
+// ---------------------------------------------------------------------------
+
+export const Large: Story = {
+  render: () => html`
+    <div style="width: 100%; height: 600px;">
+      <flex-layout size="large">
+        <!-- Panel Left -->
+          <flex-layout direction="column" size="large" style="flex: 1; padding: 0;">
+            <!-- Panel Top -->
+            <flex-panel>
+              <flex-panel-header slot="header" heading="Card Heading" size="large" variant="tabs">
+                ${tabs("s")}
+              </flex-panel-header>
+              <div style="${panelContentStyle}">Content</div>
+            </flex-panel>
+            <!-- Panel Bottom (split) -->
+            <flex-layout size="large" style="flex: 1; padding: 0;">
+              <flex-panel>
+                <flex-panel-header slot="header" heading="Card Heading" size="large" variant="tabs">
+                  ${tabs("s")}
+                </flex-panel-header>
+                <div style="${panelContentStyle}">Content</div>
+              </flex-panel>
+              <flex-panel>
+                <flex-panel-header slot="header" heading="Card Heading" size="large" variant="tabs">
+                  ${tabs("s")}
+                </flex-panel-header>
+                <div style="${panelContentStyle}">Content</div>
+              </flex-panel>
+            </flex-layout>
+          </flex-layout>
+        <!-- Panel Right (fixed 300px) -->
+        <flex-panel width="300">
+          <flex-panel-header slot="header" heading="Card Heading" size="large" variant="tabs">
+            ${tabs("s")}
+          </flex-panel-header>
+          <div style="${panelContentStyle}">Content</div>
+        </flex-panel>
+      </flex-layout>
+    </div>
+  `,
+};
+
+// ---------------------------------------------------------------------------
+// Medium
+// ---------------------------------------------------------------------------
+
+export const Medium: Story = {
+  render: () => html`
+    <div style="width: 100%; height: 600px;">
+      <flex-layout size="medium">
+        <!-- Panel Left -->
+          <flex-layout direction="column" size="medium" style="flex: 1; padding: 0;">
+            <!-- Panel Top -->
+            <flex-panel>
+              <flex-panel-header slot="header" heading="Card Heading" size="medium" variant="tabs">
+                ${tabs("s")}
+              </flex-panel-header>
+              <div style="${panelContentStyle}">Content</div>
+            </flex-panel>
+            <!-- Panel Bottom (split) -->
+            <flex-layout size="medium" style="flex: 1; padding: 0;">
+              <flex-panel>
+                <flex-panel-header slot="header" heading="Card Heading" size="medium" variant="tabs">
+                  ${tabs("s")}
+                </flex-panel-header>
+                <div style="${panelContentStyle}">Content</div>
+              </flex-panel>
+              <flex-panel>
+                <flex-panel-header slot="header" heading="Card Heading" size="medium" variant="tabs">
+                  ${tabs("s")}
+                </flex-panel-header>
+                <div style="${panelContentStyle}">Content</div>
+              </flex-panel>
+            </flex-layout>
+          </flex-layout>
+        <!-- Panel Right (fixed 300px) -->
+        <flex-panel width="300">
+          <flex-panel-header slot="header" heading="Card Heading" size="medium" variant="tabs">
+            ${tabs("s")}
+          </flex-panel-header>
+          <div style="${panelContentStyle}">Content</div>
+        </flex-panel>
+      </flex-layout>
+    </div>
+  `,
+};
+
+// ---------------------------------------------------------------------------
+// Small
+// ---------------------------------------------------------------------------
+
+export const Small: Story = {
+  render: () => html`
+    <div style="width: 100%; height: 600px;">
+      <flex-layout size="small">
+        <!-- Panel Left -->
+          <flex-layout direction="column" size="small" style="flex: 1; padding: 0;">
+            <!-- Panel Top -->
+            <flex-panel>
+              <flex-panel-header slot="header" heading="Card Heading" size="small" variant="tabs">
+                ${tabs("s")}
+              </flex-panel-header>
+              <div style="${panelContentStyle}">Content</div>
+            </flex-panel>
+            <!-- Panel Bottom (split) -->
+            <flex-layout size="small" style="flex: 1; padding: 0;">
+              <flex-panel>
+                <flex-panel-header slot="header" heading="Card Heading" size="small" variant="tabs">
+                  ${tabs("s")}
+                </flex-panel-header>
+                <div style="${panelContentStyle}">Content</div>
+              </flex-panel>
+              <flex-panel>
+                <flex-panel-header slot="header" heading="Card Heading" size="small" variant="tabs">
+                  ${tabs("s")}
+                </flex-panel-header>
+                <div style="${panelContentStyle}">Content</div>
+              </flex-panel>
+            </flex-layout>
+          </flex-layout>
+        <!-- Panel Right (fixed 300px) -->
+        <flex-panel width="300">
+          <flex-panel-header slot="header" heading="Card Heading" size="small" variant="tabs">
+            ${tabs("s")}
+          </flex-panel-header>
+          <div style="${panelContentStyle}">Content</div>
+        </flex-panel>
+      </flex-layout>
+    </div>
+  `,
+};

--- a/packages/flex-layout/src/stories/title-options.stories.ts
+++ b/packages/flex-layout/src/stories/title-options.stories.ts
@@ -1,0 +1,158 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import { injectAllTokens } from "@maneki/foundation";
+import "@maneki/ui-components/src/components/ui-tab-item.js";
+import "@maneki/ui-components/src/components/ui-tab-group.js";
+import "../components/flex-layout.js";
+import "../components/flex-panel.js";
+import "../components/flex-panel-header.js";
+
+injectAllTokens();
+
+const meta: Meta = {
+  title: "Flex Layout/Title Options",
+};
+export default meta;
+type Story = StoryObj;
+
+const panelContentStyle = `
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--fd-text-tertiary);
+  font-family: "Inter", sans-serif;
+  font-size: 16px;
+  font-weight: 500;
+`;
+
+function tabs() {
+  return html`
+    <ui-tab-group slot="tabs" size="s" closable>
+      <ui-tab-item label="Tab 1" selected></ui-tab-item>
+      <ui-tab-item label="Tab 2"></ui-tab-item>
+      <ui-tab-item label="Tab 3"></ui-tab-item>
+    </ui-tab-group>
+  `;
+}
+
+// ---------------------------------------------------------------------------
+// Tabs Only (variant="tabs")
+// ---------------------------------------------------------------------------
+
+export const TabsOnly: Story = {
+  name: "Tabs Only",
+  render: () => html`
+    <div style="width: 100%; height: 600px;">
+      <flex-layout size="medium">
+        <!-- Panel Left -->
+          <flex-layout direction="column" size="medium" style="flex: 1; padding: 0;">
+            <flex-panel>
+              <flex-panel-header slot="header" size="medium" variant="tabs">
+                ${tabs()}
+              </flex-panel-header>
+              <div style="${panelContentStyle}">Content</div>
+            </flex-panel>
+            <flex-layout size="medium" style="flex: 1; padding: 0;">
+              <flex-panel>
+                <flex-panel-header slot="header" size="medium" variant="tabs">
+                  ${tabs()}
+                </flex-panel-header>
+                <div style="${panelContentStyle}">Content</div>
+              </flex-panel>
+              <flex-panel>
+                <flex-panel-header slot="header" size="medium" variant="tabs">
+                  ${tabs()}
+                </flex-panel-header>
+                <div style="${panelContentStyle}">Content</div>
+              </flex-panel>
+            </flex-layout>
+          </flex-layout>
+        <flex-panel width="300">
+          <flex-panel-header slot="header" size="medium" variant="tabs">
+            ${tabs()}
+          </flex-panel-header>
+          <div style="${panelContentStyle}">Content</div>
+        </flex-panel>
+      </flex-layout>
+    </div>
+  `,
+};
+
+// ---------------------------------------------------------------------------
+// Title Only (variant="title")
+// ---------------------------------------------------------------------------
+
+export const TitleOnly: Story = {
+  name: "Title Only",
+  render: () => html`
+    <div style="width: 100%; height: 600px;">
+      <flex-layout size="medium">
+        <!-- Panel Left -->
+          <flex-layout direction="column" size="medium" style="flex: 1; padding: 0;">
+            <flex-panel>
+              <flex-panel-header slot="header" heading="Card Heading" size="medium" variant="title"></flex-panel-header>
+              <div style="${panelContentStyle}">Content</div>
+            </flex-panel>
+            <flex-layout size="medium" style="flex: 1; padding: 0;">
+              <flex-panel>
+                <flex-panel-header slot="header" heading="Card Heading" size="medium" variant="title"></flex-panel-header>
+                <div style="${panelContentStyle}">Content</div>
+              </flex-panel>
+              <flex-panel>
+                <flex-panel-header slot="header" heading="Card Heading" size="medium" variant="title"></flex-panel-header>
+                <div style="${panelContentStyle}">Content</div>
+              </flex-panel>
+            </flex-layout>
+          </flex-layout>
+        <flex-panel width="300">
+          <flex-panel-header slot="header" heading="Card Heading" size="medium" variant="title"></flex-panel-header>
+          <div style="${panelContentStyle}">Content</div>
+        </flex-panel>
+      </flex-layout>
+    </div>
+  `,
+};
+
+// ---------------------------------------------------------------------------
+// Title + Tabs (variant="title-tabs")
+// ---------------------------------------------------------------------------
+
+export const TitleAndTabs: Story = {
+  name: "Title + Tabs",
+  render: () => html`
+    <div style="width: 100%; height: 600px;">
+      <flex-layout size="medium">
+        <!-- Panel Left -->
+          <flex-layout direction="column" size="medium" style="flex: 1; padding: 0;">
+            <flex-panel>
+              <flex-panel-header slot="header" heading="Card Heading" size="medium" variant="title-tabs">
+                ${tabs()}
+              </flex-panel-header>
+              <div style="${panelContentStyle}">Content</div>
+            </flex-panel>
+            <flex-layout size="medium" style="flex: 1; padding: 0;">
+              <flex-panel>
+                <flex-panel-header slot="header" heading="Card Heading" size="medium" variant="title-tabs">
+                  ${tabs()}
+                </flex-panel-header>
+                <div style="${panelContentStyle}">Content</div>
+              </flex-panel>
+              <flex-panel>
+                <flex-panel-header slot="header" heading="Card Heading" size="medium" variant="title-tabs">
+                  ${tabs()}
+                </flex-panel-header>
+                <div style="${panelContentStyle}">Content</div>
+              </flex-panel>
+            </flex-layout>
+          </flex-layout>
+        <flex-panel width="300">
+          <flex-panel-header slot="header" heading="Card Heading" size="medium" variant="title-tabs">
+            ${tabs()}
+          </flex-panel-header>
+          <div style="${panelContentStyle}">Content</div>
+        </flex-panel>
+      </flex-layout>
+    </div>
+  `,
+};

--- a/packages/flex-layout/tsconfig.json
+++ b/packages/flex-layout/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "declaration": true,
+    "declarationDir": "dist",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "useDefineForClassFields": true,
+    "isolatedModules": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/flex-layout/vite.config.ts
+++ b/packages/flex-layout/vite.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "vitest/config";
+import { resolve } from "path";
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, "src/index.ts"),
+      name: "WcFlexLayout",
+      fileName: "index",
+      formats: ["es"],
+    },
+    outDir: "dist",
+    sourcemap: true,
+  },
+  test: {
+    environment: "happy-dom",
+    include: ["src/**/*.test.ts"],
+  },
+  server: {
+    open: "/demo.html",
+  },
+});

--- a/packages/ui-components/src/components/ui-tab-group.test.ts
+++ b/packages/ui-components/src/components/ui-tab-group.test.ts
@@ -395,4 +395,39 @@ describe("ui-tab-group", () => {
     expect(wrapper?.querySelector(".more-btn")).toBeTruthy();
     expect(wrapper?.querySelector(".overflow-menu")).toBeTruthy();
   });
+
+  // ── Closable propagation ─────────────────────────────────────────────────
+
+  it("defaults closable to false", () => {
+    expect((group as unknown as { closable: boolean }).closable).toBe(false);
+  });
+
+  it("propagates closable to children", async () => {
+    const tab1 = document.createElement("ui-tab-item");
+    tab1.setAttribute("label", "Tab 1");
+    group.appendChild(tab1);
+    await new Promise((r) => requestAnimationFrame(r));
+
+    expect(tab1.hasAttribute("closable")).toBe(false);
+
+    group.setAttribute("closable", "");
+    await new Promise((r) => requestAnimationFrame(r));
+
+    expect(tab1.hasAttribute("closable")).toBe(true);
+  });
+
+  it("removes closable from children when removed from group", async () => {
+    group.setAttribute("closable", "");
+    const tab1 = document.createElement("ui-tab-item");
+    tab1.setAttribute("label", "Tab 1");
+    group.appendChild(tab1);
+    await new Promise((r) => requestAnimationFrame(r));
+
+    expect(tab1.hasAttribute("closable")).toBe(true);
+
+    group.removeAttribute("closable");
+    await new Promise((r) => requestAnimationFrame(r));
+
+    expect(tab1.hasAttribute("closable")).toBe(false);
+  });
 });

--- a/packages/ui-components/src/components/ui-tab-group.ts
+++ b/packages/ui-components/src/components/ui-tab-group.ts
@@ -59,7 +59,8 @@ const STYLES = /* css */ `
     overflow-x: auto;
     overflow-y: hidden;
     scrollbar-width: none;
-    border-bottom: 1px solid ${BORDER_MINIMAL};
+    border-bottom: var(--ui-tab-group-border, none);
+    box-shadow: var(--ui-tab-group-border-shadow, inset 0 -1px 0 ${BORDER_MINIMAL});
     flex: 1 1 0%;
     min-width: 0;
   }
@@ -91,7 +92,8 @@ const STYLES = /* css */ `
     overflow-x: hidden;
     scrollbar-width: none;
     border-bottom: none;
-    border-left: 1px solid ${BORDER_MINIMAL};
+    border-left: none;
+    box-shadow: var(--ui-tab-group-border-shadow, inset 1px 0 0 ${BORDER_MINIMAL});
     flex: 1 1 0%;
     min-height: 0;
   }
@@ -147,6 +149,10 @@ const STYLES = /* css */ `
     font-size: 20px;
   }
 
+  .more-btn.has-selected {
+    color: ${semanticVar("icon", "action")};
+  }
+
   :host([orientation="vertical"]) .more-btn {
     padding: 4px 0;
   }
@@ -191,12 +197,11 @@ const STYLES = /* css */ `
     flex-shrink: 0;
     display: flex;
     align-items: stretch;
-    border-bottom: 1px solid ${BORDER_MINIMAL};
+    box-shadow: var(--ui-tab-group-border-shadow, inset 0 -1px 0 ${BORDER_MINIMAL});
   }
 
   :host([orientation="vertical"]) .more-container {
-    border-bottom: none;
-    border-left: 1px solid ${BORDER_MINIMAL};
+    box-shadow: var(--ui-tab-group-border-shadow, inset 1px 0 0 ${BORDER_MINIMAL});
   }
 
   .overflow-menu.open.horizontal {
@@ -244,19 +249,20 @@ const STYLES = /* css */ `
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
-const PROPAGATED_ATTRS = ["size", "orientation"] as const;
+const PROPAGATED_ATTRS = ["size", "orientation", "closable"] as const;
 
 const sheet = new CSSStyleSheet();
 sheet.replaceSync(STYLES);
 
 export class UiTabGroup extends HTMLElement {
-  static readonly observedAttributes = ["size", "orientation", "overflow"];
+  static readonly observedAttributes = ["size", "orientation", "overflow", "closable"];
 
   private _tablist!: HTMLDivElement;
   private _moreBtn!: HTMLButtonElement;
   private _overflowMenu!: HTMLDivElement;
   private _resizeObserver: ResizeObserver | null = null;
   private _hiddenItems: Element[] = [];
+  private _childObserver: MutationObserver | null = null;
 
   constructor() {
     super();
@@ -318,6 +324,9 @@ export class UiTabGroup extends HTMLElement {
     // Listen for tab-select events for mutual exclusion
     this.addEventListener("tab-select", this._handleTabSelect.bind(this));
 
+    // Listen for tab-close events to remove tabs
+    this.addEventListener("tab-close", this._handleTabClose.bind(this));
+
     // More button click
     moreBtn.addEventListener("click", this._toggleOverflowMenu.bind(this));
   }
@@ -329,6 +338,22 @@ export class UiTabGroup extends HTMLElement {
     this.addEventListener("keydown", this._handleKeydown);
     document.addEventListener("click", this._handleOutsideClick);
 
+    // Watch for children added after connection (e.g., lit rendering)
+    this._childObserver = new MutationObserver(() => {
+      this._propagateAttributes();
+      this._syncTabindex();
+    });
+    this._childObserver.observe(this, { childList: true });
+
+    // Re-propagate after render — handles nested slot scenarios
+    // where assignedElements() is empty and children exist but
+    // connectedCallback fires before layout is complete
+    requestAnimationFrame(() => {
+      this._propagateAttributes();
+      this._syncTabindex();
+      this._updateOverflow();
+    });
+
     if (this.overflow === "menu") {
       this._startObserving();
     }
@@ -338,6 +363,10 @@ export class UiTabGroup extends HTMLElement {
     this.removeEventListener("keydown", this._handleKeydown);
     document.removeEventListener("click", this._handleOutsideClick);
     this._stopObserving();
+    if (this._childObserver) {
+      this._childObserver.disconnect();
+      this._childObserver = null;
+    }
   }
 
   attributeChangedCallback(
@@ -388,9 +417,26 @@ export class UiTabGroup extends HTMLElement {
     this.setAttribute("overflow", value);
   }
 
+  get closable(): boolean {
+    return this.hasAttribute("closable");
+  }
+
+  set closable(value: boolean) {
+    if (value) {
+      this.setAttribute("closable", "");
+    } else {
+      this.removeAttribute("closable");
+    }
+  }
+
   // ── Private ─────────────────────────────────────────────────────────────
 
   private _getChildItems(): Element[] {
+    // Use direct children as primary source — assignedElements() is unreliable
+    // in nested shadow DOM slot scenarios (e.g., tab-group slotted into flex-panel-header)
+    const directItems = Array.from(this.children).filter((el) => el.tagName === "UI-TAB-ITEM");
+    if (directItems.length > 0) return directItems;
+    // Fallback to slot assignment for non-nested usage
     const slot = this.shadowRoot!.querySelector("slot")!;
     return slot
       .assignedElements({ flatten: true })
@@ -402,7 +448,7 @@ export class UiTabGroup extends HTMLElement {
     for (const attr of PROPAGATED_ATTRS) {
       const value = this.getAttribute(attr);
       for (const item of items) {
-        if (value) {
+        if (value !== null) {
           item.setAttribute(attr, value);
         } else {
           item.removeAttribute(attr);
@@ -434,6 +480,30 @@ export class UiTabGroup extends HTMLElement {
     );
 
     this._closeOverflowMenu();
+    this._updateOverflow();
+  }
+
+  /** Handle tab-close: remove the tab and select a neighbor if it was selected. */
+  private _handleTabClose(e: Event): void {
+    const target = e.target as HTMLElement;
+    if (target.tagName !== "UI-TAB-ITEM") return;
+
+    const items = this._getChildItems();
+    const index = items.indexOf(target);
+    const wasSelected = target.hasAttribute("selected");
+
+    target.remove();
+
+    // If the closed tab was selected, select the nearest sibling
+    if (wasSelected) {
+      const remaining = this._getChildItems();
+      if (remaining.length > 0) {
+        const next = remaining[Math.min(index, remaining.length - 1)];
+        next.setAttribute("selected", "");
+      }
+    }
+
+    this._syncTabindex();
     this._updateOverflow();
   }
 
@@ -505,8 +575,11 @@ export class UiTabGroup extends HTMLElement {
     if (this._hiddenItems.length > 0) {
       this._moreBtn.classList.add("visible");
       this._moreBtn.setAttribute("tabindex", "0");
+      // Highlight more button if a hidden tab is selected
+      const hasSelected = this._hiddenItems.some((item) => item.hasAttribute("selected"));
+      this._moreBtn.classList.toggle("has-selected", hasSelected);
     } else {
-      this._moreBtn.classList.remove("visible");
+      this._moreBtn.classList.remove("visible", "has-selected");
       this._moreBtn.setAttribute("tabindex", "-1");
       this._closeOverflowMenu();
     }

--- a/packages/ui-components/src/components/ui-tab-item.test.ts
+++ b/packages/ui-components/src/components/ui-tab-item.test.ts
@@ -332,4 +332,66 @@ describe("ui-tab-item", () => {
     component.value = "test-val";
     expect(component.value).toBe("test-val");
   });
+
+  // ── Closable ──────────────────────────────────────────────────────────
+
+  it("defaults closable to false", () => {
+    expect((el as unknown as { closable: boolean }).closable).toBe(false);
+  });
+
+  it("reflects closable attribute", () => {
+    el.setAttribute("closable", "");
+    expect((el as unknown as { closable: boolean }).closable).toBe(true);
+    el.removeAttribute("closable");
+    expect((el as unknown as { closable: boolean }).closable).toBe(false);
+  });
+
+  it("has close button element in shadow DOM", () => {
+    const closeBtn = el.shadowRoot!.querySelector(".close-btn");
+    expect(closeBtn).toBeTruthy();
+    expect(closeBtn?.getAttribute("aria-label")).toBe("Close tab");
+  });
+
+  it("has CSS rule to show close button when closable", () => {
+    const styles = el.shadowRoot!.adoptedStyleSheets
+      .map((s: CSSStyleSheet) =>
+        Array.from(s.cssRules)
+          .map((r: CSSRule) => r.cssText)
+          .join("")
+      )
+      .join("");
+    expect(styles).toContain("closable");
+    expect(styles).toContain("close-btn");
+  });
+
+  it("dispatches tab-close event on close button click", () => {
+    el.setAttribute("closable", "");
+    el.setAttribute("value", "my-tab");
+    let detail: { value: string } | null = null;
+    el.addEventListener("tab-close", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+    const closeBtn = el.shadowRoot!.querySelector(".close-btn") as HTMLElement;
+    closeBtn.click();
+    expect(detail).toEqual({ value: "my-tab" });
+  });
+
+  it("does not dispatch tab-close when disabled", () => {
+    el.setAttribute("closable", "");
+    el.setAttribute("disabled", "");
+    let fired = false;
+    el.addEventListener("tab-close", () => { fired = true; });
+    const closeBtn = el.shadowRoot!.querySelector(".close-btn") as HTMLElement;
+    closeBtn.click();
+    expect(fired).toBe(false);
+  });
+
+  it("close button click does not trigger tab-select", () => {
+    el.setAttribute("closable", "");
+    let selectFired = false;
+    el.addEventListener("tab-select", () => { selectFired = true; });
+    const closeBtn = el.shadowRoot!.querySelector(".close-btn") as HTMLElement;
+    closeBtn.click();
+    expect(selectFired).toBe(false);
+  });
 });

--- a/packages/ui-components/src/components/ui-tab-item.ts
+++ b/packages/ui-components/src/components/ui-tab-item.ts
@@ -1,4 +1,4 @@
-import { semanticVar, spaceVar, ICON_EXPAND_MORE } from "@maneki/foundation";
+import { semanticVar, spaceVar, ICON_EXPAND_MORE, ICON_CLOSE } from "@maneki/foundation";
 
 // ─── Type-safe property unions ───────────────────────────────────────────────
 
@@ -13,6 +13,8 @@ const SELECTED_BOLD = semanticVar("stateSelected", "surfaceBold");
 const DISABLED_TEXT = semanticVar("stateDisabled", "text");
 const ICON_PRIMARY = semanticVar("icon", "primary");
 const ICON_SECONDARY = semanticVar("icon", "secondary");
+const ICON_ACTION = semanticVar("icon", "action");
+const BORDER_MINIMAL = semanticVar("border", "minimal");
 const SP_1 = spaceVar("1");
 const SP_0_5 = spaceVar("0.5");
 const SP_1_5 = spaceVar("1.5");
@@ -109,6 +111,9 @@ const STYLES = /* css */ `
 
   :host([orientation="vertical"]) {
     flex-direction: row;
+  }
+  :host([orientation="vertical"]) .base {
+    justify-content: flex-start;
   }
 
   :host([orientation="vertical"]) .highlight {
@@ -216,6 +221,13 @@ const STYLES = /* css */ `
     --ui-tab-highlight-color: transparent;
   }
 
+  /* ── State: hover ─────────────────────────────────────────────────────── */
+
+  :host(:hover:not([selected]):not([disabled])) {
+    --ui-tab-text-color: ${TEXT_PRIMARY};
+    --ui-tab-highlight-color: ${BORDER_MINIMAL};
+  }
+
   /* ── State: selected ────────────────────────────────────────────────────── */
 
   :host([selected]) {
@@ -225,8 +237,9 @@ const STYLES = /* css */ `
   }
 
   :host([selected]) .leading-icon,
-  :host([selected]) .trailing-icon {
-    color: var(--ui-tab-icon-color, ${TEXT_LINK});
+  :host([selected]) .trailing-icon,
+  :host([selected]) .close-btn {
+    color: var(--ui-tab-icon-color, ${ICON_ACTION});
   }
 
   /* ── State: disabled ────────────────────────────────────────────────────── */
@@ -243,6 +256,62 @@ const STYLES = /* css */ `
   :host([disabled]) .trailing-icon,
   :host([disabled]) .chevron {
     color: ${DISABLED_TEXT};
+  }
+
+  /* ── Close button ──────────────────────────────────────────────────────── */
+
+  .close-btn {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    cursor: pointer;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    color: var(--ui-tab-icon-color, ${ICON_PRIMARY});
+    border-radius: 2px;
+    transition: color 0.15s ease;
+  }
+
+  :host([closable]) .close-btn {
+    display: inline-flex;
+  }
+
+  .close-btn:hover {
+    color: var(--ui-tab-text-color, ${TEXT_PRIMARY});
+    background: rgba(0, 0, 0, 0.08);
+  }
+
+  .close-btn:focus-visible {
+    outline: 2px solid ${semanticVar("border", "focus")};
+    outline-offset: -1px;
+  }
+
+  :host([disabled]) .close-btn {
+    color: ${DISABLED_TEXT};
+    pointer-events: none;
+  }
+
+  /* Close button sizes */
+  :host .close-btn,
+  :host([size="m"]) .close-btn {
+    width: 16px;
+    height: 16px;
+    font-size: 16px;
+  }
+
+  :host([size="s"]) .close-btn {
+    width: 12px;
+    height: 12px;
+    font-size: 12px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .close-btn {
+      transition: none;
+    }
   }
 
   /* ── Reduced motion ─────────────────────────────────────────────────────── */
@@ -268,6 +337,7 @@ export class UiTabItem extends HTMLElement {
     "label",
     "sub-menu",
     "value",
+    "closable",
   ];
 
   private _labelEl!: HTMLSpanElement;
@@ -328,6 +398,22 @@ export class UiTabItem extends HTMLElement {
     labelContainer.appendChild(labelSpan);
     labelContainer.appendChild(trailingIcon);
     labelContainer.appendChild(chevron);
+
+    // Close button
+    const closeBtn = document.createElement("button");
+    closeBtn.className = "close-btn material-symbols-outlined";
+    closeBtn.setAttribute("type", "button");
+    closeBtn.setAttribute("aria-label", "Close tab");
+    closeBtn.setAttribute("tabindex", "-1");
+    closeBtn.textContent = ICON_CLOSE;
+    closeBtn.addEventListener("click", (e: Event) => {
+      e.stopPropagation();
+      if (this.disabled) return;
+      this.dispatchEvent(
+        new CustomEvent("tab-close", { bubbles: true, composed: true, detail: { value: this.value } }),
+      );
+    });
+    labelContainer.appendChild(closeBtn);
 
     base.appendChild(labelContainer);
     base.appendChild(highlight);
@@ -431,6 +517,18 @@ export class UiTabItem extends HTMLElement {
 
   set value(v: string) {
     this.setAttribute("value", v);
+  }
+
+  get closable(): boolean {
+    return this.hasAttribute("closable");
+  }
+
+  set closable(value: boolean) {
+    if (value) {
+      this.setAttribute("closable", "");
+    } else {
+      this.removeAttribute("closable");
+    }
   }
 
   // ── Private ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- New `@maneki/flex-layout` package with 3 Web Components: `<flex-layout>`, `<flex-panel>`, `<flex-panel-header>`
- Implements the "Flex Layout" Figma page — panel-based dashboard layouts with size variants (L/M/S) and header options (title/tabs/title+tabs)
- 50 unit tests passing, types clean, Storybook stories verified via Playwright

## Components

| Component | Description |
|-----------|-------------|
| `<flex-layout>` | Flex container with `size` attribute controlling gap/padding presets |
| `<flex-panel>` | Content panel with optional header slot, fixed or flex width |
| `<flex-panel-header>` | Panel header with `variant` (title/tabs/title-tabs) and `size` presets |

## Design tokens

- Container background: `Surface/surface-moderate`
- Panel content: white
- Panel header: `Surface/surface-secondary`
- Header divider: `Border/border-minimal`
- CSS custom properties: `--flex-*` prefix for consumer overrides

## Files

- `packages/flex-layout/` — full package (components, tests, stories, build config, AGENTS.md)
- `.storybook/main.ts` — added flex-layout stories glob