### PR TITLE
refactor(ui-components): replace internal Material Symbols spans with ui-icon in input, select, tab-item, tab-group

### DIFF
--- a/packages/ui-components/src/components/ui-icon.ts
+++ b/packages/ui-components/src/components/ui-icon.ts
@@ -114,7 +114,7 @@ export const STYLES = /* css */ `
 
   :host .icon,
   :host([state="enabled"]) .icon {
-    color: var(--ui-icon-color, ${ICON_PRIMARY});
+    color: var(--ui-icon-color, currentColor);
     background: var(--ui-icon-bg, none);
   }
 
@@ -209,11 +209,14 @@ export class UiIcon extends HTMLElement {
     iconEl.className = "icon";
     this.#iconEl = iconEl;
 
-    // default accessibility: presentational
-    this.setAttribute("role", "presentation");
-    this.setAttribute("aria-hidden", "true");
-
     shadow.appendChild(iconEl);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("role")) {
+      this.setAttribute("role", "presentation");
+      this.setAttribute("aria-hidden", "true");
+    }
   }
 
   attributeChangedCallback(

--- a/packages/ui-components/src/components/ui-input.styles.ts
+++ b/packages/ui-components/src/components/ui-input.styles.ts
@@ -1,4 +1,4 @@
-import { semanticVar, spaceVar, ICON_WARNING, ICON_ERROR, ICON_CHECK_CIRCLE, ICON_PROGRESS_ACTIVITY } from "@maneki/foundation";
+import { semanticVar, spaceVar } from "@maneki/foundation";
 
 // ─── Token constants ─────────────────────────────────────────────────────────
 
@@ -15,7 +15,6 @@ const STATUS_WARNING = semanticVar("statusGeneral", "warning");
 const STATUS_SUCCESS = semanticVar("statusGeneral", "success");
 const BORDER_MINIMAL = semanticVar("border", "minimal");
 const SURFACE_SECONDARY = semanticVar("surface", "secondary");
-const DISABLED_MINIMAL = semanticVar("stateDisabled", "minimal");
 const ICON_PRIMARY = semanticVar("icon", "primary");
 const SP_05 = spaceVar("0.5");
 const SP_1 = spaceVar("1");
@@ -24,37 +23,15 @@ const SP_15 = spaceVar("1.5");
 // ─── Status icon map ─────────────────────────────────────────────────────────
 
 export const STATUS_ICON_MAP: Record<string, string> = {
-  warning: ICON_WARNING,
-  error: ICON_ERROR,
-  success: ICON_CHECK_CIRCLE,
-  loading: ICON_PROGRESS_ACTIVITY,
+  warning: "warning",
+  error: "error",
+  success: "check_circle",
+  loading: "progress_activity",
 };
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
 
 export const STYLES = /* css */ `
-  @font-face {
-    font-family: "Material Symbols Outlined";
-    font-style: normal;
-    src: local("Material Symbols Outlined");
-  }
-
-  .material-symbols-outlined {
-    font-family: "Material Symbols Outlined";
-    font-weight: normal;
-    font-style: normal;
-    font-size: inherit;
-    line-height: 1;
-    letter-spacing: normal;
-    text-transform: none;
-    display: inline-block;
-    white-space: nowrap;
-    word-wrap: normal;
-    direction: ltr;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    text-rendering: optimizeLegibility;
-  }
   *,
   *::before,
   *::after {
@@ -154,10 +131,6 @@ export const STYLES = /* css */ `
     font-size: var(--_status-icon-size);
     line-height: 1;
   }
-  .status-icon .material-symbols-outlined {
-    font-variation-settings: 'FILL' 1;
-  }
-
 
   :host([status="warning"]) .status-icon {
     display: flex;
@@ -180,7 +153,7 @@ export const STYLES = /* css */ `
     color: ${TEXT_SECONDARY};
   }
 
-  :host([status="loading"]) .status-icon .material-symbols-outlined {
+  :host([status="loading"]) .status-icon ui-icon {
     animation: spin 1s linear infinite;
   }
 
@@ -208,10 +181,6 @@ export const STYLES = /* css */ `
     color: ${TEXT_PRIMARY};
   }
 
-  .clear-btn .material-symbols-outlined {
-    font-size: var(--_clear-size);
-  }
-
   :host([type="clearable"]) .clear-btn.has-value {
     display: flex;
   }
@@ -233,10 +202,6 @@ export const STYLES = /* css */ `
 
   .password-toggle:hover {
     color: ${TEXT_PRIMARY};
-  }
-
-  .password-toggle .material-symbols-outlined {
-    font-size: var(--_clear-size);
   }
 
   :host([type="password"]) .password-toggle {
@@ -268,6 +233,7 @@ export const STYLES = /* css */ `
     padding: 0;
     color: ${TEXT_SECONDARY};
     line-height: 1;
+    --ui-icon-size: var(--_numeric-icon-size, 20px);
   }
 
   .spinner-btn:hover {
@@ -278,10 +244,6 @@ export const STYLES = /* css */ `
   .spinner-divider {
     height: 1px;
     background-color: ${BORDER_MINIMAL};
-  }
-
-  .spinner-btn .material-symbols-outlined {
-    font-size: 16px;
   }
 
   /* ── Supportive text ───────────────────────────────────────────────────── */
@@ -321,6 +283,7 @@ export const STYLES = /* css */ `
     --_status-icon-size: 18px;
     --_clear-size: 16px;
     --_numeric-width: 24px;
+    --_numeric-icon-size: 14px;
   }
 
   /* ── Size: s ───────────────────────────────────────────────────────────── */
@@ -333,6 +296,7 @@ export const STYLES = /* css */ `
     --_status-icon-size: 14px;
     --_clear-size: 12px;
     --_numeric-width: 20px;
+    --_numeric-icon-size: 10px;
   }
 
   /* ── Size: l ───────────────────────────────────────────────────────────── */
@@ -345,6 +309,7 @@ export const STYLES = /* css */ `
     --_status-icon-size: 20px;
     --_clear-size: 18px;
     --_numeric-width: 28px;
+    --_numeric-icon-size: 18px;
   }
 
   .input-container {
@@ -354,11 +319,14 @@ export const STYLES = /* css */ `
     gap: ${SP_05};
   }
 
+  :host([type="numeric"]) .input-container {
+    padding-right: 0;
+  }
+
   .native-input {
     font-size: var(--_input-font-size);
     line-height: var(--_input-line-height);
   }
-
 
   .status-icon {
     width: var(--_status-icon-size);
@@ -441,7 +409,6 @@ export const STYLES = /* css */ `
     color: ${DISABLED_TEXT};
   }
 
-
   :host([disabled]) .supportive-text {
     color: ${DISABLED_TEXT};
   }
@@ -475,14 +442,13 @@ export const STYLES = /* css */ `
     color: ${TEXT_SECONDARY};
   }
 
-
   /* ── Reduced motion ────────────────────────────────────────────────────── */
 
   @media (prefers-reduced-motion: reduce) {
     .input-container {
       transition-duration: 0.01ms !important;
     }
-    :host([status="loading"]) .status-icon .material-symbols-outlined {
+    :host([status="loading"]) .status-icon ui-icon {
       animation-duration: 0.01ms !important;
     }
   }

--- a/packages/ui-components/src/components/ui-input.test.ts
+++ b/packages/ui-components/src/components/ui-input.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { ICON_WARNING, ICON_ERROR, ICON_CHECK_CIRCLE, ICON_PROGRESS_ACTIVITY, ICON_VISIBILITY, ICON_VISIBILITY_OFF } from "@maneki/foundation";
+import "./ui-input.js";
 import "./ui-input.js";
 
 describe("ui-input", () => {
@@ -363,39 +363,39 @@ describe("ui-input", () => {
 
   it("shows status icon for warning", () => {
     (el as unknown as { status: string }).status = "warning";
-    const icon = el.shadowRoot!.querySelector(".status-icon");
-    expect(icon!.textContent).toContain(ICON_WARNING);
+    const icon = el.shadowRoot!.querySelector(".status-icon ui-icon");
+    expect(icon!.getAttribute("name")).toBe("warning");
   });
 
   it("shows status icon for error", () => {
     (el as unknown as { status: string }).status = "error";
-    const icon = el.shadowRoot!.querySelector(".status-icon");
-    expect(icon!.textContent).toContain(ICON_ERROR);
+    const icon = el.shadowRoot!.querySelector(".status-icon ui-icon");
+    expect(icon!.getAttribute("name")).toBe("error");
   });
 
   it("shows status icon for success", () => {
     (el as unknown as { status: string }).status = "success";
-    const icon = el.shadowRoot!.querySelector(".status-icon");
-    expect(icon!.textContent).toContain(ICON_CHECK_CIRCLE);
+    const icon = el.shadowRoot!.querySelector(".status-icon ui-icon");
+    expect(icon!.getAttribute("name")).toBe("check_circle");
   });
 
   it("shows status icon for loading", () => {
     (el as unknown as { status: string }).status = "loading";
-    const icon = el.shadowRoot!.querySelector(".status-icon");
-    expect(icon!.textContent).toContain(ICON_PROGRESS_ACTIVITY);
+    const icon = el.shadowRoot!.querySelector(".status-icon ui-icon");
+    expect(icon!.getAttribute("name")).toBe("progress_activity");
   });
 
   it("clears status icon when status is none", () => {
     (el as unknown as { status: string }).status = "error";
     (el as unknown as { status: string }).status = "none";
-    const icon = el.shadowRoot!.querySelector(".status-icon");
-    expect(icon!.textContent?.trim()).toBe("");
+    const icon = el.shadowRoot!.querySelector(".status-icon ui-icon");
+    expect(icon!.getAttribute("name") ?? "").toBe("");
   });
 
   it("shows error icon when error boolean is set", () => {
     (el as unknown as { error: boolean }).error = true;
-    const icon = el.shadowRoot!.querySelector(".status-icon");
-    expect(icon!.textContent).toContain(ICON_ERROR);
+    const icon = el.shadowRoot!.querySelector(".status-icon ui-icon");
+    expect(icon!.getAttribute("name")).toBe("error");
   });
 
   // ── Input event ──────────────────────────────────────────────────────────
@@ -697,12 +697,12 @@ describe("ui-input", () => {
   it("updates password toggle icon on click", () => {
     (el as unknown as { type: string }).type = "password";
     const toggle = el.shadowRoot!.querySelector(".password-toggle") as HTMLButtonElement;
-    const icon = toggle.querySelector(".material-symbols-outlined")!;
-    expect(icon.textContent).toBe(ICON_VISIBILITY);
+    const icon = toggle.querySelector("ui-icon")!;
+    expect(icon.getAttribute("name")).toBe("visibility");
     toggle.click();
-    expect(icon.textContent).toBe(ICON_VISIBILITY_OFF);
+    expect(icon.getAttribute("name")).toBe("visibility_off");
     toggle.click();
-    expect(icon.textContent).toBe(ICON_VISIBILITY);
+    expect(icon.getAttribute("name")).toBe("visibility");
   });
 
   it("updates aria-label on password toggle click", () => {

--- a/packages/ui-components/src/components/ui-input.ts
+++ b/packages/ui-components/src/components/ui-input.ts
@@ -1,5 +1,5 @@
 import { STYLES, STATUS_ICON_MAP } from "./ui-input.styles.js";
-import { ICON_CLOSE, ICON_VISIBILITY, ICON_VISIBILITY_OFF, ICON_ARROW_DROP_UP, ICON_ARROW_DROP_DOWN } from "@maneki/foundation";
+import "./ui-icon.js";
 import "./ui-label.js";
 
 // ─── Type-safe property unions ───────────────────────────────────────────────
@@ -32,10 +32,10 @@ export class UiInput extends HTMLElement {
 
   private _inputEl: HTMLInputElement;
   private _statusIconEl: HTMLSpanElement;
-  private _statusIconInner: HTMLSpanElement;
+  private _statusIconInner: HTMLElement;
   private _clearBtnEl: HTMLButtonElement;
   private _passwordToggleEl: HTMLButtonElement;
-  private _passwordIconEl: HTMLSpanElement;
+  private _passwordIconEl: HTMLElement;
   private _passwordVisible: boolean;
   private _labelTextEl: HTMLElement;
   private _secondaryLabelEl: HTMLElement;
@@ -84,8 +84,8 @@ export class UiInput extends HTMLElement {
     this._statusIconEl = document.createElement("span");
     this._statusIconEl.className = "status-icon";
     this._statusIconEl.setAttribute("aria-hidden", "true");
-    this._statusIconInner = document.createElement("span");
-    this._statusIconInner.className = "material-symbols-outlined";
+    this._statusIconInner = document.createElement("ui-icon") as HTMLElement;
+    this._statusIconInner.setAttribute("filled", "");
     this._statusIconEl.appendChild(this._statusIconInner);
     container.appendChild(this._statusIconEl);
 
@@ -102,9 +102,8 @@ export class UiInput extends HTMLElement {
     this._clearBtnEl.className = "clear-btn";
     this._clearBtnEl.type = "button";
     this._clearBtnEl.setAttribute("aria-label", "Clear input");
-    const clearIcon = document.createElement("span");
-    clearIcon.className = "material-symbols-outlined";
-    clearIcon.textContent = ICON_CLOSE;
+    const clearIcon = document.createElement("ui-icon") as HTMLElement;
+    clearIcon.setAttribute("name", "close");
     this._clearBtnEl.appendChild(clearIcon);
     container.appendChild(this._clearBtnEl);
 
@@ -114,9 +113,8 @@ export class UiInput extends HTMLElement {
     this._passwordToggleEl.className = "password-toggle";
     this._passwordToggleEl.type = "button";
     this._passwordToggleEl.setAttribute("aria-label", "Toggle password visibility");
-    this._passwordIconEl = document.createElement("span");
-    this._passwordIconEl.className = "material-symbols-outlined";
-    this._passwordIconEl.textContent = ICON_VISIBILITY;
+    this._passwordIconEl = document.createElement("ui-icon") as HTMLElement;
+    this._passwordIconEl.setAttribute("name", "visibility");
     this._passwordToggleEl.appendChild(this._passwordIconEl);
     container.appendChild(this._passwordToggleEl);
 
@@ -128,9 +126,8 @@ export class UiInput extends HTMLElement {
     upBtn.className = "spinner-btn spinner-up";
     upBtn.type = "button";
     upBtn.setAttribute("aria-label", "Increment");
-    const upIcon = document.createElement("span");
-    upIcon.className = "material-symbols-outlined";
-    upIcon.textContent = ICON_ARROW_DROP_UP;
+    const upIcon = document.createElement("ui-icon") as HTMLElement;
+    upIcon.setAttribute("name", "arrow_drop_up");
     upBtn.appendChild(upIcon);
     numericControls.appendChild(upBtn);
 
@@ -142,9 +139,8 @@ export class UiInput extends HTMLElement {
     downBtn.className = "spinner-btn spinner-down";
     downBtn.type = "button";
     downBtn.setAttribute("aria-label", "Decrement");
-    const downIcon = document.createElement("span");
-    downIcon.className = "material-symbols-outlined";
-    downIcon.textContent = ICON_ARROW_DROP_DOWN;
+    const downIcon = document.createElement("ui-icon") as HTMLElement;
+    downIcon.setAttribute("name", "arrow_drop_down");
     downBtn.appendChild(downIcon);
     numericControls.appendChild(downBtn);
 
@@ -407,9 +403,9 @@ export class UiInput extends HTMLElement {
     const effectiveStatus = this.error ? "error" : this.status;
     const iconName = STATUS_ICON_MAP[effectiveStatus];
     if (iconName) {
-      this._statusIconInner.textContent = iconName;
+      this._statusIconInner.setAttribute("name", iconName);
     } else {
-      this._statusIconInner.textContent = "";
+      this._statusIconInner.setAttribute("name", "");
     }
   }
 
@@ -527,7 +523,7 @@ export class UiInput extends HTMLElement {
   private _handlePasswordToggle(): void {
     this._passwordVisible = !this._passwordVisible;
     this._inputEl.type = this._passwordVisible ? "text" : "password";
-    this._passwordIconEl.textContent = this._passwordVisible ? ICON_VISIBILITY_OFF : ICON_VISIBILITY;
+    this._passwordIconEl.setAttribute("name", this._passwordVisible ? "visibility_off" : "visibility");
     this._passwordToggleEl.setAttribute(
       "aria-label",
       this._passwordVisible ? "Hide password" : "Show password",

--- a/packages/ui-components/src/components/ui-select.styles.ts
+++ b/packages/ui-components/src/components/ui-select.styles.ts
@@ -1,4 +1,4 @@
-import { semanticVar, spaceVar, elevationVar, ICON_WARNING, ICON_ERROR, ICON_CHECK_CIRCLE, ICON_PROGRESS_ACTIVITY } from "@maneki/foundation";
+import { semanticVar, spaceVar, elevationVar } from "@maneki/foundation";
 
 // ─── Token constants ─────────────────────────────────────────────────────────
 
@@ -25,36 +25,15 @@ const SP_15 = spaceVar("1.5");
 // ─── Status icon map ─────────────────────────────────────────────────────────
 
 export const STATUS_ICON_MAP: Record<string, string> = {
-  warning: ICON_WARNING,
-  error: ICON_ERROR,
-  success: ICON_CHECK_CIRCLE,
-  loading: ICON_PROGRESS_ACTIVITY,
+  warning: "warning",
+  error: "error",
+  success: "check_circle",
+  loading: "progress_activity",
 };
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
 
 export const STYLES = /* css */ `
-  @font-face {
-    font-family: "Material Symbols Outlined";
-    font-style: normal;
-    src: local("Material Symbols Outlined");
-  }
-  .material-symbols-outlined {
-    font-family: "Material Symbols Outlined";
-    font-weight: normal;
-    font-style: normal;
-    font-size: inherit;
-    line-height: 1;
-    letter-spacing: normal;
-    text-transform: none;
-    display: inline-block;
-    white-space: nowrap;
-    word-wrap: normal;
-    direction: ltr;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    text-rendering: optimizeLegibility;
-  }
   *,
   *::before,
   *::after {
@@ -148,9 +127,6 @@ export const STYLES = /* css */ `
     height: 12px;
     line-height: 0;
   }
-  .tag-dismiss .material-symbols-outlined {
-    font-size: 12px;
-  }
 
   /* ── Content right ─────────────────────────────────────────────────────── */
   .content-right {
@@ -196,9 +172,8 @@ export const STYLES = /* css */ `
   .clear-btn:hover {
     color: ${TEXT_PRIMARY};
   }
-  .clear-btn .material-symbols-outlined {
+  .clear-btn ui-icon {
     font-size: 14px;
-    font-variation-settings: 'FILL' 1;
   }
   .clear-btn.visible {
     display: flex;
@@ -212,9 +187,6 @@ export const STYLES = /* css */ `
     flex-shrink: 0;
     font-size: var(--_status-icon-size);
     line-height: 1;
-  }
-  .status-icon .material-symbols-outlined {
-    font-variation-settings: 'FILL' 1;
   }
   :host([status="warning"]) .status-icon {
     display: flex;
@@ -233,7 +205,7 @@ export const STYLES = /* css */ `
     display: flex;
     color: ${TEXT_SECONDARY};
   }
-  :host([status="loading"]) .status-icon .material-symbols-outlined {
+  :host([status="loading"]) .status-icon ui-icon {
     animation: spin 1s linear infinite;
   }
   @keyframes spin {
@@ -250,9 +222,6 @@ export const STYLES = /* css */ `
     transition: transform 0.15s ease;
     line-height: 0;
     color: ${ICON_SECONDARY};
-  }
-  .chevron .material-symbols-outlined {
-    font-size: var(--_chevron-size);
   }
   :host([open]) .chevron {
     transform: rotate(180deg);
@@ -466,7 +435,7 @@ export const STYLES = /* css */ `
     .panel {
       transition-duration: 0.01ms !important;
     }
-    :host([status="loading"]) .status-icon .material-symbols-outlined {
+    :host([status="loading"]) .status-icon ui-icon {
       animation-duration: 0.01ms !important;
     }
   }

--- a/packages/ui-components/src/components/ui-select.test.ts
+++ b/packages/ui-components/src/components/ui-select.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { ICON_WARNING, ICON_ERROR, ICON_CHECK_CIRCLE, ICON_PROGRESS_ACTIVITY, ICON_EXPAND_MORE } from "@maneki/foundation";
 import "./ui-select.js";
 import "./ui-dropdown-item.js";
 
@@ -249,32 +248,32 @@ describe("ui-select", () => {
 
   it("shows status icon for warning", () => {
     el = createSelect({ status: "warning" });
-    const icon = el.shadowRoot!.querySelector(".status-icon .material-symbols-outlined");
-    expect(icon?.textContent).toBe(ICON_WARNING);
+    const icon = el.shadowRoot!.querySelector(".status-icon ui-icon");
+    expect(icon?.getAttribute("name")).toBe("warning");
   });
 
   it("shows status icon for error", () => {
     el = createSelect({ status: "error" });
-    const icon = el.shadowRoot!.querySelector(".status-icon .material-symbols-outlined");
-    expect(icon?.textContent).toBe(ICON_ERROR);
+    const icon = el.shadowRoot!.querySelector(".status-icon ui-icon");
+    expect(icon?.getAttribute("name")).toBe("error");
   });
 
   it("shows status icon for success", () => {
     el = createSelect({ status: "success" });
-    const icon = el.shadowRoot!.querySelector(".status-icon .material-symbols-outlined");
-    expect(icon?.textContent).toBe(ICON_CHECK_CIRCLE);
+    const icon = el.shadowRoot!.querySelector(".status-icon ui-icon");
+    expect(icon?.getAttribute("name")).toBe("check_circle");
   });
 
   it("shows status icon for loading", () => {
     el = createSelect({ status: "loading" });
-    const icon = el.shadowRoot!.querySelector(".status-icon .material-symbols-outlined");
-    expect(icon?.textContent).toBe(ICON_PROGRESS_ACTIVITY);
+    const icon = el.shadowRoot!.querySelector(".status-icon ui-icon");
+    expect(icon?.getAttribute("name")).toBe("progress_activity");
   });
 
   it("error attribute overrides status for icon", () => {
     el = createSelect({ status: "warning", error: "" });
-    const icon = el.shadowRoot!.querySelector(".status-icon .material-symbols-outlined");
-    expect(icon?.textContent).toBe(ICON_ERROR);
+    const icon = el.shadowRoot!.querySelector(".status-icon ui-icon");
+    expect(icon?.getAttribute("name")).toBe("error");
   });
 
   // ── Error ────────────────────────────────────────────────────────────────
@@ -434,8 +433,8 @@ describe("ui-select", () => {
 
   it("renders chevron icon", () => {
     el = createSelect();
-    const chevron = el.shadowRoot!.querySelector(".chevron .material-symbols-outlined");
-    expect(chevron?.textContent).toBe(ICON_EXPAND_MORE);
+    const chevron = el.shadowRoot!.querySelector(".chevron ui-icon");
+    expect(chevron?.getAttribute("name")).toBe("expand_more");
   });
 
   // ── Display value ────────────────────────────────────────────────────────

--- a/packages/ui-components/src/components/ui-select.ts
+++ b/packages/ui-components/src/components/ui-select.ts
@@ -1,5 +1,5 @@
 import { STYLES, STATUS_ICON_MAP } from "./ui-select.styles.js";
-import { ICON_CANCEL, ICON_EXPAND_MORE, ICON_CLOSE } from "@maneki/foundation";
+import "./ui-icon.js";
 import "./ui-label.js";
 
 // ─── Type-safe property unions ───────────────────────────────────────────────
@@ -33,7 +33,7 @@ export class UiSelect extends HTMLElement {
   private _displayValue: HTMLSpanElement;
   private _clearBtn: HTMLButtonElement;
   private _statusIconEl: HTMLSpanElement;
-  private _statusIconInner: HTMLSpanElement;
+  private _statusIconInner: HTMLElement;
   private _chevron: HTMLSpanElement;
   private _panel: HTMLDivElement;
   private _slot: HTMLSlotElement;
@@ -102,9 +102,9 @@ export class UiSelect extends HTMLElement {
     this._clearBtn.type = "button";
     this._clearBtn.setAttribute("aria-label", "Clear selection");
     this._clearBtn.setAttribute("tabindex", "-1");
-    const clearIcon = document.createElement("span");
-    clearIcon.className = "material-symbols-outlined";
-    clearIcon.textContent = ICON_CANCEL;
+    const clearIcon = document.createElement("ui-icon") as HTMLElement;
+    clearIcon.setAttribute("name", "cancel");
+    clearIcon.setAttribute("filled", "");
     this._clearBtn.appendChild(clearIcon);
     contentRight.appendChild(this._clearBtn);
 
@@ -112,8 +112,8 @@ export class UiSelect extends HTMLElement {
     this._statusIconEl = document.createElement("span");
     this._statusIconEl.className = "status-icon";
     this._statusIconEl.setAttribute("aria-hidden", "true");
-    this._statusIconInner = document.createElement("span");
-    this._statusIconInner.className = "material-symbols-outlined";
+    this._statusIconInner = document.createElement("ui-icon") as HTMLElement;
+    this._statusIconInner.setAttribute("filled", "");
     this._statusIconEl.appendChild(this._statusIconInner);
     contentRight.appendChild(this._statusIconEl);
 
@@ -121,9 +121,8 @@ export class UiSelect extends HTMLElement {
     this._chevron = document.createElement("span");
     this._chevron.className = "chevron";
     this._chevron.setAttribute("aria-hidden", "true");
-    const chevronIcon = document.createElement("span");
-    chevronIcon.className = "material-symbols-outlined";
-    chevronIcon.textContent = ICON_EXPAND_MORE;
+    const chevronIcon = document.createElement("ui-icon") as HTMLElement;
+    chevronIcon.setAttribute("name", "expand_more");
     this._chevron.appendChild(chevronIcon);
     contentRight.appendChild(this._chevron);
 
@@ -390,9 +389,9 @@ export class UiSelect extends HTMLElement {
     const effectiveStatus = this.error ? "error" : this.status;
     const iconName = STATUS_ICON_MAP[effectiveStatus];
     if (iconName) {
-      this._statusIconInner.textContent = iconName;
+      this._statusIconInner.setAttribute("name", iconName);
     } else {
-      this._statusIconInner.textContent = "";
+      this._statusIconInner.setAttribute("name", "");
     }
   }
 
@@ -537,9 +536,9 @@ export class UiSelect extends HTMLElement {
         dismiss.type = "button";
         dismiss.setAttribute("aria-label", "Remove " + displayText);
         dismiss.setAttribute("tabindex", "-1");
-        const dismissIcon = document.createElement("span");
-        dismissIcon.className = "material-symbols-outlined";
-        dismissIcon.textContent = ICON_CLOSE;
+        const dismissIcon = document.createElement("ui-icon") as HTMLElement;
+        dismissIcon.setAttribute("name", "close");
+        dismissIcon.setAttribute("size", "xxs");
         dismiss.appendChild(dismissIcon);
         tag.appendChild(dismiss);
 

--- a/packages/ui-components/src/components/ui-tab-group.ts
+++ b/packages/ui-components/src/components/ui-tab-group.ts
@@ -1,8 +1,8 @@
 import {
   semanticVar,
   spaceVar,
-  ICON_MORE_HORIZ,
-} from "@maneki/foundation";
+  } from "@maneki/foundation";
+import "./ui-icon.js";
 import type { TabItemSize, TabItemOrientation } from "./ui-tab-item.js";
 
 // ─── Token constants ─────────────────────────────────────────────────────────
@@ -115,27 +115,6 @@ const STYLES = /* css */ `
 
   /* ── More button ───────────────────────────────────────────────────────── */
 
-  @font-face {
-    font-family: "Material Symbols Outlined";
-    font-style: normal;
-    src: local("Material Symbols Outlined");
-  }
-
-  .material-symbols-outlined {
-    font-family: "Material Symbols Outlined";
-    font-weight: normal;
-    font-style: normal;
-    font-variation-settings: "FILL" 0;
-    display: inline-block;
-    line-height: 1;
-    text-transform: none;
-    letter-spacing: normal;
-    word-wrap: normal;
-    white-space: nowrap;
-    direction: ltr;
-    -webkit-font-smoothing: antialiased;
-  }
-
   .more-btn {
     display: none;
     align-items: center;
@@ -147,6 +126,7 @@ const STYLES = /* css */ `
     padding: 0 4px;
     color: ${ICON_PRIMARY};
     font-size: 20px;
+    --ui-icon-size: 20px;
   }
 
   .more-btn.has-selected {
@@ -195,9 +175,13 @@ const STYLES = /* css */ `
   .more-container {
     position: relative;
     flex-shrink: 0;
-    display: flex;
+    display: none;
     align-items: stretch;
     box-shadow: var(--ui-tab-group-border-shadow, inset 0 -1px 0 ${BORDER_MINIMAL});
+  }
+
+  .more-container.visible {
+    display: flex;
   }
 
   :host([orientation="vertical"]) .more-container {
@@ -259,6 +243,7 @@ export class UiTabGroup extends HTMLElement {
 
   private _tablist!: HTMLDivElement;
   private _moreBtn!: HTMLButtonElement;
+  private _moreContainer!: HTMLDivElement;
   private _overflowMenu!: HTMLDivElement;
   private _resizeObserver: ResizeObserver | null = null;
   private _hiddenItems: Element[] = [];
@@ -291,9 +276,9 @@ export class UiTabGroup extends HTMLElement {
     moreBtn.setAttribute("aria-expanded", "false");
     moreBtn.setAttribute("tabindex", "-1");
     moreBtn.setAttribute("type", "button");
-    const moreIcon = document.createElement("span");
-    moreIcon.className = "material-symbols-outlined";
-    moreIcon.textContent = ICON_MORE_HORIZ;
+    const moreIcon = document.createElement("ui-icon") as HTMLElement;
+    moreIcon.setAttribute("name", "more_horiz");
+    moreIcon.setAttribute("size", "m");
     moreBtn.appendChild(moreIcon);
     this._moreBtn = moreBtn;
 
@@ -308,6 +293,7 @@ export class UiTabGroup extends HTMLElement {
     moreContainer.className = "more-container";
     moreContainer.appendChild(moreBtn);
     moreContainer.appendChild(overflowMenu);
+    this._moreContainer = moreContainer;
 
     wrapper.appendChild(tablist);
     wrapper.appendChild(moreContainer);
@@ -386,6 +372,7 @@ export class UiTabGroup extends HTMLElement {
         this._stopObserving();
         this._showAllItems();
         this._moreBtn.classList.remove("visible");
+        this._moreContainer.classList.remove("visible");
         this._closeOverflowMenu();
       }
     }
@@ -574,12 +561,14 @@ export class UiTabGroup extends HTMLElement {
 
     if (this._hiddenItems.length > 0) {
       this._moreBtn.classList.add("visible");
+      this._moreContainer.classList.add("visible");
       this._moreBtn.setAttribute("tabindex", "0");
       // Highlight more button if a hidden tab is selected
       const hasSelected = this._hiddenItems.some((item) => item.hasAttribute("selected"));
       this._moreBtn.classList.toggle("has-selected", hasSelected);
     } else {
       this._moreBtn.classList.remove("visible", "has-selected");
+      this._moreContainer.classList.remove("visible");
       this._moreBtn.setAttribute("tabindex", "-1");
       this._closeOverflowMenu();
     }

--- a/packages/ui-components/src/components/ui-tab-item.test.ts
+++ b/packages/ui-components/src/components/ui-tab-item.test.ts
@@ -287,16 +287,6 @@ describe("ui-tab-item", () => {
     expect(styles).toContain("Inter");
   });
 
-  it("includes Material Symbols font-face in styles", () => {
-    const styles = el.shadowRoot!.adoptedStyleSheets
-      .map((s: CSSStyleSheet) =>
-        Array.from(s.cssRules)
-          .map((r: CSSRule) => r.cssText)
-          .join(""),
-      )
-      .join("");
-    expect(styles).toContain("Material Symbols Outlined");
-  });
 
   // ── Property accessors ────────────────────────────────────────────────
 

--- a/packages/ui-components/src/components/ui-tab-item.ts
+++ b/packages/ui-components/src/components/ui-tab-item.ts
@@ -1,4 +1,5 @@
-import { semanticVar, spaceVar, ICON_EXPAND_MORE, ICON_CLOSE } from "@maneki/foundation";
+import { semanticVar, spaceVar } from "@maneki/foundation";
+import "./ui-icon.js";
 
 // ─── Type-safe property unions ───────────────────────────────────────────────
 
@@ -23,22 +24,6 @@ const SP_2 = spaceVar("2");
 // ─── Styles ──────────────────────────────────────────────────────────────────
 
 const STYLES = /* css */ `
-  @font-face {
-    font-family: "Material Symbols Outlined";
-    font-style: normal;
-    src: local("Material Symbols Outlined");
-  }
-
-  .material-symbols-outlined {
-    font-family: "Material Symbols Outlined";
-    font-variation-settings: "FILL" 0;
-    font-size: inherit;
-    line-height: 1;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-  }
-
   *,
   *::before,
   *::after {
@@ -186,6 +171,7 @@ const STYLES = /* css */ `
     width: 20px;
     height: 20px;
     font-size: 20px;
+    --ui-icon-size: 20px;
   }
 
   /* ── Size: s ────────────────────────────────────────────────────────────── */
@@ -211,6 +197,7 @@ const STYLES = /* css */ `
     width: 16px;
     height: 16px;
     font-size: 16px;
+    --ui-icon-size: 16px;
   }
 
   /* ── State: enabled (default) ───────────────────────────────────────────── */
@@ -300,12 +287,14 @@ const STYLES = /* css */ `
     width: 16px;
     height: 16px;
     font-size: 16px;
+    --ui-icon-size: 16px;
   }
 
   :host([size="s"]) .close-btn {
     width: 12px;
     height: 12px;
     font-size: 12px;
+    --ui-icon-size: 12px;
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -381,8 +370,10 @@ export class UiTabItem extends HTMLElement {
 
     // Chevron (sub-menu)
     const chevron = document.createElement("span");
-    chevron.className = "chevron material-symbols-outlined";
-    chevron.textContent = ICON_EXPAND_MORE;
+    chevron.className = "chevron";
+    const chevronIcon = document.createElement("ui-icon") as HTMLElement;
+    chevronIcon.setAttribute("name", "expand_more");
+    chevron.appendChild(chevronIcon);
 
     // Slot change listeners to toggle icon visibility
     leadingSlot.addEventListener("slotchange", () => {
@@ -399,13 +390,14 @@ export class UiTabItem extends HTMLElement {
     labelContainer.appendChild(trailingIcon);
     labelContainer.appendChild(chevron);
 
-    // Close button
     const closeBtn = document.createElement("button");
-    closeBtn.className = "close-btn material-symbols-outlined";
+    closeBtn.className = "close-btn";
     closeBtn.setAttribute("type", "button");
     closeBtn.setAttribute("aria-label", "Close tab");
     closeBtn.setAttribute("tabindex", "-1");
-    closeBtn.textContent = ICON_CLOSE;
+    const closeBtnIcon = document.createElement("ui-icon") as HTMLElement;
+    closeBtnIcon.setAttribute("name", "close");
+    closeBtn.appendChild(closeBtnIcon);
     closeBtn.addEventListener("click", (e: Event) => {
       e.stopPropagation();
       if (this.disabled) return;


### PR DESCRIPTION
## Summary

- Replace internal `<span class="material-symbols-outlined">` elements with `<ui-icon>` in 4 components: ui-input, ui-select, ui-tab-item, ui-tab-group
- Remove `@font-face` and `.material-symbols-outlined` CSS from refactored components (ui-icon handles its own font)
- Update STATUS_ICON_MAP in ui-input.styles.ts and ui-select.styles.ts to use name strings instead of codepoint constants
- Update tests to query `ui-icon` elements instead of `.material-symbols-outlined` spans
- 1314 tests passing, type check clean
- ui-link.ts left unchanged (font declarations are for slotted consumer content, not internal icons)