### PR TITLE
feat(ui-components): add ui-textarea component

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,12 +74,13 @@ Every change — component, fix, refactor, docs — follows this workflow:
 3. **Implement** the change
 4. **Run tests** — `npx vitest --run` in affected packages
 5. **Verify visually** in Storybook against Figma (for UI changes) — use Playwright to screenshot and compare
-6. **Update docs in the same PR** — follow the "Updating Documentation After Changes" SOP in `packages/ui-components/AGENTS.md`:
+6. **Update docs before pushing** — follow the "Updating Documentation After Changes" SOP in `packages/ui-components/AGENTS.md`:
    - Test counts in AGENTS.md + README.md
    - Component count if new component
    - Icon constants list if new icons
    - Token mappings if new tokens
    - AGENTS.md structure trees if new files
+   - ALWAYS update docs BEFORE the first `jj git push`. Never push code without docs in the same commit.
 7. **Ask user to verify visually** — share Storybook screenshots or point to the running Storybook. Wait for user confirmation before pushing. Never push without user sign-off on visual changes.
 8. **Push** — `jj bookmark set <name> -r @ --allow-backwards && jj git push --bookmark <name>`
 9. **Create PR** — `gh pr create --base main --head <name>`

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ maneki-monorepo/
 | Package | npm name | Description |
 |---|---|---|
 | `foundation` | `@maneki/foundation` | Design tokens: 131 colors, semantic tokens, typography, spacing, elevation, responsive breakpoints |
-| `ui-components` | `@maneki/ui-components` | 34 Web Components (button, badge, image, icon, tag, avatar, alert, label, link, checkbox, radio, input, file-upload, select, card, breadcrumb, accordion, dropdown, menu, modal, side-panel-menu, tabs) with Storybook 10 |
+| `ui-components` | `@maneki/ui-components` | 35 Web Components (button, badge, image, icon, tag, avatar, alert, label, link, checkbox, radio, input, textarea, file-upload, select, card, breadcrumb, accordion, dropdown, menu, modal, side-panel-menu, tabs) with Storybook 10 |
 | `grid-layout` | `@maneki/grid-layout` | Zero-dep drag/resize grid layout (220 tests) |
 | `flex-layout` | `@maneki/flex-layout` | Panel-based flex layout for dashboard-style interfaces (3 components, 50 tests) |
 

--- a/packages/ui-components/AGENTS.md
+++ b/packages/ui-components/AGENTS.md
@@ -22,6 +22,7 @@ Web Component library for the Maneki design system. Shadow DOM, CSS custom prope
 - `<ui-input-group>` — input group wrapper: 3 sizes (s/m/l), prefix/suffix slots with separators, composes `<ui-input>`
 - `<ui-file-upload>` — file upload input: 3 sizes (s/m/l), Browse button, accept/multiple attributes, disabled state
 - `<ui-select>` — select dropdown: 3 sizes (s/m/l), 7 states, 5 statuses, single/multi-select with tag pills, WAI-ARIA combobox pattern, leading slot, clearable, label/supportive text
+- `<ui-textarea>` — textarea: 3 sizes (s/m/l), 7 states (enabled/hover/focus/active/filled/disabled/readonly), 5 statuses (none/warning/error/success/loading), label with char count, secondary label, resize handle
 **Containers:**
 - `<ui-card>` — slot-based card container: 3 sizes (s/m/l), 4 elevations (00/01/02/04), bordered variant, image/default/footer slots
 - `<ui-button-group>` — segmented bar that wraps `<ui-button>` elements
@@ -79,6 +80,7 @@ ui-components/
 │   │   ├── ui-input-group.ts
 │   │   ├── ui-file-upload.ts
 │   │   ├── ui-select.ts         + ui-select.styles.ts
+│   │   ├── ui-textarea.ts        + ui-textarea.styles.ts
 │   │   ├── ui-card.ts
 │   │   ├── ui-breadcrumb-item.ts
 │   │   ├── ui-breadcrumb-group.ts
@@ -295,7 +297,7 @@ After merging a PR that adds/modifies components, icons, or tests, update these 
 ```bash
 moon run ui-components:storybook       # Dev server on port 6006
 moon run ui-components:storybook-build  # Static build
-moon run ui-components:test            # vitest --run (1405 tests)
+moon run ui-components:test            # vitest --run (1561 tests)
 moon run ui-components:build           # vite build + tsc --emitDeclarationOnly
 moon run ui-components:chromatic       # Publish to Chromatic
 ```

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -48,6 +48,7 @@ npm install @maneki/ui-components
 | `<ui-input-group>` | Input group wrapper: 3 sizes, prefix/suffix slots with separators |
 | `<ui-file-upload>` | File upload: 3 sizes, Browse button, accept/multiple, disabled |
 | `<ui-select>` | Select dropdown: 3 sizes, 7 states, 5 statuses, single/multi-select, tag pills, combobox ARIA |
+| `<ui-textarea>` | Textarea: 3 sizes, 7 states, 5 statuses, label with char count, secondary label, resize |
 | | **Containers** |
 | `<ui-card>` | Slot-based container: 3 sizes, 4 elevations, bordered variant |
 | `<ui-button-group>` | Segmented bar wrapping `<ui-button>` elements |
@@ -93,7 +94,7 @@ moon run ui-components:storybook        # Dev server on port 6006
 moon run ui-components:storybook-build  # Static build → storybook-static/
 ```
 
-34 components with stories covering all variants, sizes, actions, emphases, shapes, and statuses.
+35 components with stories covering all variants, sizes, actions, emphases, shapes, and statuses.
 
 ---
 
@@ -101,7 +102,7 @@ moon run ui-components:storybook-build  # Static build → storybook-static/
 
 ```bash
 moon run ui-components:build  # vite build + tsc --emitDeclarationOnly → dist/
-moon run ui-components:test   # vitest --run (1405 tests)
+moon run ui-components:test   # vitest --run (1524 tests)
 ```
 
 ---

--- a/packages/ui-components/src/components/ui-textarea.styles.ts
+++ b/packages/ui-components/src/components/ui-textarea.styles.ts
@@ -1,0 +1,320 @@
+import { semanticVar, spaceVar } from "@maneki/foundation";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const FORM_INPUT_BORDER = semanticVar("form", "inputBorder");
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const TEXT_SECONDARY = semanticVar("text", "secondary");
+const TEXT_TERTIARY = semanticVar("text", "tertiary");
+const HOVER_BORDER = semanticVar("stateHover", "borderModerate");
+const BORDER_FOCUS = semanticVar("border", "focus");
+const DISABLED_BORDER = semanticVar("stateDisabled", "border");
+const DISABLED_TEXT = semanticVar("stateDisabled", "text");
+const STATUS_ERROR = semanticVar("statusGeneral", "error");
+const STATUS_WARNING = semanticVar("statusGeneral", "warning");
+const STATUS_SUCCESS = semanticVar("statusGeneral", "success");
+const BORDER_MINIMAL = semanticVar("border", "minimal");
+const SURFACE_SECONDARY = semanticVar("surface", "secondary");
+const SP_05 = spaceVar("0.5");
+const SP_1 = spaceVar("1");
+const SP_15 = spaceVar("1.5");
+
+// ─── Status icon map ─────────────────────────────────────────────────────────
+
+export const STATUS_ICON_MAP: Record<string, string> = {
+  warning: "warning",
+  error: "error",
+  success: "check_circle",
+  loading: "progress_activity",
+};
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+export const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: inline-flex;
+    flex-direction: column;
+    gap: ${SP_05};
+    font-family: "Inter", sans-serif;
+  }
+
+  /* ── Label row ─────────────────────────────────────────────────────────── */
+
+  .label-row {
+    display: none;
+    align-items: center;
+    gap: ${SP_1};
+  }
+
+  :host([label]) .label-row {
+    display: flex;
+  }
+
+  .label-row ui-label {
+    display: inline;
+    flex: 1;
+  }
+
+  .char-count {
+    display: none;
+    font-size: 11px;
+    line-height: 16px;
+    color: ${TEXT_SECONDARY};
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+
+  :host([maxlength]) .char-count {
+    display: block;
+  }
+
+  /* ── Textarea container ─────────────────────────────────────────────────── */
+
+  .textarea-container {
+    display: flex;
+    position: relative;
+    border: 1px solid var(--ui-textarea-border, ${FORM_INPUT_BORDER});
+    border-radius: 2px;
+    background-color: var(--ui-textarea-bg, #ffffff);
+    transition:
+      border-color 0.15s ease,
+      box-shadow 0.15s ease;
+    overflow: hidden;
+    flex: 1;
+    min-height: 0;
+  }
+
+  /* ── Native textarea ────────────────────────────────────────────────────── */
+
+  .native-textarea {
+    flex: 1;
+    min-width: 0;
+    min-height: 0;
+    border: none;
+    outline: none;
+    background: transparent;
+    font-family: inherit;
+    color: var(--ui-textarea-color, ${TEXT_PRIMARY});
+    padding: var(--_textarea-padding);
+    margin: 0;
+    resize: both;
+  }
+
+  .native-textarea::placeholder {
+    color: var(--ui-textarea-placeholder-color, ${TEXT_TERTIARY});
+  }
+
+  /* ── Status icon ───────────────────────────────────────────────────────── */
+
+  .status-icon {
+    display: none;
+    position: absolute;
+    top: var(--_textarea-padding);
+    right: var(--_textarea-padding);
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    --ui-icon-size: var(--_status-icon-size);
+    line-height: 1;
+  }
+
+  :host([status="warning"]) .status-icon {
+    display: flex;
+    color: ${STATUS_WARNING};
+  }
+
+  :host([status="error"]) .status-icon,
+  :host([error]) .status-icon {
+    display: flex;
+    color: ${STATUS_ERROR};
+  }
+
+  :host([status="success"]) .status-icon {
+    display: flex;
+    color: ${STATUS_SUCCESS};
+  }
+
+  :host([status="loading"]) .status-icon {
+    display: flex;
+    color: ${TEXT_SECONDARY};
+  }
+
+  :host([status="loading"]) .status-icon ui-icon {
+    animation: spin 1s linear infinite;
+  }
+
+  @keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+  }
+
+  /* ── Secondary label ────────────────────────────────────────────────────── */
+
+  .secondary-label {
+    display: none;
+    font-size: 11px;
+    line-height: 16px;
+    color: var(--ui-textarea-secondary-color, ${TEXT_SECONDARY});
+  }
+
+  :host([secondary-label]) .secondary-label {
+    display: block;
+  }
+
+  /* ── Size: m (default) ─────────────────────────────────────────────────── */
+
+  :host,
+  :host([size="m"]) {
+    --_textarea-padding: 7px;
+    --_textarea-font-size: 14px;
+    --_textarea-line-height: 20px;
+    --_status-icon-size: 16px;
+  }
+
+  /* ── Size: s ───────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) {
+    --_textarea-padding: 7px;
+    --_textarea-font-size: 12px;
+    --_textarea-line-height: 16px;
+    --_status-icon-size: 12px;
+  }
+
+  /* ── Size: l ───────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) {
+    --_textarea-padding: 7px;
+    --_textarea-font-size: 16px;
+    --_textarea-line-height: 24px;
+    --_status-icon-size: 20px;
+  }
+
+  .native-textarea {
+    font-size: var(--_textarea-font-size);
+    line-height: var(--_textarea-line-height);
+  }
+
+  /* ── Hover ─────────────────────────────────────────────────────────────── */
+
+  :host(:hover:not([disabled]):not([readonly])) .textarea-container {
+    border-color: var(--ui-textarea-hover-border, ${HOVER_BORDER});
+  }
+
+  /* ── Focus ─────────────────────────────────────────────────────────────── */
+
+  :host(:focus-within:not([disabled]):not([readonly])) .textarea-container {
+    border-color: var(--ui-textarea-focus-border, ${BORDER_FOCUS});
+    box-shadow: 0 0 0 1px var(--ui-textarea-focus-border, ${BORDER_FOCUS});
+  }
+
+  /* ── Error state ───────────────────────────────────────────────────────── */
+
+  :host([status="error"]) .textarea-container,
+  :host([error]) .textarea-container {
+    border-color: ${STATUS_ERROR};
+  }
+
+  :host([status="error"]:focus-within) .textarea-container,
+  :host([error]:focus-within) .textarea-container {
+    border-color: ${STATUS_ERROR};
+    box-shadow: 0 0 0 1px ${STATUS_ERROR};
+  }
+
+  /* ── Warning state ─────────────────────────────────────────────────────── */
+
+  :host([status="warning"]) .textarea-container {
+    border-color: ${BORDER_FOCUS};
+  }
+
+  :host([status="warning"]:focus-within) .textarea-container {
+    border-color: ${BORDER_FOCUS};
+    box-shadow: 0 0 0 1px ${BORDER_FOCUS};
+  }
+
+  /* ── Success state ─────────────────────────────────────────────────────── */
+
+  :host([status="success"]) .textarea-container {
+    border-color: ${STATUS_SUCCESS};
+  }
+
+  :host([status="success"]:focus-within) .textarea-container {
+    border-color: ${STATUS_SUCCESS};
+    box-shadow: 0 0 0 1px ${STATUS_SUCCESS};
+  }
+
+  /* ── Disabled ──────────────────────────────────────────────────────────── */
+
+  :host([disabled]) {
+    pointer-events: none;
+  }
+
+  :host([disabled]) .textarea-container {
+    border-color: ${DISABLED_BORDER};
+    background-color: ${SURFACE_SECONDARY};
+  }
+
+  :host([disabled]) .native-textarea {
+    color: ${DISABLED_TEXT};
+  }
+
+  :host([disabled]) .native-textarea::placeholder {
+    color: ${DISABLED_TEXT};
+  }
+
+  :host([disabled]) .secondary-label {
+    color: ${DISABLED_TEXT};
+  }
+
+  :host([disabled]) .char-count {
+    color: ${DISABLED_TEXT};
+  }
+
+  :host([disabled]) .status-icon {
+    color: ${DISABLED_TEXT} !important;
+  }
+
+  /* ── Readonly ──────────────────────────────────────────────────────────── */
+
+  :host([readonly]) .textarea-container {
+    border-color: ${BORDER_MINIMAL};
+    background-color: ${SURFACE_SECONDARY};
+  }
+
+  :host([readonly]) .native-textarea {
+    cursor: default;
+    color: ${TEXT_PRIMARY};
+    resize: none;
+  }
+
+  /* ── Status secondary label color ──────────────────────────────────────── */
+
+  :host([status="warning"]) .secondary-label {
+    color: ${STATUS_WARNING};
+  }
+
+  :host([status="error"]) .secondary-label,
+  :host([error]) .secondary-label {
+    color: ${STATUS_ERROR};
+  }
+
+  :host([status="success"]) .secondary-label {
+    color: ${STATUS_SUCCESS};
+  }
+
+  /* ── Reduced motion ────────────────────────────────────────────────────── */
+
+  @media (prefers-reduced-motion: reduce) {
+    .textarea-container {
+      transition-duration: 0.01ms !important;
+    }
+    :host([status="loading"]) .status-icon ui-icon {
+      animation-duration: 0.01ms !important;
+    }
+  }
+`;

--- a/packages/ui-components/src/components/ui-textarea.test.ts
+++ b/packages/ui-components/src/components/ui-textarea.test.ts
@@ -1,0 +1,711 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import "./ui-textarea.js";
+
+describe("ui-textarea", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-textarea");
+    document.body.appendChild(el);
+  });
+
+  // ── Registration ─────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-textarea")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).toBeTruthy();
+  });
+
+  it("has correct tag name", () => {
+    expect(el.tagName.toLowerCase()).toBe("ui-textarea");
+  });
+
+  // ── Default attributes ───────────────────────────────────────────────────
+
+  it("defaults size to 'm'", () => {
+    expect((el as unknown as { size: string }).size).toBe("m");
+  });
+
+  it("defaults status to 'none'", () => {
+    expect((el as unknown as { status: string }).status).toBe("none");
+  });
+
+  it("defaults value to empty string", () => {
+    expect((el as unknown as { value: string }).value).toBe("");
+  });
+
+  it("defaults label to empty string", () => {
+    expect((el as unknown as { label: string }).label).toBe("");
+  });
+
+  it("defaults secondaryLabel to empty string", () => {
+    expect((el as unknown as { secondaryLabel: string }).secondaryLabel).toBe("");
+  });
+
+  it("defaults placeholder to empty string", () => {
+    expect((el as unknown as { placeholder: string }).placeholder).toBe("");
+  });
+
+  it("defaults disabled to false", () => {
+    expect((el as unknown as { disabled: boolean }).disabled).toBe(false);
+  });
+
+  it("defaults readonly to false", () => {
+    expect((el as unknown as { readonly: boolean }).readonly).toBe(false);
+  });
+
+  it("defaults error to false", () => {
+    expect((el as unknown as { error: boolean }).error).toBe(false);
+  });
+
+  it("defaults name to empty string", () => {
+    expect((el as unknown as { name: string }).name).toBe("");
+  });
+
+  it("defaults rows to 4", () => {
+    expect((el as unknown as { rows: number }).rows).toBe(4);
+  });
+
+  it("defaults maxlength to null", () => {
+    expect((el as unknown as { maxlength: number | null }).maxlength).toBe(null);
+  });
+
+  // ── Size attribute ───────────────────────────────────────────────────────
+
+  it("reflects size='s' to attribute", () => {
+    (el as unknown as { size: string }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("reflects size='m' to attribute", () => {
+    (el as unknown as { size: string }).size = "m";
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("reflects size='l' to attribute", () => {
+    (el as unknown as { size: string }).size = "l";
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  // ── Status attribute ─────────────────────────────────────────────────────
+
+  it("reflects status='warning' to attribute", () => {
+    (el as unknown as { status: string }).status = "warning";
+    expect(el.getAttribute("status")).toBe("warning");
+  });
+
+  it("reflects status='error' to attribute", () => {
+    (el as unknown as { status: string }).status = "error";
+    expect(el.getAttribute("status")).toBe("error");
+  });
+
+  it("reflects status='success' to attribute", () => {
+    (el as unknown as { status: string }).status = "success";
+    expect(el.getAttribute("status")).toBe("success");
+  });
+
+  it("reflects status='loading' to attribute", () => {
+    (el as unknown as { status: string }).status = "loading";
+    expect(el.getAttribute("status")).toBe("loading");
+  });
+
+  // ── Boolean attributes ───────────────────────────────────────────────────
+
+  it("sets disabled attribute when property is true", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    expect(el.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("removes disabled attribute when property is false", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    (el as unknown as { disabled: boolean }).disabled = false;
+    expect(el.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("sets readonly attribute when property is true", () => {
+    (el as unknown as { readonly: boolean }).readonly = true;
+    expect(el.hasAttribute("readonly")).toBe(true);
+  });
+
+  it("removes readonly attribute when property is false", () => {
+    (el as unknown as { readonly: boolean }).readonly = true;
+    (el as unknown as { readonly: boolean }).readonly = false;
+    expect(el.hasAttribute("readonly")).toBe(false);
+  });
+
+  it("sets error attribute when property is true", () => {
+    (el as unknown as { error: boolean }).error = true;
+    expect(el.hasAttribute("error")).toBe(true);
+  });
+
+  it("removes error attribute when property is false", () => {
+    (el as unknown as { error: boolean }).error = true;
+    (el as unknown as { error: boolean }).error = false;
+    expect(el.hasAttribute("error")).toBe(false);
+  });
+
+  // ── Value ────────────────────────────────────────────────────────────────
+
+  it("sets value on native textarea", () => {
+    (el as unknown as { value: string }).value = "hello";
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(textarea.value).toBe("hello");
+  });
+
+  it("reflects value to attribute", () => {
+    (el as unknown as { value: string }).value = "test";
+    expect(el.getAttribute("value")).toBe("test");
+  });
+
+  it("syncs value from attribute", () => {
+    el.setAttribute("value", "from-attr");
+    expect((el as unknown as { value: string }).value).toBe("from-attr");
+  });
+
+  it("gets value from native textarea element", () => {
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    textarea.value = "native-set";
+    expect((el as unknown as { value: string }).value).toBe("native-set");
+  });
+
+  // ── Placeholder ──────────────────────────────────────────────────────────
+
+  it("sets placeholder on native textarea", () => {
+    (el as unknown as { placeholder: string }).placeholder = "Enter text...";
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(textarea.placeholder).toBe("Enter text...");
+  });
+
+  it("syncs placeholder from attribute", () => {
+    el.setAttribute("placeholder", "Type here");
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(textarea.placeholder).toBe("Type here");
+  });
+
+  // ── Name ─────────────────────────────────────────────────────────────────
+
+  it("sets name on native textarea", () => {
+    (el as unknown as { name: string }).name = "message";
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(textarea.name).toBe("message");
+  });
+
+  it("syncs name from attribute", () => {
+    el.setAttribute("name", "comment");
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(textarea.name).toBe("comment");
+  });
+
+  // ── Label ────────────────────────────────────────────────────────────────
+
+  it("sets label attribute and shows label text", () => {
+    (el as unknown as { label: string }).label = "Description";
+    expect(el.getAttribute("label")).toBe("Description");
+    const labelEl = el.shadowRoot!.querySelector("ui-label[emphasis='bold']");
+    expect(labelEl!.textContent).toBe("Description");
+  });
+
+  it("removes label attribute when set to empty", () => {
+    (el as unknown as { label: string }).label = "Description";
+    (el as unknown as { label: string }).label = "";
+    expect(el.hasAttribute("label")).toBe(false);
+  });
+
+  it("syncs label size with component size", () => {
+    (el as unknown as { label: string }).label = "Test";
+    (el as unknown as { size: string }).size = "l";
+    const labelEl = el.shadowRoot!.querySelector("ui-label[emphasis='bold']");
+    expect(labelEl!.getAttribute("size")).toBe("l");
+  });
+
+  it("sets disabled on label when component is disabled", () => {
+    (el as unknown as { label: string }).label = "Test";
+    (el as unknown as { disabled: boolean }).disabled = true;
+    const labelEl = el.shadowRoot!.querySelector("ui-label[emphasis='bold']");
+    expect(labelEl!.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("removes disabled from label when component is enabled", () => {
+    (el as unknown as { label: string }).label = "Test";
+    (el as unknown as { disabled: boolean }).disabled = true;
+    (el as unknown as { disabled: boolean }).disabled = false;
+    const labelEl = el.shadowRoot!.querySelector("ui-label[emphasis='bold']");
+    expect(labelEl!.hasAttribute("disabled")).toBe(false);
+  });
+
+  // ── Secondary label ──────────────────────────────────────────────────────
+
+  it("sets secondary-label attribute", () => {
+    (el as unknown as { secondaryLabel: string }).secondaryLabel = "Optional";
+    expect(el.getAttribute("secondary-label")).toBe("Optional");
+    const secEl = el.shadowRoot!.querySelector(".secondary-label");
+    expect(secEl!.textContent).toBe("Optional");
+  });
+
+  it("removes secondary-label attribute when set to empty", () => {
+    (el as unknown as { secondaryLabel: string }).secondaryLabel = "Optional";
+    (el as unknown as { secondaryLabel: string }).secondaryLabel = "";
+    expect(el.hasAttribute("secondary-label")).toBe(false);
+  });
+
+  // ── Rows ─────────────────────────────────────────────────────────────────
+
+  it("defaults native textarea rows to 4", () => {
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(Number(textarea.rows)).toBe(4);
+  });
+
+  it("sets custom rows on native textarea", () => {
+    (el as unknown as { rows: number }).rows = 8;
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(Number(textarea.rows)).toBe(8);
+  });
+
+  it("reflects rows to attribute", () => {
+    (el as unknown as { rows: number }).rows = 6;
+    expect(el.getAttribute("rows")).toBe("6");
+  });
+
+  it("syncs rows from attribute", () => {
+    el.setAttribute("rows", "10");
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(Number(textarea.rows)).toBe(10);
+  });
+
+  // ── Maxlength ────────────────────────────────────────────────────────────
+
+  it("sets maxlength on native textarea", () => {
+    (el as unknown as { maxlength: number | null }).maxlength = 500;
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(textarea.maxLength).toBe(500);
+  });
+
+  it("reflects maxlength to attribute", () => {
+    (el as unknown as { maxlength: number | null }).maxlength = 200;
+    expect(el.getAttribute("maxlength")).toBe("200");
+  });
+
+  it("removes maxlength when set to null", () => {
+    (el as unknown as { maxlength: number | null }).maxlength = 200;
+    (el as unknown as { maxlength: number | null }).maxlength = null;
+    expect(el.hasAttribute("maxlength")).toBe(false);
+  });
+
+  it("removes maxlength from native textarea when set to null", () => {
+    (el as unknown as { maxlength: number | null }).maxlength = 200;
+    (el as unknown as { maxlength: number | null }).maxlength = null;
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(textarea.hasAttribute("maxlength")).toBe(false);
+  });
+
+  it("syncs maxlength from attribute", () => {
+    el.setAttribute("maxlength", "300");
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(textarea.maxLength).toBe(300);
+  });
+
+  // ── Char count ───────────────────────────────────────────────────────────
+
+  it("shows char count when maxlength is set", () => {
+    (el as unknown as { maxlength: number | null }).maxlength = 500;
+    const charCount = el.shadowRoot!.querySelector(".char-count");
+    expect(charCount!.textContent).toBe("0/500");
+  });
+
+  it("updates char count when value changes via property", () => {
+    (el as unknown as { maxlength: number | null }).maxlength = 100;
+    (el as unknown as { value: string }).value = "hello";
+    const charCount = el.shadowRoot!.querySelector(".char-count");
+    expect(charCount!.textContent).toBe("5/100");
+  });
+
+  it("updates char count on native input event", () => {
+    (el as unknown as { maxlength: number | null }).maxlength = 100;
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    textarea.value = "test input";
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    const charCount = el.shadowRoot!.querySelector(".char-count");
+    expect(charCount!.textContent).toBe("10/100");
+  });
+
+  it("does not show char count when maxlength is not set", () => {
+    const charCount = el.shadowRoot!.querySelector(".char-count");
+    expect(charCount!.textContent).toBe("");
+  });
+
+  // ── Shadow DOM structure ─────────────────────────────────────────────────
+
+  it("has .label-row element", () => {
+    expect(el.shadowRoot!.querySelector(".label-row")).toBeTruthy();
+  });
+
+  it("has .textarea-container element", () => {
+    expect(el.shadowRoot!.querySelector(".textarea-container")).toBeTruthy();
+  });
+
+  it("has .native-textarea element", () => {
+    expect(el.shadowRoot!.querySelector(".native-textarea")).toBeTruthy();
+  });
+
+  it("has .status-icon element", () => {
+    expect(el.shadowRoot!.querySelector(".status-icon")).toBeTruthy();
+  });
+
+  it("has .secondary-label element", () => {
+    expect(el.shadowRoot!.querySelector(".secondary-label")).toBeTruthy();
+  });
+
+  it("has .char-count element", () => {
+    expect(el.shadowRoot!.querySelector(".char-count")).toBeTruthy();
+  });
+
+  it("has ui-label element", () => {
+    expect(el.shadowRoot!.querySelector("ui-label")).toBeTruthy();
+  });
+
+  // ── Disabled state ───────────────────────────────────────────────────────
+
+  it("disables native textarea when disabled", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(textarea.disabled).toBe(true);
+  });
+
+  it("enables native textarea when not disabled", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    (el as unknown as { disabled: boolean }).disabled = false;
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(textarea.disabled).toBe(false);
+  });
+
+  // ── Readonly state ───────────────────────────────────────────────────────
+
+  it("sets readOnly on native textarea when readonly", () => {
+    (el as unknown as { readonly: boolean }).readonly = true;
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(textarea.readOnly).toBe(true);
+  });
+
+  it("removes readOnly on native textarea when not readonly", () => {
+    (el as unknown as { readonly: boolean }).readonly = true;
+    (el as unknown as { readonly: boolean }).readonly = false;
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(textarea.readOnly).toBe(false);
+  });
+
+  // ── Status icon ──────────────────────────────────────────────────────────
+
+  it("shows status icon for warning", () => {
+    (el as unknown as { status: string }).status = "warning";
+    const icon = el.shadowRoot!.querySelector(".status-icon ui-icon");
+    expect(icon!.getAttribute("name")).toBe("warning");
+  });
+
+  it("shows status icon for error", () => {
+    (el as unknown as { status: string }).status = "error";
+    const icon = el.shadowRoot!.querySelector(".status-icon ui-icon");
+    expect(icon!.getAttribute("name")).toBe("error");
+  });
+
+  it("shows status icon for success", () => {
+    (el as unknown as { status: string }).status = "success";
+    const icon = el.shadowRoot!.querySelector(".status-icon ui-icon");
+    expect(icon!.getAttribute("name")).toBe("check_circle");
+  });
+
+  it("shows status icon for loading", () => {
+    (el as unknown as { status: string }).status = "loading";
+    const icon = el.shadowRoot!.querySelector(".status-icon ui-icon");
+    expect(icon!.getAttribute("name")).toBe("progress_activity");
+  });
+
+  it("clears status icon when status is none", () => {
+    (el as unknown as { status: string }).status = "error";
+    (el as unknown as { status: string }).status = "none";
+    const icon = el.shadowRoot!.querySelector(".status-icon ui-icon");
+    expect(icon!.getAttribute("name") ?? "").toBe("");
+  });
+
+  it("shows error icon when error boolean is set", () => {
+    (el as unknown as { error: boolean }).error = true;
+    const icon = el.shadowRoot!.querySelector(".status-icon ui-icon");
+    expect(icon!.getAttribute("name")).toBe("error");
+  });
+
+  it("error boolean overrides status attribute", () => {
+    (el as unknown as { status: string }).status = "success";
+    (el as unknown as { error: boolean }).error = true;
+    const icon = el.shadowRoot!.querySelector(".status-icon ui-icon");
+    expect(icon!.getAttribute("name")).toBe("error");
+  });
+
+  it("status icon has filled attribute", () => {
+    const icon = el.shadowRoot!.querySelector(".status-icon ui-icon");
+    expect(icon!.hasAttribute("filled")).toBe(true);
+  });
+
+  // ── Accessibility ────────────────────────────────────────────────────────
+
+  it("sets role='textbox' on connected", () => {
+    expect(el.getAttribute("role")).toBe("textbox");
+  });
+
+  it("sets aria-multiline='true' on connected", () => {
+    expect(el.getAttribute("aria-multiline")).toBe("true");
+  });
+
+  it("sets aria-invalid='true' when status is error", () => {
+    (el as unknown as { status: string }).status = "error";
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(textarea.getAttribute("aria-invalid")).toBe("true");
+  });
+
+  it("sets aria-invalid='true' when error attribute is set", () => {
+    (el as unknown as { error: boolean }).error = true;
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(textarea.getAttribute("aria-invalid")).toBe("true");
+  });
+
+  it("removes aria-invalid when status is not error", () => {
+    (el as unknown as { status: string }).status = "error";
+    (el as unknown as { status: string }).status = "none";
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(textarea.hasAttribute("aria-invalid")).toBe(false);
+  });
+
+  it("sets aria-disabled='true' when disabled", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    expect(el.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("removes aria-disabled when not disabled", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    (el as unknown as { disabled: boolean }).disabled = false;
+    expect(el.hasAttribute("aria-disabled")).toBe(false);
+  });
+
+  it("sets aria-readonly on native textarea when readonly", () => {
+    (el as unknown as { readonly: boolean }).readonly = true;
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(textarea.getAttribute("aria-readonly")).toBe("true");
+  });
+
+  it("removes aria-readonly when not readonly", () => {
+    (el as unknown as { readonly: boolean }).readonly = true;
+    (el as unknown as { readonly: boolean }).readonly = false;
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(textarea.hasAttribute("aria-readonly")).toBe(false);
+  });
+
+  it("sets aria-label on native textarea from label attribute", () => {
+    (el as unknown as { label: string }).label = "Message";
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    expect(textarea.getAttribute("aria-label")).toBe("Message");
+  });
+
+  it("sets aria-label on host from label attribute", () => {
+    (el as unknown as { label: string }).label = "Message";
+    expect(el.getAttribute("aria-label")).toBe("Message");
+  });
+
+  it("does not override role if already set", () => {
+    document.body.innerHTML = "";
+    const custom = document.createElement("ui-textarea");
+    custom.setAttribute("role", "custom");
+    document.body.appendChild(custom);
+    expect(custom.getAttribute("role")).toBe("custom");
+  });
+
+  it("does not override aria-multiline if already set", () => {
+    document.body.innerHTML = "";
+    const custom = document.createElement("ui-textarea");
+    custom.setAttribute("aria-multiline", "false");
+    document.body.appendChild(custom);
+    expect(custom.getAttribute("aria-multiline")).toBe("false");
+  });
+
+  // ── Status icon aria-hidden ──────────────────────────────────────────────
+
+  it("status icon has aria-hidden='true'", () => {
+    const icon = el.shadowRoot!.querySelector(".status-icon");
+    expect(icon!.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  // ── Input event ──────────────────────────────────────────────────────────
+
+  it("dispatches input event on native input", () => {
+    let detail: { value: string } | null = null;
+    el.addEventListener("input", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    textarea.value = "typed";
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(detail).toEqual({ value: "typed" });
+  });
+
+  it("input event bubbles and is composed", () => {
+    let event: CustomEvent | null = null;
+    el.addEventListener("input", ((e: CustomEvent) => {
+      event = e;
+    }) as EventListener);
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    textarea.value = "test";
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(event).toBeTruthy();
+    expect(event!.bubbles).toBe(true);
+    expect(event!.composed).toBe(true);
+  });
+
+  it("syncs value attribute on input event", () => {
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    textarea.value = "synced";
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(el.getAttribute("value")).toBe("synced");
+  });
+
+  // ── Change event ─────────────────────────────────────────────────────────
+
+  it("dispatches change event on native change", () => {
+    let detail: { value: string } | null = null;
+    el.addEventListener("change", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    textarea.value = "changed";
+    textarea.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(detail).toEqual({ value: "changed" });
+  });
+
+  it("change event bubbles and is composed", () => {
+    let event: CustomEvent | null = null;
+    el.addEventListener("change", ((e: CustomEvent) => {
+      event = e;
+    }) as EventListener);
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    textarea.value = "test";
+    textarea.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(event).toBeTruthy();
+    expect(event!.bubbles).toBe(true);
+    expect(event!.composed).toBe(true);
+  });
+
+  it("syncs value attribute on change event", () => {
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    textarea.value = "changed-val";
+    textarea.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(el.getAttribute("value")).toBe("changed-val");
+  });
+
+  // ── Focus / blur delegation ──────────────────────────────────────────────
+
+  it("delegates focus to native textarea", () => {
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    const spy = vi.spyOn(textarea, "focus");
+    (el as unknown as { focus: () => void }).focus();
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("delegates blur to native textarea", () => {
+    const textarea = el.shadowRoot!.querySelector(".native-textarea") as HTMLTextAreaElement;
+    const spy = vi.spyOn(textarea, "blur");
+    (el as unknown as { blur: () => void }).blur();
+    expect(spy).toHaveBeenCalled();
+  });
+
+  // ── Property accessors roundtrip ─────────────────────────────────────────
+
+  it("exposes all typed property accessors", () => {
+    const component = el as unknown as {
+      size: string;
+      label: string;
+      secondaryLabel: string;
+      placeholder: string;
+      value: string;
+      name: string;
+      disabled: boolean;
+      readonly: boolean;
+      error: boolean;
+      status: string;
+      rows: number;
+      maxlength: number | null;
+    };
+
+    component.size = "l";
+    expect(component.size).toBe("l");
+
+    component.label = "Description";
+    expect(component.label).toBe("Description");
+
+    component.secondaryLabel = "Optional";
+    expect(component.secondaryLabel).toBe("Optional");
+
+    component.placeholder = "Type here";
+    expect(component.placeholder).toBe("Type here");
+
+    component.value = "test";
+    expect(component.value).toBe("test");
+
+    component.name = "field";
+    expect(component.name).toBe("field");
+
+    component.disabled = true;
+    expect(component.disabled).toBe(true);
+
+    component.readonly = true;
+    expect(component.readonly).toBe(true);
+
+    component.error = true;
+    expect(component.error).toBe(true);
+
+    component.status = "warning";
+    expect(component.status).toBe("warning");
+
+    component.rows = 10;
+    expect(component.rows).toBe(10);
+
+    component.maxlength = 500;
+    expect(component.maxlength).toBe(500);
+  });
+
+  // ── Attribute → property sync ────────────────────────────────────────────
+
+  it("syncs size from attribute to property", () => {
+    el.setAttribute("size", "l");
+    expect((el as unknown as { size: string }).size).toBe("l");
+  });
+
+  it("syncs status from attribute to property", () => {
+    el.setAttribute("status", "warning");
+    expect((el as unknown as { status: string }).status).toBe("warning");
+  });
+
+  it("syncs disabled from attribute to property", () => {
+    el.setAttribute("disabled", "");
+    expect((el as unknown as { disabled: boolean }).disabled).toBe(true);
+  });
+
+  it("syncs readonly from attribute to property", () => {
+    el.setAttribute("readonly", "");
+    expect((el as unknown as { readonly: boolean }).readonly).toBe(true);
+  });
+
+  it("syncs error from attribute to property", () => {
+    el.setAttribute("error", "");
+    expect((el as unknown as { error: boolean }).error).toBe(true);
+  });
+
+  it("syncs rows from attribute to property", () => {
+    el.setAttribute("rows", "12");
+    expect((el as unknown as { rows: number }).rows).toBe(12);
+  });
+
+  it("syncs maxlength from attribute to property", () => {
+    el.setAttribute("maxlength", "250");
+    expect((el as unknown as { maxlength: number | null }).maxlength).toBe(250);
+  });
+});

--- a/packages/ui-components/src/components/ui-textarea.ts
+++ b/packages/ui-components/src/components/ui-textarea.ts
@@ -1,0 +1,422 @@
+import { STYLES, STATUS_ICON_MAP } from "./ui-textarea.styles.js";
+import "./ui-icon.js";
+import "./ui-label.js";
+
+// ─── Type-safe property unions ───────────────────────────────────────────────
+
+export type TextareaSize = "s" | "m" | "l";
+export type TextareaStatus = "none" | "warning" | "error" | "success" | "loading";
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiTextarea extends HTMLElement {
+  static readonly observedAttributes = [
+    "size",
+    "label",
+    "secondary-label",
+    "placeholder",
+    "value",
+    "name",
+    "disabled",
+    "readonly",
+    "error",
+    "status",
+    "rows",
+    "maxlength",
+  ];
+
+  private _textareaEl: HTMLTextAreaElement;
+  private _statusIconEl: HTMLSpanElement;
+  private _statusIconInner: HTMLElement;
+  private _labelTextEl: HTMLElement;
+  private _charCountEl: HTMLSpanElement;
+  private _secondaryLabelEl: HTMLSpanElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+
+    shadow.adoptedStyleSheets = [sheet];
+
+    // ── Label row ──────────────────────────────────────────────────────
+    const labelRow = document.createElement("div");
+    labelRow.className = "label-row";
+
+    this._labelTextEl = document.createElement("ui-label");
+    this._labelTextEl.setAttribute("emphasis", "bold");
+    labelRow.appendChild(this._labelTextEl);
+
+    this._charCountEl = document.createElement("span");
+    this._charCountEl.className = "char-count";
+    labelRow.appendChild(this._charCountEl);
+
+    shadow.appendChild(labelRow);
+
+    // ── Textarea container ─────────────────────────────────────────────
+    const container = document.createElement("div");
+    container.className = "textarea-container";
+
+    // Native textarea
+    this._textareaEl = document.createElement("textarea");
+    this._textareaEl.className = "native-textarea";
+    container.appendChild(this._textareaEl);
+
+    // Status icon
+    this._statusIconEl = document.createElement("span");
+    this._statusIconEl.className = "status-icon";
+    this._statusIconEl.setAttribute("aria-hidden", "true");
+    this._statusIconInner = document.createElement("ui-icon") as HTMLElement;
+    this._statusIconInner.setAttribute("filled", "");
+    this._statusIconEl.appendChild(this._statusIconInner);
+    container.appendChild(this._statusIconEl);
+
+    shadow.appendChild(container);
+
+    // ── Secondary label ────────────────────────────────────────────────
+    this._secondaryLabelEl = document.createElement("span");
+    this._secondaryLabelEl.className = "secondary-label";
+    shadow.appendChild(this._secondaryLabelEl);
+
+    // ── Event listeners ────────────────────────────────────────────────
+    this._textareaEl.addEventListener("input", this._handleInput.bind(this));
+    this._textareaEl.addEventListener("change", this._handleChange.bind(this));
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("role")) {
+      this.setAttribute("role", "textbox");
+    }
+    if (!this.hasAttribute("aria-multiline")) {
+      this.setAttribute("aria-multiline", "true");
+    }
+    this._syncValue();
+    this._syncPlaceholder();
+    this._syncDisabled();
+    this._syncReadonly();
+    this._syncStatusIcon();
+    this._syncLabels();
+    this._syncSecondaryLabel();
+    this._syncRows();
+    this._syncMaxlength();
+    this._syncCharCount();
+    this._syncAria();
+  }
+
+  attributeChangedCallback(
+    name: string,
+    _oldValue: string | null,
+    _newValue: string | null,
+  ): void {
+    switch (name) {
+      case "value":
+        this._syncValue();
+        this._syncCharCount();
+        break;
+      case "placeholder":
+        this._syncPlaceholder();
+        break;
+      case "disabled":
+        this._syncDisabled();
+        this._syncLabels();
+        this._syncAria();
+        break;
+      case "readonly":
+        this._syncReadonly();
+        this._syncAria();
+        break;
+      case "size":
+        this._syncLabels();
+        break;
+      case "status":
+      case "error":
+        this._syncStatusIcon();
+        this._syncAria();
+        break;
+      case "label":
+        this._syncLabels();
+        this._syncAria();
+        break;
+      case "secondary-label":
+        this._syncSecondaryLabel();
+        break;
+      case "rows":
+        this._syncRows();
+        break;
+      case "maxlength":
+        this._syncMaxlength();
+        this._syncCharCount();
+        break;
+      case "name":
+        this._textareaEl.name = this.getAttribute("name") ?? "";
+        break;
+    }
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): TextareaSize {
+    return (this.getAttribute("size") as TextareaSize) ?? "m";
+  }
+
+  set size(value: TextareaSize) {
+    this.setAttribute("size", value);
+  }
+
+  get label(): string {
+    return this.getAttribute("label") ?? "";
+  }
+
+  set label(value: string) {
+    if (value) {
+      this.setAttribute("label", value);
+    } else {
+      this.removeAttribute("label");
+    }
+  }
+
+  get secondaryLabel(): string {
+    return this.getAttribute("secondary-label") ?? "";
+  }
+
+  set secondaryLabel(value: string) {
+    if (value) {
+      this.setAttribute("secondary-label", value);
+    } else {
+      this.removeAttribute("secondary-label");
+    }
+  }
+
+  get placeholder(): string {
+    return this.getAttribute("placeholder") ?? "";
+  }
+
+  set placeholder(value: string) {
+    this.setAttribute("placeholder", value);
+  }
+
+  get value(): string {
+    return this._textareaEl.value;
+  }
+
+  set value(v: string) {
+    this._textareaEl.value = v;
+    this.setAttribute("value", v);
+    this._syncCharCount();
+  }
+
+  get name(): string {
+    return this.getAttribute("name") ?? "";
+  }
+
+  set name(value: string) {
+    this.setAttribute("name", value);
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute("disabled");
+  }
+
+  set disabled(value: boolean) {
+    if (value) {
+      this.setAttribute("disabled", "");
+    } else {
+      this.removeAttribute("disabled");
+    }
+  }
+
+  get readonly(): boolean {
+    return this.hasAttribute("readonly");
+  }
+
+  set readonly(value: boolean) {
+    if (value) {
+      this.setAttribute("readonly", "");
+    } else {
+      this.removeAttribute("readonly");
+    }
+  }
+
+  get error(): boolean {
+    return this.hasAttribute("error");
+  }
+
+  set error(value: boolean) {
+    if (value) {
+      this.setAttribute("error", "");
+    } else {
+      this.removeAttribute("error");
+    }
+  }
+
+  get status(): TextareaStatus {
+    return (this.getAttribute("status") as TextareaStatus) ?? "none";
+  }
+
+  set status(value: TextareaStatus) {
+    this.setAttribute("status", value);
+  }
+
+  get rows(): number {
+    const val = this.getAttribute("rows");
+    return val ? parseInt(val, 10) : 4;
+  }
+
+  set rows(value: number) {
+    this.setAttribute("rows", String(value));
+  }
+
+  get maxlength(): number | null {
+    const val = this.getAttribute("maxlength");
+    return val ? parseInt(val, 10) : null;
+  }
+
+  set maxlength(value: number | null) {
+    if (value !== null) {
+      this.setAttribute("maxlength", String(value));
+    } else {
+      this.removeAttribute("maxlength");
+    }
+  }
+
+  // ── Public methods ─────────────────────────────────────────────────────
+
+  focus(): void {
+    this._textareaEl.focus();
+  }
+
+  blur(): void {
+    this._textareaEl.blur();
+  }
+
+  // ── Private sync methods ───────────────────────────────────────────────
+
+  private _syncValue(): void {
+    const val = this.getAttribute("value") ?? "";
+    if (this._textareaEl.value !== val) {
+      this._textareaEl.value = val;
+    }
+  }
+
+  private _syncPlaceholder(): void {
+    this._textareaEl.placeholder = this.getAttribute("placeholder") ?? "";
+  }
+
+  private _syncDisabled(): void {
+    this._textareaEl.disabled = this.disabled;
+  }
+
+  private _syncReadonly(): void {
+    this._textareaEl.readOnly = this.readonly;
+  }
+
+  private _syncRows(): void {
+    this._textareaEl.rows = this.rows;
+  }
+
+  private _syncMaxlength(): void {
+    const ml = this.maxlength;
+    if (ml !== null) {
+      this._textareaEl.maxLength = ml;
+    } else {
+      this._textareaEl.removeAttribute("maxlength");
+    }
+  }
+
+  private _syncStatusIcon(): void {
+    const effectiveStatus = this.error ? "error" : this.status;
+    const iconName = STATUS_ICON_MAP[effectiveStatus];
+    if (iconName) {
+      this._statusIconInner.setAttribute("name", iconName);
+    } else {
+      this._statusIconInner.setAttribute("name", "");
+    }
+  }
+
+  private _syncLabels(): void {
+    this._labelTextEl.textContent = this.label;
+    const size = this.getAttribute("size") || "m";
+    this._labelTextEl.setAttribute("size", size);
+    if (this.disabled) {
+      this._labelTextEl.setAttribute("disabled", "");
+    } else {
+      this._labelTextEl.removeAttribute("disabled");
+    }
+  }
+
+  private _syncSecondaryLabel(): void {
+    this._secondaryLabelEl.textContent = this.secondaryLabel;
+  }
+
+  private _syncCharCount(): void {
+    const ml = this.maxlength;
+    if (ml !== null) {
+      const current = this._textareaEl.value.length;
+      this._charCountEl.textContent = `${current}/${ml}`;
+    }
+  }
+
+  private _syncAria(): void {
+    // aria-invalid
+    const effectiveStatus = this.error ? "error" : this.status;
+    if (effectiveStatus === "error") {
+      this._textareaEl.setAttribute("aria-invalid", "true");
+    } else {
+      this._textareaEl.removeAttribute("aria-invalid");
+    }
+
+    // aria-disabled
+    if (this.disabled) {
+      this.setAttribute("aria-disabled", "true");
+    } else {
+      this.removeAttribute("aria-disabled");
+    }
+
+    // aria-readonly
+    if (this.readonly) {
+      this._textareaEl.setAttribute("aria-readonly", "true");
+    } else {
+      this._textareaEl.removeAttribute("aria-readonly");
+    }
+
+    // aria-label
+    if (this.label) {
+      this._textareaEl.setAttribute("aria-label", this.label);
+      this.setAttribute("aria-label", this.label);
+    } else {
+      const hostAriaLabel = this.getAttribute("aria-label");
+      if (hostAriaLabel) {
+        this._textareaEl.setAttribute("aria-label", hostAriaLabel);
+      }
+    }
+  }
+
+  // ── Event handlers ─────────────────────────────────────────────────────
+
+  private _handleInput(): void {
+    this.setAttribute("value", this._textareaEl.value);
+    this._syncCharCount();
+    this.dispatchEvent(
+      new CustomEvent("input", {
+        bubbles: true,
+        composed: true,
+        detail: { value: this._textareaEl.value },
+      }),
+    );
+  }
+
+  private _handleChange(): void {
+    this.setAttribute("value", this._textareaEl.value);
+    this.dispatchEvent(
+      new CustomEvent("change", {
+        bubbles: true,
+        composed: true,
+        detail: { value: this._textareaEl.value },
+      }),
+    );
+  }
+}
+
+customElements.define("ui-textarea", UiTextarea);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -51,6 +51,8 @@ export { UiFileUpload } from "./components/ui-file-upload.js";
 export type { FileUploadSize } from "./components/ui-file-upload.js";
 export { UiSelect } from "./components/ui-select.js";
 export type { SelectSize, SelectStatus } from "./components/ui-select.js";
+export { UiTextarea } from "./components/ui-textarea.js";
+export type { TextareaSize, TextareaStatus } from "./components/ui-textarea.js";
 
 // ─── Containers ─────────────────────────────────────────────────────────────
 

--- a/packages/ui-components/src/stories/ui-textarea.stories.ts
+++ b/packages/ui-components/src/stories/ui-textarea.stories.ts
@@ -1,0 +1,218 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-icon.js";
+import "../components/ui-textarea.js";
+
+const meta: Meta = {
+  title: "Components/Textarea",
+  component: "ui-textarea",
+  argTypes: {
+    size: { control: { type: "select" }, options: ["s", "m", "l"] },
+    status: {
+      control: { type: "select" },
+      options: ["none", "warning", "error", "success", "loading"],
+    },
+    label: { control: "text" },
+    "secondary-label": { control: "text" },
+    placeholder: { control: "text" },
+    value: { control: "text" },
+    rows: { control: "number" },
+    maxlength: { control: "number" },
+    disabled: { control: "boolean" },
+    readonly: { control: "boolean" },
+    error: { control: "boolean" },
+  },
+  parameters: {
+    a11y: {
+      config: {
+        rules: [{ id: "color-contrast", enabled: false }],
+      },
+    },
+  },
+  args: {
+    size: "m",
+    status: "none",
+    placeholder: "Placeholder Text",
+    label: "",
+    "secondary-label": "",
+    value: "",
+    rows: 4,
+    disabled: false,
+    readonly: false,
+    error: false,
+  },
+  render: (args) => html`
+    <ui-textarea
+      size=${args.size}
+      status=${args.status}
+      label=${args.label || undefined}
+      secondary-label=${args["secondary-label"] || undefined}
+      placeholder=${args.placeholder}
+      value=${args.value}
+      rows=${args.rows}
+      maxlength=${args.maxlength || undefined}
+      ?disabled=${args.disabled}
+      ?readonly=${args.readonly}
+      ?error=${args.error}
+    ></ui-textarea>
+  `,
+};
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => html`
+    <ui-textarea placeholder="Enter text..." label="Text area"></ui-textarea>
+  `,
+};
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 16px; max-width: 320px;">
+      <ui-textarea size="s" label="Small" placeholder="Size S"></ui-textarea>
+      <ui-textarea size="m" label="Medium" placeholder="Size M"></ui-textarea>
+      <ui-textarea size="l" label="Large" placeholder="Size L"></ui-textarea>
+    </div>
+  `,
+};
+
+export const WithLabel: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 16px; max-width: 320px;">
+      <ui-textarea label="Description" placeholder="Enter a description..."></ui-textarea>
+      <ui-textarea
+        label="Bio"
+        placeholder="Tell us about yourself..."
+        maxlength="200"
+      ></ui-textarea>
+    </div>
+  `,
+};
+
+export const WithSecondaryLabel: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 16px; max-width: 320px;">
+      <ui-textarea
+        label="Notes"
+        placeholder="Add notes..."
+        secondary-label="Optional"
+      ></ui-textarea>
+      <ui-textarea
+        label="Feedback"
+        placeholder="Share your feedback..."
+        secondary-label="Max 500 characters"
+      ></ui-textarea>
+    </div>
+  `,
+};
+
+export const States: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 16px; max-width: 320px;">
+      <ui-textarea label="Enabled" placeholder="Default state"></ui-textarea>
+      <ui-textarea label="Filled" value="Some value entered by the user"></ui-textarea>
+      <ui-textarea label="Disabled" placeholder="Cannot edit" disabled></ui-textarea>
+      <ui-textarea label="Disabled filled" value="Cannot edit this content" disabled></ui-textarea>
+      <ui-textarea label="Readonly" value="Read only value" readonly></ui-textarea>
+    </div>
+  `,
+};
+
+export const Statuses: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 16px; max-width: 320px;">
+      <ui-textarea
+        label="None"
+        placeholder="No status"
+        status="none"
+        secondary-label="Default secondary text"
+      ></ui-textarea>
+      <ui-textarea
+        label="Warning"
+        value="Might be wrong"
+        status="warning"
+        secondary-label="Please double-check this value"
+      ></ui-textarea>
+      <ui-textarea
+        label="Error"
+        value="Invalid"
+        status="error"
+        secondary-label="This field is required"
+      ></ui-textarea>
+      <ui-textarea
+        label="Error (boolean)"
+        value="Invalid"
+        error
+        secondary-label="This field has an error"
+      ></ui-textarea>
+      <ui-textarea
+        label="Success"
+        value="Valid input"
+        status="success"
+        secondary-label="Looks good!"
+      ></ui-textarea>
+      <ui-textarea
+        label="Loading"
+        value="Checking..."
+        status="loading"
+        secondary-label="Validating..."
+      ></ui-textarea>
+    </div>
+  `,
+};
+
+export const Hover: Story = {
+  render: () => html`
+    <ui-textarea
+      label="Hover state"
+      placeholder="Hover over this textarea"
+      style="max-width: 320px;"
+    ></ui-textarea>
+  `,
+};
+
+export const Focus: Story = {
+  render: () => html`
+    <ui-textarea
+      label="Focus state"
+      placeholder="Click to focus this textarea"
+      secondary-label="Focus ring appears on click or tab"
+      style="max-width: 320px;"
+    ></ui-textarea>
+  `,
+};
+
+export const Active: Story = {
+  render: () => html`
+    <ui-textarea
+      label="Active / Filled"
+      value="This textarea has content, showing the active/filled state."
+      style="max-width: 320px;"
+    ></ui-textarea>
+  `,
+};
+
+export const FullFeatured: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 24px; max-width: 400px;">
+      <ui-textarea
+        size="m"
+        label="Description"
+        secondary-label="Required"
+        placeholder="Enter a detailed description..."
+        value="This is a fully featured textarea with all options enabled."
+        maxlength="300"
+        status="success"
+      ></ui-textarea>
+
+      <ui-textarea
+        size="l"
+        label="Comments"
+        secondary-label="Optional"
+        placeholder="Leave a comment..."
+        rows="6"
+        maxlength="500"
+      ></ui-textarea>
+    </div>
+  `,
+};


### PR DESCRIPTION
## Summary

- New `<ui-textarea>` Web Component with full Figma spec: 3 sizes (S/M/L), 7 states, 5 statuses, label with character count, secondary label, resize handle
- 105 tests, 10 Storybook stories
- Mirrors `<ui-input>` patterns: Shadow DOM, constructable stylesheets, foundation tokens, status icons via `<ui-icon>`

## Files

- `ui-textarea.ts` — component (423 lines)
- `ui-textarea.styles.ts` — styles + tokens (321 lines)
- `ui-textarea.test.ts` — 105 tests
- `ui-textarea.stories.ts` — 10 stories
- `index.ts` — barrel export added