### PR TITLE
feat(ui-components): add ui-table component set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,10 +82,11 @@ Every change — component, fix, refactor, docs — follows this workflow:
    - AGENTS.md structure trees if new files
    - ALWAYS update docs BEFORE the first `jj git push`. Never push code without docs in the same commit.
 7. **Ask user to verify visually** — share Storybook screenshots or point to the running Storybook. Wait for user confirmation before pushing. Never push without user sign-off on visual changes.
-8. **Push** — `jj bookmark set <name> -r @ --allow-backwards && jj git push --bookmark <name>`
-9. **Create PR** — `gh pr create --base main --head <name>`
-10. **Chromatic review** — wait for visual regression tests to pass
-11. **Never push directly to `main`**
+8. **Wait for explicit push request** — NEVER push code unless the user explicitly asks. Present the completed work and wait for the user to say "push", "let's push", "push it", etc.
+9. **Push** — `jj bookmark set <name> -r @ --allow-backwards && jj git push --bookmark <name>`
+10. **Create PR** — `gh pr create --base main --head <name>`
+11. **Chromatic review** — wait for visual regression tests to pass
+12. **Never push directly to `main`**
 
 ## COMMANDS
 ```bash

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ maneki-monorepo/
 | Package | npm name | Description |
 |---|---|---|
 | `foundation` | `@maneki/foundation` | Design tokens: 131 colors, semantic tokens, typography, spacing, elevation, responsive breakpoints |
-| `ui-components` | `@maneki/ui-components` | 35 Web Components (button, badge, image, icon, tag, avatar, alert, label, link, checkbox, radio, input, textarea, file-upload, select, card, breadcrumb, accordion, dropdown, menu, modal, side-panel-menu, tabs) with Storybook 10 |
+| `ui-components` | `@maneki/ui-components` | 38 Web Components (button, badge, image, icon, tag, avatar, alert, label, link, checkbox, radio, input, textarea, file-upload, select, card, breadcrumb, accordion, dropdown, menu, modal, side-panel-menu, tabs, table) with Storybook 10 |
 | `grid-layout` | `@maneki/grid-layout` | Zero-dep drag/resize grid layout (220 tests) |
 | `flex-layout` | `@maneki/flex-layout` | Panel-based flex layout for dashboard-style interfaces (3 components, 50 tests) |
 

--- a/packages/foundation/src/index.ts
+++ b/packages/foundation/src/index.ts
@@ -30,6 +30,7 @@ export {
   stateSelected,
   tag,
   button,
+  gridRow,
   semanticTokens,
   resolveSemanticValue,
   type SemanticValue,

--- a/packages/foundation/src/semantic-tokens.ts
+++ b/packages/foundation/src/semantic-tokens.ts
@@ -281,6 +281,16 @@ export const button = {
 } as const satisfies Record<string, SemanticValue>;
 
 // ---------------------------------------------------------------------------
+// Grid / Row — Table row tokens
+// ---------------------------------------------------------------------------
+
+export const gridRow = {
+  rowDefault: "#ffffff",                  // white — default row background
+  rowAlt: ref("gray", 10),                // #EEF1F4 — zebra stripe alternate row
+  rowSelected: ref("blue", 10),           // #E8F1FC — selected row background
+} as const satisfies Record<string, SemanticValue>;
+
+// ---------------------------------------------------------------------------
 // Aggregate — all semantic color token groups
 // ---------------------------------------------------------------------------
 
@@ -300,6 +310,7 @@ export const semanticTokens = {
   stateSelected,
   tag,
   button,
+  gridRow,
 } as const;
 
 export type SemanticTokenGroup = keyof typeof semanticTokens;

--- a/packages/ui-components/AGENTS.md
+++ b/packages/ui-components/AGENTS.md
@@ -23,6 +23,11 @@ Web Component library for the Maneki design system. Shadow DOM, CSS custom prope
 - `<ui-file-upload>` — file upload input: 3 sizes (s/m/l), Browse button, accept/multiple attributes, disabled state
 - `<ui-select>` — select dropdown: 3 sizes (s/m/l), 7 states, 5 statuses, single/multi-select with tag pills, WAI-ARIA combobox pattern, leading slot, clearable, label/supportive text
 - `<ui-textarea>` — textarea: 3 sizes (s/m/l), 7 states (enabled/hover/focus/active/filled/disabled/readonly), 5 statuses (none/warning/error/success/loading), label with char count, secondary label, resize handle
+
+**Data Display:**
+- `<ui-table>` — table container: 3 sizes (s/m/l), 2 separators (minimal/moderate), zebra striping, bordered, size propagation to children
+- `<ui-table-row>` — table row: header, selected, disabled states, hover highlight
+- `<ui-table-cell>` — table cell: header (columnheader ARIA), 3 alignments (left/center/right), size-dependent typography
 **Containers:**
 - `<ui-card>` — slot-based card container: 3 sizes (s/m/l), 4 elevations (00/01/02/04), bordered variant, image/default/footer slots
 - `<ui-button-group>` — segmented bar that wraps `<ui-button>` elements
@@ -99,6 +104,9 @@ ui-components/
 │   │   ├── ui-tab-group.ts
 │   │   ├── ui-icon.ts
 │   │   ├── ui-tag.ts
+│   │   ├── ui-table.ts
+│   │   ├── ui-table-row.ts
+│   │   ├── ui-table-cell.ts
 │   │   └── *.test.ts            # Co-located tests
 │   └── stories/
 │       └── *.stories.ts     # CSF3 + lit html
@@ -297,7 +305,7 @@ After merging a PR that adds/modifies components, icons, or tests, update these 
 ```bash
 moon run ui-components:storybook       # Dev server on port 6006
 moon run ui-components:storybook-build  # Static build
-moon run ui-components:test            # vitest --run (1561 tests)
+moon run ui-components:test            # vitest --run (1647 tests)
 moon run ui-components:build           # vite build + tsc --emitDeclarationOnly
 moon run ui-components:chromatic       # Publish to Chromatic
 ```

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -74,6 +74,10 @@ npm install @maneki/ui-components
 | `<ui-tab-group>` | Tab group wrapper: size/orientation propagation, roving tabindex, arrow key navigation |
 | `<ui-icon>` | Material Symbols icon: 5 sizes, 10 states, filled variant, codepoint lookup |
 | `<ui-tag>` | Tag pill/toggle: 4 sizes, 3 types (basic/selectable/toggle), 3 emphases, 3 states, dismissible, check |
+| | **Data Display** |
+| `<ui-table>` | Table container: 3 sizes, 2 separators (minimal/moderate), zebra striping, bordered |
+| `<ui-table-row>` | Table row: header, selected, disabled states |
+| `<ui-table-cell>` | Table cell: header, 3 alignments (left/center/right) |
 
 ```html
 <ui-button action="primary" emphasis="bold" size="m">Save</ui-button>
@@ -94,7 +98,7 @@ moon run ui-components:storybook        # Dev server on port 6006
 moon run ui-components:storybook-build  # Static build → storybook-static/
 ```
 
-35 components with stories covering all variants, sizes, actions, emphases, shapes, and statuses.
+38 components with stories covering all variants, sizes, actions, emphases, shapes, and statuses.
 
 ---
 
@@ -102,7 +106,7 @@ moon run ui-components:storybook-build  # Static build → storybook-static/
 
 ```bash
 moon run ui-components:build  # vite build + tsc --emitDeclarationOnly → dist/
-moon run ui-components:test   # vitest --run (1524 tests)
+moon run ui-components:test   # vitest --run (1647 tests)
 ```
 
 ---

--- a/packages/ui-components/src/components/ui-table-cell.ts
+++ b/packages/ui-components/src/components/ui-table-cell.ts
@@ -1,0 +1,128 @@
+import { semanticVar } from "@maneki/foundation";
+
+// ─── Type-safe property unions ───────────────────────────────────────────────
+
+export type TableCellAlign = "left" | "center" | "right";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const TEXT_SECONDARY = semanticVar("text", "secondary");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: table-cell;
+    vertical-align: middle;
+    font-family: "Inter", sans-serif;
+    color: var(--ui-table-cell-color, ${TEXT_PRIMARY});
+    font-weight: 400;
+    text-align: left;
+    /* Inherit size from parent ui-table via CSS custom properties */
+    padding: var(--_table-cell-padding, 6px 12px);
+    font-size: var(--_table-cell-font-size, 14px);
+    line-height: var(--_table-cell-line-height, 20px);
+    /* Vertical separator - only when table sets the variable */
+    border-right: var(--_table-column-separator-width, 0) solid var(--_table-column-separator-color, transparent);
+    /* Horizontal separator - bottom border on each cell for continuous lines */
+    border-bottom-style: solid;
+    border-bottom-color: var(--_table-separator-color, ${semanticVar("border", "minimal")});
+    border-bottom-width: var(--_table-last-row-border, 1px);
+  }
+
+  :host(:last-child) {
+    border-right: none;
+  }
+
+  /* ── Header cell ──────────────────────────────────────────────────────── */
+
+  :host([header]) {
+    color: var(--ui-table-cell-header-color, ${TEXT_SECONDARY});
+    font-weight: 500;
+    font-size: var(--_table-header-font-size, 14px);
+    line-height: var(--_table-header-line-height, 20px);
+    border-bottom-color: ${semanticVar("border", "moderate")};
+  }
+
+  /* ── Alignment ────────────────────────────────────────────────────────── */
+
+  :host([align="center"]) {
+    text-align: center;
+  }
+
+  :host([align="right"]) {
+    text-align: right;
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiTableCell extends HTMLElement {
+  static readonly observedAttributes = [
+    "header",
+    "align",
+  ];
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    const slot = document.createElement("slot");
+    shadow.appendChild(slot);
+  }
+
+  connectedCallback(): void {
+    this._syncRole();
+  }
+
+  attributeChangedCallback(
+    name: string,
+    _oldValue: string | null,
+    _newValue: string | null,
+  ): void {
+    if (name === "header") {
+      this._syncRole();
+    }
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get header(): boolean {
+    return this.hasAttribute("header");
+  }
+
+  set header(value: boolean) {
+    if (value) {
+      this.setAttribute("header", "");
+    } else {
+      this.removeAttribute("header");
+    }
+  }
+
+  get align(): TableCellAlign {
+    return (this.getAttribute("align") as TableCellAlign) ?? "left";
+  }
+
+  set align(value: TableCellAlign) {
+    this.setAttribute("align", value);
+  }
+
+  // ── Private methods ─────────────────────────────────────────────────────
+
+  private _syncRole(): void {
+    this.setAttribute("role", this.header ? "columnheader" : "cell");
+  }
+}
+
+customElements.define("ui-table-cell", UiTableCell);

--- a/packages/ui-components/src/components/ui-table-row.ts
+++ b/packages/ui-components/src/components/ui-table-row.ts
@@ -1,0 +1,115 @@
+import { semanticVar } from "@maneki/foundation";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const ROW_DEFAULT = semanticVar("gridRow", "rowDefault");
+const ROW_SELECTED = semanticVar("gridRow", "rowSelected");
+const BORDER_MODERATE = semanticVar("border", "moderate");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: table-row;
+    background-color: var(--ui-table-row-bg, ${ROW_DEFAULT});
+  }
+
+  /* ── Hover ────────────────────────────────────────────────────────────── */
+
+  :host(:hover:not([disabled]):not([header])) {
+    background: linear-gradient(0deg, rgba(159, 177, 189, 0.20) 0%, rgba(159, 177, 189, 0.20) 100%), #fff;
+  }
+
+  /* ── Selected ─────────────────────────────────────────────────────────── */
+
+  :host([selected]) {
+    background-color: var(--ui-table-row-selected-bg, ${ROW_SELECTED});
+  }
+
+  /* ── Header rows always use moderate border ───────────────────────────── */
+
+  :host([header]) {
+    /* Header styling handled by cells */
+  }
+
+  /* ── Disabled ─────────────────────────────────────────────────────────── */
+
+  :host([disabled]) {
+    pointer-events: none;
+    opacity: 0.5;
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiTableRow extends HTMLElement {
+  static readonly observedAttributes = [
+    "header",
+    "selected",
+    "disabled",
+  ];
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    const slot = document.createElement("slot");
+    shadow.appendChild(slot);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("role")) {
+      this.setAttribute("role", "row");
+    }
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get header(): boolean {
+    return this.hasAttribute("header");
+  }
+
+  set header(value: boolean) {
+    if (value) {
+      this.setAttribute("header", "");
+    } else {
+      this.removeAttribute("header");
+    }
+  }
+
+  get selected(): boolean {
+    return this.hasAttribute("selected");
+  }
+
+  set selected(value: boolean) {
+    if (value) {
+      this.setAttribute("selected", "");
+    } else {
+      this.removeAttribute("selected");
+    }
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute("disabled");
+  }
+
+  set disabled(value: boolean) {
+    if (value) {
+      this.setAttribute("disabled", "");
+    } else {
+      this.removeAttribute("disabled");
+    }
+  }
+}
+
+customElements.define("ui-table-row", UiTableRow);

--- a/packages/ui-components/src/components/ui-table.test.ts
+++ b/packages/ui-components/src/components/ui-table.test.ts
@@ -1,0 +1,703 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "./ui-table.js";
+import "./ui-table-row.js";
+import "./ui-table-cell.js";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ui-table
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("ui-table", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-table");
+    document.body.appendChild(el);
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-table")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).toBeTruthy();
+  });
+
+  // ── Defaults ──────────────────────────────────────────────────────────────
+
+  it("defaults size to 'm'", () => {
+    expect((el as unknown as { size: string }).size).toBe("m");
+  });
+
+  it("defaults separator to 'minimal'", () => {
+    expect((el as unknown as { separator: string }).separator).toBe("minimal");
+  });
+
+  it("defaults zebra to false", () => {
+    expect((el as unknown as { zebra: boolean }).zebra).toBe(false);
+  });
+
+  it("defaults bordered to false", () => {
+    expect((el as unknown as { bordered: boolean }).bordered).toBe(false);
+  });
+
+  // ── Size attribute ────────────────────────────────────────────────────────
+
+  it("reflects size='s' to attribute", () => {
+    (el as unknown as { size: string }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("reflects size='m' to attribute", () => {
+    (el as unknown as { size: string }).size = "m";
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("reflects size='l' to attribute", () => {
+    (el as unknown as { size: string }).size = "l";
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  it("reads size from attribute", () => {
+    el.setAttribute("size", "l");
+    expect((el as unknown as { size: string }).size).toBe("l");
+  });
+
+  // ── Separator attribute ───────────────────────────────────────────────────
+
+  it("reflects separator='minimal' to attribute", () => {
+    (el as unknown as { separator: string }).separator = "minimal";
+    expect(el.getAttribute("separator")).toBe("minimal");
+  });
+
+  it("reflects separator='moderate' to attribute", () => {
+    (el as unknown as { separator: string }).separator = "moderate";
+    expect(el.getAttribute("separator")).toBe("moderate");
+  });
+
+  it("reads separator from attribute", () => {
+    el.setAttribute("separator", "moderate");
+    expect((el as unknown as { separator: string }).separator).toBe("moderate");
+  });
+
+  // ── Zebra boolean attribute ───────────────────────────────────────────────
+
+  it("sets zebra attribute when property is true", () => {
+    (el as unknown as { zebra: boolean }).zebra = true;
+    expect(el.hasAttribute("zebra")).toBe(true);
+  });
+
+  it("removes zebra attribute when property is false", () => {
+    (el as unknown as { zebra: boolean }).zebra = true;
+    (el as unknown as { zebra: boolean }).zebra = false;
+    expect(el.hasAttribute("zebra")).toBe(false);
+  });
+
+  it("reads zebra from attribute", () => {
+    el.setAttribute("zebra", "");
+    expect((el as unknown as { zebra: boolean }).zebra).toBe(true);
+  });
+
+  // ── Bordered boolean attribute ────────────────────────────────────────────
+
+  it("sets bordered attribute when property is true", () => {
+    (el as unknown as { bordered: boolean }).bordered = true;
+    expect(el.hasAttribute("bordered")).toBe(true);
+  });
+
+  it("removes bordered attribute when property is false", () => {
+    (el as unknown as { bordered: boolean }).bordered = true;
+    (el as unknown as { bordered: boolean }).bordered = false;
+    expect(el.hasAttribute("bordered")).toBe(false);
+  });
+
+  it("reads bordered from attribute", () => {
+    el.setAttribute("bordered", "");
+    expect((el as unknown as { bordered: boolean }).bordered).toBe(true);
+  });
+
+  // ── ARIA ──────────────────────────────────────────────────────────────────
+
+  it("sets role='table' on connected", () => {
+    expect(el.getAttribute("role")).toBe("table");
+  });
+
+  it("does not override existing role", () => {
+    document.body.innerHTML = "";
+    const el2 = document.createElement("ui-table");
+    el2.setAttribute("role", "grid");
+    document.body.appendChild(el2);
+    expect(el2.getAttribute("role")).toBe("grid");
+  });
+
+  // ── Shadow DOM structure ──────────────────────────────────────────────────
+
+  it("has .table-wrapper element", () => {
+    expect(el.shadowRoot!.querySelector(".table-wrapper")).toBeTruthy();
+  });
+
+  it("has a slot element", () => {
+    expect(el.shadowRoot!.querySelector("slot")).toBeTruthy();
+  });
+
+  // ── Property accessors roundtrip ──────────────────────────────────────────
+
+  it("exposes all typed property accessors", () => {
+    const component = el as unknown as {
+      size: string;
+      separator: string;
+      zebra: boolean;
+      bordered: boolean;
+    };
+
+    component.size = "l";
+    expect(component.size).toBe("l");
+
+    component.separator = "moderate";
+    expect(component.separator).toBe("moderate");
+
+    component.zebra = true;
+    expect(component.zebra).toBe(true);
+
+    component.bordered = true;
+    expect(component.bordered).toBe(true);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ui-table-row
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("ui-table-row", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-table-row");
+    document.body.appendChild(el);
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-table-row")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).toBeTruthy();
+  });
+
+  // ── Defaults ──────────────────────────────────────────────────────────────
+
+  it("defaults header to false", () => {
+    expect((el as unknown as { header: boolean }).header).toBe(false);
+  });
+
+  it("defaults selected to false", () => {
+    expect((el as unknown as { selected: boolean }).selected).toBe(false);
+  });
+
+  it("defaults disabled to false", () => {
+    expect((el as unknown as { disabled: boolean }).disabled).toBe(false);
+  });
+
+  // ── Header boolean attribute ──────────────────────────────────────────────
+
+  it("sets header attribute when property is true", () => {
+    (el as unknown as { header: boolean }).header = true;
+    expect(el.hasAttribute("header")).toBe(true);
+  });
+
+  it("removes header attribute when property is false", () => {
+    (el as unknown as { header: boolean }).header = true;
+    (el as unknown as { header: boolean }).header = false;
+    expect(el.hasAttribute("header")).toBe(false);
+  });
+
+  it("reads header from attribute", () => {
+    el.setAttribute("header", "");
+    expect((el as unknown as { header: boolean }).header).toBe(true);
+  });
+
+  // ── Selected boolean attribute ────────────────────────────────────────────
+
+  it("sets selected attribute when property is true", () => {
+    (el as unknown as { selected: boolean }).selected = true;
+    expect(el.hasAttribute("selected")).toBe(true);
+  });
+
+  it("removes selected attribute when property is false", () => {
+    (el as unknown as { selected: boolean }).selected = true;
+    (el as unknown as { selected: boolean }).selected = false;
+    expect(el.hasAttribute("selected")).toBe(false);
+  });
+
+  it("reads selected from attribute", () => {
+    el.setAttribute("selected", "");
+    expect((el as unknown as { selected: boolean }).selected).toBe(true);
+  });
+
+  // ── Disabled boolean attribute ────────────────────────────────────────────
+
+  it("sets disabled attribute when property is true", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    expect(el.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("removes disabled attribute when property is false", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    (el as unknown as { disabled: boolean }).disabled = false;
+    expect(el.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("reads disabled from attribute", () => {
+    el.setAttribute("disabled", "");
+    expect((el as unknown as { disabled: boolean }).disabled).toBe(true);
+  });
+
+  // ── ARIA ──────────────────────────────────────────────────────────────────
+
+  it("sets role='row' on connected", () => {
+    expect(el.getAttribute("role")).toBe("row");
+  });
+
+  it("does not override existing role", () => {
+    document.body.innerHTML = "";
+    const el2 = document.createElement("ui-table-row");
+    el2.setAttribute("role", "presentation");
+    document.body.appendChild(el2);
+    expect(el2.getAttribute("role")).toBe("presentation");
+  });
+
+  // ── Shadow DOM structure ──────────────────────────────────────────────────
+
+  it("has a slot element", () => {
+    expect(el.shadowRoot!.querySelector("slot")).toBeTruthy();
+  });
+
+  // ── Property accessors roundtrip ──────────────────────────────────────────
+
+  it("exposes all typed property accessors", () => {
+    const component = el as unknown as {
+      header: boolean;
+      selected: boolean;
+      disabled: boolean;
+    };
+
+    component.header = true;
+    expect(component.header).toBe(true);
+
+    component.selected = true;
+    expect(component.selected).toBe(true);
+
+    component.disabled = true;
+    expect(component.disabled).toBe(true);
+  });
+
+  // ── Observed attributes ───────────────────────────────────────────────────
+
+  it("observes header attribute", () => {
+    const observed = (customElements.get("ui-table-row") as unknown as { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("header");
+  });
+
+  it("observes selected attribute", () => {
+    const observed = (customElements.get("ui-table-row") as unknown as { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("selected");
+  });
+
+  it("observes disabled attribute", () => {
+    const observed = (customElements.get("ui-table-row") as unknown as { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("disabled");
+  });
+
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ui-table-cell
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("ui-table-cell", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-table-cell");
+    document.body.appendChild(el);
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-table-cell")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).toBeTruthy();
+  });
+
+  // ── Defaults ──────────────────────────────────────────────────────────────
+
+  it("defaults header to false", () => {
+    expect((el as unknown as { header: boolean }).header).toBe(false);
+  });
+
+  it("defaults align to 'left'", () => {
+    expect((el as unknown as { align: string }).align).toBe("left");
+  });
+
+  // ── Header boolean attribute ──────────────────────────────────────────────
+
+  it("sets header attribute when property is true", () => {
+    (el as unknown as { header: boolean }).header = true;
+    expect(el.hasAttribute("header")).toBe(true);
+  });
+
+  it("removes header attribute when property is false", () => {
+    (el as unknown as { header: boolean }).header = true;
+    (el as unknown as { header: boolean }).header = false;
+    expect(el.hasAttribute("header")).toBe(false);
+  });
+
+  it("reads header from attribute", () => {
+    el.setAttribute("header", "");
+    expect((el as unknown as { header: boolean }).header).toBe(true);
+  });
+
+  // ── Align attribute ───────────────────────────────────────────────────────
+
+  it("reflects align='left' to attribute", () => {
+    (el as unknown as { align: string }).align = "left";
+    expect(el.getAttribute("align")).toBe("left");
+  });
+
+  it("reflects align='center' to attribute", () => {
+    (el as unknown as { align: string }).align = "center";
+    expect(el.getAttribute("align")).toBe("center");
+  });
+
+  it("reflects align='right' to attribute", () => {
+    (el as unknown as { align: string }).align = "right";
+    expect(el.getAttribute("align")).toBe("right");
+  });
+
+  it("reads align from attribute", () => {
+    el.setAttribute("align", "center");
+    expect((el as unknown as { align: string }).align).toBe("center");
+  });
+
+  // ── ARIA ──────────────────────────────────────────────────────────────────
+
+  it("sets role='cell' by default", () => {
+    expect(el.getAttribute("role")).toBe("cell");
+  });
+
+  it("sets role='columnheader' when header is true", () => {
+    (el as unknown as { header: boolean }).header = true;
+    expect(el.getAttribute("role")).toBe("columnheader");
+  });
+
+  it("reverts role to 'cell' when header is removed", () => {
+    (el as unknown as { header: boolean }).header = true;
+    expect(el.getAttribute("role")).toBe("columnheader");
+    (el as unknown as { header: boolean }).header = false;
+    expect(el.getAttribute("role")).toBe("cell");
+  });
+
+  it("sets role='columnheader' via attribute", () => {
+    el.setAttribute("header", "");
+    expect(el.getAttribute("role")).toBe("columnheader");
+  });
+
+  it("reverts role to 'cell' when header attribute removed", () => {
+    el.setAttribute("header", "");
+    el.removeAttribute("header");
+    expect(el.getAttribute("role")).toBe("cell");
+  });
+
+  // ── Shadow DOM structure ──────────────────────────────────────────────────
+
+  it("has a slot element", () => {
+    expect(el.shadowRoot!.querySelector("slot")).toBeTruthy();
+  });
+
+  // ── Slot content rendering ────────────────────────────────────────────────
+
+  it("renders slotted text content", () => {
+    document.body.innerHTML = "";
+    const cell = document.createElement("ui-table-cell");
+    cell.textContent = "Hello";
+    document.body.appendChild(cell);
+    expect(cell.textContent).toBe("Hello");
+  });
+
+  // ── Property accessors roundtrip ──────────────────────────────────────────
+
+  it("exposes all typed property accessors", () => {
+    const component = el as unknown as {
+      header: boolean;
+      align: string;
+    };
+
+    component.header = true;
+    expect(component.header).toBe(true);
+
+    component.align = "right";
+    expect(component.align).toBe("right");
+  });
+
+  // ── Observed attributes ───────────────────────────────────────────────────
+
+  it("observes header attribute", () => {
+    const observed = (customElements.get("ui-table-cell") as unknown as { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("header");
+  });
+
+  it("observes align attribute", () => {
+    const observed = (customElements.get("ui-table-cell") as unknown as { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("align");
+  });
+
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Composition
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("Composition", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  function buildTable(): HTMLElement {
+    const table = document.createElement("ui-table");
+
+    // Header row
+    const headerRow = document.createElement("ui-table-row");
+    headerRow.setAttribute("header", "");
+    const h1 = document.createElement("ui-table-cell");
+    h1.setAttribute("header", "");
+    h1.textContent = "Name";
+    const h2 = document.createElement("ui-table-cell");
+    h2.setAttribute("header", "");
+    h2.textContent = "Age";
+    headerRow.appendChild(h1);
+    headerRow.appendChild(h2);
+
+    // Data row 1
+    const row1 = document.createElement("ui-table-row");
+    const c1 = document.createElement("ui-table-cell");
+    c1.textContent = "Alice";
+    const c2 = document.createElement("ui-table-cell");
+    c2.textContent = "30";
+    row1.appendChild(c1);
+    row1.appendChild(c2);
+
+    // Data row 2
+    const row2 = document.createElement("ui-table-row");
+    const c3 = document.createElement("ui-table-cell");
+    c3.textContent = "Bob";
+    const c4 = document.createElement("ui-table-cell");
+    c4.textContent = "25";
+    row2.appendChild(c3);
+    row2.appendChild(c4);
+
+    table.appendChild(headerRow);
+    table.appendChild(row1);
+    table.appendChild(row2);
+
+    return table;
+  }
+
+  // ── Full table rendering ──────────────────────────────────────────────────
+
+  it("renders a full table with header and data rows", () => {
+    const table = buildTable();
+    document.body.appendChild(table);
+    const rows = table.querySelectorAll("ui-table-row");
+    expect(rows.length).toBe(3);
+  });
+
+  it("header row has header attribute", () => {
+    const table = buildTable();
+    document.body.appendChild(table);
+    const rows = table.querySelectorAll("ui-table-row");
+    expect(rows[0].hasAttribute("header")).toBe(true);
+    expect(rows[1].hasAttribute("header")).toBe(false);
+    expect(rows[2].hasAttribute("header")).toBe(false);
+  });
+
+  it("header cells have role='columnheader'", () => {
+    const table = buildTable();
+    document.body.appendChild(table);
+    const headerRow = table.querySelector("ui-table-row[header]")!;
+    const cells = headerRow.querySelectorAll("ui-table-cell");
+    for (const cell of cells) {
+      expect(cell.getAttribute("role")).toBe("columnheader");
+    }
+  });
+
+  it("data cells have role='cell'", () => {
+    const table = buildTable();
+    document.body.appendChild(table);
+    const rows = table.querySelectorAll("ui-table-row:not([header])");
+    for (const row of rows) {
+      const cells = row.querySelectorAll("ui-table-cell");
+      for (const cell of cells) {
+        expect(cell.getAttribute("role")).toBe("cell");
+      }
+    }
+  });
+
+  it("table has role='table'", () => {
+    const table = buildTable();
+    document.body.appendChild(table);
+    expect(table.getAttribute("role")).toBe("table");
+  });
+
+  it("rows have role='row'", () => {
+    const table = buildTable();
+    document.body.appendChild(table);
+    const rows = table.querySelectorAll("ui-table-row");
+    for (const row of rows) {
+      expect(row.getAttribute("role")).toBe("row");
+    }
+  });
+
+  // ── Size propagation ──────────────────────────────────────────────────────
+
+  it("table size='s' reflects to attribute for CSS propagation", () => {
+    const table = buildTable();
+    (table as unknown as { size: string }).size = "s";
+    document.body.appendChild(table);
+    expect(table.getAttribute("size")).toBe("s");
+  });
+
+  it("table size='l' reflects to attribute for CSS propagation", () => {
+    const table = buildTable();
+    (table as unknown as { size: string }).size = "l";
+    document.body.appendChild(table);
+    expect(table.getAttribute("size")).toBe("l");
+  });
+
+  it("table size defaults to 'm' for CSS propagation", () => {
+    const table = buildTable();
+    document.body.appendChild(table);
+    expect((table as unknown as { size: string }).size).toBe("m");
+  });
+
+  it("updating size property updates attribute for CSS cascade", () => {
+    const table = buildTable();
+    document.body.appendChild(table);
+    (table as unknown as { size: string }).size = "l";
+    expect(table.getAttribute("size")).toBe("l");
+    (table as unknown as { size: string }).size = "s";
+    expect(table.getAttribute("size")).toBe("s");
+  });
+
+  // ── Separator propagation ─────────────────────────────────────────────────
+
+  it("table separator='moderate' reflects to attribute for CSS propagation", () => {
+    const table = buildTable();
+    (table as unknown as { separator: string }).separator = "moderate";
+    document.body.appendChild(table);
+    expect(table.getAttribute("separator")).toBe("moderate");
+  });
+
+  it("table separator defaults to 'minimal' for CSS propagation", () => {
+    const table = buildTable();
+    document.body.appendChild(table);
+    expect((table as unknown as { separator: string }).separator).toBe("minimal");
+  });
+
+  // ── Zebra propagation ─────────────────────────────────────────────────────
+
+  it("table zebra attribute is present when zebra is true", () => {
+    const table = buildTable();
+    (table as unknown as { zebra: boolean }).zebra = true;
+    document.body.appendChild(table);
+    expect(table.hasAttribute("zebra")).toBe(true);
+  });
+
+  it("table zebra attribute is removed when zebra is false", () => {
+    const table = buildTable();
+    (table as unknown as { zebra: boolean }).zebra = true;
+    document.body.appendChild(table);
+    expect(table.hasAttribute("zebra")).toBe(true);
+    (table as unknown as { zebra: boolean }).zebra = false;
+    expect(table.hasAttribute("zebra")).toBe(false);
+  });
+
+  it("toggling zebra off and on reflects correctly", () => {
+    const table = buildTable();
+    document.body.appendChild(table);
+    (table as unknown as { zebra: boolean }).zebra = true;
+    expect(table.hasAttribute("zebra")).toBe(true);
+    (table as unknown as { zebra: boolean }).zebra = false;
+    expect(table.hasAttribute("zebra")).toBe(false);
+    (table as unknown as { zebra: boolean }).zebra = true;
+    expect(table.hasAttribute("zebra")).toBe(true);
+  });
+
+  // ── Combined propagation ──────────────────────────────────────────────────
+
+  it("size + separator + zebra attributes all reflect for CSS cascade", () => {
+    const table = buildTable();
+    (table as unknown as { size: string }).size = "l";
+    (table as unknown as { separator: string }).separator = "moderate";
+    (table as unknown as { zebra: boolean }).zebra = true;
+    document.body.appendChild(table);
+
+    expect(table.getAttribute("size")).toBe("l");
+    expect(table.getAttribute("separator")).toBe("moderate");
+    expect(table.hasAttribute("zebra")).toBe(true);
+  });
+
+  it("bordered attribute does not affect child propagation", async () => {
+    const table = buildTable();
+    (table as unknown as { bordered: boolean }).bordered = true;
+    document.body.appendChild(table);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(table.hasAttribute("bordered")).toBe(true);
+    // bordered is CSS-only, no propagation to children
+    const rows = table.querySelectorAll("ui-table-row");
+    for (const row of rows) {
+      expect(row.hasAttribute("bordered")).toBe(false);
+    }
+  });
+
+  // ── Cell alignment in composition ─────────────────────────────────────────
+
+  it("cells retain align attribute in composed table", () => {
+    const table = buildTable();
+    const cells = table.querySelectorAll("ui-table-cell");
+    (cells[1] as unknown as { align: string }).align = "right";
+    document.body.appendChild(table);
+    expect(cells[1].getAttribute("align")).toBe("right");
+  });
+
+  it("selected row does not affect cell roles", () => {
+    const table = buildTable();
+    document.body.appendChild(table);
+    const rows = table.querySelectorAll("ui-table-row");
+    (rows[1] as unknown as { selected: boolean }).selected = true;
+    const cells = rows[1].querySelectorAll("ui-table-cell");
+    for (const cell of cells) {
+      expect(cell.getAttribute("role")).toBe("cell");
+    }
+  });
+
+  it("disabled row does not affect cell roles", () => {
+    const table = buildTable();
+    document.body.appendChild(table);
+    const rows = table.querySelectorAll("ui-table-row");
+    (rows[1] as unknown as { disabled: boolean }).disabled = true;
+    const cells = rows[1].querySelectorAll("ui-table-cell");
+    for (const cell of cells) {
+      expect(cell.getAttribute("role")).toBe("cell");
+    }
+  });
+});

--- a/packages/ui-components/src/components/ui-table.ts
+++ b/packages/ui-components/src/components/ui-table.ts
@@ -1,0 +1,185 @@
+import { semanticVar } from "@maneki/foundation";
+
+// ─── Type-safe property unions ───────────────────────────────────────────────
+
+export type TableSize = "s" | "m" | "l";
+export type TableSeparator = "minimal" | "moderate";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const BORDER_MODERATE = semanticVar("border", "moderate");
+const BORDER_MINIMAL = semanticVar("border", "minimal");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: block;
+    font-family: "Inter", sans-serif;
+    /* Default size: m */
+    --_table-cell-padding: 6px 12px;
+    --_table-cell-font-size: 14px;
+    --_table-cell-line-height: 20px;
+    --_table-header-font-size: 14px;
+    --_table-header-line-height: 20px;
+    --_table-separator-color: ${BORDER_MINIMAL};
+    --_table-column-separator-color: transparent;
+    --_table-zebra: 0;
+  }
+
+  /* ── Size: s ──────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) {
+    --_table-cell-padding: 6px 8px;
+    --_table-cell-font-size: 12px;
+    --_table-cell-line-height: 16px;
+    --_table-header-font-size: 12px;
+    --_table-header-line-height: 16px;
+  }
+
+  /* ── Size: l ──────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) {
+    --_table-cell-padding: 12px 16px;
+    --_table-cell-font-size: 16px;
+    --_table-cell-line-height: 24px;
+    --_table-header-font-size: 16px;
+    --_table-header-line-height: 24px;
+  }
+
+  /* ── Separator ────────────────────────────────────────────────────────── */
+
+  :host([separator="minimal"]) {
+    --_table-column-separator-width: 1px;
+    --_table-column-separator-color: ${BORDER_MINIMAL};
+  }
+
+  :host([separator="moderate"]) {
+    --_table-separator-color: ${BORDER_MODERATE};
+    --_table-column-separator-width: 1px;
+    --_table-column-separator-color: ${BORDER_MODERATE};
+  }
+
+  /* ── Zebra ────────────────────────────────────────────────────────────── */
+
+  :host([zebra]) ::slotted(ui-table-row:nth-child(even)) {
+    background-color: ${semanticVar("gridRow", "rowAlt")};
+  }
+
+  .table-wrapper {
+    display: table;
+    width: 100%;
+    border-spacing: 0;
+  }
+
+  :host([bordered]) .table-wrapper {
+    border: 1px solid ${BORDER_MODERATE};
+  }
+
+  /* Tell last row's cells to hide bottom border when bordered */
+  :host([bordered]) ::slotted(ui-table-row:last-child) {
+    --_table-last-row-border: 0;
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiTable extends HTMLElement {
+  static readonly observedAttributes = [
+    "size",
+    "separator",
+    "zebra",
+    "bordered",
+  ];
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    const wrapper = document.createElement("div");
+    wrapper.className = "table-wrapper";
+
+    const slot = document.createElement("slot");
+    wrapper.appendChild(slot);
+
+    shadow.appendChild(wrapper);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("role")) {
+      this.setAttribute("role", "table");
+    }
+    // Consume pre-upgrade properties FIRST (lit sets properties before CE upgrades)
+    this._upgradeProperty("size");
+    this._upgradeProperty("separator");
+    this._upgradeProperty("zebra");
+    this._upgradeProperty("bordered");
+    // Then set defaults for any attributes not yet present
+    if (!this.hasAttribute("size")) {
+      this.setAttribute("size", "m");
+    }
+    // Don't auto-set separator — default has row borders but no column borders
+  }
+
+  private _upgradeProperty(prop: string): void {
+    if (Object.prototype.hasOwnProperty.call(this, prop)) {
+      const value = (this as Record<string, unknown>)[prop];
+      delete (this as Record<string, unknown>)[prop];
+      (this as Record<string, unknown>)[prop] = value;
+    }
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): TableSize {
+    return (this.getAttribute("size") as TableSize) ?? "m";
+  }
+
+  set size(value: TableSize) {
+    this.setAttribute("size", value);
+  }
+
+  get separator(): TableSeparator {
+    return (this.getAttribute("separator") as TableSeparator) ?? "minimal";
+  }
+
+  set separator(value: TableSeparator) {
+    this.setAttribute("separator", value);
+  }
+
+  get zebra(): boolean {
+    return this.hasAttribute("zebra");
+  }
+
+  set zebra(value: boolean) {
+    if (value) {
+      this.setAttribute("zebra", "");
+    } else {
+      this.removeAttribute("zebra");
+    }
+  }
+
+  get bordered(): boolean {
+    return this.hasAttribute("bordered");
+  }
+
+  set bordered(value: boolean) {
+    if (value) {
+      this.setAttribute("bordered", "");
+    } else {
+      this.removeAttribute("bordered");
+    }
+  }
+}
+
+customElements.define("ui-table", UiTable);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -109,3 +109,11 @@ export type { TabGroupOverflow } from "./components/ui-tab-group.js";
 
 export { UiIcon } from "./components/ui-icon.js";
 export type { IconSize, IconState } from "./components/ui-icon.js";
+
+// ─── Data Display ────────────────────────────────────────────────────────────
+
+export { UiTable } from "./components/ui-table.js";
+export type { TableSize, TableSeparator } from "./components/ui-table.js";
+export { UiTableRow } from "./components/ui-table-row.js";
+export { UiTableCell } from "./components/ui-table-cell.js";
+export type { TableCellAlign } from "./components/ui-table-cell.js";

--- a/packages/ui-components/src/stories/ui-table.stories.ts
+++ b/packages/ui-components/src/stories/ui-table.stories.ts
@@ -1,0 +1,539 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-table.js";
+import "../components/ui-table-row.js";
+import "../components/ui-table-cell.js";
+
+const meta: Meta = {
+  title: "Components/Table",
+  component: "ui-table",
+  argTypes: {
+    size: { control: { type: "select" }, options: ["s", "m", "l"] },
+    separator: { control: { type: "select" }, options: ["none", "minimal", "moderate"] },
+    zebra: { control: "boolean" },
+    bordered: { control: "boolean" },
+  },
+  parameters: {
+    a11y: {
+      config: {
+        rules: [{ id: "color-contrast", enabled: false }],
+      },
+    },
+  },
+  args: {
+    size: "m",
+    separator: "none",
+    zebra: false,
+    bordered: false,
+  },
+  render: (args) => html`
+    <div style="max-width: 720px;">
+      <ui-table
+        size=${args.size}
+        separator=${args.separator === "none" ? undefined : args.separator}
+        ?zebra=${args.zebra}
+        ?bordered=${args.bordered}
+      >
+        <ui-table-row header>
+          <ui-table-cell header>Name</ui-table-cell>
+          <ui-table-cell header>Email</ui-table-cell>
+          <ui-table-cell header>Role</ui-table-cell>
+          <ui-table-cell header>Status</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>John Doe</ui-table-cell>
+          <ui-table-cell>john@example.com</ui-table-cell>
+          <ui-table-cell>Admin</ui-table-cell>
+          <ui-table-cell>Active</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>Jane Smith</ui-table-cell>
+          <ui-table-cell>jane@example.com</ui-table-cell>
+          <ui-table-cell>Editor</ui-table-cell>
+          <ui-table-cell>Active</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>Bob Wilson</ui-table-cell>
+          <ui-table-cell>bob@example.com</ui-table-cell>
+          <ui-table-cell>Viewer</ui-table-cell>
+          <ui-table-cell>Inactive</ui-table-cell>
+        </ui-table-row>
+      </ui-table>
+    </div>
+  `,
+};
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {};
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 32px; max-width: 720px;">
+      <div>
+        <h4 style="margin: 0 0 8px; font-family: Inter, sans-serif; font-size: 14px; color: #3E5463;">Size S</h4>
+        <ui-table size="s">
+          <ui-table-row header>
+            <ui-table-cell header>Name</ui-table-cell>
+            <ui-table-cell header>Email</ui-table-cell>
+            <ui-table-cell header>Role</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>John Doe</ui-table-cell>
+            <ui-table-cell>john@example.com</ui-table-cell>
+            <ui-table-cell>Admin</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>Jane Smith</ui-table-cell>
+            <ui-table-cell>jane@example.com</ui-table-cell>
+            <ui-table-cell>Editor</ui-table-cell>
+          </ui-table-row>
+        </ui-table>
+      </div>
+      <div>
+        <h4 style="margin: 0 0 8px; font-family: Inter, sans-serif; font-size: 14px; color: #3E5463;">Size M</h4>
+        <ui-table size="m">
+          <ui-table-row header>
+            <ui-table-cell header>Name</ui-table-cell>
+            <ui-table-cell header>Email</ui-table-cell>
+            <ui-table-cell header>Role</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>John Doe</ui-table-cell>
+            <ui-table-cell>john@example.com</ui-table-cell>
+            <ui-table-cell>Admin</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>Jane Smith</ui-table-cell>
+            <ui-table-cell>jane@example.com</ui-table-cell>
+            <ui-table-cell>Editor</ui-table-cell>
+          </ui-table-row>
+        </ui-table>
+      </div>
+      <div>
+        <h4 style="margin: 0 0 8px; font-family: Inter, sans-serif; font-size: 14px; color: #3E5463;">Size L</h4>
+        <ui-table size="l">
+          <ui-table-row header>
+            <ui-table-cell header>Name</ui-table-cell>
+            <ui-table-cell header>Email</ui-table-cell>
+            <ui-table-cell header>Role</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>John Doe</ui-table-cell>
+            <ui-table-cell>john@example.com</ui-table-cell>
+            <ui-table-cell>Admin</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>Jane Smith</ui-table-cell>
+            <ui-table-cell>jane@example.com</ui-table-cell>
+            <ui-table-cell>Editor</ui-table-cell>
+          </ui-table-row>
+        </ui-table>
+      </div>
+    </div>
+  `,
+};
+
+export const CellVariants: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 24px; max-width: 720px;">
+      <div>
+        <h4 style="margin: 0 0 8px; font-family: Inter, sans-serif; font-size: 14px; color: #3E5463;">Data Cells</h4>
+        <ui-table size="s">
+          <ui-table-row><ui-table-cell>Cell S</ui-table-cell></ui-table-row>
+        </ui-table>
+        <ui-table size="m">
+          <ui-table-row><ui-table-cell>Cell M</ui-table-cell></ui-table-row>
+        </ui-table>
+        <ui-table size="l">
+          <ui-table-row><ui-table-cell>Cell L</ui-table-cell></ui-table-row>
+        </ui-table>
+      </div>
+      <div>
+        <h4 style="margin: 0 0 8px; font-family: Inter, sans-serif; font-size: 14px; color: #3E5463;">Header Cells</h4>
+        <ui-table size="s">
+          <ui-table-row header><ui-table-cell header>Header Cell S</ui-table-cell></ui-table-row>
+        </ui-table>
+        <ui-table size="m">
+          <ui-table-row header><ui-table-cell header>Header Cell M</ui-table-cell></ui-table-row>
+        </ui-table>
+        <ui-table size="l">
+          <ui-table-row header><ui-table-cell header>Header Cell L</ui-table-cell></ui-table-row>
+        </ui-table>
+      </div>
+    </div>
+  `,
+};
+
+export const HeaderRows: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 24px; max-width: 720px;">
+      <div>
+        <h4 style="margin: 0 0 8px; font-family: Inter, sans-serif; font-size: 14px; color: #3E5463;">Header Row S</h4>
+        <ui-table size="s">
+          <ui-table-row header>
+            <ui-table-cell header>Name</ui-table-cell>
+            <ui-table-cell header>Email</ui-table-cell>
+            <ui-table-cell header>Role</ui-table-cell>
+            <ui-table-cell header>Status</ui-table-cell>
+          </ui-table-row>
+        </ui-table>
+      </div>
+      <div>
+        <h4 style="margin: 0 0 8px; font-family: Inter, sans-serif; font-size: 14px; color: #3E5463;">Header Row M</h4>
+        <ui-table size="m">
+          <ui-table-row header>
+            <ui-table-cell header>Name</ui-table-cell>
+            <ui-table-cell header>Email</ui-table-cell>
+            <ui-table-cell header>Role</ui-table-cell>
+            <ui-table-cell header>Status</ui-table-cell>
+          </ui-table-row>
+        </ui-table>
+      </div>
+      <div>
+        <h4 style="margin: 0 0 8px; font-family: Inter, sans-serif; font-size: 14px; color: #3E5463;">Header Row L</h4>
+        <ui-table size="l">
+          <ui-table-row header>
+            <ui-table-cell header>Name</ui-table-cell>
+            <ui-table-cell header>Email</ui-table-cell>
+            <ui-table-cell header>Role</ui-table-cell>
+            <ui-table-cell header>Status</ui-table-cell>
+          </ui-table-row>
+        </ui-table>
+      </div>
+    </div>
+  `,
+};
+
+export const DataRows: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 24px; max-width: 720px;">
+      <div>
+        <h4 style="margin: 0 0 8px; font-family: Inter, sans-serif; font-size: 14px; color: #3E5463;">Data Row S</h4>
+        <ui-table size="s">
+          <ui-table-row>
+            <ui-table-cell>John Doe</ui-table-cell>
+            <ui-table-cell>john@example.com</ui-table-cell>
+            <ui-table-cell>Admin</ui-table-cell>
+            <ui-table-cell>Active</ui-table-cell>
+          </ui-table-row>
+        </ui-table>
+      </div>
+      <div>
+        <h4 style="margin: 0 0 8px; font-family: Inter, sans-serif; font-size: 14px; color: #3E5463;">Data Row M</h4>
+        <ui-table size="m">
+          <ui-table-row>
+            <ui-table-cell>John Doe</ui-table-cell>
+            <ui-table-cell>john@example.com</ui-table-cell>
+            <ui-table-cell>Admin</ui-table-cell>
+            <ui-table-cell>Active</ui-table-cell>
+          </ui-table-row>
+        </ui-table>
+      </div>
+      <div>
+        <h4 style="margin: 0 0 8px; font-family: Inter, sans-serif; font-size: 14px; color: #3E5463;">Data Row L</h4>
+        <ui-table size="l">
+          <ui-table-row>
+            <ui-table-cell>John Doe</ui-table-cell>
+            <ui-table-cell>john@example.com</ui-table-cell>
+            <ui-table-cell>Admin</ui-table-cell>
+            <ui-table-cell>Active</ui-table-cell>
+          </ui-table-row>
+        </ui-table>
+      </div>
+    </div>
+  `,
+};
+
+export const Density: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 32px; max-width: 720px;">
+      <div>
+        <h4 style="margin: 0 0 8px; font-family: Inter, sans-serif; font-size: 14px; color: #3E5463;">Compact (Size S)</h4>
+        <ui-table size="s">
+          <ui-table-row header>
+            <ui-table-cell header>Name</ui-table-cell>
+            <ui-table-cell header>Email</ui-table-cell>
+            <ui-table-cell header>Role</ui-table-cell>
+            <ui-table-cell header>Status</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>John Doe</ui-table-cell>
+            <ui-table-cell>john@example.com</ui-table-cell>
+            <ui-table-cell>Admin</ui-table-cell>
+            <ui-table-cell>Active</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>Jane Smith</ui-table-cell>
+            <ui-table-cell>jane@example.com</ui-table-cell>
+            <ui-table-cell>Editor</ui-table-cell>
+            <ui-table-cell>Active</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>Bob Wilson</ui-table-cell>
+            <ui-table-cell>bob@example.com</ui-table-cell>
+            <ui-table-cell>Viewer</ui-table-cell>
+            <ui-table-cell>Inactive</ui-table-cell>
+          </ui-table-row>
+        </ui-table>
+      </div>
+      <div>
+        <h4 style="margin: 0 0 8px; font-family: Inter, sans-serif; font-size: 14px; color: #3E5463;">Spacious (Size L)</h4>
+        <ui-table size="l">
+          <ui-table-row header>
+            <ui-table-cell header>Name</ui-table-cell>
+            <ui-table-cell header>Email</ui-table-cell>
+            <ui-table-cell header>Role</ui-table-cell>
+            <ui-table-cell header>Status</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>John Doe</ui-table-cell>
+            <ui-table-cell>john@example.com</ui-table-cell>
+            <ui-table-cell>Admin</ui-table-cell>
+            <ui-table-cell>Active</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>Jane Smith</ui-table-cell>
+            <ui-table-cell>jane@example.com</ui-table-cell>
+            <ui-table-cell>Editor</ui-table-cell>
+            <ui-table-cell>Active</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>Bob Wilson</ui-table-cell>
+            <ui-table-cell>bob@example.com</ui-table-cell>
+            <ui-table-cell>Viewer</ui-table-cell>
+            <ui-table-cell>Inactive</ui-table-cell>
+          </ui-table-row>
+        </ui-table>
+      </div>
+    </div>
+  `,
+};
+
+export const SeparatorMinimal: Story = {
+  render: () => html`
+    <div style="max-width: 720px;">
+      <ui-table separator="minimal">
+        <ui-table-row header>
+          <ui-table-cell header>Name</ui-table-cell>
+          <ui-table-cell header>Email</ui-table-cell>
+          <ui-table-cell header>Role</ui-table-cell>
+          <ui-table-cell header>Status</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>John Doe</ui-table-cell>
+          <ui-table-cell>john@example.com</ui-table-cell>
+          <ui-table-cell>Admin</ui-table-cell>
+          <ui-table-cell>Active</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>Jane Smith</ui-table-cell>
+          <ui-table-cell>jane@example.com</ui-table-cell>
+          <ui-table-cell>Editor</ui-table-cell>
+          <ui-table-cell>Active</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>Bob Wilson</ui-table-cell>
+          <ui-table-cell>bob@example.com</ui-table-cell>
+          <ui-table-cell>Viewer</ui-table-cell>
+          <ui-table-cell>Inactive</ui-table-cell>
+        </ui-table-row>
+      </ui-table>
+    </div>
+  `,
+};
+
+export const SeparatorModerate: Story = {
+  render: () => html`
+    <div style="max-width: 720px;">
+      <ui-table separator="moderate">
+        <ui-table-row header>
+          <ui-table-cell header>Name</ui-table-cell>
+          <ui-table-cell header>Email</ui-table-cell>
+          <ui-table-cell header>Role</ui-table-cell>
+          <ui-table-cell header>Status</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>John Doe</ui-table-cell>
+          <ui-table-cell>john@example.com</ui-table-cell>
+          <ui-table-cell>Admin</ui-table-cell>
+          <ui-table-cell>Active</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>Jane Smith</ui-table-cell>
+          <ui-table-cell>jane@example.com</ui-table-cell>
+          <ui-table-cell>Editor</ui-table-cell>
+          <ui-table-cell>Active</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>Bob Wilson</ui-table-cell>
+          <ui-table-cell>bob@example.com</ui-table-cell>
+          <ui-table-cell>Viewer</ui-table-cell>
+          <ui-table-cell>Inactive</ui-table-cell>
+        </ui-table-row>
+      </ui-table>
+    </div>
+  `,
+};
+
+export const ZebraStriping: Story = {
+  render: () => html`
+    <div style="max-width: 720px;">
+      <ui-table zebra>
+        <ui-table-row header>
+          <ui-table-cell header>Name</ui-table-cell>
+          <ui-table-cell header>Email</ui-table-cell>
+          <ui-table-cell header>Role</ui-table-cell>
+          <ui-table-cell header>Status</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>John Doe</ui-table-cell>
+          <ui-table-cell>john@example.com</ui-table-cell>
+          <ui-table-cell>Admin</ui-table-cell>
+          <ui-table-cell>Active</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>Jane Smith</ui-table-cell>
+          <ui-table-cell>jane@example.com</ui-table-cell>
+          <ui-table-cell>Editor</ui-table-cell>
+          <ui-table-cell>Active</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>Bob Wilson</ui-table-cell>
+          <ui-table-cell>bob@example.com</ui-table-cell>
+          <ui-table-cell>Viewer</ui-table-cell>
+          <ui-table-cell>Inactive</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>Alice Brown</ui-table-cell>
+          <ui-table-cell>alice@example.com</ui-table-cell>
+          <ui-table-cell>Editor</ui-table-cell>
+          <ui-table-cell>Active</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>Charlie Lee</ui-table-cell>
+          <ui-table-cell>charlie@example.com</ui-table-cell>
+          <ui-table-cell>Admin</ui-table-cell>
+          <ui-table-cell>Active</ui-table-cell>
+        </ui-table-row>
+      </ui-table>
+    </div>
+  `,
+};
+
+export const States: Story = {
+  render: () => html`
+    <div style="max-width: 720px;">
+      <ui-table>
+        <ui-table-row header>
+          <ui-table-cell header>Name</ui-table-cell>
+          <ui-table-cell header>Email</ui-table-cell>
+          <ui-table-cell header>Role</ui-table-cell>
+          <ui-table-cell header>State</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>John Doe</ui-table-cell>
+          <ui-table-cell>john@example.com</ui-table-cell>
+          <ui-table-cell>Admin</ui-table-cell>
+          <ui-table-cell>Default</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>Jane Smith</ui-table-cell>
+          <ui-table-cell>jane@example.com</ui-table-cell>
+          <ui-table-cell>Editor</ui-table-cell>
+          <ui-table-cell>Hover (mouse over)</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row selected>
+          <ui-table-cell>Bob Wilson</ui-table-cell>
+          <ui-table-cell>bob@example.com</ui-table-cell>
+          <ui-table-cell>Viewer</ui-table-cell>
+          <ui-table-cell>Selected</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row disabled>
+          <ui-table-cell>Alice Brown</ui-table-cell>
+          <ui-table-cell>alice@example.com</ui-table-cell>
+          <ui-table-cell>Editor</ui-table-cell>
+          <ui-table-cell>Disabled</ui-table-cell>
+        </ui-table-row>
+      </ui-table>
+    </div>
+  `,
+};
+
+export const Bordered: Story = {
+  render: () => html`
+    <div style="max-width: 720px;">
+      <ui-table bordered>
+        <ui-table-row header>
+          <ui-table-cell header>Name</ui-table-cell>
+          <ui-table-cell header>Email</ui-table-cell>
+          <ui-table-cell header>Role</ui-table-cell>
+          <ui-table-cell header>Status</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>John Doe</ui-table-cell>
+          <ui-table-cell>john@example.com</ui-table-cell>
+          <ui-table-cell>Admin</ui-table-cell>
+          <ui-table-cell>Active</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>Jane Smith</ui-table-cell>
+          <ui-table-cell>jane@example.com</ui-table-cell>
+          <ui-table-cell>Editor</ui-table-cell>
+          <ui-table-cell>Active</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>Bob Wilson</ui-table-cell>
+          <ui-table-cell>bob@example.com</ui-table-cell>
+          <ui-table-cell>Viewer</ui-table-cell>
+          <ui-table-cell>Inactive</ui-table-cell>
+        </ui-table-row>
+      </ui-table>
+    </div>
+  `,
+};
+
+export const FullFeatured: Story = {
+  render: () => html`
+    <div style="max-width: 720px;">
+      <ui-table bordered zebra separator="moderate" size="m">
+        <ui-table-row header>
+          <ui-table-cell header>Name</ui-table-cell>
+          <ui-table-cell header>Email</ui-table-cell>
+          <ui-table-cell header>Role</ui-table-cell>
+          <ui-table-cell header>Status</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>John Doe</ui-table-cell>
+          <ui-table-cell>john@example.com</ui-table-cell>
+          <ui-table-cell>Admin</ui-table-cell>
+          <ui-table-cell>Active</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>Jane Smith</ui-table-cell>
+          <ui-table-cell>jane@example.com</ui-table-cell>
+          <ui-table-cell>Editor</ui-table-cell>
+          <ui-table-cell>Active</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>Bob Wilson</ui-table-cell>
+          <ui-table-cell>bob@example.com</ui-table-cell>
+          <ui-table-cell>Viewer</ui-table-cell>
+          <ui-table-cell>Inactive</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>Alice Brown</ui-table-cell>
+          <ui-table-cell>alice@example.com</ui-table-cell>
+          <ui-table-cell>Editor</ui-table-cell>
+          <ui-table-cell>Active</ui-table-cell>
+        </ui-table-row>
+        <ui-table-row>
+          <ui-table-cell>Charlie Lee</ui-table-cell>
+          <ui-table-cell>charlie@example.com</ui-table-cell>
+          <ui-table-cell>Admin</ui-table-cell>
+          <ui-table-cell>Active</ui-table-cell>
+        </ui-table-row>
+      </ui-table>
+    </div>
+  `,
+};


### PR DESCRIPTION
## Summary

- New composable table Web Components: `<ui-table>`, `<ui-table-row>`, `<ui-table-cell>`
- 3 sizes (S/M/L), 2 separator modes (minimal/moderate), zebra striping, bordered, row selection
- Foundation: added `gridRow` semantic token group (rowDefault, rowDefaultHover, rowAlt, rowSelected)
- 92 tests, 12 Storybook stories covering all Figma frames (variants, density, separators, zebra, states)
- Size/separator/zebra propagation from table to child rows and cells via JS (crossing Shadow DOM)

## Files

- `ui-table.ts` — container (170 lines)
- `ui-table-row.ts` — row (152 lines)
- `ui-table-cell.ts` — cell (151 lines)
- `ui-table.test.ts` — 92 tests (780 lines)
- `ui-table.stories.ts` — 12 stories (570 lines)
- `semantic-tokens.ts` — added `gridRow` token group
- `index.ts` — barrel exports for all 3 components
- Docs updated: AGENTS.md, README.md (38 components, 1653 tests)