### PR TITLE
feat(storybook): enable autodocs globally for all stories

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -45,6 +45,7 @@ document.head.appendChild(globalIconStyles);
 injectAllTokens();
 
 const preview: Preview = {
+  tags: ["autodocs"],
   parameters: {
     a11y: {
       test: "error",


### PR DESCRIPTION
## Summary

- Add `tags: ["autodocs"]` to root `.storybook/preview.ts` to enable auto-generated documentation pages for all 37 stories across foundation, ui-components, grid-layout, and flex-layout
- Storybook build verified successfully