### PR TITLE
feat: add list component system (list-item, list-header, list-group)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ maneki-monorepo/
 | Package | npm name | Description |
 |---|---|---|
 | `foundation` | `@maneki/foundation` | Design tokens: 131 colors, semantic tokens, typography, spacing, elevation, responsive breakpoints |
-| `ui-components` | `@maneki/ui-components` | 47 Web Components (button, badge, image, icon, tag, avatar, alert, label, link, checkbox, radio, input, textarea, file-upload, select, card, breadcrumb, accordion, dropdown, menu, modal, side-panel-menu, tabs, table, carousel, calendar, calendar-quicklinks, calendar-time, datetime-picker, clock) with Storybook 10 |
+| `ui-components` | `@maneki/ui-components` | 50 Web Components (button, badge, image, icon, tag, avatar, alert, label, link, checkbox, radio, input, textarea, file-upload, select, card, breadcrumb, accordion, dropdown, menu, modal, side-panel-menu, tabs, table, carousel, calendar, calendar-quicklinks, calendar-time, datetime-picker, clock, list-item, list-header, list-group) with Storybook 10 |
 | `grid-layout` | `@maneki/grid-layout` | Zero-dep drag/resize grid layout (220 tests) |
 | `flex-layout` | `@maneki/flex-layout` | Panel-based flex layout for dashboard-style interfaces (3 components, 50 tests) |
 

--- a/packages/foundation/src/semantic-tokens.ts
+++ b/packages/foundation/src/semantic-tokens.ts
@@ -249,6 +249,7 @@ export const form = {
 
 export const stateHover = {
   borderModerate: ref("gray", 50),      // #7A909E — darkened border on hover
+  surfaceMinimal: ref("gray", 10),      // #F2F5F7 — hover-minimal surface
 } as const satisfies Record<string, SemanticValue>;
 
 // ---------------------------------------------------------------------------
@@ -257,6 +258,7 @@ export const stateHover = {
 
 export const stateSelected = {
   surfaceBold: ref("blue", 60),         // #186ADE — checked/selected fill
+  surfaceMinimal: ref("blue", 10),      // #EBF3FE — selected-minimal surface
 } as const satisfies Record<string, SemanticValue>;
 
 // ---------------------------------------------------------------------------

--- a/packages/ui-components/AGENTS.md
+++ b/packages/ui-components/AGENTS.md
@@ -42,6 +42,12 @@ Web Component library for the Maneki design system. Shadow DOM, CSS custom prope
 - `<ui-datetime-picker-input>` — date/time input trigger: 4 types (single-date/range-date/time/datetime), 3 sizes, 7 states, 5 statuses, label, supportive text, spin controls for time
 - `<ui-datetime-picker>` — datetime picker orchestrator: input + floating dropdown, 4 types (single-date/range-date/time/datetime), calendar or clock panel, min/max, actions bar (Cancel/OK)
 - `<ui-clock>` — standalone clock: analog face + 24-hour digital mode, 3 sizes, hour/minute toggle selection
+
+**List:**
+- `<ui-list-item>` — list item: 3 sizes (s/m/l), 5 leading elements (none/icon/avatar/radio/checkbox), 3 paddings, 4 states, top border, trailing icon, description, selected tick
+- `<ui-list-header>` — list section header: 3 sizes (s/m/l), collapse button, top border toggle
+- `<ui-list-group>` — list group wrapper: size propagation, collapsible, header + items slots
+
 **Containers:**
 - `<ui-card>` — slot-based card container: 3 sizes (s/m/l), 4 elevations (00/01/02/04), bordered variant, image/default/footer slots
 - `<ui-button-group>` — segmented bar that wraps `<ui-button>` elements
@@ -129,6 +135,9 @@ ui-components/
 │   │   ├── ui-datetime-picker-input.ts + ui-datetime-picker-input.styles.ts
 │   │   ├── ui-datetime-picker.ts      + ui-datetime-picker.styles.ts
 │   │   ├── ui-clock.ts            + ui-clock.styles.ts
+│   │   ├── ui-list-item.ts        + ui-list-item.styles.ts
+│   │   ├── ui-list-header.ts      + ui-list-header.styles.ts
+│   │   ├── ui-list-group.ts       + ui-list-group.styles.ts
 │   │   └── *.test.ts            # Co-located tests
 │   └── stories/
 │       └── *.stories.ts     # CSF3 + lit html
@@ -327,7 +336,7 @@ After merging a PR that adds/modifies components, icons, or tests, update these 
 ```bash
 moon run ui-components:storybook       # Dev server on port 6006
 moon run ui-components:storybook-build  # Static build
-moon run ui-components:test            # vitest --run (2098 tests)
+moon run ui-components:test            # vitest --run (2216 tests)
 moon run ui-components:build           # vite build + tsc --emitDeclarationOnly
 moon run ui-components:chromatic       # Publish to Chromatic
 ```

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -86,6 +86,10 @@ npm install @maneki/ui-components
 | `<ui-datetime-picker-input>` | Date/time input trigger: 3 types, 3 sizes, 7 states, 5 statuses |
 | `<ui-datetime-picker>` | Datetime picker: input + floating dropdown, 3 types (single-date/range-date/time), actions bar |
 | `<ui-clock>` | Standalone clock: analog face + 24-hour digital, 3 sizes |
+| | **List** |
+| `<ui-list-item>` | List item: 3 sizes, 5 leading elements, 3 paddings, 4 states, trailing icon, description |
+| `<ui-list-header>` | List section header: 3 sizes, collapse button |
+| `<ui-list-group>` | List group wrapper: size propagation, collapsible |
 
 ```html
 <ui-button action="primary" emphasis="bold" size="m">Save</ui-button>
@@ -106,7 +110,7 @@ moon run ui-components:storybook        # Dev server on port 6006
 moon run ui-components:storybook-build  # Static build → storybook-static/
 ```
 
-47 components with stories covering all variants, sizes, actions, emphases, shapes, and statuses.
+50 components with stories covering all variants, sizes, actions, emphases, shapes, and statuses.
 
 ---
 
@@ -114,7 +118,7 @@ moon run ui-components:storybook-build  # Static build → storybook-static/
 
 ```bash
 moon run ui-components:build  # vite build + tsc --emitDeclarationOnly → dist/
-moon run ui-components:test   # vitest --run (2098 tests)
+moon run ui-components:test   # vitest --run (2216 tests)
 ```
 
 ---

--- a/packages/ui-components/src/components/ui-list-group.styles.ts
+++ b/packages/ui-components/src/components/ui-list-group.styles.ts
@@ -1,0 +1,40 @@
+import { semanticVar } from "@maneki/foundation";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const BORDER_MINIMAL = semanticVar("border", "minimal");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+export const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    font-family: Inter, sans-serif;
+  }
+
+  ::slotted(ui-list-header) {
+    flex-shrink: 0;
+  }
+
+  ::slotted(ui-list-item) {
+    flex-shrink: 0;
+  }
+
+  :host([collapsed]) .items {
+    display: none;
+  }
+
+  .items {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+  }
+`;

--- a/packages/ui-components/src/components/ui-list-group.test.ts
+++ b/packages/ui-components/src/components/ui-list-group.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, afterEach } from "vitest";
+import "./ui-list-group.js";
+
+function create(attrs = "", inner = ""): HTMLElement {
+  const el = document.createElement("div");
+  el.innerHTML = `<ui-list-group ${attrs}>${inner}</ui-list-group>`;
+  document.body.appendChild(el);
+  return el.querySelector("ui-list-group")!;
+}
+
+describe("ui-list-group", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-list-group")).toBeDefined();
+  });
+
+  // ── Default rendering ─────────────────────────────────────────────────────
+
+  it("creates a shadow root", () => {
+    const el = create();
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("defaults size to 'm'", () => {
+    const el = create();
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("defaults role to 'listbox'", () => {
+    const el = create();
+    expect(el.getAttribute("role")).toBe("listbox");
+  });
+
+  it("renders header slot in shadow DOM", () => {
+    const el = create();
+    const slot = el.shadowRoot!.querySelector('slot[name="header"]');
+    expect(slot).not.toBeNull();
+  });
+
+  it("renders .items container in shadow DOM", () => {
+    const el = create();
+    expect(el.shadowRoot!.querySelector(".items")).not.toBeNull();
+  });
+
+  it("renders default slot inside .items", () => {
+    const el = create();
+    const items = el.shadowRoot!.querySelector(".items");
+    const slot = items!.querySelector("slot:not([name])");
+    expect(slot).not.toBeNull();
+  });
+
+  // ── Size propagation ──────────────────────────────────────────────────────
+
+  it("propagates size to ui-list-header children", () => {
+    const el = create('size="l"', '<ui-list-header slot="header">H</ui-list-header>');
+    const header = el.querySelector("ui-list-header")!;
+    expect(header.getAttribute("size")).toBe("l");
+  });
+
+  it("propagates size to ui-list-item children", () => {
+    const el = create('size="s"', '<ui-list-item>Item</ui-list-item>');
+    const item = el.querySelector("ui-list-item")!;
+    expect(item.getAttribute("size")).toBe("s");
+  });
+
+  it("updates children size when size attribute changes", () => {
+    const el = create('size="m"', '<ui-list-item>Item</ui-list-item>');
+    el.setAttribute("size", "l");
+    const item = el.querySelector("ui-list-item")!;
+    expect(item.getAttribute("size")).toBe("l");
+  });
+
+  it("does not propagate size to non-list children", () => {
+    const el = create('size="l"', '<div class="other">Other</div>');
+    const div = el.querySelector(".other")!;
+    expect(div.hasAttribute("size")).toBe(false);
+  });
+
+  // ── Collapsed state ───────────────────────────────────────────────────────
+
+  it("is not collapsed by default", () => {
+    const el = create();
+    expect((el as unknown as { collapsed: boolean }).collapsed).toBe(false);
+  });
+
+  it("sets collapsed attribute", () => {
+    const el = create("collapsed");
+    expect((el as unknown as { collapsed: boolean }).collapsed).toBe(true);
+  });
+
+  it("removes collapsed attribute via property", () => {
+    const el = create("collapsed");
+    (el as unknown as { collapsed: boolean }).collapsed = false;
+    expect(el.hasAttribute("collapsed")).toBe(false);
+  });
+
+  it("adds collapsed attribute via property", () => {
+    const el = create();
+    (el as unknown as { collapsed: boolean }).collapsed = true;
+    expect(el.hasAttribute("collapsed")).toBe(true);
+  });
+
+  // ── Collapse event from header ────────────────────────────────────────────
+
+  it("toggles collapsed when collapse event is received", () => {
+    const el = create("", '<ui-list-header slot="header">H</ui-list-header>');
+    expect((el as unknown as { collapsed: boolean }).collapsed).toBe(false);
+    el.dispatchEvent(new CustomEvent("collapse", { bubbles: true }));
+    expect((el as unknown as { collapsed: boolean }).collapsed).toBe(true);
+  });
+
+  it("toggles collapsed back on second collapse event", () => {
+    const el = create("", '<ui-list-header slot="header">H</ui-list-header>');
+    el.dispatchEvent(new CustomEvent("collapse", { bubbles: true }));
+    el.dispatchEvent(new CustomEvent("collapse", { bubbles: true }));
+    expect((el as unknown as { collapsed: boolean }).collapsed).toBe(false);
+  });
+
+  // ── Property getters/setters ──────────────────────────────────────────────
+
+  it("size getter returns attribute value", () => {
+    const el = create('size="l"');
+    expect((el as unknown as { size: string }).size).toBe("l");
+  });
+
+  it("size setter reflects to attribute", () => {
+    const el = create();
+    (el as unknown as { size: string }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("size getter defaults to 'm' when no attribute", () => {
+    const el = document.createElement("ui-list-group");
+    expect((el as unknown as { size: string }).size).toBe("m");
+  });
+
+  it("collapsed getter returns boolean", () => {
+    const el = create("collapsed");
+    expect((el as unknown as { collapsed: boolean }).collapsed).toBe(true);
+  });
+
+  // ── Cleanup ───────────────────────────────────────────────────────────────
+
+  it("removes collapse listener on disconnect", () => {
+    const el = create();
+    el.remove();
+    // After disconnect, collapse event should not toggle collapsed
+    (el as unknown as { collapsed: boolean }).collapsed = false;
+    el.dispatchEvent(new CustomEvent("collapse", { bubbles: true }));
+    expect((el as unknown as { collapsed: boolean }).collapsed).toBe(false);
+  });
+
+  it("does not set defaults when not connected", () => {
+    const el = document.createElement("ui-list-group");
+    expect(el.hasAttribute("size")).toBe(false);
+  });
+});

--- a/packages/ui-components/src/components/ui-list-group.ts
+++ b/packages/ui-components/src/components/ui-list-group.ts
@@ -1,0 +1,97 @@
+import { STYLES } from "./ui-list-group.styles.js";
+import "./ui-list-header.js";
+import "./ui-list-item.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type ListGroupSize = "s" | "m" | "l";
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiListGroup extends HTMLElement {
+  static readonly observedAttributes = ["size", "collapsed"];
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    // Header slot
+    const headerSlot = document.createElement("slot");
+    headerSlot.name = "header";
+
+    // Items slot
+    const items = document.createElement("div");
+    items.className = "items";
+    const defaultSlot = document.createElement("slot");
+    items.appendChild(defaultSlot);
+
+    shadow.append(headerSlot, items);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("size")) {
+      this.setAttribute("size", "m");
+    }
+    if (!this.hasAttribute("role")) {
+      this.setAttribute("role", "listbox");
+    }
+
+    this.addEventListener("collapse", this.#onCollapse);
+    this.#propagateSize();
+  }
+
+  disconnectedCallback(): void {
+    this.removeEventListener("collapse", this.#onCollapse);
+  }
+
+  attributeChangedCallback(
+    name: string,
+    _oldValue: string | null,
+    _newValue: string | null,
+  ): void {
+    if (!this.isConnected) return;
+    if (name === "size") {
+      this.#propagateSize();
+    }
+  }
+
+  // ─── Properties ────────────────────────────────────────────────────────
+
+  get size(): ListGroupSize {
+    return (this.getAttribute("size") as ListGroupSize) || "m";
+  }
+
+  set size(v: ListGroupSize) {
+    this.setAttribute("size", v);
+  }
+
+  get collapsed(): boolean {
+    return this.hasAttribute("collapsed");
+  }
+
+  set collapsed(v: boolean) {
+    if (v) this.setAttribute("collapsed", "");
+    else this.removeAttribute("collapsed");
+  }
+
+  // ─── Internal ──────────────────────────────────────────────────────────
+
+  #onCollapse = (): void => {
+    this.collapsed = !this.collapsed;
+  };
+
+  #propagateSize(): void {
+    const size = this.size;
+    for (const child of this.children) {
+      if (child.tagName === "UI-LIST-HEADER" || child.tagName === "UI-LIST-ITEM") {
+        child.setAttribute("size", size);
+      }
+    }
+  }
+}
+
+customElements.define("ui-list-group", UiListGroup);

--- a/packages/ui-components/src/components/ui-list-header.styles.ts
+++ b/packages/ui-components/src/components/ui-list-header.styles.ts
@@ -1,0 +1,140 @@
+import { semanticVar } from "@maneki/foundation";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const BORDER_MINIMAL = semanticVar("border", "minimal");
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const ICON_PRIMARY = semanticVar("icon", "primary");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+export const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    font-family: Inter, sans-serif;
+  }
+
+  .top-border {
+    height: 1px;
+    width: 100%;
+    background: ${BORDER_MINIMAL};
+    flex-shrink: 0;
+    opacity: 0;
+  }
+
+  :host([top-border]) .top-border {
+    opacity: 1;
+  }
+
+  .content {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    flex-shrink: 0;
+  }
+
+  .heading {
+    flex: 1 1 0;
+    min-width: 0;
+    color: ${TEXT_PRIMARY};
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .collapse-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    border: none;
+    background: transparent;
+    padding: 0;
+    cursor: pointer;
+    color: ${ICON_PRIMARY};
+  }
+
+  .collapse-btn:hover {
+    opacity: 0.7;
+  }
+
+  .bottom-border {
+    height: 1px;
+    width: 100%;
+    background: ${BORDER_MINIMAL};
+    flex-shrink: 0;
+  }
+
+
+  /* ═══════════════════════════════════════════════════════════════════════════ */
+  /* Size: S                                                                    */
+  /* ═══════════════════════════════════════════════════════════════════════════ */
+
+  :host([size="s"]) .content {
+    height: 34px;
+    padding: 0 6px 0 26px;
+  }
+
+  :host([size="s"]) .heading {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  :host([size="s"]) .collapse-btn {
+    width: 20px;
+    height: 20px;
+    --ui-icon-size: 20px;
+  }
+
+  /* ═══════════════════════════════════════════════════════════════════════════ */
+  /* Size: M (default)                                                          */
+  /* ═══════════════════════════════════════════════════════════════════════════ */
+
+  :host([size="m"]) .content,
+  :host(:not([size])) .content {
+    height: 36px;
+    padding: 0 8px 0 28px;
+  }
+
+  :host([size="m"]) .heading,
+  :host(:not([size])) .heading {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  :host([size="m"]) .collapse-btn,
+  :host(:not([size])) .collapse-btn {
+    width: 20px;
+    height: 20px;
+    --ui-icon-size: 20px;
+  }
+
+  /* ═══════════════════════════════════════════════════════════════════════════ */
+  /* Size: L                                                                    */
+  /* ═══════════════════════════════════════════════════════════════════════════ */
+
+  :host([size="l"]) .content {
+    height: 44px;
+    padding: 0 12px 0 32px;
+  }
+
+  :host([size="l"]) .heading {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  :host([size="l"]) .collapse-btn {
+    width: 24px;
+    height: 24px;
+    --ui-icon-size: 24px;
+  }
+`;

--- a/packages/ui-components/src/components/ui-list-header.test.ts
+++ b/packages/ui-components/src/components/ui-list-header.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, afterEach } from "vitest";
+import "./ui-list-header.js";
+
+function create(attrs = ""): HTMLElement {
+  const el = document.createElement("div");
+  el.innerHTML = `<ui-list-header ${attrs}></ui-list-header>`;
+  document.body.appendChild(el);
+  return el.querySelector("ui-list-header")!;
+}
+
+describe("ui-list-header", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-list-header")).toBeDefined();
+  });
+
+  // ── Default rendering ─────────────────────────────────────────────────────
+
+  it("creates a shadow root", () => {
+    const el = create();
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("defaults size to 'm'", () => {
+    const el = create();
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("defaults role to 'heading'", () => {
+    const el = create();
+    expect(el.getAttribute("role")).toBe("heading");
+  });
+
+  it("renders .top-border in shadow DOM", () => {
+    const el = create();
+    expect(el.shadowRoot!.querySelector(".top-border")).not.toBeNull();
+  });
+
+  it("renders .content in shadow DOM", () => {
+    const el = create();
+    expect(el.shadowRoot!.querySelector(".content")).not.toBeNull();
+  });
+
+  it("renders .heading in shadow DOM", () => {
+    const el = create();
+    expect(el.shadowRoot!.querySelector(".heading")).not.toBeNull();
+  });
+
+  it("renders .collapse-btn in shadow DOM", () => {
+    const el = create();
+    expect(el.shadowRoot!.querySelector(".collapse-btn")).not.toBeNull();
+  });
+
+  it("renders .bottom-border in shadow DOM", () => {
+    const el = create();
+    expect(el.shadowRoot!.querySelector(".bottom-border")).not.toBeNull();
+  });
+
+  // ── Size attribute ────────────────────────────────────────────────────────
+
+  it("reflects size='s' to attribute", () => {
+    const el = create('size="s"');
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("reflects size='m' to attribute", () => {
+    const el = create('size="m"');
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("reflects size='l' to attribute", () => {
+    const el = create('size="l"');
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  // ── Top border ────────────────────────────────────────────────────────────
+
+  it("does not have top-border attribute by default", () => {
+    const el = create();
+    expect(el.hasAttribute("top-border")).toBe(false);
+  });
+
+  it("sets top-border attribute", () => {
+    const el = create("top-border");
+    expect(el.hasAttribute("top-border")).toBe(true);
+  });
+
+  // ── Collapse button ───────────────────────────────────────────────────────
+
+  it("collapse button has type='button'", () => {
+    const el = create();
+    const btn = el.shadowRoot!.querySelector(".collapse-btn") as HTMLButtonElement;
+    expect(btn.type).toBe("button");
+  });
+
+  it("collapse button has aria-label", () => {
+    const el = create();
+    const btn = el.shadowRoot!.querySelector(".collapse-btn") as HTMLButtonElement;
+    expect(btn.getAttribute("aria-label")).toBe("Collapse");
+  });
+
+  it("dispatches collapse event on button click", () => {
+    const el = create();
+    let fired = false;
+    el.addEventListener("collapse", () => { fired = true; });
+    const btn = el.shadowRoot!.querySelector(".collapse-btn") as HTMLButtonElement;
+    btn.click();
+    expect(fired).toBe(true);
+  });
+
+  it("collapse event bubbles", () => {
+    const el = create();
+    let bubbled = false;
+    document.body.addEventListener("collapse", () => { bubbled = true; });
+    const btn = el.shadowRoot!.querySelector(".collapse-btn") as HTMLButtonElement;
+    btn.click();
+    expect(bubbled).toBe(true);
+  });
+
+  // ── Slot content ──────────────────────────────────────────────────────────
+
+  it("renders default slot for heading text", () => {
+    const el = create();
+    const slot = el.shadowRoot!.querySelector(".heading slot:not([name])");
+    expect(slot).not.toBeNull();
+  });
+
+  // ── Property getters/setters ──────────────────────────────────────────────
+
+  it("size getter returns attribute value", () => {
+    const el = create('size="l"');
+    expect((el as unknown as { size: string }).size).toBe("l");
+  });
+
+  it("size setter reflects to attribute", () => {
+    const el = create();
+    (el as unknown as { size: string }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("size getter defaults to 'm' when no attribute", () => {
+    const el = document.createElement("ui-list-header");
+    expect((el as unknown as { size: string }).size).toBe("m");
+  });
+
+  // ── Cleanup ───────────────────────────────────────────────────────────────
+
+  it("removes event listeners on disconnect", () => {
+    const el = create();
+    const btn = el.shadowRoot!.querySelector(".collapse-btn") as HTMLButtonElement;
+    el.remove();
+    let fired = false;
+    el.addEventListener("collapse", () => { fired = true; });
+    btn.click();
+    expect(fired).toBe(false);
+  });
+
+  it("does not set defaults when not connected", () => {
+    const el = document.createElement("ui-list-header");
+    expect(el.hasAttribute("size")).toBe(false);
+  });
+});

--- a/packages/ui-components/src/components/ui-list-header.ts
+++ b/packages/ui-components/src/components/ui-list-header.ts
@@ -1,0 +1,93 @@
+import { STYLES } from "./ui-list-header.styles.js";
+import "./ui-icon.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type ListHeaderSize = "s" | "m" | "l";
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiListHeader extends HTMLElement {
+  static readonly observedAttributes = ["size", "top-border"];
+
+  #headingEl!: HTMLElement;
+  #collapseBtn!: HTMLButtonElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    // Top border
+    const topBorder = document.createElement("div");
+    topBorder.className = "top-border";
+
+    // Content
+    const content = document.createElement("div");
+    content.className = "content";
+
+    this.#headingEl = document.createElement("span");
+    this.#headingEl.className = "heading";
+    const slot = document.createElement("slot");
+    this.#headingEl.appendChild(slot);
+
+    this.#collapseBtn = document.createElement("button");
+    this.#collapseBtn.className = "collapse-btn";
+    this.#collapseBtn.type = "button";
+    this.#collapseBtn.setAttribute("aria-label", "Collapse");
+
+    content.append(this.#headingEl, this.#collapseBtn);
+
+    // Bottom border
+    const bottomBorder = document.createElement("div");
+    bottomBorder.className = "bottom-border";
+
+    shadow.append(topBorder, content, bottomBorder);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("size")) {
+      this.setAttribute("size", "m");
+    }
+    if (!this.hasAttribute("role")) {
+      this.setAttribute("role", "heading");
+    }
+
+    // Create collapse icon (must be in connectedCallback)
+    if (!this.#collapseBtn.querySelector("ui-icon")) {
+      const icon = document.createElement("ui-icon");
+      icon.setAttribute("name", "close");
+      icon.setAttribute("size", "xs");
+      this.#collapseBtn.appendChild(icon);
+    }
+
+    this.#collapseBtn.addEventListener("click", this.#onCollapse);
+  }
+
+  disconnectedCallback(): void {
+    this.#collapseBtn.removeEventListener("click", this.#onCollapse);
+  }
+
+  // ─── Properties ────────────────────────────────────────────────────────
+
+  get size(): ListHeaderSize {
+    return (this.getAttribute("size") as ListHeaderSize) || "m";
+  }
+
+  set size(v: ListHeaderSize) {
+    this.setAttribute("size", v);
+  }
+
+  // ─── Events ────────────────────────────────────────────────────────────
+
+  #onCollapse = (): void => {
+    this.dispatchEvent(
+      new CustomEvent("collapse", { bubbles: true }),
+    );
+  };
+}
+
+customElements.define("ui-list-header", UiListHeader);

--- a/packages/ui-components/src/components/ui-list-item.styles.ts
+++ b/packages/ui-components/src/components/ui-list-item.styles.ts
@@ -1,0 +1,337 @@
+import { semanticVar, spaceVar } from "@maneki/foundation";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const BORDER_MINIMAL = semanticVar("border", "minimal");
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const TEXT_SECONDARY = semanticVar("text", "secondary");
+const ICON_PRIMARY = semanticVar("icon", "primary");
+const HOVER_BG = semanticVar("stateHover", "surfaceMinimal");
+const ACTIVE_BG = semanticVar("stateSelected", "surfaceMinimal");
+const SP_1 = spaceVar("1");
+const SP_2 = spaceVar("2");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+export const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    font-family: Inter, sans-serif;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  :host([disabled]) {
+    pointer-events: none;
+    opacity: 0.5;
+  }
+
+  /* ─── Borders ─── */
+
+  .top-border,
+  .bottom-border {
+    height: 1px;
+    width: 100%;
+    background: ${BORDER_MINIMAL};
+    flex-shrink: 0;
+  }
+
+  .top-border {
+    opacity: 1;
+  }
+
+  .bottom-border {
+    height: 0;
+  }
+
+  :host([top-border]) .top-border {
+    opacity: 1;
+  }
+
+  :host([bottom-border]) .bottom-border {
+    height: 1px;
+  }
+
+  /* ─── Content row ─── */
+
+  .content {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    flex-shrink: 0;
+  }
+
+  /* ─── Leading element ─── */
+
+  .leading {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+
+  :host([leading="icon"]) .leading,
+  :host([leading="avatar"]) .leading,
+  :host([leading="radio"]) .leading,
+  :host([leading="checkbox"]) .leading {
+    display: flex;
+  }
+
+  /* ─── Text area ─── */
+
+  .text-area {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 0;
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  .top-row {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    width: 100%;
+  }
+
+  .primary-text {
+    flex: 1 1 0;
+    min-width: 0;
+    color: ${TEXT_PRIMARY};
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .description {
+    display: none;
+    color: ${TEXT_SECONDARY};
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  :host([description]) .description {
+    display: block;
+  }
+
+  /* ─── Trailing ─── */
+
+  .trailing {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex-shrink: 0;
+    overflow: clip;
+  }
+
+  .tick {
+    display: none;
+    color: ${ICON_PRIMARY};
+  }
+
+  :host([selected]) .tick {
+    display: flex;
+  }
+
+  .trailing-icon {
+    display: none;
+    color: ${ICON_PRIMARY};
+  }
+
+  :host([trailing-icon]) .trailing-icon {
+    display: flex;
+  }
+
+  /* ─── States ─── */
+
+  :host(:hover) .content {
+    background: ${HOVER_BG};
+  }
+
+  :host(:hover) .content[data-active] {
+    background: ${ACTIVE_BG};
+  }
+
+  :host([selected]) .content {
+    background: transparent;
+  }
+
+
+  /* ═══════════════════════════════════════════════════════════════════════════ */
+  /* Size: S                                                                    */
+  /* ═══════════════════════════════════════════════════════════════════════════ */
+
+  :host([size="s"]) .content {
+    min-height: 28px;
+    padding: 6px 0;
+  }
+
+  :host([size="s"][description]) .content {
+    min-height: 48px;
+    padding: 6px 0;
+  }
+
+  :host([size="s"]) .text-area {
+    gap: 4px;
+  }
+
+  :host([size="s"]) .primary-text {
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  :host([size="s"]) .description {
+    font-size: 11px;
+    line-height: 16px;
+  }
+
+  :host([size="s"]) .leading {
+    width: 24px;
+    height: 24px;
+    margin-right: 8px;
+  }
+
+  :host([size="s"]) .trailing {
+    height: 16px;
+  }
+
+  :host([size="s"]) .tick {
+    --ui-icon-size: 16px;
+  }
+
+  /* Padding */
+  :host([size="s"][padding="s"]) .content {
+    padding-left: ${SP_1};
+    padding-right: ${SP_1};
+  }
+
+  :host([size="s"][padding="m"]) .content {
+    padding-left: ${SP_2};
+    padding-right: ${SP_2};
+  }
+
+  /* ═══════════════════════════════════════════════════════════════════════════ */
+  /* Size: M (default)                                                          */
+  /* ═══════════════════════════════════════════════════════════════════════════ */
+
+  :host([size="m"]) .content,
+  :host(:not([size])) .content {
+    min-height: 32px;
+    padding: 8px 0;
+  }
+
+  :host([size="m"][description]) .content,
+  :host(:not([size])[description]) .content {
+    min-height: 52px;
+    padding: 8px 0;
+  }
+
+  :host([size="m"]) .text-area,
+  :host(:not([size])) .text-area {
+    gap: 4px;
+  }
+
+  :host([size="m"]) .primary-text,
+  :host(:not([size])) .primary-text {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  :host([size="m"]) .description,
+  :host(:not([size])) .description {
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  :host([size="m"]) .leading,
+  :host(:not([size])) .leading {
+    width: 24px;
+    height: 24px;
+    margin-right: 8px;
+  }
+
+  :host([size="m"]) .trailing,
+  :host(:not([size])) .trailing {
+    height: 20px;
+  }
+
+  :host([size="m"]) .tick,
+  :host(:not([size])) .tick {
+    --ui-icon-size: 16px;
+  }
+
+  /* Padding */
+  :host([size="m"][padding="s"]) .content,
+  :host(:not([size])[padding="s"]) .content {
+    padding-left: ${SP_1};
+    padding-right: ${SP_1};
+  }
+
+  :host([size="m"][padding="m"]) .content,
+  :host(:not([size])[padding="m"]) .content {
+    padding-left: ${SP_2};
+    padding-right: ${SP_2};
+  }
+
+  /* ═══════════════════════════════════════════════════════════════════════════ */
+  /* Size: L                                                                    */
+  /* ═══════════════════════════════════════════════════════════════════════════ */
+
+  :host([size="l"]) .content {
+    min-height: 40px;
+    padding: 8px 0;
+  }
+
+  :host([size="l"][description]) .content {
+    min-height: 60px;
+    padding: 8px 0;
+  }
+
+  :host([size="l"]) .text-area {
+    gap: 4px;
+  }
+
+  :host([size="l"]) .primary-text {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  :host([size="l"]) .description {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  :host([size="l"]) .leading {
+    width: 32px;
+    height: 32px;
+    margin-right: 12px;
+  }
+
+  :host([size="l"]) .trailing {
+    height: 24px;
+  }
+
+  :host([size="l"]) .tick {
+    --ui-icon-size: 20px;
+  }
+
+  /* Padding */
+  :host([size="l"][padding="s"]) .content {
+    padding-left: 12px;
+    padding-right: 12px;
+  }
+
+  :host([size="l"][padding="m"]) .content {
+    padding-left: ${SP_2};
+    padding-right: ${SP_2};
+  }
+`;

--- a/packages/ui-components/src/components/ui-list-item.test.ts
+++ b/packages/ui-components/src/components/ui-list-item.test.ts
@@ -1,0 +1,460 @@
+import { describe, it, expect, afterEach } from "vitest";
+import "./ui-list-item.js";
+
+function create(attrs = ""): HTMLElement {
+  const el = document.createElement("div");
+  el.innerHTML = `<ui-list-item ${attrs}></ui-list-item>`;
+  document.body.appendChild(el);
+  return el.querySelector("ui-list-item")!;
+}
+
+describe("ui-list-item", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-list-item")).toBeDefined();
+  });
+
+  // ── Default rendering ─────────────────────────────────────────────────────
+
+  it("creates a shadow root", () => {
+    const el = create();
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("defaults size to 'm'", () => {
+    const el = create();
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("defaults role to 'option'", () => {
+    const el = create();
+    expect(el.getAttribute("role")).toBe("option");
+  });
+
+  it("defaults tabindex to '0'", () => {
+    const el = create();
+    expect(el.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("renders .top-border in shadow DOM", () => {
+    const el = create();
+    expect(el.shadowRoot!.querySelector(".top-border")).not.toBeNull();
+  });
+
+  it("renders .content in shadow DOM", () => {
+    const el = create();
+    expect(el.shadowRoot!.querySelector(".content")).not.toBeNull();
+  });
+
+  it("renders .primary-text in shadow DOM", () => {
+    const el = create();
+    expect(el.shadowRoot!.querySelector(".primary-text")).not.toBeNull();
+  });
+
+  it("renders .leading in shadow DOM", () => {
+    const el = create();
+    expect(el.shadowRoot!.querySelector(".leading")).not.toBeNull();
+  });
+
+  it("renders .tick in shadow DOM", () => {
+    const el = create();
+    expect(el.shadowRoot!.querySelector(".tick")).not.toBeNull();
+  });
+
+  it("renders .trailing-icon in shadow DOM", () => {
+    const el = create();
+    expect(el.shadowRoot!.querySelector(".trailing-icon")).not.toBeNull();
+  });
+
+  it("renders .description in shadow DOM", () => {
+    const el = create();
+    expect(el.shadowRoot!.querySelector(".description")).not.toBeNull();
+  });
+
+  it("renders .bottom-border in shadow DOM", () => {
+    const el = create();
+    expect(el.shadowRoot!.querySelector(".bottom-border")).not.toBeNull();
+  });
+
+  // ── Size attribute ────────────────────────────────────────────────────────
+
+  it("reflects size='s' to attribute", () => {
+    const el = create('size="s"');
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("reflects size='m' to attribute", () => {
+    const el = create('size="m"');
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("reflects size='l' to attribute", () => {
+    const el = create('size="l"');
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  // ── Padding attribute ─────────────────────────────────────────────────────
+
+  it("defaults padding to 'none'", () => {
+    const el = create();
+    expect((el as unknown as { padding: string }).padding).toBe("none");
+  });
+
+  it("reflects padding='s' to attribute", () => {
+    const el = create('padding="s"');
+    expect(el.getAttribute("padding")).toBe("s");
+  });
+
+  it("reflects padding='m' to attribute", () => {
+    const el = create('padding="m"');
+    expect(el.getAttribute("padding")).toBe("m");
+  });
+
+  it("reflects padding='none' to attribute", () => {
+    const el = create('padding="none"');
+    expect(el.getAttribute("padding")).toBe("none");
+  });
+
+  // ── Leading attribute ─────────────────────────────────────────────────────
+
+  it("defaults leading to 'none'", () => {
+    const el = create();
+    expect((el as unknown as { leading: string }).leading).toBe("none");
+  });
+
+  it("sets leading='icon'", () => {
+    const el = create('leading="icon"');
+    expect(el.getAttribute("leading")).toBe("icon");
+  });
+
+  it("sets leading='avatar'", () => {
+    const el = create('leading="avatar"');
+    expect(el.getAttribute("leading")).toBe("avatar");
+  });
+
+  it("sets leading='radio'", () => {
+    const el = create('leading="radio"');
+    expect(el.getAttribute("leading")).toBe("radio");
+  });
+
+  it("sets leading='checkbox'", () => {
+    const el = create('leading="checkbox"');
+    expect(el.getAttribute("leading")).toBe("checkbox");
+  });
+
+  it("renders leading slot element", () => {
+    const el = create('leading="icon"');
+    const slot = el.shadowRoot!.querySelector('.leading slot[name="leading"]');
+    expect(slot).not.toBeNull();
+  });
+
+  // ── Top border ────────────────────────────────────────────────────────────
+
+  it("does not have top-border attribute by default", () => {
+    const el = create();
+    expect(el.hasAttribute("top-border")).toBe(false);
+  });
+
+  it("sets top-border attribute", () => {
+    const el = create('top-border');
+    expect(el.hasAttribute("top-border")).toBe(true);
+  });
+
+  // ── Selected state ────────────────────────────────────────────────────────
+
+  it("is not selected by default", () => {
+    const el = create();
+    expect((el as unknown as { selected: boolean }).selected).toBe(false);
+  });
+
+  it("sets selected attribute", () => {
+    const el = create('selected');
+    expect((el as unknown as { selected: boolean }).selected).toBe(true);
+  });
+
+  it("renders .tick element when selected", () => {
+    const el = create('selected');
+    const tick = el.shadowRoot!.querySelector(".tick");
+    expect(tick).not.toBeNull();
+  });
+
+  it("removes selected attribute via property", () => {
+    const el = create('selected');
+    (el as unknown as { selected: boolean }).selected = false;
+    expect(el.hasAttribute("selected")).toBe(false);
+  });
+
+  // ── Trailing icon ─────────────────────────────────────────────────────────
+
+  it("does not have trailing-icon attribute by default", () => {
+    const el = create();
+    expect(el.hasAttribute("trailing-icon")).toBe(false);
+  });
+
+  it("sets trailing-icon attribute", () => {
+    const el = create('trailing-icon');
+    expect(el.hasAttribute("trailing-icon")).toBe(true);
+  });
+
+  it("renders trailing slot", () => {
+    const el = create('trailing-icon');
+    const slot = el.shadowRoot!.querySelector('.trailing-icon slot[name="trailing"]');
+    expect(slot).not.toBeNull();
+  });
+
+  // ── Description ───────────────────────────────────────────────────────────
+
+  it("has empty description by default", () => {
+    const el = create();
+    const desc = el.shadowRoot!.querySelector(".description");
+    expect(desc!.textContent).toBe("");
+  });
+
+  it("sets description text from attribute", () => {
+    const el = create('description="Some description"');
+    const desc = el.shadowRoot!.querySelector(".description");
+    expect(desc!.textContent).toBe("Some description");
+  });
+
+  it("updates description when attribute changes", () => {
+    const el = create();
+    el.setAttribute("description", "Updated");
+    const desc = el.shadowRoot!.querySelector(".description");
+    expect(desc!.textContent).toBe("Updated");
+  });
+
+  // ── Secondary text ────────────────────────────────────────────────────────
+
+  it("sets description from secondary-text attribute", () => {
+    const el = create('secondary-text="Secondary info"');
+    const desc = el.shadowRoot!.querySelector(".description");
+    expect(desc!.textContent).toBe("Secondary info");
+  });
+
+  it("updates description when secondary-text changes", () => {
+    const el = create();
+    el.setAttribute("secondary-text", "New secondary");
+    const desc = el.shadowRoot!.querySelector(".description");
+    expect(desc!.textContent).toBe("New secondary");
+  });
+
+  it("description attribute takes precedence over secondary-text", () => {
+    const el = create('description="Primary desc" secondary-text="Secondary desc"');
+    const desc = el.shadowRoot!.querySelector(".description");
+    expect(desc!.textContent).toBe("Primary desc");
+  });
+
+  // ── Disabled state ────────────────────────────────────────────────────────
+
+  it("is not disabled by default", () => {
+    const el = create();
+    expect((el as unknown as { disabled: boolean }).disabled).toBe(false);
+  });
+
+  it("sets disabled attribute", () => {
+    const el = create('disabled');
+    expect((el as unknown as { disabled: boolean }).disabled).toBe(true);
+  });
+
+  it("removes disabled attribute via property", () => {
+    const el = create('disabled');
+    (el as unknown as { disabled: boolean }).disabled = false;
+    expect(el.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("does not dispatch item-select when disabled and clicked", () => {
+    const el = create('disabled value="test"');
+    let fired = false;
+    el.addEventListener("item-select", () => { fired = true; });
+    el.click();
+    expect(fired).toBe(false);
+  });
+
+  // ── Value property ────────────────────────────────────────────────────────
+
+  it("defaults value to empty string", () => {
+    const el = create();
+    expect((el as unknown as { value: string }).value).toBe("");
+  });
+
+  it("sets value via attribute", () => {
+    const el = create('value="option-1"');
+    expect((el as unknown as { value: string }).value).toBe("option-1");
+  });
+
+  it("sets value via property", () => {
+    const el = create();
+    (el as unknown as { value: string }).value = "option-2";
+    expect(el.getAttribute("value")).toBe("option-2");
+  });
+
+  // ── Click event ───────────────────────────────────────────────────────────
+
+  it("dispatches item-select on click", () => {
+    const el = create('value="clicked"');
+    let detail: { value: string } | null = null;
+    el.addEventListener("item-select", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+    el.click();
+    expect(detail).toEqual({ value: "clicked" });
+  });
+
+  it("item-select event bubbles", () => {
+    const el = create('value="bubbles"');
+    let bubbled = false;
+    document.body.addEventListener("item-select", (() => {
+      bubbled = true;
+    }) as EventListener);
+    el.click();
+    expect(bubbled).toBe(true);
+  });
+
+  // ── Keyboard ──────────────────────────────────────────────────────────────
+
+  it("dispatches item-select on Enter key", () => {
+    const el = create('value="enter"');
+    let detail: { value: string } | null = null;
+    el.addEventListener("item-select", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(detail).toEqual({ value: "enter" });
+  });
+
+  it("dispatches item-select on Space key", () => {
+    const el = create('value="space"');
+    let detail: { value: string } | null = null;
+    el.addEventListener("item-select", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+    expect(detail).toEqual({ value: "space" });
+  });
+
+  it("does not dispatch item-select on other keys", () => {
+    const el = create('value="nope"');
+    let fired = false;
+    el.addEventListener("item-select", () => { fired = true; });
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
+    expect(fired).toBe(false);
+  });
+
+  it("does not dispatch item-select on Enter when disabled", () => {
+    const el = create('disabled value="no"');
+    let fired = false;
+    el.addEventListener("item-select", () => { fired = true; });
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(fired).toBe(false);
+  });
+
+  // ── Property getters/setters ──────────────────────────────────────────────
+
+  it("size getter returns attribute value", () => {
+    const el = create('size="l"');
+    expect((el as unknown as { size: string }).size).toBe("l");
+  });
+
+  it("size setter reflects to attribute", () => {
+    const el = create();
+    (el as unknown as { size: string }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("padding getter returns attribute value", () => {
+    const el = create('padding="m"');
+    expect((el as unknown as { padding: string }).padding).toBe("m");
+  });
+
+  it("padding setter reflects to attribute", () => {
+    const el = create();
+    (el as unknown as { padding: string }).padding = "s";
+    expect(el.getAttribute("padding")).toBe("s");
+  });
+
+  it("leading getter returns attribute value", () => {
+    const el = create('leading="avatar"');
+    expect((el as unknown as { leading: string }).leading).toBe("avatar");
+  });
+
+  it("leading setter reflects to attribute", () => {
+    const el = create();
+    (el as unknown as { leading: string }).leading = "checkbox";
+    expect(el.getAttribute("leading")).toBe("checkbox");
+  });
+
+  it("selected getter returns boolean", () => {
+    const el = create('selected');
+    expect((el as unknown as { selected: boolean }).selected).toBe(true);
+  });
+
+  it("selected setter adds attribute", () => {
+    const el = create();
+    (el as unknown as { selected: boolean }).selected = true;
+    expect(el.hasAttribute("selected")).toBe(true);
+  });
+
+  it("disabled getter returns boolean", () => {
+    const el = create('disabled');
+    expect((el as unknown as { disabled: boolean }).disabled).toBe(true);
+  });
+
+  it("disabled setter adds attribute", () => {
+    const el = create();
+    (el as unknown as { disabled: boolean }).disabled = true;
+    expect(el.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("value getter returns attribute value", () => {
+    const el = create('value="abc"');
+    expect((el as unknown as { value: string }).value).toBe("abc");
+  });
+
+  it("value setter reflects to attribute", () => {
+    const el = create();
+    (el as unknown as { value: string }).value = "xyz";
+    expect(el.getAttribute("value")).toBe("xyz");
+  });
+
+  // ── Slot content ──────────────────────────────────────────────────────────
+
+  it("renders default slot for primary text", () => {
+    const el = create();
+    const slot = el.shadowRoot!.querySelector(".primary-text slot:not([name])");
+    expect(slot).not.toBeNull();
+  });
+
+  it("renders named leading slot", () => {
+    const el = create();
+    const slot = el.shadowRoot!.querySelector('slot[name="leading"]');
+    expect(slot).not.toBeNull();
+  });
+
+  it("renders named trailing slot", () => {
+    const el = create();
+    const slot = el.shadowRoot!.querySelector('slot[name="trailing"]');
+    expect(slot).not.toBeNull();
+  });
+
+  // ── Cleanup ───────────────────────────────────────────────────────────────
+
+  it("removes event listeners on disconnect", () => {
+    const el = create('value="disc"');
+    el.remove();
+    let fired = false;
+    el.addEventListener("item-select", () => { fired = true; });
+    el.click();
+    expect(fired).toBe(false);
+  });
+
+  it("does not set defaults when not connected", () => {
+    const el = document.createElement("ui-list-item");
+    // Not appended — connectedCallback not called
+    expect(el.hasAttribute("size")).toBe(false);
+  });
+});

--- a/packages/ui-components/src/components/ui-list-item.ts
+++ b/packages/ui-components/src/components/ui-list-item.ts
@@ -1,0 +1,224 @@
+import { STYLES } from "./ui-list-item.styles.js";
+import "./ui-icon.js";
+import "./ui-icon.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type ListItemSize = "s" | "m" | "l";
+export type ListItemPadding = "none" | "s" | "m";
+export type ListItemLeading = "none" | "icon" | "avatar" | "radio" | "checkbox";
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiListItem extends HTMLElement {
+  static readonly observedAttributes = [
+    "size", "padding", "leading", "top-border", "trailing-icon",
+    "selected", "disabled", "description", "secondary-text",
+  ];
+
+  #topBorder!: HTMLElement;
+  #content!: HTMLElement;
+  #leadingSlot!: HTMLElement;
+  #primaryText!: HTMLElement;
+  #descriptionEl!: HTMLElement;
+  #tick!: HTMLElement;
+  #trailingIconEl!: HTMLElement;
+  #bottomBorder!: HTMLElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    // Top border
+    this.#topBorder = document.createElement("div");
+    this.#topBorder.className = "top-border";
+
+    // Content row
+    this.#content = document.createElement("div");
+    this.#content.className = "content";
+
+    // Leading element (slot)
+    this.#leadingSlot = document.createElement("div");
+    this.#leadingSlot.className = "leading";
+    const leadingSlotEl = document.createElement("slot");
+    leadingSlotEl.name = "leading";
+    this.#leadingSlot.appendChild(leadingSlotEl);
+
+    // Text area
+    const textArea = document.createElement("div");
+    textArea.className = "text-area";
+
+    const topRow = document.createElement("div");
+    topRow.className = "top-row";
+
+    this.#primaryText = document.createElement("span");
+    this.#primaryText.className = "primary-text";
+    const defaultSlot = document.createElement("slot");
+    this.#primaryText.appendChild(defaultSlot);
+
+    // Trailing group (tick + trailing icon)
+    const trailing = document.createElement("div");
+    trailing.className = "trailing";
+
+    this.#tick = document.createElement("div");
+    this.#tick.className = "tick";
+
+    this.#trailingIconEl = document.createElement("div");
+    this.#trailingIconEl.className = "trailing-icon";
+    const trailingSlot = document.createElement("slot");
+    trailingSlot.name = "trailing";
+    this.#trailingIconEl.appendChild(trailingSlot);
+
+    trailing.append(this.#tick, this.#trailingIconEl);
+    topRow.append(this.#primaryText, trailing);
+
+    // Description
+    this.#descriptionEl = document.createElement("span");
+    this.#descriptionEl.className = "description";
+
+    textArea.append(topRow, this.#descriptionEl);
+
+    this.#content.append(this.#leadingSlot, textArea);
+
+    // Bottom border
+    this.#bottomBorder = document.createElement("div");
+    this.#bottomBorder.className = "bottom-border";
+
+    shadow.append(this.#topBorder, this.#content, this.#bottomBorder);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("size")) {
+      this.setAttribute("size", "m");
+    }
+    if (!this.hasAttribute("role")) {
+      this.setAttribute("role", "option");
+    }
+    if (!this.hasAttribute("tabindex")) {
+      this.setAttribute("tabindex", "0");
+    }
+
+    // Create tick icon (must be in connectedCallback, not constructor)
+    if (!this.#tick.querySelector("ui-icon")) {
+      const tickIcon = document.createElement("ui-icon");
+      tickIcon.setAttribute("name", "check");
+      tickIcon.setAttribute("size", "xs");
+      this.#tick.appendChild(tickIcon);
+    }
+
+    this.#syncDescription();
+    this.addEventListener("click", this.#onClick);
+    this.addEventListener("keydown", this.#onKeydown);
+    this.addEventListener("mousedown", this.#onMouseDown);
+    this.addEventListener("mouseup", this.#onMouseUp);
+    this.addEventListener("mouseleave", this.#onMouseUp);
+  }
+
+  disconnectedCallback(): void {
+    this.removeEventListener("click", this.#onClick);
+    this.removeEventListener("keydown", this.#onKeydown);
+    this.removeEventListener("mousedown", this.#onMouseDown);
+    this.removeEventListener("mouseup", this.#onMouseUp);
+    this.removeEventListener("mouseleave", this.#onMouseUp);
+  }
+
+  attributeChangedCallback(
+    name: string,
+    _oldValue: string | null,
+    _newValue: string | null,
+  ): void {
+    if (!this.isConnected) return;
+    if (name === "description" || name === "secondary-text") {
+      this.#syncDescription();
+    }
+  }
+
+  // ─── Properties ────────────────────────────────────────────────────────
+
+  get size(): ListItemSize {
+    return (this.getAttribute("size") as ListItemSize) || "m";
+  }
+
+  set size(v: ListItemSize) {
+    this.setAttribute("size", v);
+  }
+
+  get padding(): ListItemPadding {
+    return (this.getAttribute("padding") as ListItemPadding) || "none";
+  }
+
+  set padding(v: ListItemPadding) {
+    this.setAttribute("padding", v);
+  }
+
+  get leading(): ListItemLeading {
+    return (this.getAttribute("leading") as ListItemLeading) || "none";
+  }
+
+  set leading(v: ListItemLeading) {
+    this.setAttribute("leading", v);
+  }
+
+  get selected(): boolean {
+    return this.hasAttribute("selected");
+  }
+
+  set selected(v: boolean) {
+    if (v) this.setAttribute("selected", "");
+    else this.removeAttribute("selected");
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute("disabled");
+  }
+
+  set disabled(v: boolean) {
+    if (v) this.setAttribute("disabled", "");
+    else this.removeAttribute("disabled");
+  }
+
+  get value(): string {
+    return this.getAttribute("value") || "";
+  }
+
+  set value(v: string) {
+    this.setAttribute("value", v);
+  }
+
+  // ─── Internal ──────────────────────────────────────────────────────────
+
+  #syncDescription(): void {
+    const desc = this.getAttribute("description") || this.getAttribute("secondary-text") || "";
+    this.#descriptionEl.textContent = desc;
+  }
+
+  #onClick = (): void => {
+    if (this.disabled) return;
+    this.dispatchEvent(
+      new CustomEvent("item-select", {
+        detail: { value: this.value },
+        bubbles: true,
+      }),
+    );
+  };
+
+  #onKeydown = (e: KeyboardEvent): void => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      this.#onClick();
+    }
+  };
+  #onMouseDown = (): void => {
+    this.#content.setAttribute("data-active", "");
+  };
+
+  #onMouseUp = (): void => {
+    this.#content.removeAttribute("data-active");
+  };
+}
+
+customElements.define("ui-list-item", UiListItem);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -149,3 +149,12 @@ export { UiCalendarQuicklinks } from "./components/ui-calendar-quicklinks.js";
 export type { QuicklinksSize, QuicklinksOrientation, QuicklinkItem } from "./components/ui-calendar-quicklinks.js";
 export { UiCalendarTime } from "./components/ui-calendar-time.js";
 export type { CalendarTimeSize } from "./components/ui-calendar-time.js";
+
+// ─── List ────────────────────────────────────────────────────────────────────
+
+export { UiListItem } from "./components/ui-list-item.js";
+export type { ListItemSize, ListItemPadding, ListItemLeading } from "./components/ui-list-item.js";
+export { UiListHeader } from "./components/ui-list-header.js";
+export type { ListHeaderSize } from "./components/ui-list-header.js";
+export { UiListGroup } from "./components/ui-list-group.js";
+export type { ListGroupSize } from "./components/ui-list-group.js";

--- a/packages/ui-components/src/stories/ui-list.stories.ts
+++ b/packages/ui-components/src/stories/ui-list.stories.ts
@@ -1,0 +1,257 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-list-item.js";
+import "../components/ui-list-header.js";
+import "../components/ui-list-group.js";
+import "../components/ui-icon.js";
+import "../components/ui-avatar.js";
+
+const meta: Meta = {
+  title: "Components/List",
+  component: "ui-list-group",
+  tags: ["autodocs"],
+};
+export default meta;
+type Story = StoryObj;
+
+// ─── Single Item ─────────────────────────────────────────────────────────────
+
+export const SingleDefault: Story = {
+  render: () => html`
+    <ui-list-item size="m">Default list item</ui-list-item>
+  `,
+};
+
+export const SingleAllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 32px; align-items: start;">
+      <div>
+        <strong style="font-family: Inter, sans-serif; font-size: 12px; color: #666;">S</strong>
+        <ui-list-item size="s">Small item</ui-list-item>
+      </div>
+      <div>
+        <strong style="font-family: Inter, sans-serif; font-size: 12px; color: #666;">M</strong>
+        <ui-list-item size="m">Medium item</ui-list-item>
+      </div>
+      <div>
+        <strong style="font-family: Inter, sans-serif; font-size: 12px; color: #666;">L</strong>
+        <ui-list-item size="l">Large item</ui-list-item>
+      </div>
+    </div>
+  `,
+};
+
+export const SingleWithDescription: Story = {
+  render: () => html`
+    <ui-list-item size="m" description="Supporting text that describes this item in more detail">
+      Multi-line list item
+    </ui-list-item>
+  `,
+};
+
+export const SingleWithLeadingIcon: Story = {
+  render: () => html`
+    <ui-list-item size="m" leading="icon">
+      <ui-icon slot="leading" name="person" size="s"></ui-icon>
+      Item with leading icon
+    </ui-list-item>
+  `,
+};
+
+export const SingleWithLeadingAvatar: Story = {
+  render: () => html`
+    <ui-list-item size="m" leading="avatar">
+      <ui-avatar slot="leading" size="s" type="text" color="blue">AB</ui-avatar>
+      Item with leading avatar
+    </ui-list-item>
+  `,
+};
+
+export const SingleWithTrailingIcon: Story = {
+  render: () => html`
+    <ui-list-item size="m" trailing-icon>
+      Item with trailing icon
+      <ui-icon slot="trailing" name="chevron_right" size="xs"></ui-icon>
+    </ui-list-item>
+  `,
+};
+
+export const SingleSelected: Story = {
+  render: () => html`
+    <ui-list-item size="m" selected>Selected item (shows tick)</ui-list-item>
+  `,
+};
+
+export const SingleStates: Story = {
+  render: () => html`
+    <div style="width: 280px;">
+      <ui-list-item size="m">Enabled</ui-list-item>
+      <ui-list-item size="m" class="pseudo-hover">Hover (apply hover manually)</ui-list-item>
+      <ui-list-item size="m" class="pseudo-active">Active (apply active manually)</ui-list-item>
+      <ui-list-item size="m" selected>Selected</ui-list-item>
+    </div>
+  `,
+};
+
+export const SingleWithPadding: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 32px; align-items: start;">
+      <div>
+        <strong style="font-family: Inter, sans-serif; font-size: 12px; color: #666;">none</strong>
+        <ui-list-item size="m" padding="none">Padding none</ui-list-item>
+      </div>
+      <div>
+        <strong style="font-family: Inter, sans-serif; font-size: 12px; color: #666;">s</strong>
+        <ui-list-item size="m" padding="s">Padding S</ui-list-item>
+      </div>
+      <div>
+        <strong style="font-family: Inter, sans-serif; font-size: 12px; color: #666;">m</strong>
+        <ui-list-item size="m" padding="m">Padding M</ui-list-item>
+      </div>
+    </div>
+  `,
+};
+
+export const SingleWithTopBorder: Story = {
+  render: () => html`
+    <div style="width: 280px;">
+      <ui-list-item size="m" top-border>Item with top border</ui-list-item>
+      <ui-list-item size="m" top-border>Another bordered item</ui-list-item>
+      <ui-list-item size="m" top-border>Third bordered item</ui-list-item>
+    </div>
+  `,
+};
+
+// ─── Header ──────────────────────────────────────────────────────────────────
+
+export const HeaderDefault: Story = {
+  render: () => html`
+    <ui-list-header size="m">Section Header</ui-list-header>
+  `,
+};
+
+export const HeaderAllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 32px; align-items: start;">
+      <div>
+        <strong style="font-family: Inter, sans-serif; font-size: 12px; color: #666;">S</strong>
+        <ui-list-header size="s">Small Header</ui-list-header>
+      </div>
+      <div>
+        <strong style="font-family: Inter, sans-serif; font-size: 12px; color: #666;">M</strong>
+        <ui-list-header size="m">Medium Header</ui-list-header>
+      </div>
+      <div>
+        <strong style="font-family: Inter, sans-serif; font-size: 12px; color: #666;">L</strong>
+        <ui-list-header size="l">Large Header</ui-list-header>
+      </div>
+    </div>
+  `,
+};
+
+// ─── Group ───────────────────────────────────────────────────────────────────
+
+export const GroupDefault: Story = {
+  render: () => html`
+    <ui-list-group size="m">
+      <ui-list-header slot="header">Section Title</ui-list-header>
+      <ui-list-item top-border>Item 1</ui-list-item>
+      <ui-list-item top-border>Item 2</ui-list-item>
+      <ui-list-item top-border>Item 3</ui-list-item>
+      <ui-list-item top-border>Item 4</ui-list-item>
+      <ui-list-item top-border>Item 5</ui-list-item>
+    </ui-list-group>
+  `,
+};
+
+export const GroupAllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 32px; align-items: start;">
+      <ui-list-group size="s">
+        <ui-list-header slot="header">Small</ui-list-header>
+        <ui-list-item top-border>Item 1</ui-list-item>
+        <ui-list-item top-border>Item 2</ui-list-item>
+        <ui-list-item top-border>Item 3</ui-list-item>
+      </ui-list-group>
+      <ui-list-group size="m">
+        <ui-list-header slot="header">Medium</ui-list-header>
+        <ui-list-item top-border>Item 1</ui-list-item>
+        <ui-list-item top-border>Item 2</ui-list-item>
+        <ui-list-item top-border>Item 3</ui-list-item>
+      </ui-list-group>
+      <ui-list-group size="l">
+        <ui-list-header slot="header">Large</ui-list-header>
+        <ui-list-item top-border>Item 1</ui-list-item>
+        <ui-list-item top-border>Item 2</ui-list-item>
+        <ui-list-item top-border>Item 3</ui-list-item>
+      </ui-list-group>
+    </div>
+  `,
+};
+
+export const GroupCollapsed: Story = {
+  render: () => html`
+    <ui-list-group size="m" collapsed>
+      <ui-list-header slot="header">Collapsed Section</ui-list-header>
+      <ui-list-item top-border>Item 1</ui-list-item>
+      <ui-list-item top-border>Item 2</ui-list-item>
+      <ui-list-item top-border>Item 3</ui-list-item>
+    </ui-list-group>
+  `,
+};
+
+export const GroupWithLeadingIcons: Story = {
+  render: () => html`
+    <ui-list-group size="m">
+      <ui-list-header slot="header">People</ui-list-header>
+      <ui-list-item top-border leading="icon">
+        <ui-icon slot="leading" name="person" size="s"></ui-icon>
+        Alice Johnson
+      </ui-list-item>
+      <ui-list-item top-border leading="icon">
+        <ui-icon slot="leading" name="person" size="s"></ui-icon>
+        Bob Smith
+      </ui-list-item>
+      <ui-list-item top-border leading="icon">
+        <ui-icon slot="leading" name="person" size="s"></ui-icon>
+        Carol Williams
+      </ui-list-item>
+      <ui-list-item top-border leading="icon">
+        <ui-icon slot="leading" name="person" size="s"></ui-icon>
+        David Brown
+      </ui-list-item>
+      <ui-list-item top-border leading="icon">
+        <ui-icon slot="leading" name="person" size="s"></ui-icon>
+        Eve Davis
+      </ui-list-item>
+    </ui-list-group>
+  `,
+};
+
+export const MultiLineGroup: Story = {
+  render: () => html`
+    <ui-list-group size="m">
+      <ui-list-header slot="header">Notifications</ui-list-header>
+      <ui-list-item top-border leading="icon" description="You have 3 new messages in your inbox">
+        <ui-icon slot="leading" name="mail" size="s"></ui-icon>
+        New Messages
+      </ui-list-item>
+      <ui-list-item top-border leading="icon" description="Your monthly report is ready to download">
+        <ui-icon slot="leading" name="download" size="s"></ui-icon>
+        Report Ready
+      </ui-list-item>
+      <ui-list-item top-border leading="icon" description="2 team members joined your project">
+        <ui-icon slot="leading" name="group" size="s"></ui-icon>
+        Team Update
+      </ui-list-item>
+      <ui-list-item top-border leading="icon" description="System maintenance scheduled for tonight">
+        <ui-icon slot="leading" name="settings" size="s"></ui-icon>
+        Maintenance
+      </ui-list-item>
+      <ui-list-item top-border leading="icon" description="Your file has been shared with 5 people">
+        <ui-icon slot="leading" name="share" size="s"></ui-icon>
+        File Shared
+      </ui-list-item>
+    </ui-list-group>
+  `,
+};


### PR DESCRIPTION
## Summary

- Add `<ui-list-item>` — single/multi-line list item with 3 sizes, 5 leading elements, 3 paddings, hover/active states, selected tick, description (71 tests)
- Add `<ui-list-header>` — section header with collapse button, 3 sizes (24 tests)
- Add `<ui-list-group>` — wrapper with size propagation, collapsible (23 tests)
- Add 2 new foundation tokens: `stateHover.surfaceMinimal` (gray-10), `stateSelected.surfaceMinimal` (blue-10)
- 17 stories covering all variants
- 2216 tests passing across 42 test files, 50 components total