### PR TITLE
feat(ui-components): add ui-icon component and refactor stories to use it

### DIFF
--- a/packages/ui-components/AGENTS.md
+++ b/packages/ui-components/AGENTS.md
@@ -50,6 +50,9 @@ Web Component library for the Maneki design system. Shadow DOM, CSS custom prope
 - `<ui-tab-item>` — tab item: 2 sizes (s/m), 3 states (enabled/selected/disabled), 2 orientations (horizontal/vertical), leading/trailing icon slots, sub-menu chevron, smooth transition
 - `<ui-tab-group>` — tab group wrapper: size/orientation propagation, single selection, roving tabindex, arrow key navigation
 
+**Icons:**
+- `<ui-icon>` — Material Symbols icon: 5 sizes (xxs/xs/s/m/l), 10 states (enabled/hover/active/focus/disabled + inverse variants), filled variant, ICON_CODEPOINTS lookup with ligature fallback, accessible label
+
 ## STRUCTURE
 ```
 ui-components/
@@ -93,6 +96,7 @@ ui-components/
 │   │   ├── ui-modal.ts
 │   │   ├── ui-tab-item.ts
 │   │   ├── ui-tab-group.ts
+│   │   ├── ui-icon.ts
 │   │   └── *.test.ts            # Co-located tests
 │   └── stories/
 │       └── *.stories.ts     # CSF3 + lit html

--- a/packages/ui-components/src/components/ui-icon.test.ts
+++ b/packages/ui-components/src/components/ui-icon.test.ts
@@ -1,0 +1,435 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "./ui-icon.js";
+import { STYLES } from "./ui-icon.js";
+
+describe("ui-icon", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-icon");
+    document.body.appendChild(el);
+  });
+
+  // ── Registration ─────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-icon")).toBeDefined();
+  });
+
+  // ── Default attributes ───────────────────────────────────────────────────
+
+  it("defaults name to ''", () => {
+    expect((el as unknown as { name: string }).name).toBe("");
+  });
+
+  it("defaults size to 's'", () => {
+    expect((el as unknown as { size: string }).size).toBe("s");
+  });
+
+  it("defaults state to 'enabled'", () => {
+    expect((el as unknown as { state: string }).state).toBe("enabled");
+  });
+
+  it("defaults filled to false", () => {
+    expect((el as unknown as { filled: boolean }).filled).toBe(false);
+  });
+
+  it("defaults label to ''", () => {
+    expect((el as unknown as { label: string }).label).toBe("");
+  });
+
+  // ── Size attribute ──────────────────────────────────────────────────────
+
+  it("reflects size='xxs' to attribute", () => {
+    (el as unknown as { size: string }).size = "xxs";
+    expect(el.getAttribute("size")).toBe("xxs");
+  });
+
+  it("reflects size='xs' to attribute", () => {
+    (el as unknown as { size: string }).size = "xs";
+    expect(el.getAttribute("size")).toBe("xs");
+  });
+
+  it("reflects size='s' to attribute", () => {
+    (el as unknown as { size: string }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("reflects size='m' to attribute", () => {
+    (el as unknown as { size: string }).size = "m";
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("reflects size='l' to attribute", () => {
+    (el as unknown as { size: string }).size = "l";
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  // ── State attribute ─────────────────────────────────────────────────────
+
+  it("reflects state='enabled' to attribute", () => {
+    (el as unknown as { state: string }).state = "enabled";
+    expect(el.getAttribute("state")).toBe("enabled");
+  });
+
+  it("reflects state='enabled-inverse' to attribute", () => {
+    (el as unknown as { state: string }).state = "enabled-inverse";
+    expect(el.getAttribute("state")).toBe("enabled-inverse");
+  });
+
+  it("reflects state='hover' to attribute", () => {
+    (el as unknown as { state: string }).state = "hover";
+    expect(el.getAttribute("state")).toBe("hover");
+  });
+
+  it("reflects state='hover-inverse' to attribute", () => {
+    (el as unknown as { state: string }).state = "hover-inverse";
+    expect(el.getAttribute("state")).toBe("hover-inverse");
+  });
+
+  it("reflects state='active' to attribute", () => {
+    (el as unknown as { state: string }).state = "active";
+    expect(el.getAttribute("state")).toBe("active");
+  });
+
+  it("reflects state='active-inverse' to attribute", () => {
+    (el as unknown as { state: string }).state = "active-inverse";
+    expect(el.getAttribute("state")).toBe("active-inverse");
+  });
+
+  it("reflects state='focus' to attribute", () => {
+    (el as unknown as { state: string }).state = "focus";
+    expect(el.getAttribute("state")).toBe("focus");
+  });
+
+  it("reflects state='focus-inverse' to attribute", () => {
+    (el as unknown as { state: string }).state = "focus-inverse";
+    expect(el.getAttribute("state")).toBe("focus-inverse");
+  });
+
+  it("reflects state='disabled' to attribute", () => {
+    (el as unknown as { state: string }).state = "disabled";
+    expect(el.getAttribute("state")).toBe("disabled");
+  });
+
+  it("reflects state='disabled-inverse' to attribute", () => {
+    (el as unknown as { state: string }).state = "disabled-inverse";
+    expect(el.getAttribute("state")).toBe("disabled-inverse");
+  });
+
+  // ── Filled attribute ────────────────────────────────────────────────────
+
+  it("sets filled attribute when filled=true", () => {
+    (el as unknown as { filled: boolean }).filled = true;
+    expect(el.hasAttribute("filled")).toBe(true);
+  });
+
+  it("removes filled attribute when filled=false", () => {
+    (el as unknown as { filled: boolean }).filled = true;
+    (el as unknown as { filled: boolean }).filled = false;
+    expect(el.hasAttribute("filled")).toBe(false);
+  });
+
+  // ── Name attribute + ICON_CODEPOINTS lookup ─────────────────────────────
+
+  it("reflects name to attribute", () => {
+    (el as unknown as { name: string }).name = "home";
+    expect(el.getAttribute("name")).toBe("home");
+  });
+
+  it("renders codepoint for known icon name", () => {
+    el.setAttribute("name", "home");
+    const shadow = el.shadowRoot!;
+    const iconEl = shadow.querySelector(".icon")!;
+    // ICON_HOME = "\uE88A"
+    expect(iconEl.textContent).toBe("\uE88A");
+  });
+
+  it("renders codepoint for 'settings'", () => {
+    el.setAttribute("name", "settings");
+    const shadow = el.shadowRoot!;
+    const iconEl = shadow.querySelector(".icon")!;
+    // ICON_SETTINGS = "\uE8B8"
+    expect(iconEl.textContent).toBe("\uE8B8");
+  });
+
+  it("renders codepoint for 'close'", () => {
+    el.setAttribute("name", "close");
+    const shadow = el.shadowRoot!;
+    const iconEl = shadow.querySelector(".icon")!;
+    // ICON_CLOSE = "\uE5CD"
+    expect(iconEl.textContent).toBe("\uE5CD");
+  });
+
+  it("falls back to ligature text for unknown icon name", () => {
+    el.setAttribute("name", "unknown_icon_xyz");
+    const shadow = el.shadowRoot!;
+    const iconEl = shadow.querySelector(".icon")!;
+    expect(iconEl.textContent).toBe("unknown_icon_xyz");
+  });
+
+  it("falls back to ligature text for arbitrary name", () => {
+    el.setAttribute("name", "star");
+    const shadow = el.shadowRoot!;
+    const iconEl = shadow.querySelector(".icon")!;
+    expect(iconEl.textContent).toBe("star");
+  });
+
+  it("renders empty text when name is empty", () => {
+    el.setAttribute("name", "");
+    const shadow = el.shadowRoot!;
+    const iconEl = shadow.querySelector(".icon")!;
+    expect(iconEl.textContent).toBe("");
+  });
+
+  // ── Label / Accessibility ───────────────────────────────────────────────
+
+  it("defaults to role='presentation' and aria-hidden='true'", () => {
+    expect(el.getAttribute("role")).toBe("presentation");
+    expect(el.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("sets role='img' and aria-label when label is provided", () => {
+    (el as unknown as { label: string }).label = "Home icon";
+    expect(el.getAttribute("role")).toBe("img");
+    expect(el.getAttribute("aria-label")).toBe("Home icon");
+    expect(el.hasAttribute("aria-hidden")).toBe(false);
+  });
+
+  it("reverts to presentation when label is cleared", () => {
+    (el as unknown as { label: string }).label = "Home icon";
+    (el as unknown as { label: string }).label = "";
+    expect(el.getAttribute("role")).toBe("presentation");
+    expect(el.getAttribute("aria-hidden")).toBe("true");
+    expect(el.hasAttribute("aria-label")).toBe(false);
+  });
+
+  it("sets accessibility via setAttribute('label', ...)", () => {
+    el.setAttribute("label", "Settings");
+    expect(el.getAttribute("role")).toBe("img");
+    expect(el.getAttribute("aria-label")).toBe("Settings");
+  });
+
+  // ── Shadow DOM structure ───────────────────────────────────────────────
+
+  it("has .icon element in shadow DOM", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.querySelector(".icon")).toBeTruthy();
+  });
+
+  it("has a <span> as .icon element", () => {
+    const shadow = el.shadowRoot!;
+    const iconEl = shadow.querySelector(".icon");
+    expect(iconEl!.tagName).toBe("SPAN");
+  });
+
+  it("has adopted stylesheets", () => {
+    const shadow = el.shadowRoot!;
+    expect(shadow.adoptedStyleSheets.length).toBeGreaterThan(0);
+  });
+
+  // ── Property accessors ────────────────────────────────────────────────
+
+  it("exposes name property accessor", () => {
+    const component = el as unknown as { name: string };
+    component.name = "home";
+    expect(component.name).toBe("home");
+    expect(el.getAttribute("name")).toBe("home");
+  });
+
+  it("exposes size property accessor", () => {
+    const component = el as unknown as { size: string };
+    component.size = "l";
+    expect(component.size).toBe("l");
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  it("exposes state property accessor", () => {
+    const component = el as unknown as { state: string };
+    component.state = "hover";
+    expect(component.state).toBe("hover");
+    expect(el.getAttribute("state")).toBe("hover");
+  });
+
+  it("exposes filled property accessor", () => {
+    const component = el as unknown as { filled: boolean };
+    component.filled = true;
+    expect(component.filled).toBe(true);
+    expect(el.hasAttribute("filled")).toBe(true);
+  });
+
+  it("exposes label property accessor", () => {
+    const component = el as unknown as { label: string };
+    component.label = "Close";
+    expect(component.label).toBe("Close");
+    expect(el.getAttribute("label")).toBe("Close");
+  });
+
+  it("exposes all typed property accessors together", () => {
+    const component = el as unknown as {
+      name: string;
+      size: string;
+      state: string;
+      filled: boolean;
+      label: string;
+    };
+
+    component.name = "settings";
+    expect(component.name).toBe("settings");
+
+    component.size = "m";
+    expect(component.size).toBe("m");
+
+    component.state = "active";
+    expect(component.state).toBe("active");
+
+    component.filled = true;
+    expect(component.filled).toBe(true);
+
+    component.label = "Settings icon";
+    expect(component.label).toBe("Settings icon");
+  });
+
+  // ── observedAttributes ────────────────────────────────────────────────
+
+  it("observes name attribute", () => {
+    const observed = (
+      customElements.get("ui-icon") as unknown as {
+        observedAttributes: string[];
+      }
+    ).observedAttributes;
+    expect(observed).toContain("name");
+  });
+
+  it("observes size attribute", () => {
+    const observed = (
+      customElements.get("ui-icon") as unknown as {
+        observedAttributes: string[];
+      }
+    ).observedAttributes;
+    expect(observed).toContain("size");
+  });
+
+  it("observes state attribute", () => {
+    const observed = (
+      customElements.get("ui-icon") as unknown as {
+        observedAttributes: string[];
+      }
+    ).observedAttributes;
+    expect(observed).toContain("state");
+  });
+
+  it("observes filled attribute", () => {
+    const observed = (
+      customElements.get("ui-icon") as unknown as {
+        observedAttributes: string[];
+      }
+    ).observedAttributes;
+    expect(observed).toContain("filled");
+  });
+
+  it("observes label attribute", () => {
+    const observed = (
+      customElements.get("ui-icon") as unknown as {
+        observedAttributes: string[];
+      }
+    ).observedAttributes;
+    expect(observed).toContain("label");
+  });
+
+  // ── Attribute via setAttribute ────────────────────────────────────────
+
+  it("reads name from setAttribute", () => {
+    el.setAttribute("name", "error");
+    expect((el as unknown as { name: string }).name).toBe("error");
+  });
+
+  it("reads size from setAttribute", () => {
+    el.setAttribute("size", "xxs");
+    expect((el as unknown as { size: string }).size).toBe("xxs");
+  });
+
+  it("reads state from setAttribute", () => {
+    el.setAttribute("state", "disabled");
+    expect((el as unknown as { state: string }).state).toBe("disabled");
+  });
+
+  it("reads filled from setAttribute", () => {
+    el.setAttribute("filled", "");
+    expect((el as unknown as { filled: boolean }).filled).toBe(true);
+  });
+
+  it("reads label from setAttribute", () => {
+    el.setAttribute("label", "Info");
+    expect((el as unknown as { label: string }).label).toBe("Info");
+  });
+
+  // ── Display ───────────────────────────────────────────────────────────
+
+  it("is an inline-flex element via :host", () => {
+    const shadow = el.shadowRoot!;
+    const styles = shadow.adoptedStyleSheets.map((s: CSSStyleSheet) => Array.from(s.cssRules).map((r: CSSRule) => r.cssText).join("")).join("");
+    expect(styles).toContain("display: inline-flex");
+  });
+
+  // ── CSS contains expected token references ────────────────────────────
+
+  it("CSS contains --ui-icon-color custom property", () => {
+    expect(STYLES).toContain("--ui-icon-color");
+  });
+
+  it("CSS contains --ui-icon-size custom property", () => {
+    expect(STYLES).toContain("--ui-icon-size");
+  });
+
+  it("CSS contains --ui-icon-bg custom property", () => {
+    expect(STYLES).toContain("--ui-icon-bg");
+  });
+
+  it("CSS contains font-family: Material Symbols Outlined", () => {
+    expect(STYLES).toContain('font-family: "Material Symbols Outlined"');
+  });
+
+  it("CSS contains font-variation-settings for FILL 0", () => {
+    expect(STYLES).toContain("'FILL' 0");
+  });
+
+  it("CSS contains font-variation-settings for FILL 1 (filled)", () => {
+    expect(STYLES).toContain("'FILL' 1");
+  });
+
+  it("CSS contains @font-face declaration", () => {
+    expect(STYLES).toContain("@font-face");
+    expect(STYLES).toContain('src: local("Material Symbols Outlined")');
+  });
+
+  // ── Multiple instances ────────────────────────────────────────────────
+
+  it("supports multiple independent instances", () => {
+    const el2 = document.createElement("ui-icon");
+    document.body.appendChild(el2);
+
+    (el as unknown as { name: string }).name = "home";
+    (el2 as unknown as { name: string }).name = "settings";
+
+    expect((el as unknown as { name: string }).name).toBe("home");
+    expect((el2 as unknown as { name: string }).name).toBe("settings");
+
+    const icon1 = el.shadowRoot!.querySelector(".icon")!;
+    const icon2 = el2.shadowRoot!.querySelector(".icon")!;
+    expect(icon1.textContent).toBe("\uE88A");
+    expect(icon2.textContent).toBe("\uE8B8");
+  });
+
+  it("supports independent state on multiple instances", () => {
+    const el2 = document.createElement("ui-icon");
+    document.body.appendChild(el2);
+
+    (el as unknown as { state: string }).state = "hover";
+    (el2 as unknown as { state: string }).state = "disabled";
+
+    expect((el as unknown as { state: string }).state).toBe("hover");
+    expect((el2 as unknown as { state: string }).state).toBe("disabled");
+  });
+});

--- a/packages/ui-components/src/components/ui-icon.ts
+++ b/packages/ui-components/src/components/ui-icon.ts
@@ -1,0 +1,301 @@
+import { semanticVar, ICON_CODEPOINTS } from "@maneki/foundation";
+
+// ─── Type-safe property unions ───────────────────────────────────────────────
+
+export type IconSize = "xxs" | "xs" | "s" | "m" | "l";
+export type IconState =
+  | "enabled"
+  | "enabled-inverse"
+  | "hover"
+  | "hover-inverse"
+  | "active"
+  | "active-inverse"
+  | "focus"
+  | "focus-inverse"
+  | "disabled"
+  | "disabled-inverse";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const ICON_PRIMARY = semanticVar("icon", "primary");
+const ICON_REVERSED = semanticVar("icon", "reversed");
+const ICON_ACTION = semanticVar("icon", "action");
+const DISABLED_MINIMAL = semanticVar("stateDisabled", "minimal");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+export const STYLES = /* css */ `
+  @font-face {
+    font-family: "Material Symbols Outlined";
+    font-style: normal;
+    src: local("Material Symbols Outlined");
+  }
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: inline-flex;
+  }
+
+  /* ── Base icon ─────────────────────────────────────────────────────────────── */
+
+  .icon {
+    font-family: "Material Symbols Outlined";
+    font-weight: normal;
+    font-style: normal;
+    font-variation-settings: 'FILL' 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    letter-spacing: normal;
+    text-transform: none;
+    white-space: nowrap;
+    word-wrap: normal;
+    direction: ltr;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+    font-feature-settings: 'liga';
+  }
+
+  /* ── Filled variant ────────────────────────────────────────────────────────── */
+
+  :host([filled]) .icon {
+    font-variation-settings: 'FILL' 1;
+  }
+
+  /* ── Size: s (default) ─────────────────────────────────────────────────────── */
+
+  :host .icon,
+  :host([size="s"]) .icon {
+    font-size: var(--ui-icon-size, 16px);
+    width: var(--ui-icon-size, 16px);
+    height: var(--ui-icon-size, 16px);
+  }
+
+  /* ── Size: xxs ─────────────────────────────────────────────────────────────── */
+
+  :host([size="xxs"]) .icon {
+    font-size: var(--ui-icon-size, 12px);
+    width: var(--ui-icon-size, 12px);
+    height: var(--ui-icon-size, 12px);
+  }
+
+  /* ── Size: xs ──────────────────────────────────────────────────────────────── */
+
+  :host([size="xs"]) .icon {
+    font-size: var(--ui-icon-size, 14px);
+    width: var(--ui-icon-size, 14px);
+    height: var(--ui-icon-size, 14px);
+  }
+
+  /* ── Size: m ───────────────────────────────────────────────────────────────── */
+
+  :host([size="m"]) .icon {
+    font-size: var(--ui-icon-size, 20px);
+    width: var(--ui-icon-size, 20px);
+    height: var(--ui-icon-size, 20px);
+  }
+
+  /* ── Size: l ───────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) .icon {
+    font-size: var(--ui-icon-size, 24px);
+    width: var(--ui-icon-size, 24px);
+    height: var(--ui-icon-size, 24px);
+  }
+
+  /* ── State: enabled (default) ──────────────────────────────────────────────── */
+
+  :host .icon,
+  :host([state="enabled"]) .icon {
+    color: var(--ui-icon-color, ${ICON_PRIMARY});
+    background: var(--ui-icon-bg, none);
+  }
+
+  /* ── State: enabled-inverse ────────────────────────────────────────────────── */
+
+  :host([state="enabled-inverse"]) .icon {
+    color: var(--ui-icon-color, ${ICON_REVERSED});
+    background: var(--ui-icon-bg, none);
+  }
+
+  /* ── State: hover ──────────────────────────────────────────────────────────── */
+
+  :host([state="hover"]) .icon {
+    color: var(--ui-icon-color, ${ICON_ACTION});
+    background: var(--ui-icon-bg, none);
+  }
+
+  /* ── State: hover-inverse ──────────────────────────────────────────────────── */
+
+  :host([state="hover-inverse"]) .icon {
+    color: var(--ui-icon-color, ${ICON_REVERSED});
+    background: var(--ui-icon-bg, rgba(255, 255, 255, 0.1));
+  }
+
+  /* ── State: active ─────────────────────────────────────────────────────────── */
+
+  :host([state="active"]) .icon {
+    color: var(--ui-icon-color, ${ICON_ACTION});
+    background: var(--ui-icon-bg, none);
+  }
+
+  /* ── State: active-inverse ─────────────────────────────────────────────────── */
+
+  :host([state="active-inverse"]) .icon {
+    color: var(--ui-icon-color, ${ICON_REVERSED});
+    background: var(--ui-icon-bg, rgba(255, 255, 255, 0.2));
+  }
+
+  /* ── State: focus ──────────────────────────────────────────────────────────── */
+
+  :host([state="focus"]) .icon {
+    color: var(--ui-icon-color, ${ICON_ACTION});
+    background: var(--ui-icon-bg, none);
+  }
+
+  /* ── State: focus-inverse ──────────────────────────────────────────────────── */
+
+  :host([state="focus-inverse"]) .icon {
+    color: var(--ui-icon-color, ${ICON_REVERSED});
+    background: var(--ui-icon-bg, none);
+  }
+
+  /* ── State: disabled ───────────────────────────────────────────────────────── */
+
+  :host([state="disabled"]) .icon {
+    color: var(--ui-icon-color, ${DISABLED_MINIMAL});
+    background: var(--ui-icon-bg, none);
+  }
+
+  /* ── State: disabled-inverse ───────────────────────────────────────────────── */
+
+  :host([state="disabled-inverse"]) .icon {
+    color: var(--ui-icon-color, rgba(255, 255, 255, 0.3));
+    background: var(--ui-icon-bg, none);
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiIcon extends HTMLElement {
+  static readonly observedAttributes = [
+    "name",
+    "size",
+    "state",
+    "filled",
+    "label",
+  ];
+
+  #iconEl: HTMLSpanElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+
+    shadow.adoptedStyleSheets = [sheet];
+
+    // .icon
+    const iconEl = document.createElement("span");
+    iconEl.className = "icon";
+    this.#iconEl = iconEl;
+
+    // default accessibility: presentational
+    this.setAttribute("role", "presentation");
+    this.setAttribute("aria-hidden", "true");
+
+    shadow.appendChild(iconEl);
+  }
+
+  attributeChangedCallback(
+    attrName: string,
+    _oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    if (attrName === "name") {
+      this.#updateIcon();
+    } else if (attrName === "label") {
+      this.#updateAccessibility(newValue);
+    }
+    // size, state, filled are handled via :host([attr]) CSS selectors
+  }
+
+  #updateIcon(): void {
+    const name = this.getAttribute("name") ?? "";
+    const codepoint = ICON_CODEPOINTS[name];
+    this.#iconEl.textContent = codepoint ?? name;
+  }
+
+  #updateAccessibility(label: string | null): void {
+    if (label) {
+      this.setAttribute("role", "img");
+      this.setAttribute("aria-label", label);
+      this.removeAttribute("aria-hidden");
+    } else {
+      this.setAttribute("role", "presentation");
+      this.removeAttribute("aria-label");
+      this.setAttribute("aria-hidden", "true");
+    }
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get name(): string {
+    return this.getAttribute("name") ?? "";
+  }
+
+  set name(value: string) {
+    this.setAttribute("name", value);
+  }
+
+  get size(): IconSize {
+    return (this.getAttribute("size") as IconSize) ?? "s";
+  }
+
+  set size(value: IconSize) {
+    this.setAttribute("size", value);
+  }
+
+  get state(): IconState {
+    return (this.getAttribute("state") as IconState) ?? "enabled";
+  }
+
+  set state(value: IconState) {
+    this.setAttribute("state", value);
+  }
+
+  get filled(): boolean {
+    return this.hasAttribute("filled");
+  }
+
+  set filled(value: boolean) {
+    if (value) {
+      this.setAttribute("filled", "");
+    } else {
+      this.removeAttribute("filled");
+    }
+  }
+
+  get label(): string {
+    return this.getAttribute("label") ?? "";
+  }
+
+  set label(value: string) {
+    if (value) {
+      this.setAttribute("label", value);
+    } else {
+      this.removeAttribute("label");
+    }
+  }
+}
+
+customElements.define("ui-icon", UiIcon);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -100,3 +100,8 @@ export { UiTabItem } from "./components/ui-tab-item.js";
 export type { TabItemSize, TabItemOrientation } from "./components/ui-tab-item.js";
 export { UiTabGroup } from "./components/ui-tab-group.js";
 export type { TabGroupOverflow } from "./components/ui-tab-group.js";
+
+// ─── Icons ──────────────────────────────────────────────────────────────────
+
+export { UiIcon } from "./components/ui-icon.js";
+export type { IconSize, IconState } from "./components/ui-icon.js";

--- a/packages/ui-components/src/stories/ui-accordion-item.stories.ts
+++ b/packages/ui-components/src/stories/ui-accordion-item.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/web-components";
 import { html } from "lit";
-import { ICON_INFO } from "@maneki/foundation";
+import "../components/ui-icon.js";
 import "../components/ui-accordion-item.js";
 
 const meta: Meta = {
@@ -69,7 +69,7 @@ export const BoldEmphasis: Story = {
 export const WithLeadingIcon: Story = {
   render: () => html`
     <ui-accordion-item leading-icon expanded>
-      <span slot="icon" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">${ICON_INFO}</span>
+      <ui-icon name="info" size="m" slot="icon"></ui-icon>
       <span slot="label">With Leading Icon</span>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
     </ui-accordion-item>

--- a/packages/ui-components/src/stories/ui-alert.stories.ts
+++ b/packages/ui-components/src/stories/ui-alert.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/web-components";
 import { html } from "lit";
-import { ICON_INFO, ICON_NOTIFICATIONS, ICON_CHECK_CIRCLE, ICON_ERROR, ICON_WARNING } from "@maneki/foundation";
+import "../components/ui-icon.js";
 import "../components/ui-alert.js";
 import "../components/ui-button.js";
 
@@ -95,7 +95,7 @@ export const WithDescription: Story = {
 export const WithLeadingIcon: Story = {
   render: () => html`
     <ui-alert status="information" leading-icon>
-      <span slot="icon" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">${ICON_INFO}</span>
+      <ui-icon name="info" size="m" slot="icon"></ui-icon>
       Alert with leading icon
     </ui-alert>
   `,
@@ -113,23 +113,23 @@ export const AllStatuses: Story = {
   render: () => html`
     <div style="display: flex; flex-direction: column; gap: 16px;">
       <ui-alert status="none" leading-icon>
-        <span slot="icon" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">${ICON_NOTIFICATIONS}</span>
+        <ui-icon name="notifications" size="m" slot="icon"></ui-icon>
         None status
       </ui-alert>
       <ui-alert status="information" leading-icon>
-        <span slot="icon" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">${ICON_INFO}</span>
+        <ui-icon name="info" size="m" slot="icon"></ui-icon>
         Information status
       </ui-alert>
       <ui-alert status="success" leading-icon>
-        <span slot="icon" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">${ICON_CHECK_CIRCLE}</span>
+        <ui-icon name="check_circle" size="m" slot="icon"></ui-icon>
         Success status
       </ui-alert>
       <ui-alert status="error" leading-icon>
-        <span slot="icon" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">${ICON_ERROR}</span>
+        <ui-icon name="error" size="m" slot="icon"></ui-icon>
         Error status
       </ui-alert>
       <ui-alert status="warning" leading-icon>
-        <span slot="icon" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">${ICON_WARNING}</span>
+        <ui-icon name="warning" size="m" slot="icon"></ui-icon>
         Warning status
       </ui-alert>
     </div>
@@ -139,7 +139,7 @@ export const AllStatuses: Story = {
 export const WithFooterButton: Story = {
   render: () => html`
     <ui-alert status="none" leading-icon dismissable>
-      <span slot="icon" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">${ICON_NOTIFICATIONS}</span>
+      <ui-icon name="notifications" size="m" slot="icon"></ui-icon>
       Alert Title
       <span slot="description">Description text explaining the alert in more detail.</span>
       <div slot="footer">

--- a/packages/ui-components/src/stories/ui-button.stories.ts
+++ b/packages/ui-components/src/stories/ui-button.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/web-components";
 import { html } from "lit";
-import { ICON_ADD_CIRCLE } from "@maneki/foundation";
+import "../components/ui-icon.js";
+import "../components/ui-icon.js";
 import "../components/ui-button.js";
 
 const meta: Meta = {
@@ -109,15 +110,15 @@ export const WithIcons: Story = {
   render: () => html`
     <div style="display: flex; gap: 12px; align-items: center;">
       <ui-button icon="leading-icon">
-        <span slot="icon-start" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">${ICON_ADD_CIRCLE}</span>
+        <ui-icon name="add_circle" size="m" slot="icon-start"></ui-icon>
         Leading
       </ui-button>
       <ui-button icon="trailing-icon">
         Trailing
-        <span slot="icon-end" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">${ICON_ADD_CIRCLE}</span>
+        <ui-icon name="add_circle" size="m" slot="icon-end"></ui-icon>
       </ui-button>
       <ui-button icon="icon-only">
-        <span slot="icon-start" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">${ICON_ADD_CIRCLE}</span>
+        <ui-icon name="add_circle" size="m" slot="icon-start"></ui-icon>
       </ui-button>
     </div>
   `,

--- a/packages/ui-components/src/stories/ui-card.stories.ts
+++ b/packages/ui-components/src/stories/ui-card.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/web-components";
 import { html } from "lit";
-import { ICON_SHARE } from "@maneki/foundation";
+import "../components/ui-icon.js";
 import "../components/ui-card.js";
 import "../components/ui-button.js";
 import "../components/ui-image.js";
@@ -180,7 +180,7 @@ export const ArticleCard: Story = {
         style="display: flex; justify-content: space-between; align-items: center; padding: 0 16px 16px;"
       >
         <span style="font-size: 12px; color: #5b7282;">5 min read</span>
-        <span class="material-symbols-outlined" style="font-size: 20px; color: #5b7282;">${ICON_SHARE}</span>
+        <ui-icon name="share" size="m" style="--ui-icon-color: #5b7282;"></ui-icon>
       </div>
     </ui-card>
   `,

--- a/packages/ui-components/src/stories/ui-dropdown-split.stories.ts
+++ b/packages/ui-components/src/stories/ui-dropdown-split.stories.ts
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/web-components";
 import { html } from "lit";
-import { ICON_DOWNLOAD, ICON_UPLOAD, ICON_MORE_VERT } from "@maneki/foundation";
+import "../components/ui-icon.js";
+import "../components/ui-icon.js";
 import "../components/ui-dropdown-split.js";
 import "../components/ui-dropdown-item.js";
 import "../components/ui-dropdown-heading.js";
@@ -157,18 +158,18 @@ export const WithIcons: Story = {
   render: () => html`
     <div style="display: flex; gap: 12px; align-items: flex-start;">
       <ui-dropdown-split icon="leading-icon" label="Download">
-        <span slot="icon-start" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">${ICON_DOWNLOAD}</span>
+        <ui-icon name="download" size="m" slot="icon-start"></ui-icon>
         <ui-dropdown-item>Download as PDF</ui-dropdown-item>
         <ui-dropdown-item>Download as CSV</ui-dropdown-item>
         <ui-dropdown-item>Download as XLSX</ui-dropdown-item>
       </ui-dropdown-split>
       <ui-dropdown-split icon="trailing-icon" label="Export">
-        <span slot="icon-end" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">${ICON_UPLOAD}</span>
+        <ui-icon name="upload" size="m" slot="icon-end"></ui-icon>
         <ui-dropdown-item>Export JSON</ui-dropdown-item>
         <ui-dropdown-item>Export XML</ui-dropdown-item>
       </ui-dropdown-split>
       <ui-dropdown-split icon="icon-only">
-        <span slot="icon-start" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">${ICON_MORE_VERT}</span>
+        <ui-icon name="more_vert" size="m" slot="icon-start"></ui-icon>
         <ui-dropdown-item>Edit</ui-dropdown-item>
         <ui-dropdown-item>Delete</ui-dropdown-item>
       </ui-dropdown-split>

--- a/packages/ui-components/src/stories/ui-icon.stories.ts
+++ b/packages/ui-components/src/stories/ui-icon.stories.ts
@@ -1,0 +1,208 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import { ICON_CODEPOINTS } from "@maneki/foundation";
+import "../components/ui-icon.js";
+
+const meta: Meta = {
+  title: "Components/Icon",
+  component: "ui-icon",
+  argTypes: {
+    name: {
+      control: { type: "select" },
+      options: Object.keys(ICON_CODEPOINTS),
+    },
+    size: {
+      control: { type: "select" },
+      options: ["xxs", "xs", "s", "m", "l"],
+    },
+    state: {
+      control: { type: "select" },
+      options: [
+        "enabled",
+        "enabled-inverse",
+        "hover",
+        "hover-inverse",
+        "active",
+        "active-inverse",
+        "focus",
+        "focus-inverse",
+        "disabled",
+        "disabled-inverse",
+      ],
+    },
+    filled: {
+      control: { type: "boolean" },
+    },
+    label: {
+      control: { type: "text" },
+    },
+  },
+  args: {
+    name: "home",
+    size: "s",
+    state: "enabled",
+    filled: false,
+    label: "",
+  },
+  render: (args) => html`
+    <ui-icon
+      name=${args.name}
+      size=${args.size}
+      state=${args.state}
+      ?filled=${args.filled}
+      label=${args.label || ""}
+    ></ui-icon>
+  `,
+};
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => html`<ui-icon name="home"></ui-icon>`,
+};
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 12px; align-items: center;">
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="home" size="xxs"></ui-icon>
+        <span style="font-size: 11px; color: #6b7280;">xxs (12)</span>
+      </div>
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="home" size="xs"></ui-icon>
+        <span style="font-size: 11px; color: #6b7280;">xs (14)</span>
+      </div>
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="home" size="s"></ui-icon>
+        <span style="font-size: 11px; color: #6b7280;">s (16)</span>
+      </div>
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="home" size="m"></ui-icon>
+        <span style="font-size: 11px; color: #6b7280;">m (20)</span>
+      </div>
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="home" size="l"></ui-icon>
+        <span style="font-size: 11px; color: #6b7280;">l (24)</span>
+      </div>
+    </div>
+  `,
+};
+
+export const AllStates: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 16px; align-items: center; flex-wrap: wrap;">
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="home" size="m" state="enabled"></ui-icon>
+        <span style="font-size: 11px; color: #6b7280;">enabled</span>
+      </div>
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="home" size="m" state="hover"></ui-icon>
+        <span style="font-size: 11px; color: #6b7280;">hover</span>
+      </div>
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="home" size="m" state="active"></ui-icon>
+        <span style="font-size: 11px; color: #6b7280;">active</span>
+      </div>
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="home" size="m" state="focus"></ui-icon>
+        <span style="font-size: 11px; color: #6b7280;">focus</span>
+      </div>
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="home" size="m" state="disabled"></ui-icon>
+        <span style="font-size: 11px; color: #6b7280;">disabled</span>
+      </div>
+    </div>
+  `,
+};
+
+export const AllStatesInverse: Story = {
+  render: () => html`
+    <div
+      style="display: flex; gap: 16px; align-items: center; flex-wrap: wrap; background: #1C2B36; padding: 24px; border-radius: 8px;"
+    >
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="home" size="m" state="enabled-inverse"></ui-icon>
+        <span style="font-size: 11px; color: rgba(255,255,255,0.6);">enabled</span>
+      </div>
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="home" size="m" state="hover-inverse"></ui-icon>
+        <span style="font-size: 11px; color: rgba(255,255,255,0.6);">hover</span>
+      </div>
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="home" size="m" state="active-inverse"></ui-icon>
+        <span style="font-size: 11px; color: rgba(255,255,255,0.6);">active</span>
+      </div>
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="home" size="m" state="focus-inverse"></ui-icon>
+        <span style="font-size: 11px; color: rgba(255,255,255,0.6);">focus</span>
+      </div>
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="home" size="m" state="disabled-inverse"></ui-icon>
+        <span style="font-size: 11px; color: rgba(255,255,255,0.6);">disabled</span>
+      </div>
+    </div>
+  `,
+};
+
+export const Filled: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 16px; align-items: center;">
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="home" size="m"></ui-icon>
+        <span style="font-size: 11px; color: #6b7280;">outlined</span>
+      </div>
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="home" size="m" filled></ui-icon>
+        <span style="font-size: 11px; color: #6b7280;">filled</span>
+      </div>
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="settings" size="m"></ui-icon>
+        <span style="font-size: 11px; color: #6b7280;">outlined</span>
+      </div>
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="settings" size="m" filled></ui-icon>
+        <span style="font-size: 11px; color: #6b7280;">filled</span>
+      </div>
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="check_circle" size="m"></ui-icon>
+        <span style="font-size: 11px; color: #6b7280;">outlined</span>
+      </div>
+      <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+        <ui-icon name="check_circle" size="m" filled></ui-icon>
+        <span style="font-size: 11px; color: #6b7280;">filled</span>
+      </div>
+    </div>
+  `,
+};
+
+export const WithLabel: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 16px; align-items: center;">
+      <ui-icon name="home" size="m" label="Home"></ui-icon>
+      <ui-icon name="settings" size="m" label="Settings"></ui-icon>
+      <ui-icon name="person" size="m" label="User profile"></ui-icon>
+    </div>
+  `,
+};
+
+export const IconGrid: Story = {
+  render: () => html`
+    <div
+      style="display: grid; grid-template-columns: repeat(auto-fill, minmax(80px, 1fr)); gap: 16px;"
+    >
+      ${Object.keys(ICON_CODEPOINTS).map(
+        (name) => html`
+          <div
+            style="display: flex; flex-direction: column; align-items: center; gap: 6px; padding: 12px 4px;"
+          >
+            <ui-icon name=${name} size="m"></ui-icon>
+            <span
+              style="font-size: 10px; color: #6b7280; text-align: center; word-break: break-all;"
+              >${name}</span
+            >
+          </div>
+        `,
+      )}
+    </div>
+  `,
+};

--- a/packages/ui-components/src/stories/ui-input.stories.ts
+++ b/packages/ui-components/src/stories/ui-input.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/web-components";
 import { html } from "lit";
-import { ICON_SEARCH, ICON_ATTACH_MONEY, ICON_MAIL } from "@maneki/foundation";
+import "../components/ui-icon.js";
 import "../components/ui-input.js";
 
 const meta: Meta = {
@@ -114,10 +114,10 @@ export const LeadingElement: Story = {
   render: () => html`
     <div style="display: flex; flex-direction: column; gap: 16px; max-width: 320px;">
       <ui-input label="Search" placeholder="Search...">
-        <span slot="leading" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">${ICON_SEARCH}</span>
+        <ui-icon name="search" size="m" slot="leading"></ui-icon>
       </ui-input>
       <ui-input label="Amount" placeholder="0.00">
-        <span slot="leading" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">${ICON_ATTACH_MONEY}</span>
+        <ui-icon name="attach_money" size="m" slot="leading"></ui-icon>
       </ui-input>
     </div>
   `,
@@ -250,7 +250,7 @@ export const FullFeatured: Story = {
         status="success"
         supportive="Email verified successfully"
       >
-        <span slot="leading" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">${ICON_MAIL}</span>
+        <ui-icon name="mail" size="m" slot="leading"></ui-icon>
       </ui-input>
 
       <ui-input

--- a/packages/ui-components/src/stories/ui-select.stories.ts
+++ b/packages/ui-components/src/stories/ui-select.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/web-components";
 import { html } from "lit";
-import { ICON_ACCOUNT_CIRCLE } from "@maneki/foundation";
+import "../components/ui-icon.js";
 import "../components/ui-select.js";
 import "../components/ui-dropdown-item.js";
 import "../components/ui-dropdown-heading.js";
@@ -198,7 +198,7 @@ export const LeadingIcon: Story = {
   render: () => html`
     <div style="display: flex; gap: 32px; align-items: flex-start;">
       <ui-select label="With Leading Icon" supportive="Supportive Text" placeholder="Select an option">
-        <span slot="leading" class="material-symbols-outlined" style="font-size: 20px;">${ICON_ACCOUNT_CIRCLE}</span>
+        <ui-icon name="account_circle" size="m" slot="leading"></ui-icon>
         <ui-dropdown-item value="a">Option A</ui-dropdown-item>
         <ui-dropdown-item value="b">Option B</ui-dropdown-item>
         <ui-dropdown-item value="c">Option C</ui-dropdown-item>

--- a/packages/ui-components/src/stories/ui-side-panel-menu.stories.ts
+++ b/packages/ui-components/src/stories/ui-side-panel-menu.stories.ts
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/web-components";
 import { html } from "lit";
-import { ICON_CODEPOINTS } from "@maneki/foundation";
+import "../components/ui-icon.js";
 import "../components/ui-side-panel-menu.js";
 import "../components/ui-side-panel-menu-item.js";
 
 // Material Symbols icon helper (font loaded in .storybook/preview.ts)
 const icon = (name: string) =>
-  html`<span slot="icon" class="material-symbols-outlined" style="font-size: 20px; font-variation-settings: 'wght' 500;">${ICON_CODEPOINTS[name] ?? name}</span>`;
+  html`<ui-icon name="${name}" size="m" slot="icon"></ui-icon>`;
 
 const meta: Meta = {
   title: "Components/Side Panel Menu",

--- a/packages/ui-components/src/stories/ui-tab-item.stories.ts
+++ b/packages/ui-components/src/stories/ui-tab-item.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/web-components";
 import { html } from "lit";
-import { ICON_CODEPOINTS } from "@maneki/foundation";
+import "../components/ui-icon.js";
 import "../components/ui-tab-item.js";
 import "../components/ui-tab-group.js";
 
@@ -98,8 +98,7 @@ export const Orientation: Story = {
 // ---------------------------------------------------------------------------
 
 function iconSpan(name: string): string {
-  const cp = ICON_CODEPOINTS[name as keyof typeof ICON_CODEPOINTS] || "";
-  return `<span class="material-symbols-outlined" slot="leading-icon">${cp}</span>`;
+  return `<ui-icon name="${name}" size="m" slot="leading-icon"></ui-icon>`;
 }
 
 export const LeadingIcon: Story = {
@@ -109,13 +108,13 @@ export const LeadingIcon: Story = {
         <div style="margin-bottom: 8px; font-family: Inter, sans-serif; font-size: 13px; color: #5b7282;">Leading Icon — On</div>
         <ui-tab-group>
           <ui-tab-item label="Data Grid" selected>
-            <span class="material-symbols-outlined" slot="leading-icon">${ICON_CODEPOINTS["bar_chart"]}</span>
+            <ui-icon name="bar_chart" size="m" slot="leading-icon"></ui-icon>
           </ui-tab-item>
           <ui-tab-item label="Table">
-            <span class="material-symbols-outlined" slot="leading-icon">${ICON_CODEPOINTS["bar_chart"]}</span>
+            <ui-icon name="bar_chart" size="m" slot="leading-icon"></ui-icon>
           </ui-tab-item>
           <ui-tab-item label="Pie Chart">
-            <span class="material-symbols-outlined" slot="leading-icon">${ICON_CODEPOINTS["bar_chart"]}</span>
+            <ui-icon name="bar_chart" size="m" slot="leading-icon"></ui-icon>
           </ui-tab-item>
         </ui-tab-group>
       </div>
@@ -142,10 +141,10 @@ export const TrailingIcon: Story = {
         <div style="margin-bottom: 8px; font-family: Inter, sans-serif; font-size: 13px; color: #5b7282;">Trailing Icon — On</div>
         <ui-tab-group>
           <ui-tab-item label="Data Grid" selected>
-            <span class="material-symbols-outlined" slot="trailing-icon">${ICON_CODEPOINTS["bar_chart"]}</span>
+            <ui-icon name="bar_chart" size="m" slot="trailing-icon"></ui-icon>
           </ui-tab-item>
           <ui-tab-item label="Table">
-            <span class="material-symbols-outlined" slot="trailing-icon">${ICON_CODEPOINTS["bar_chart"]}</span>
+            <ui-icon name="bar_chart" size="m" slot="trailing-icon"></ui-icon>
           </ui-tab-item>
         </ui-tab-group>
       </div>
@@ -180,13 +179,13 @@ export const LabelOnly: Story = {
         <div style="margin-bottom: 8px; font-family: Inter, sans-serif; font-size: 13px; color: #5b7282;">Label — Off (icon only)</div>
         <ui-tab-group>
           <ui-tab-item selected>
-            <span class="material-symbols-outlined" slot="leading-icon">${ICON_CODEPOINTS["bar_chart"]}</span>
+            <ui-icon name="bar_chart" size="m" slot="leading-icon"></ui-icon>
           </ui-tab-item>
           <ui-tab-item>
-            <span class="material-symbols-outlined" slot="leading-icon">${ICON_CODEPOINTS["home"]}</span>
+            <ui-icon name="home" size="m" slot="leading-icon"></ui-icon>
           </ui-tab-item>
           <ui-tab-item>
-            <span class="material-symbols-outlined" slot="leading-icon">${ICON_CODEPOINTS["settings"]}</span>
+            <ui-icon name="settings" size="m" slot="leading-icon"></ui-icon>
           </ui-tab-item>
         </ui-tab-group>
       </div>


### PR DESCRIPTION
## Summary

- Add `<ui-icon>` Web Component: Material Symbols icon wrapper with 5 sizes (xxs/xs/s/m/l), 10 states (enabled/hover/active/focus/disabled + inverse variants), filled variant, ICON_CODEPOINTS lookup with ligature fallback, accessible label support
- Refactor 9 story files to replace raw `<span class="material-symbols-outlined">` with `<ui-icon>` (28 occurrences)
- 63 new tests (1315 total), type check clean, Storybook build passes
- Stories: Default, AllSizes, AllStates, AllStatesInverse, Filled, WithLabel, IconGrid