### PR TITLE
feat: add visual catalog app with Playwright regression tests

### DIFF
--- a/.github/workflows/deploy-catalog.yml
+++ b/.github/workflows/deploy-catalog.yml
@@ -1,0 +1,72 @@
+name: Deploy Catalog
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/catalog/**'
+      - 'packages/ui-components/**'
+      - 'packages/foundation/**'
+      - 'packages/grid-layout/**'
+      - 'packages/flex-layout/**'
+      - '.github/workflows/deploy-catalog.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/catalog/**'
+      - 'packages/ui-components/**'
+      - 'packages/foundation/**'
+      - 'packages/grid-layout/**'
+      - 'packages/flex-layout/**'
+      - '.github/workflows/deploy-catalog.yml'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.16.0'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Build foundation
+        run: npm run build
+        working-directory: packages/foundation
+
+      - name: Build ui-components
+        run: npm run build
+        working-directory: packages/ui-components
+
+      - name: Build grid-layout
+        run: npm run build
+        working-directory: packages/grid-layout
+
+      - name: Build flex-layout
+        run: npm run build
+        working-directory: packages/flex-layout
+
+      - name: Build catalog
+        run: npx vite build
+        working-directory: apps/catalog
+
+      - name: Create Cloudflare Pages project (if needed)
+        uses: cloudflare/wrangler-action@v3
+        continue-on-error: true
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages project create maneki-catalog --production-branch=main
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy apps/catalog/dist --project-name=maneki-catalog --branch=${{ github.head_ref || github.ref_name }} --commit-dirty=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,12 @@ maneki-monorepo/
 │   │                        # Overlays: modal
 │   │                        # Tabs: tab-item, tab-group
 │   └── foundation/          # Design tokens: colors, semantic, typography, spacing, elevation, breakpoints (@maneki/foundation)
+├── apps/
+│   └── catalog/             # Visual catalog app + Playwright regression tests (@maneki/catalog)
+│       ├── src/pages/        # 34 pages (5 foundation + 29 component)
+│       ├── e2e/             # Playwright visual specs + baseline snapshots
+│       └── playwright.config.ts
+```
 ```
 
 ## WHERE TO LOOK
@@ -42,6 +48,7 @@ maneki-monorepo/
 | Grid layout library | `packages/grid-layout/` | Has its own detailed AGENTS.md |
 | Flex layout library | `packages/flex-layout/` | Panel-based flex layout, has its own AGENTS.md |
 | Storybook (all packages) | `.storybook/` | Root-level, aggregates foundation + ui-components + grid-layout + flex-layout |
+| Visual catalog + Playwright tests | `apps/catalog/` | 34 pages, 36 visual regression tests |
 
 ## CONVENTIONS
 - **Zero runtime deps** (except `ui-components`, `grid-layout`, and `flex-layout` → `@maneki/foundation`). Foundation has zero production dependencies.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ maneki-monorepo/
 | `grid-layout` | `@maneki/grid-layout` | Zero-dep drag/resize grid layout (220 tests) |
 | `flex-layout` | `@maneki/flex-layout` | Panel-based flex layout for dashboard-style interfaces (3 components, 50 tests) |
 
+### Apps
+
+| App | Description |
+|---|---|
+| `catalog` | Visual catalog for all foundation tokens + 50 components. Used for Playwright visual regression tests (36 screenshot tests). |
+| `flex-layout` | `@maneki/flex-layout` | Panel-based flex layout for dashboard-style interfaces (3 components, 50 tests) |
+
 ---
 
 ## Getting Started

--- a/apps/catalog/AGENTS.md
+++ b/apps/catalog/AGENTS.md
@@ -1,0 +1,136 @@
+# apps/catalog — Visual Catalog & Playwright Regression Tests
+
+## OVERVIEW
+Dedicated visual catalog app for the Maneki design system. Renders all foundation tokens and 50 UI components with key variants on static pages. Used as the target for Playwright screenshot-based visual regression tests. No Storybook dependency — pure Vite + vanilla TS.
+
+## STRUCTURE
+```
+catalog/
+├── index.html              # App shell (sidebar + content area + CSS)
+├── vite.config.ts          # Vite config with @maneki/* aliases
+├── tsconfig.json           # TypeScript config
+├── playwright.config.ts    # Playwright: chromium, 1280×900, vite preview server
+├── moon.yml                # Moon tasks: dev, build, test-visual, test-visual-update
+├── package.json            # @maneki/catalog — deps on foundation + ui-components
+├── src/
+│   ├── main.ts             # App entry: injects tokens, registers icon font, imports all pages, hash router
+│   └── pages/              # 34 page modules (5 foundation + 29 component)
+│       ├── colors.ts
+│       ├── spacing.ts
+│       ├── typography.ts
+│       ├── elevation.ts
+│       ├── semantic-tokens.ts
+│       ├── badge.ts
+│       ├── button.ts
+│       ├── avatar.ts
+│       ├── alert.ts
+│       ├── icon.ts
+│       ├── image.ts
+│       ├── label.ts
+│       ├── link.ts
+│       ├── tag.ts
+│       ├── checkbox.ts
+│       ├── radio.ts
+│       ├── input.ts
+│       ├── textarea.ts
+│       ├── file-upload.ts
+│       ├── select.ts
+│       ├── card.ts
+│       ├── breadcrumb.ts
+│       ├── accordion.ts
+│       ├── dropdown.ts
+│       ├── menu.ts
+│       ├── modal.ts
+│       ├── side-panel-menu.ts
+│       ├── tabs.ts
+│       ├── table.ts
+│       ├── carousel.ts
+│       ├── calendar.ts
+│       ├── datetime-picker.ts
+│       ├── clock.ts
+│       └── list.ts
+└── e2e/
+    ├── visual.spec.ts      # 36 Playwright screenshot tests
+    ├── test-results/        # Playwright test artifacts (gitignored)
+    └── snapshots/           # Baseline screenshots (committed)
+        └── visual.spec.ts/
+            ├── visual-colors/colors-chromium.png
+            ├── visual-button/button-chromium.png
+            ├── visual-sidebar/sidebar-chromium.png
+            ├── visual-full-layout/full-layout-chromium.png
+            └── ... (36 snapshot directories total)
+```
+
+## WHERE TO LOOK
+| Task | Location | Notes |
+|------|----------|-------|
+| Add a new catalog page | `src/pages/` | Create file + import in `main.ts` |
+| Add page to visual tests | `e2e/visual.spec.ts` | Add page ID to `pages` array |
+| Update baseline snapshots | Run `test-visual-update` | After intentional visual changes |
+| Modify app shell/layout | `index.html` | Sidebar, content area, CSS classes |
+| Change Playwright config | `playwright.config.ts` | Viewport, threshold, browser |
+
+## ARCHITECTURE
+
+### Page Registration
+Each page module calls `registerPage(id, { title, section, render, setup? })`:
+- `id` — URL hash fragment (e.g., `"button"` → `/#button`)
+- `title` — displayed as `<h2>` heading
+- `section` — sidebar group (`"Foundation"` or `"Components"`)
+- `render()` — returns plain HTML string with web component tags
+- `setup()` — optional, runs after render for imperative DOM manipulation (e.g., `setItems()`)
+
+### Router
+Hash-based routing. `window.location.hash` maps to page IDs. Sidebar links update the hash, `hashchange` event triggers re-render.
+
+### Visual Tests
+One screenshot test per page, targeting `#content` element (excludes sidebar for focused component comparison). Plus sidebar and full-layout tests.
+
+## CONVENTIONS
+- **Plain HTML strings** — no lit, no JSX. `render()` returns template literal HTML.
+- **CSS classes from index.html** — `variant-row`, `variant-col`, `variant-label`, `variant-group` for consistent layout.
+- **Components auto-registered** — `import "@maneki/ui-components"` in `main.ts` registers all custom elements globally.
+- **Snapshot naming** — `{pageId}-chromium.png` inside `visual-{pageId}/` directory.
+- **1% pixel diff threshold** — `maxDiffPixelRatio: 0.01` in Playwright config.
+
+## ANTI-PATTERNS
+- **Don't use Storybook patterns** — no lit html, no CSF3, no decorators. Plain HTML strings only.
+- **Don't open dropdowns/modals by default** — they overlay other content and break screenshots.
+- **Don't use external images** — they cause flaky tests. Use colored divs or inline SVGs.
+- **Don't forget to add new pages to both `main.ts` imports AND `visual.spec.ts` pages array.**
+
+## COMMANDS
+```bash
+# Development
+moon run catalog:dev                # Vite dev server on port 5174
+npx vite --port 5174               # Same, from apps/catalog/
+
+# Build
+moon run catalog:build              # Vite production build → dist/
+
+# Visual regression tests
+moon run catalog:test-visual        # Run 36 Playwright screenshot tests
+moon run catalog:test-visual-update # Regenerate baseline snapshots
+
+# From apps/catalog/ directly
+npx playwright test                 # Run tests
+npx playwright test --update-snapshots  # Update baselines
+```
+
+## SOP: Adding a New Catalog Page
+
+1. Create `src/pages/{component}.ts`
+2. Import `registerPage` from `"../main.js"`
+3. Call `registerPage("{id}", { title, section: "Components", render: () => html })` 
+4. Add `import "./pages/{component}.js"` to `src/main.ts`
+5. Add `"{id}"` to the `pages` array in `e2e/visual.spec.ts`
+6. Run `npx vite build && npx playwright test --update-snapshots` to generate baseline
+7. Verify the snapshot looks correct
+8. Commit the new page file + snapshot
+
+## NOTES
+- Vite aliases resolve `@maneki/foundation` and `@maneki/ui-components` to source (not dist) for HMR in dev
+- Playwright uses `vite preview` (production build) for deterministic rendering
+- 36 tests run in ~44s on Chromium
+- Snapshots are platform-specific (chromium on macOS) — CI may need its own baselines
+- The `setup()` callback uses `requestAnimationFrame` to ensure DOM is ready before imperative manipulation

--- a/apps/catalog/README.md
+++ b/apps/catalog/README.md
@@ -1,0 +1,87 @@
+# @maneki/catalog
+
+Visual catalog app for the Maneki design system. Renders all foundation tokens and 50 UI components with key variants on deterministic pages. Used as the target for Playwright screenshot-based visual regression tests.
+
+- 34 pages (5 foundation + 29 component)
+- 36 Playwright visual regression tests
+- Hash-based routing, sidebar navigation
+- Pure Vite + vanilla TypeScript — no Storybook dependency
+
+## Quick Start
+
+```bash
+# Development
+moon run catalog:dev          # http://localhost:5174
+
+# Visual regression tests
+moon run catalog:test-visual  # Run 36 screenshot tests
+```
+
+## Pages
+
+### Foundation
+| Page | Description |
+|------|-------------|
+| Colors | 13 color families × 10 steps |
+| Spacing | 17-step spacing scale |
+| Typography | 7 groups (display, heading, body, ui, caption, badge, code) |
+| Elevation | 6 elevation levels |
+| Semantic Tokens | Surface, border, text, icon token swatches |
+
+### Components
+| Page | Variants |
+|------|----------|
+| Badge | Sizes, emphases, colors, shapes, statuses |
+| Button | Actions × emphases, sizes, shapes, states, icon modes |
+| Avatar | Types, sizes, colors, emphases, shapes, statuses |
+| Alert | Statuses, sizes, emphases |
+| Icon | All 34 icons, sizes, filled |
+| Image | Aspect ratios, object fit |
+| Label | Sizes, emphases, states |
+| Link | Sizes, states, external |
+| Tag | Sizes, types, emphases, dismissible |
+| Checkbox | Sizes, states, label positions, groups |
+| Radio | Sizes, states, label positions, groups |
+| Input | Sizes, types, states, statuses |
+| Textarea | Sizes, states, statuses |
+| File Upload | Sizes, disabled |
+| Select | Sizes, statuses |
+| Card | Sizes, elevations, bordered |
+| Breadcrumb | Sizes |
+| Accordion | Sizes, emphases |
+| Dropdown | Sizes, split variant |
+| Menu | Items, headings, separators |
+| Modal | Trigger button |
+| Side Panel Menu | Expanded with primary/secondary items |
+| Tabs | Sizes, orientations |
+| Table | Sizes, zebra, bordered |
+| Carousel | Basic with colored slides |
+| Calendar | Sizes, range, monthly, quicklinks, time |
+| Datetime Picker | Single-date, range-date, time, datetime |
+| Clock | Sizes |
+| List | Sizes, description, leading/trailing, groups |
+
+## Visual Regression Tests
+
+```bash
+# Run tests (requires build first)
+moon run catalog:test-visual
+
+# Update baselines after intentional changes
+moon run catalog:test-visual-update
+```
+
+36 tests: one screenshot per page (targeting `#content`), plus sidebar and full-layout screenshots. Chromium only, 1280×900 viewport, 1% pixel diff threshold.
+
+## Development
+
+```bash
+moon run catalog:dev              # Vite dev server on port 5174
+moon run catalog:build            # Production build → dist/
+moon run catalog:test-visual      # Playwright screenshot tests
+moon run catalog:test-visual-update  # Regenerate baselines
+```
+
+## License
+
+MIT

--- a/apps/catalog/e2e/visual.spec.ts
+++ b/apps/catalog/e2e/visual.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from "@playwright/test";
+
+// All catalog page IDs — must match registerPage() calls in src/pages/*.ts
+const pages = [
+  // Foundation
+  "colors",
+  "spacing",
+  "typography",
+  "elevation",
+  "semantic-tokens",
+  // Components
+  "badge",
+  "button",
+  "avatar",
+  "alert",
+  "icon",
+  "image",
+  "label",
+  "link",
+  "tag",
+  "checkbox",
+  "radio",
+  "input",
+  "textarea",
+  "file-upload",
+  "select",
+  "card",
+  "breadcrumb",
+  "accordion",
+  "dropdown",
+  "menu",
+  "modal",
+  "side-panel-menu",
+  "tabs",
+  "table",
+  "carousel",
+  "calendar",
+  "datetime-picker",
+  "clock",
+  "list",
+  // Layouts
+  "grid-layout",
+  "flex-layout",
+];
+
+async function navigateToPage(page: import("@playwright/test").Page, pageId: string) {
+  await page.goto(`/#${pageId}`);
+  // Wait for custom elements to upgrade + render
+  await page.waitForTimeout(500);
+  // Wait for any fonts to load
+  await page.evaluate(() => document.fonts.ready);
+}
+
+// ─── Full-page visual regression per catalog page ────────────────────────────
+
+for (const pageId of pages) {
+  test(`visual: ${pageId}`, async ({ page }) => {
+    await navigateToPage(page, pageId);
+    const content = page.locator("#content");
+    await expect(content).toHaveScreenshot(`${pageId}.png`, {
+      fullPage: false,
+      animations: "disabled",
+    });
+  });
+}
+
+// ─── Sidebar navigation ─────────────────────────────────────────────────────
+
+test("visual: sidebar", async ({ page }) => {
+  await page.goto("/");
+  await page.waitForTimeout(500);
+  const sidebar = page.locator("#sidebar");
+  await expect(sidebar).toHaveScreenshot("sidebar.png");
+});
+
+// ─── Full app layout ─────────────────────────────────────────────────────────
+
+test("visual: full layout", async ({ page }) => {
+  await navigateToPage(page, "button");
+  await expect(page).toHaveScreenshot("full-layout.png");
+});

--- a/apps/catalog/index.html
+++ b/apps/catalog/index.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Maneki Design System Catalog</title>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; }
+
+    html, body {
+      height: 100%;
+      font-family: Inter, sans-serif;
+      color: #1c2b36;
+      background: #f8f9fa;
+    }
+
+    #app {
+      display: flex;
+      height: 100vh;
+    }
+
+    /* Sidebar */
+    #sidebar {
+      width: 240px;
+      min-width: 240px;
+      height: 100vh;
+      overflow-y: auto;
+      background: #fff;
+      border-right: 1px solid #dce3e8;
+      padding: 16px 0;
+      scrollbar-width: thin;
+    }
+
+    #sidebar h1 {
+      font-size: 16px;
+      font-weight: 700;
+      padding: 0 16px 12px;
+      color: #1c2b36;
+    }
+
+    #sidebar .section-title {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: #7a909e;
+      padding: 12px 16px 4px;
+    }
+
+    #sidebar a {
+      display: block;
+      padding: 6px 16px 6px 24px;
+      font-size: 13px;
+      color: #3e5463;
+      text-decoration: none;
+      line-height: 20px;
+      transition: background 0.1s;
+    }
+
+    #sidebar a:hover {
+      background: #f2f5f7;
+    }
+
+    #sidebar a.active {
+      background: #ebf3fe;
+      color: #186ade;
+      font-weight: 500;
+    }
+
+    /* Content */
+    #content {
+      flex: 1;
+      overflow-y: auto;
+      padding: 32px 40px;
+    }
+
+    #content h2 {
+      font-size: 24px;
+      font-weight: 700;
+      margin-bottom: 24px;
+      color: #1c2b36;
+    }
+
+    #content h3 {
+      font-size: 16px;
+      font-weight: 600;
+      margin: 24px 0 12px;
+      color: #3e5463;
+    }
+
+    .variant-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 16px;
+      align-items: flex-start;
+      margin-bottom: 24px;
+    }
+
+    .variant-col {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      align-items: flex-start;
+    }
+
+    .variant-label {
+      font-size: 11px;
+      font-weight: 500;
+      color: #7a909e;
+      text-transform: uppercase;
+      letter-spacing: 0.3px;
+    }
+
+    .variant-group {
+      border: 1px solid #dce3e8;
+      border-radius: 4px;
+      padding: 16px;
+      background: #fff;
+      margin-bottom: 16px;
+    }
+
+    .variant-group-title {
+      font-size: 13px;
+      font-weight: 600;
+      color: #3e5463;
+      margin-bottom: 12px;
+    }
+
+    /* Page-specific: color swatches */
+    .swatch-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, 64px);
+      gap: 8px;
+    }
+
+    .swatch {
+      width: 64px;
+      height: 40px;
+      border-radius: 4px;
+      border: 1px solid rgba(0,0,0,0.08);
+    }
+
+    .swatch-label {
+      font-size: 10px;
+      color: #7a909e;
+      text-align: center;
+      margin-top: 2px;
+    }
+
+    /* Page-specific: spacing */
+    .spacing-bar {
+      height: 24px;
+      background: #186ade;
+      border-radius: 2px;
+      opacity: 0.6;
+    }
+
+    /* Page-specific: typography */
+    .type-sample {
+      margin-bottom: 8px;
+    }
+
+    /* Elevation samples */
+    .elevation-card {
+      width: 120px;
+      height: 80px;
+      background: #fff;
+      border-radius: 4px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 12px;
+      color: #7a909e;
+    }
+
+    /* List container for component demos */
+    .demo-list {
+      width: 300px;
+    }
+
+    /* ─── Reusable layout utilities ─── */
+
+    .stack-s { display: flex; flex-direction: column; gap: 12px; }
+    .stack-m { display: flex; flex-direction: column; gap: 16px; }
+    .stack-l { display: flex; flex-direction: column; gap: 24px; }
+
+    .w-320 { max-width: 320px; }
+    .w-360 { max-width: 360px; }
+    .w-400 { max-width: 400px; }
+    .w-600 { max-width: 600px; }
+    .w-720 { max-width: 720px; }
+    .w-280 { width: 280px; }
+
+    .grid-2 { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
+    .grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+    .grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
+
+    .matrix { display: grid; gap: 8px 12px; align-items: center; }
+    .matrix-3 { grid-template-columns: 80px repeat(3, 1fr); }
+    .matrix-4 { grid-template-columns: 80px repeat(4, 1fr); }
+    .matrix-5 { grid-template-columns: 80px repeat(5, 1fr); }
+
+    .row-wrap { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+    .row-start { align-items: flex-start; }
+
+    .panel-border { max-width: 280px; border: 1px solid #dce3e8; border-radius: 8px; overflow: hidden; }
+    .pos-relative { position: relative; }
+
+    .card-content { display: flex; flex-direction: column; gap: 4px; }
+    .card-title { margin: 0; font-size: 16px; font-weight: 500; }
+    .card-text { margin: 0; font-size: 14px; }
+    .flex-1 { flex: 1; }
+    .full { width: 100%; height: 100%; }
+    .row-gap-8 { display: flex; gap: 8px; }
+    .row-start-wrap { display: flex; align-items: flex-start; gap: 24px; flex-wrap: wrap; }
+    .text-secondary { font-size: 12px; color: #9FB1BD; }
+
+    .gap-24 { gap: 24px; }
+    .gap-32 { gap: 32px; }
+    .gap-48 { gap: 48px; }
+    .items-center { align-items: center; }
+
+    .section-label { margin: 0 0 12px; font-size: 14px; color: #5b7282; }
+    .mono-label { margin: 0 0 8px; font-size: 13px; font-family: monospace; }
+    .hint { margin: 0 0 4px; font-size: 12px; color: #5b7282; }
+    .main-content { flex: 1; padding: 24px; background: #fff; }
+    .main-content p { margin: 0; color: #1c2b36; font-size: 14px; }
+
+    .layout-frame { display: flex; border: 1px solid #dce3e8; border-radius: 8px; overflow: hidden; }
+    .layout-frame-400 { height: 400px; }
+    .layout-frame-500 { height: 500px; }
+    .w-200 { max-width: 200px; }
+    .w-300 { max-width: 300px; }
+    .h-100 { height: 100px; }
+    .h-120 { height: 120px; }
+    .h-180 { max-height: 180px; }
+
+    /* Layout demo utilities */
+    .demo-frame { width: 100%; }
+    .demo-frame-400 { height: 400px; }
+    .demo-frame-500 { height: 500px; }
+    .demo-frame-600 { height: 600px; }
+    .flex-fill { flex: 1; padding: 0; }
+    .panel-content { display: flex; align-items: center; justify-content: center; height: 100%; color: #5b7282; font-family: Inter, sans-serif; font-size: 16px; font-weight: 500; }
+    .grid-item-cell { border-radius: 6px; display: flex; align-items: center; justify-content: center; font-family: Inter, sans-serif; font-size: 14px; font-weight: 600; height: 100%; user-select: none; }
+    .grid-item-static { background: #5B7282; border: 1px solid #DCE3E8; color: #fff; }
+  </style>
+</head>
+<body>
+  <div id="app">
+    <nav id="sidebar"></nav>
+    <main id="content"></main>
+  </div>
+  <script type="module" src="/src/main.ts"></script>
+</body>
+</html>

--- a/apps/catalog/moon.yml
+++ b/apps/catalog/moon.yml
@@ -1,0 +1,40 @@
+$schema: 'https://moonrepo.dev/schemas/project.json'
+
+language: 'typescript'
+
+dependsOn:
+  - 'foundation'
+  - 'ui-components'
+
+tasks:
+  dev:
+    command: 'vite --port 5174'
+    preset: 'server'
+
+  build:
+    script: 'vite build'
+    inputs:
+      - 'src/**/*'
+      - 'index.html'
+      - 'tsconfig.json'
+      - 'vite.config.ts'
+    outputs:
+      - 'dist'
+    deps:
+      - '^:build'
+
+  test-visual:
+    command: 'playwright test'
+    inputs:
+      - 'src/**/*'
+      - 'e2e/**/*'
+      - 'playwright.config.ts'
+    deps:
+      - '~:build'
+
+  test-visual-update:
+    command: 'playwright test --update-snapshots'
+    inputs:
+      - 'src/**/*'
+      - 'e2e/**/*'
+      - 'playwright.config.ts'

--- a/apps/catalog/package.json
+++ b/apps/catalog/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@maneki/catalog",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Visual catalog for Maneki design system — used for Playwright regression tests",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --port 5174",
+    "build": "vite build",
+    "preview": "vite preview --port 5174",
+    "test:visual": "playwright test",
+    "test:visual:update": "playwright test --update-snapshots"
+  },
+  "dependencies": {
+    "@maneki/foundation": "*",
+    "@maneki/ui-components": "*",
+    "@maneki/grid-layout": "*",
+    "@maneki/flex-layout": "*"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.58.2",
+    "typescript": "^5.4.0",
+    "vite": "^5.4.0"
+  }
+}

--- a/apps/catalog/playwright.config.ts
+++ b/apps/catalog/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  outputDir: "./e2e/test-results",
+  snapshotDir: "./e2e/snapshots",
+  snapshotPathTemplate: "{snapshotDir}/{testFilePath}/{testName}/{arg}-{projectName}{ext}",
+  timeout: 30000,
+  expect: {
+    toHaveScreenshot: {
+      maxDiffPixelRatio: 0.01,
+    },
+  },
+  use: {
+    baseURL: "http://localhost:5174",
+    viewport: { width: 1280, height: 900 },
+    actionTimeout: 5000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { browserName: "chromium" },
+    },
+  ],
+  webServer: {
+    command: "npx vite preview --port 5174",
+    port: 5174,
+    reuseExistingServer: true,
+    timeout: 10000,
+  },
+});

--- a/apps/catalog/src/main.ts
+++ b/apps/catalog/src/main.ts
@@ -1,0 +1,119 @@
+import { injectAllTokens, registerIconFont } from "@maneki/foundation";
+import materialSymbolsWoff2 from "@maneki/foundation/assets/material-symbols-outlined-subset.woff2?url";
+import "@maneki/ui-components";
+
+// Inject foundation tokens + icon font
+injectAllTokens();
+registerIconFont(materialSymbolsWoff2);
+
+import { pages } from "./registry.js";
+
+// ─── Import all pages ────────────────────────────────────────────────────────
+
+import "./pages/colors.js";
+import "./pages/spacing.js";
+import "./pages/typography.js";
+import "./pages/elevation.js";
+import "./pages/semantic-tokens.js";
+import "./pages/badge.js";
+import "./pages/button.js";
+import "./pages/avatar.js";
+import "./pages/alert.js";
+import "./pages/icon.js";
+import "./pages/image.js";
+import "./pages/label.js";
+import "./pages/link.js";
+import "./pages/tag.js";
+import "./pages/checkbox.js";
+import "./pages/radio.js";
+import "./pages/input.js";
+import "./pages/textarea.js";
+import "./pages/file-upload.js";
+import "./pages/select.js";
+import "./pages/card.js";
+import "./pages/breadcrumb.js";
+import "./pages/accordion.js";
+import "./pages/dropdown.js";
+import "./pages/menu.js";
+import "./pages/modal.js";
+import "./pages/side-panel-menu.js";
+import "./pages/tabs.js";
+import "./pages/table.js";
+import "./pages/carousel.js";
+import "./pages/calendar.js";
+import "./pages/datetime-picker.js";
+import "./pages/clock.js";
+import "./pages/list.js";
+import "./pages/grid-layout.js";
+import "./pages/flex-layout.js";
+
+// ─── Router ──────────────────────────────────────────────────────────────────
+
+function buildSidebar(): void {
+  const sidebar = document.getElementById("sidebar")!;
+  const sections: Record<string, { id: string; title: string }[]> = {};
+
+  const sectionOrder = ["Foundation", "Primitives", "Form Controls", "Containers", "Navigation", "Disclosure", "Menus & Dropdowns", "Overlays", "Tabs", "Data Display", "Calendar & Date", "List", "Layouts"];
+
+  for (const [id, page] of Object.entries(pages)) {
+    if (!sections[page.section]) sections[page.section] = [];
+    sections[page.section].push({ id, title: page.title });
+  }
+
+  let html = `<h1>Maneki</h1>`;
+  for (const section of sectionOrder) {
+    const items = sections[section];
+    if (!items) continue;
+    html += `<div class="section-title">${section}</div>`;
+    for (const item of items) {
+      html += `<a href="#${item.id}" data-page="${item.id}">${item.title}</a>`;
+    }
+  }
+  sidebar.innerHTML = html;
+
+  sidebar.addEventListener("click", (e) => {
+    const link = (e.target as HTMLElement).closest("a");
+    if (!link) return;
+    e.preventDefault();
+    const pageId = link.dataset.page;
+    if (pageId) navigate(pageId);
+  });
+}
+
+function navigate(pageId: string): void {
+  window.location.hash = pageId;
+  renderPage(pageId);
+}
+
+function renderPage(pageId: string): void {
+  const page = pages[pageId];
+  const content = document.getElementById("content")!;
+
+  if (!page) {
+    content.innerHTML = `<h2>Welcome</h2><p>Select a page from the sidebar.</p>`;
+    return;
+  }
+
+  content.innerHTML = `<h2>${page.title}</h2>${page.render()}`;
+
+  // Update active link
+  document.querySelectorAll("#sidebar a").forEach((a) => {
+    a.classList.toggle("active", (a as HTMLElement).dataset.page === pageId);
+  });
+
+  // Run page setup (imperative DOM manipulation)
+  if (page.setup) {
+    requestAnimationFrame(() => page.setup!());
+  }
+}
+
+function onHashChange(): void {
+  const hash = window.location.hash.slice(1);
+  renderPage(hash || Object.keys(pages)[0]);
+}
+
+// ─── Init ────────────────────────────────────────────────────────────────────
+
+buildSidebar();
+window.addEventListener("hashchange", onHashChange);
+onHashChange();

--- a/apps/catalog/src/pages/accordion.ts
+++ b/apps/catalog/src/pages/accordion.ts
@@ -1,0 +1,132 @@
+import { registerPage } from "../registry.js";
+
+registerPage("accordion", {
+  title: "Accordion",
+  section: "Disclosure",
+  render: () => `
+    <h3>Sizes</h3>
+    <div class="stack-l">
+      <div>
+        <span class="variant-label">S</span>
+        <ui-accordion-group size="s">
+          <ui-accordion-item expanded>
+            <span slot="label">Small Item One</span>
+            Content for small item one.
+          </ui-accordion-item>
+          <ui-accordion-item>
+            <span slot="label">Small Item Two</span>
+            Content for small item two.
+          </ui-accordion-item>
+          <ui-accordion-item>
+            <span slot="label">Small Item Three</span>
+            Content for small item three.
+          </ui-accordion-item>
+        </ui-accordion-group>
+      </div>
+      <div>
+        <span class="variant-label">M</span>
+        <ui-accordion-group size="m">
+          <ui-accordion-item expanded>
+            <span slot="label">Medium Item One</span>
+            Content for medium item one.
+          </ui-accordion-item>
+          <ui-accordion-item>
+            <span slot="label">Medium Item Two</span>
+            Content for medium item two.
+          </ui-accordion-item>
+          <ui-accordion-item>
+            <span slot="label">Medium Item Three</span>
+            Content for medium item three.
+          </ui-accordion-item>
+        </ui-accordion-group>
+      </div>
+      <div>
+        <span class="variant-label">L</span>
+        <ui-accordion-group size="l">
+          <ui-accordion-item expanded>
+            <span slot="label">Large Item One</span>
+            Content for large item one.
+          </ui-accordion-item>
+          <ui-accordion-item>
+            <span slot="label">Large Item Two</span>
+            Content for large item two.
+          </ui-accordion-item>
+          <ui-accordion-item>
+            <span slot="label">Large Item Three</span>
+            Content for large item three.
+          </ui-accordion-item>
+        </ui-accordion-group>
+      </div>
+    </div>
+
+    <h3>Emphases</h3>
+    <div class="grid-2">
+      <div>
+        <span class="variant-label">Bold</span>
+        <ui-accordion-group size="m" emphasis="bold">
+          <ui-accordion-item expanded>
+            <span slot="label">Bold Item One</span>
+            Bold emphasis content.
+          </ui-accordion-item>
+          <ui-accordion-item>
+            <span slot="label">Bold Item Two</span>
+            More content.
+          </ui-accordion-item>
+        </ui-accordion-group>
+      </div>
+      <div>
+        <span class="variant-label">Subtle</span>
+        <ui-accordion-group size="m" emphasis="subtle">
+          <ui-accordion-item expanded>
+            <span slot="label">Subtle Item One</span>
+            Subtle emphasis content.
+          </ui-accordion-item>
+          <ui-accordion-item>
+            <span slot="label">Subtle Item Two</span>
+            More content.
+          </ui-accordion-item>
+        </ui-accordion-group>
+      </div>
+    </div>
+
+    <h3>Statuses</h3>
+    <ui-accordion-group size="m">
+      <ui-accordion-item status="error" expanded>
+        <span slot="label">Error Status</span>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      </ui-accordion-item>
+      <ui-accordion-item status="warning" expanded>
+        <span slot="label">Warning Status</span>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      </ui-accordion-item>
+      <ui-accordion-item status="success" expanded>
+        <span slot="label">Success Status</span>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      </ui-accordion-item>
+    </ui-accordion-group>
+
+    <h3>Disabled</h3>
+    <div class="variant-row">
+      <ui-accordion-item disabled>
+        <span slot="label">Disabled Accordion</span>
+        This content is not accessible.
+      </ui-accordion-item>
+    </div>
+
+    <h3>Exclusive Mode</h3>
+    <ui-accordion-group size="m" exclusive>
+      <ui-accordion-item expanded>
+        <span slot="label">Section One</span>
+        Only one section can be open at a time.
+      </ui-accordion-item>
+      <ui-accordion-item>
+        <span slot="label">Section Two</span>
+        Content for section two.
+      </ui-accordion-item>
+      <ui-accordion-item>
+        <span slot="label">Section Three</span>
+        Content for section three.
+      </ui-accordion-item>
+    </ui-accordion-group>
+  `,
+});

--- a/apps/catalog/src/pages/alert.ts
+++ b/apps/catalog/src/pages/alert.ts
@@ -1,0 +1,79 @@
+import { registerPage } from "../registry.js";
+
+registerPage("alert", {
+  title: "Alert",
+  section: "Primitives",
+  render: () => `
+    <h3>All Statuses (with icons)</h3>
+    <div class="variant-group stack-s">
+      <ui-alert status="none" leading-icon>
+        <ui-icon name="notifications" size="m" slot="icon"></ui-icon>
+        None status
+      </ui-alert>
+      <ui-alert status="information" leading-icon>
+        <ui-icon name="info" size="m" slot="icon"></ui-icon>
+        Information status
+      </ui-alert>
+      <ui-alert status="success" leading-icon>
+        <ui-icon name="check_circle" size="m" slot="icon"></ui-icon>
+        Success status
+      </ui-alert>
+      <ui-alert status="error" leading-icon>
+        <ui-icon name="error" size="m" slot="icon"></ui-icon>
+        Error status
+      </ui-alert>
+      <ui-alert status="warning" leading-icon>
+        <ui-icon name="warning" size="m" slot="icon"></ui-icon>
+        Warning status
+      </ui-alert>
+    </div>
+
+    <h3>Sizes</h3>
+    <div class="variant-group stack-s">
+      <ui-alert status="information" size="s">Small alert</ui-alert>
+      <ui-alert status="information" size="m">Medium alert</ui-alert>
+      <ui-alert status="information" size="l">Large alert</ui-alert>
+    </div>
+
+    <h3>Bold Emphasis</h3>
+    <div class="variant-group stack-s">
+      <ui-alert status="information" emphasis="bold">Information bold</ui-alert>
+      <ui-alert status="success" emphasis="bold">Success bold</ui-alert>
+      <ui-alert status="error" emphasis="bold">Error bold</ui-alert>
+      <ui-alert status="warning" emphasis="bold">Warning bold</ui-alert>
+    </div>
+
+    <h3>Subtle Emphasis</h3>
+    <div class="variant-group stack-s">
+      <ui-alert status="information" emphasis="subtle">Information subtle</ui-alert>
+      <ui-alert status="success" emphasis="subtle">Success subtle</ui-alert>
+      <ui-alert status="error" emphasis="subtle">Error subtle</ui-alert>
+      <ui-alert status="warning" emphasis="subtle">Warning subtle</ui-alert>
+    </div>
+
+    <h3>With Description</h3>
+    <div class="variant-group stack-s">
+      <ui-alert status="information">
+        Alert Title
+        <span slot="description">This is a longer description that provides more context about the alert.</span>
+      </ui-alert>
+    </div>
+
+    <h3>Dismissable</h3>
+    <div class="variant-group stack-s">
+      <ui-alert status="information" dismissable>This alert can be dismissed</ui-alert>
+    </div>
+
+    <h3>With Footer Button</h3>
+    <div class="variant-group stack-s">
+      <ui-alert status="none" leading-icon dismissable>
+        <ui-icon name="notifications" size="m" slot="icon"></ui-icon>
+        Alert Title
+        <span slot="description">Description text explaining the alert in more detail.</span>
+        <div slot="footer">
+          <ui-button action="contrast" emphasis="subtle" size="s">Refresh</ui-button>
+        </div>
+      </ui-alert>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/avatar.ts
+++ b/apps/catalog/src/pages/avatar.ts
@@ -1,0 +1,73 @@
+import { registerPage } from "../registry.js";
+
+registerPage("avatar", {
+  title: "Avatar",
+  section: "Primitives",
+  render: () => `
+    <h3>Sizes</h3>
+    <div class="variant-row">
+      <ui-avatar type="text" size="xs" color="blue">XS</ui-avatar>
+      <ui-avatar type="text" size="s" color="blue">S</ui-avatar>
+      <ui-avatar type="text" size="m" color="blue">M</ui-avatar>
+      <ui-avatar type="text" size="l" color="blue">L</ui-avatar>
+      <ui-avatar type="text" size="xl" color="blue">XL</ui-avatar>
+    </div>
+
+    <h3>Types</h3>
+    <div class="variant-group matrix matrix-5">
+      <span class="variant-label"></span>
+      <span class="variant-label">XS</span>
+      <span class="variant-label">S</span>
+      <span class="variant-label">M</span>
+      <span class="variant-label">L</span>
+      <span class="variant-label">XL</span>
+      <span class="variant-label">Text</span>
+      <ui-avatar type="text" size="xs" color="blue">AB</ui-avatar>
+      <ui-avatar type="text" size="s" color="blue">AB</ui-avatar>
+      <ui-avatar type="text" size="m" color="blue">AB</ui-avatar>
+      <ui-avatar type="text" size="l" color="blue">AB</ui-avatar>
+      <ui-avatar type="text" size="xl" color="blue">AB</ui-avatar>
+      <span class="variant-label">Icon</span>
+      <ui-avatar type="icon" size="xs" color="green"></ui-avatar>
+      <ui-avatar type="icon" size="s" color="green"></ui-avatar>
+      <ui-avatar type="icon" size="m" color="green"></ui-avatar>
+      <ui-avatar type="icon" size="l" color="green"></ui-avatar>
+      <ui-avatar type="icon" size="xl" color="green"></ui-avatar>
+    </div>
+
+    <h3>Colors</h3>
+    <div style="display:grid;grid-template-columns:repeat(7,auto);gap:8px;align-items:center;">
+      ${["gray","red","orange","yellow","lime","green","teal","turquoise","aqua","blue","ultramarine","purple","pink"].map(c =>
+        `<ui-avatar type="text" size="m" color="${c}">${c.substring(0,2).toUpperCase()}</ui-avatar>`
+      ).join("")}
+    </div>
+
+    <h3>Emphasis × Shape</h3>
+    <div class="variant-group" style="display:grid;grid-template-columns:80px repeat(4,auto);gap:8px 16px;align-items:center;">
+      <span class="variant-label"></span>
+      <span class="variant-label">Bold Circle</span>
+      <span class="variant-label">Bold Square</span>
+      <span class="variant-label">Subtle Circle</span>
+      <span class="variant-label">Subtle Square</span>
+      <span class="variant-label">Text</span>
+      <ui-avatar type="text" emphasis="bold" shape="circle" color="blue">AB</ui-avatar>
+      <ui-avatar type="text" emphasis="bold" shape="square" color="blue">AB</ui-avatar>
+      <ui-avatar type="text" emphasis="subtle" shape="circle" color="blue">AB</ui-avatar>
+      <ui-avatar type="text" emphasis="subtle" shape="square" color="blue">AB</ui-avatar>
+      <span class="variant-label">Icon</span>
+      <ui-avatar type="icon" emphasis="bold" shape="circle" color="red"></ui-avatar>
+      <ui-avatar type="icon" emphasis="bold" shape="square" color="red"></ui-avatar>
+      <ui-avatar type="icon" emphasis="subtle" shape="circle" color="red"></ui-avatar>
+      <ui-avatar type="icon" emphasis="subtle" shape="square" color="red"></ui-avatar>
+    </div>
+
+    <h3>Statuses</h3>
+    <div class="variant-row">
+      <div class="variant-col"><span class="variant-label">None</span><ui-avatar type="text" size="m" color="blue" status="none">AB</ui-avatar></div>
+      <div class="variant-col"><span class="variant-label">Success</span><ui-avatar type="text" size="m" color="blue" status="success">AB</ui-avatar></div>
+      <div class="variant-col"><span class="variant-label">Error</span><ui-avatar type="text" size="m" color="blue" status="error">AB</ui-avatar></div>
+      <div class="variant-col"><span class="variant-label">Warning</span><ui-avatar type="text" size="m" color="blue" status="warning">AB</ui-avatar></div>
+      <div class="variant-col"><span class="variant-label">Info</span><ui-avatar type="text" size="m" color="blue" status="information">AB</ui-avatar></div>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/badge.ts
+++ b/apps/catalog/src/pages/badge.ts
@@ -1,0 +1,48 @@
+import { registerPage } from "../registry.js";
+
+registerPage("badge", {
+  title: "Badge",
+  section: "Primitives",
+  render: () => `
+    <h3>Sizes</h3>
+    <div class="variant-row">
+      <div class="variant-col"><span class="variant-label">XS</span><ui-badge size="xs">Badge XS</ui-badge></div>
+      <div class="variant-col"><span class="variant-label">S</span><ui-badge size="s">Badge S</ui-badge></div>
+      <div class="variant-col"><span class="variant-label">M</span><ui-badge size="m">Badge M</ui-badge></div>
+      <div class="variant-col"><span class="variant-label">L</span><ui-badge size="l">Badge L</ui-badge></div>
+    </div>
+    <h3>Emphases</h3>
+    <div class="variant-row">
+      <ui-badge emphasis="bold" color="blue">Bold</ui-badge>
+      <ui-badge emphasis="subtle" color="blue">Subtle</ui-badge>
+      <ui-badge emphasis="minimal" color="blue">Minimal</ui-badge>
+    </div>
+    <h3>Colors</h3>
+    <div class="variant-row">
+      <ui-badge color="red">Red</ui-badge>
+      <ui-badge color="orange">Orange</ui-badge>
+      <ui-badge color="yellow">Yellow</ui-badge>
+      <ui-badge color="lime">Lime</ui-badge>
+      <ui-badge color="green">Green</ui-badge>
+      <ui-badge color="teal">Teal</ui-badge>
+      <ui-badge color="turquoise">Turquoise</ui-badge>
+      <ui-badge color="aqua">Aqua</ui-badge>
+      <ui-badge color="blue">Blue</ui-badge>
+      <ui-badge color="ultramarine">Ultramarine</ui-badge>
+      <ui-badge color="purple">Purple</ui-badge>
+      <ui-badge color="pink">Pink</ui-badge>
+    </div>
+    <h3>Shapes</h3>
+    <div class="variant-row">
+      <ui-badge shape="square">Square</ui-badge>
+      <ui-badge shape="rounded">Rounded</ui-badge>
+    </div>
+    <h3>Statuses</h3>
+    <div class="variant-row">
+      <ui-badge status="information">Info</ui-badge>
+      <ui-badge status="success">Success</ui-badge>
+      <ui-badge status="warning">Warning</ui-badge>
+      <ui-badge status="error">Error</ui-badge>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/breadcrumb.ts
+++ b/apps/catalog/src/pages/breadcrumb.ts
@@ -1,0 +1,66 @@
+import { registerPage } from "../registry.js";
+
+registerPage("breadcrumb", {
+  title: "Breadcrumb",
+  section: "Navigation",
+  render: () => `
+    <h3>Default</h3>
+    <div class="variant-row">
+      <ui-breadcrumb-group>
+        <ui-breadcrumb-item href="#">Home</ui-breadcrumb-item>
+        <ui-breadcrumb-item href="#">Products</ui-breadcrumb-item>
+        <ui-breadcrumb-item href="#">Shoes</ui-breadcrumb-item>
+        <ui-breadcrumb-item>Running Shoes</ui-breadcrumb-item>
+      </ui-breadcrumb-group>
+    </div>
+
+    <h3>Sizes</h3>
+    <div class="stack-l">
+      <div class="variant-row">
+        <span class="variant-label" style="width:30px">S</span>
+        <ui-breadcrumb-group size="s">
+          <ui-breadcrumb-item href="#">Home</ui-breadcrumb-item>
+          <ui-breadcrumb-item href="#">Docs</ui-breadcrumb-item>
+          <ui-breadcrumb-item>Current</ui-breadcrumb-item>
+        </ui-breadcrumb-group>
+      </div>
+      <div class="variant-row">
+        <span class="variant-label" style="width:30px">M</span>
+        <ui-breadcrumb-group size="m">
+          <ui-breadcrumb-item href="#">Home</ui-breadcrumb-item>
+          <ui-breadcrumb-item href="#">Docs</ui-breadcrumb-item>
+          <ui-breadcrumb-item>Current</ui-breadcrumb-item>
+        </ui-breadcrumb-group>
+      </div>
+      <div class="variant-row">
+        <span class="variant-label" style="width:30px">L</span>
+        <ui-breadcrumb-group size="l">
+          <ui-breadcrumb-item href="#">Home</ui-breadcrumb-item>
+          <ui-breadcrumb-item href="#">Docs</ui-breadcrumb-item>
+          <ui-breadcrumb-item>Current</ui-breadcrumb-item>
+        </ui-breadcrumb-group>
+      </div>
+    </div>
+
+    <h3>States</h3>
+    <div class="variant-row">
+      <ui-breadcrumb-group size="m">
+        <ui-breadcrumb-item href="#">Enabled</ui-breadcrumb-item>
+        <ui-breadcrumb-item disabled>Disabled</ui-breadcrumb-item>
+        <ui-breadcrumb-item>Current</ui-breadcrumb-item>
+      </ui-breadcrumb-group>
+    </div>
+
+    <h3>With Many Items</h3>
+    <div class="variant-row">
+      <ui-breadcrumb-group size="m">
+        <ui-breadcrumb-item href="#">Home</ui-breadcrumb-item>
+        <ui-breadcrumb-item href="#">Products</ui-breadcrumb-item>
+        <ui-breadcrumb-item href="#">Clothing</ui-breadcrumb-item>
+        <ui-breadcrumb-item href="#">Men's</ui-breadcrumb-item>
+        <ui-breadcrumb-item href="#">Shirts</ui-breadcrumb-item>
+        <ui-breadcrumb-item>Oxford Button-Down</ui-breadcrumb-item>
+      </ui-breadcrumb-group>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/button.ts
+++ b/apps/catalog/src/pages/button.ts
@@ -1,0 +1,58 @@
+import { registerPage } from "../registry.js";
+
+registerPage("button", {
+  title: "Button",
+  section: "Primitives",
+  render: () => `
+    <h3>Actions × Emphases</h3>
+    <div class="variant-group" style="display:grid;grid-template-columns:80px 1fr 1fr 1fr;gap:8px 12px;align-items:center;">
+      <span class="variant-label"></span>
+      <span class="variant-label">Bold</span>
+      <span class="variant-label">Subtle</span>
+      <span class="variant-label">Minimal</span>
+      ${["primary", "secondary", "destructive", "info", "contrast"].map(action =>
+        `<span class="variant-label">${action}</span>
+          <ui-button action="${action}" emphasis="bold" size="m">${action}</ui-button>
+          <ui-button action="${action}" emphasis="subtle" size="m">${action}</ui-button>
+          <ui-button action="${action}" emphasis="minimal" size="m">${action}</ui-button>`
+      ).join("")}
+    </div>
+    <h3>Sizes</h3>
+    <div class="variant-group" style="display:grid;grid-template-columns:80px 1fr 1fr 1fr 1fr;gap:8px 12px;align-items:center;">
+      <span class="variant-label"></span>
+      <span class="variant-label">S</span>
+      <span class="variant-label">M</span>
+      <span class="variant-label">L</span>
+      <span class="variant-label">XL</span>
+      <span class="variant-label">Basic</span>
+      <ui-button size="s">Small</ui-button>
+      <ui-button size="m">Medium</ui-button>
+      <ui-button size="l">Large</ui-button>
+      <ui-button size="xl">XL</ui-button>
+      <span class="variant-label">Rounded</span>
+      <ui-button size="s" shape="rounded">Small</ui-button>
+      <ui-button size="m" shape="rounded">Medium</ui-button>
+      <ui-button size="l" shape="rounded">Large</ui-button>
+      <ui-button size="xl" shape="rounded">XL</ui-button>
+    </div>
+    <h3>States</h3>
+    <div class="variant-row">
+      <ui-button>Enabled</ui-button>
+      <ui-button disabled>Disabled</ui-button>
+      <ui-button status="loading">Loading</ui-button>
+    </div>
+    <h3>Icon Modes</h3>
+    <div class="variant-row">
+      <ui-button icon="leading-icon"><ui-icon name="add_circle" size="m" slot="icon-start"></ui-icon>Leading</ui-button>
+      <ui-button icon="trailing-icon">Trailing<ui-icon name="add_circle" size="m" slot="icon-end"></ui-icon></ui-button>
+      <ui-button icon="icon-only"><ui-icon name="add_circle" size="m" slot="icon-start"></ui-icon></ui-button>
+    </div>
+    <h3>Status Indicators</h3>
+    <div class="variant-row">
+      <ui-button status="none">Normal</ui-button>
+      <ui-button status="loading">Loading</ui-button>
+      <ui-button status="success">Success</ui-button>
+      <ui-button status="error">Error</ui-button>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/calendar.ts
+++ b/apps/catalog/src/pages/calendar.ts
@@ -1,0 +1,113 @@
+import { registerPage } from "../registry.js";
+
+registerPage("calendar", {
+  title: "Calendar",
+  section: "Calendar & Date",
+  render: () => `
+    <h3>Sizes</h3>
+    <div class="variant-row row-start-wrap">
+      ${["s", "m", "l"].map(size => `
+        <div class="variant-col">
+          <span class="variant-label">Size ${size}</span>
+          <ui-calendar size="${size}" value="2024-06-15"></ui-calendar>
+        </div>
+      `).join("")}
+    </div>
+
+    <h3>Range Selection</h3>
+    <div class="variant-row row-start-wrap">
+      ${["s", "m", "l"].map(size => `
+        <div class="variant-col">
+          <span class="variant-label">Size ${size}</span>
+          <ui-calendar id="cal-range-${size}" size="${size}" mode="range"></ui-calendar>
+        </div>
+      `).join("")}
+    </div>
+
+    <h3>Monthly View</h3>
+    <div class="variant-row row-start-wrap">
+      ${["s", "m", "l"].map(size => `
+        <div class="variant-col">
+          <span class="variant-label">Size ${size}</span>
+          <ui-calendar size="${size}" view="monthly" value="2024-06-15"></ui-calendar>
+        </div>
+      `).join("")}
+    </div>
+
+    <h3>With Min/Max Constraints</h3>
+    <ui-calendar size="m" value="2024-06-15" min="2024-06-10" max="2024-06-20"></ui-calendar>
+
+    <h3>With Events</h3>
+    <ui-calendar id="cal-events-demo" size="m" value="2024-06-15"></ui-calendar>
+
+    <h3>Quicklinks — Side</h3>
+    <ui-calendar-panel size="m">
+      <ui-calendar-quicklinks id="cal-ql-side" slot="side" orientation="side"></ui-calendar-quicklinks>
+      <ui-calendar value="2024-06-15"></ui-calendar>
+    </ui-calendar-panel>
+
+    <h3>Quicklinks — Bottom</h3>
+    <ui-calendar-panel size="m">
+      <ui-calendar value="2024-06-15"></ui-calendar>
+      <ui-calendar-quicklinks id="cal-ql-bottom" slot="bottom" orientation="bottom"></ui-calendar-quicklinks>
+    </ui-calendar-panel>
+
+    <h3>Inline Time Panel</h3>
+    <ui-calendar-panel size="m">
+      <ui-calendar value="2024-06-15"></ui-calendar>
+      <ui-calendar-time slot="bottom" value="14:30"></ui-calendar-time>
+    </ui-calendar-panel>
+
+    <h3>Inline Time Panel with Actions</h3>
+    <ui-calendar-panel size="m" show-actions>
+      <ui-calendar value="2024-06-15"></ui-calendar>
+      <ui-calendar-time slot="bottom" value="14:30"></ui-calendar-time>
+    </ui-calendar-panel>
+  `,
+  setup: () => {
+    for (const size of ["s", "m", "l"]) {
+      const cal = document.getElementById(`cal-range-${size}`) as HTMLElement | null;
+      if (cal && "rangeStart" in cal) {
+        (cal as any).rangeStart = "2024-06-10";
+        (cal as any).rangeEnd = "2024-06-20";
+      }
+    }
+
+    const qlSide = document.getElementById("cal-ql-side") as HTMLElement | null;
+    if (qlSide && "setItems" in qlSide) {
+      (qlSide as any).setItems([
+        { label: "Today", value: "today" },
+        { label: "Yesterday", value: "yesterday" },
+        { label: "Last 7 days", value: "last-7" },
+        { label: "Last 30 days", value: "last-30" },
+      ]);
+    }
+
+    const qlBottom = document.getElementById("cal-ql-bottom") as HTMLElement | null;
+    if (qlBottom && "setItems" in qlBottom) {
+      (qlBottom as any).setItems([
+        { label: "Today", value: "today" },
+        { label: "Yesterday", value: "yesterday" },
+        { label: "Last 7 days", value: "last-7" },
+        { label: "Last 30 days", value: "last-30" },
+      ]);
+    }
+
+    const calEvents = document.getElementById("cal-events-demo") as HTMLElement | null;
+    if (calEvents && "setEvents" in calEvents) {
+      const events = new Map();
+      events.set("2024-06-10", [{ color: "#FC9162", label: "Meeting" }]);
+      events.set("2024-06-15", [
+        { color: "#FC9162", label: "Meeting" },
+        { color: "#4EBFB9", label: "Holiday" },
+      ]);
+      events.set("2024-06-20", [
+        { color: "#FC9162", label: "Meeting" },
+        { color: "#4EBFB9", label: "Holiday" },
+        { color: "#C89AFC", label: "Birthday" },
+      ]);
+      events.set("2024-06-25", [{ color: "#4EBFB9", label: "Holiday" }]);
+      (calEvents as any).setEvents(events);
+    }
+  },
+});

--- a/apps/catalog/src/pages/card.ts
+++ b/apps/catalog/src/pages/card.ts
@@ -1,0 +1,124 @@
+import { registerPage } from "../registry.js";
+import { landscapeSvg } from "../shared.js";
+
+registerPage("card", {
+  title: "Card",
+  section: "Containers",
+  render: () => `
+    <h3>Sizes</h3>
+    <div class="variant-row row-start gap-24">
+      <ui-card size="s" class="flex-1">
+        <div class="card-content">
+          <h4 class="card-title">Small</h4>
+          <p class="card-text">Size s card content.</p>
+        </div>
+      </ui-card>
+      <ui-card size="m" class="flex-1">
+        <div class="card-content">
+          <h4 class="card-title">Medium</h4>
+          <p class="card-text">Size m card content.</p>
+        </div>
+      </ui-card>
+      <ui-card size="l" class="flex-1">
+        <div class="card-content">
+          <h4 class="card-title">Large</h4>
+          <p class="card-text">Size l card content.</p>
+        </div>
+      </ui-card>
+    </div>
+
+    <h3>Elevations</h3>
+    <div class="variant-row row-start gap-24">
+      <ui-card elevation="00" class="flex-1">
+        <div class="card-content">
+          <h4 class="card-title">Elevation 00</h4>
+          <p class="card-text">No shadow.</p>
+        </div>
+      </ui-card>
+      <ui-card elevation="01" class="flex-1">
+        <div class="card-content">
+          <h4 class="card-title">Elevation 01</h4>
+          <p class="card-text">Subtle shadow.</p>
+        </div>
+      </ui-card>
+      <ui-card elevation="02" class="flex-1">
+        <div class="card-content">
+          <h4 class="card-title">Elevation 02</h4>
+          <p class="card-text">Default shadow.</p>
+        </div>
+      </ui-card>
+      <ui-card elevation="04" class="flex-1">
+        <div class="card-content">
+          <h4 class="card-title">Elevation 04</h4>
+          <p class="card-text">Strong shadow.</p>
+        </div>
+      </ui-card>
+    </div>
+
+    <h3>Bordered</h3>
+    <div class="variant-row row-start gap-24">
+      <ui-card bordered elevation="00" class="w-320">
+        <div class="card-content">
+          <h4 class="card-title">Bordered Card</h4>
+          <p class="card-text">A card with a border and no elevation shadow.</p>
+        </div>
+      </ui-card>
+      <ui-card bordered elevation="02" class="w-320">
+        <div class="card-content">
+          <h4 class="card-title">Bordered + Elevation</h4>
+          <p class="card-text">Border combined with elevation 02.</p>
+        </div>
+      </ui-card>
+    </div>
+
+    <h3>With Image</h3>
+    <div class="variant-row row-start gap-24">
+      <ui-card class="w-320">
+        <ui-image slot="image" ratio="16:9" src="${landscapeSvg}" alt="card image"></ui-image>
+        <div class="card-content">
+          <h4 class="card-title">Card Title</h4>
+          <p class="card-text">Card content below the image area.</p>
+        </div>
+      </ui-card>
+    </div>
+
+    <h3>With Footer</h3>
+    <div class="variant-row row-start gap-24">
+      <ui-card class="w-320">
+        <div class="card-content">
+          <h4 class="card-title">Card Title</h4>
+          <p class="card-text">Card body content goes here.</p>
+        </div>
+        <div slot="footer" style="display:flex;gap:8px;padding:0 16px 16px">
+          <ui-button action="primary" emphasis="bold" size="s">Confirm</ui-button>
+          <ui-button action="secondary" emphasis="subtle" size="s">Cancel</ui-button>
+        </div>
+      </ui-card>
+    </div>
+
+    <h3>Full Card (Image + Footer)</h3>
+    <div class="variant-row row-start gap-24">
+      <ui-card class="w-320">
+        <ui-image slot="image" ratio="16:9" src="${landscapeSvg}" alt="featured"></ui-image>
+        <div class="card-content">
+          <h4 class="card-title">Featured Article</h4>
+          <p class="card-text">A full card example with image, heading, body text, and an action button.</p>
+        </div>
+        <div slot="footer" style="padding:0 16px 16px">
+          <ui-button action="primary" emphasis="bold" size="s">Read More</ui-button>
+        </div>
+      </ui-card>
+      <ui-card class="w-320">
+        <ui-image slot="image" ratio="16:9" src="${landscapeSvg}" alt="article"></ui-image>
+        <div class="card-content">
+          <h4 class="card-title">Article Headline</h4>
+          <p class="card-text">Brief summary of the article content that gives readers a preview.</p>
+        </div>
+        <div slot="footer" style="display:flex;justify-content:space-between;align-items:center;padding:0 16px 16px">
+          <span class="text-secondary">5 min read</span>
+          <ui-icon name="share" size="m" style="--ui-icon-color:#5b7282"></ui-icon>
+        </div>
+      </ui-card>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/carousel.ts
+++ b/apps/catalog/src/pages/carousel.ts
@@ -1,0 +1,93 @@
+import { registerPage } from "../registry.js";
+
+registerPage("carousel", {
+  title: "Carousel",
+  section: "Containers",
+  render: () => `
+    <h3>Basic Carousel</h3>
+    <div class="w-600">
+      <ui-carousel>
+        ${[
+          { bg: "#D4E4FA", label: "Slide 1" },
+          { bg: "#DCE3E8", label: "Slide 2" },
+          { bg: "#FDDDB3", label: "Slide 3" },
+          { bg: "#C4DFD2", label: "Slide 4" },
+        ].map(s => `
+          <ui-carousel-item style="width:280px">
+            <div style="height:200px;background:${s.bg};border-radius:2px;display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:600;color:#1C2B36">${s.label}</div>
+          </ui-carousel-item>
+        `).join("")}
+      </ui-carousel>
+    </div>
+
+    <h3>With Loop</h3>
+    <div class="w-600">
+      <ui-carousel loop>
+        ${[
+          { bg: "#D4E4FA", label: "Slide 1" },
+          { bg: "#DCE3E8", label: "Slide 2" },
+          { bg: "#FDDDB3", label: "Slide 3" },
+          { bg: "#C4DFD2", label: "Slide 4" },
+        ].map(s => `
+          <ui-carousel-item style="width:280px">
+            <div style="height:200px;background:${s.bg};border-radius:2px;display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:600;color:#1C2B36">${s.label}</div>
+          </ui-carousel-item>
+        `).join("")}
+      </ui-carousel>
+    </div>
+
+    <h3>Custom Gap (32px)</h3>
+    <div class="w-600">
+      <ui-carousel gap="32">
+        ${[
+          { bg: "#D4E4FA", label: "Slide 1" },
+          { bg: "#DCE3E8", label: "Slide 2" },
+          { bg: "#FDDDB3", label: "Slide 3" },
+        ].map(s => `
+          <ui-carousel-item style="width:280px">
+            <div style="height:200px;background:${s.bg};border-radius:2px;display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:600;color:#1C2B36">${s.label}</div>
+          </ui-carousel-item>
+        `).join("")}
+      </ui-carousel>
+    </div>
+
+    <h3>No Arrows</h3>
+    <div class="w-600">
+      <ui-carousel hide-arrows>
+        ${[
+          { bg: "#D4E4FA", label: "Slide 1" },
+          { bg: "#DCE3E8", label: "Slide 2" },
+          { bg: "#FDDDB3", label: "Slide 3" },
+        ].map(s => `
+          <ui-carousel-item style="width:280px">
+            <div style="height:200px;background:${s.bg};border-radius:2px;display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:600;color:#1C2B36">${s.label}</div>
+          </ui-carousel-item>
+        `).join("")}
+      </ui-carousel>
+    </div>
+
+    <h3>No Indicators</h3>
+    <div class="w-600">
+      <ui-carousel hide-indicators>
+        ${[
+          { bg: "#D4E4FA", label: "Slide 1" },
+          { bg: "#DCE3E8", label: "Slide 2" },
+          { bg: "#FDDDB3", label: "Slide 3" },
+        ].map(s => `
+          <ui-carousel-item style="width:280px">
+            <div style="height:200px;background:${s.bg};border-radius:2px;display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:600;color:#1C2B36">${s.label}</div>
+          </ui-carousel-item>
+        `).join("")}
+      </ui-carousel>
+    </div>
+
+    <h3>Single Full-Width Slide</h3>
+    <div class="w-600">
+      <ui-carousel>
+        <ui-carousel-item style="width:100%">
+          <div style="height:240px;background:#D4E4FA;border-radius:2px;display:flex;align-items:center;justify-content:center;font-size:18px;font-weight:600;color:#1C2B36">Single Full-Width Slide</div>
+        </ui-carousel-item>
+      </ui-carousel>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/checkbox.ts
+++ b/apps/catalog/src/pages/checkbox.ts
@@ -1,0 +1,92 @@
+import { registerPage } from "../registry.js";
+
+registerPage("checkbox", {
+  title: "Checkbox",
+  section: "Form Controls",
+  render: () => `
+    <h3>Sizes</h3>
+    <div class="variant-row">
+      <div class="variant-col"><span class="variant-label">S</span><ui-checkbox-item size="s" checked label="right">Small</ui-checkbox-item></div>
+      <div class="variant-col"><span class="variant-label">M</span><ui-checkbox-item size="m" checked label="right">Medium</ui-checkbox-item></div>
+      <div class="variant-col"><span class="variant-label">L</span><ui-checkbox-item size="l" checked label="right">Large</ui-checkbox-item></div>
+    </div>
+
+    <h3>Check States</h3>
+    <div class="variant-row">
+      <ui-checkbox-item label="right">Unchecked</ui-checkbox-item>
+      <ui-checkbox-item checked label="right">Checked</ui-checkbox-item>
+      <ui-checkbox-item indeterminate label="right">Indeterminate</ui-checkbox-item>
+    </div>
+
+    <h3>Label Positions</h3>
+    <div class="variant-row">
+      <div class="variant-col"><span class="variant-label">None</span><ui-checkbox-item checked aria-label="No label checkbox">No label</ui-checkbox-item></div>
+      <div class="variant-col"><span class="variant-label">Right</span><ui-checkbox-item checked label="right">Label right</ui-checkbox-item></div>
+      <div class="variant-col"><span class="variant-label">Left</span><ui-checkbox-item checked label="left">Label left</ui-checkbox-item></div>
+    </div>
+
+    <h3>States</h3>
+    <div class="variant-row">
+      <ui-checkbox-item label="right">Enabled</ui-checkbox-item>
+      <ui-checkbox-item disabled label="right">Disabled</ui-checkbox-item>
+      <ui-checkbox-item disabled checked label="right">Disabled checked</ui-checkbox-item>
+      <ui-checkbox-item error label="right">Error</ui-checkbox-item>
+      <ui-checkbox-item error checked label="right">Error checked</ui-checkbox-item>
+    </div>
+
+    <h3>With Label (Sizes)</h3>
+    <div class="stack-m">
+      <ui-checkbox-item size="s" label="right">I agree to the terms and conditions</ui-checkbox-item>
+      <ui-checkbox-item size="m" label="right">Subscribe to newsletter</ui-checkbox-item>
+      <ui-checkbox-item size="l" label="right">Remember my preferences</ui-checkbox-item>
+    </div>
+
+    <h3>Group Sizes</h3>
+    <div class="grid-3">
+      <div>
+        <span class="variant-label">S</span>
+        <ui-checkbox-group size="s" orientation="vertical">
+          <ui-checkbox-item label="right">Option 1</ui-checkbox-item>
+          <ui-checkbox-item label="right">Option 2</ui-checkbox-item>
+          <ui-checkbox-item label="right">Option 3</ui-checkbox-item>
+        </ui-checkbox-group>
+      </div>
+      <div>
+        <span class="variant-label">M</span>
+        <ui-checkbox-group size="m" orientation="vertical">
+          <ui-checkbox-item label="right">Option 1</ui-checkbox-item>
+          <ui-checkbox-item label="right">Option 2</ui-checkbox-item>
+          <ui-checkbox-item label="right">Option 3</ui-checkbox-item>
+        </ui-checkbox-group>
+      </div>
+      <div>
+        <span class="variant-label">L</span>
+        <ui-checkbox-group size="l" orientation="vertical">
+          <ui-checkbox-item label="right">Option 1</ui-checkbox-item>
+          <ui-checkbox-item label="right">Option 2</ui-checkbox-item>
+          <ui-checkbox-item label="right">Option 3</ui-checkbox-item>
+        </ui-checkbox-group>
+      </div>
+    </div>
+
+    <h3>Checkbox Group — Vertical</h3>
+    <div class="variant-row">
+      <ui-checkbox-group orientation="vertical" size="m">
+        <ui-checkbox-item label="right">Option 1</ui-checkbox-item>
+        <ui-checkbox-item label="right" checked>Option 2</ui-checkbox-item>
+        <ui-checkbox-item label="right">Option 3</ui-checkbox-item>
+        <ui-checkbox-item label="right">Option 4</ui-checkbox-item>
+      </ui-checkbox-group>
+    </div>
+
+    <h3>Checkbox Group — Horizontal</h3>
+    <div class="variant-row">
+      <ui-checkbox-group orientation="horizontal" size="m">
+        <ui-checkbox-item label="right">Option 1</ui-checkbox-item>
+        <ui-checkbox-item label="right" checked>Option 2</ui-checkbox-item>
+        <ui-checkbox-item label="right">Option 3</ui-checkbox-item>
+        <ui-checkbox-item label="right">Option 4</ui-checkbox-item>
+      </ui-checkbox-group>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/clock.ts
+++ b/apps/catalog/src/pages/clock.ts
@@ -1,0 +1,59 @@
+import { registerPage } from "../registry.js";
+
+registerPage("clock", {
+  title: "Clock",
+  section: "Calendar & Date",
+  render: () => `
+    <h3>Analog — Sizes</h3>
+    <div class="variant-row row-start-wrap">
+      ${["s", "m", "l"].map(size => `
+        <div class="variant-col">
+          <span class="variant-label">Size ${size}</span>
+          <ui-clock size="${size}" value="03:00"></ui-clock>
+        </div>
+      `).join("")}
+    </div>
+
+    <h3>24-Hour Digital — Sizes</h3>
+    <div class="variant-row row-start-wrap">
+      ${["s", "m", "l"].map(size => `
+        <div class="variant-col">
+          <span class="variant-label">Size ${size}</span>
+          <ui-clock size="${size}" mode="24-hour" value="14:30"></ui-clock>
+        </div>
+      `).join("")}
+    </div>
+
+    <h3>With Different Values</h3>
+    <div class="variant-row row-start-wrap">
+      <div class="variant-col">
+        <span class="variant-label">03:00</span>
+        <ui-clock size="m" value="03:00"></ui-clock>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">09:00</span>
+        <ui-clock size="m" value="09:00"></ui-clock>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">14:30</span>
+        <ui-clock size="m" value="14:30"></ui-clock>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">21:45</span>
+        <ui-clock size="m" value="21:45"></ui-clock>
+      </div>
+    </div>
+
+    <h3>Default (No Value)</h3>
+    <div class="variant-row row-start-wrap">
+      <div class="variant-col">
+        <span class="variant-label">Analog</span>
+        <ui-clock size="m"></ui-clock>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">24-Hour</span>
+        <ui-clock size="m" mode="24-hour"></ui-clock>
+      </div>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/colors.ts
+++ b/apps/catalog/src/pages/colors.ts
@@ -1,0 +1,38 @@
+import { registerPage } from "../registry.js";
+import { colors } from "@maneki/foundation";
+
+const families = ["red", "orange", "yellow", "lime", "green", "teal", "turquoise", "aqua", "blue", "ultramarine", "purple", "pink", "gray"] as const;
+const steps = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100] as const;
+
+registerPage("colors", {
+  title: "Colors",
+  section: "Foundation",
+  render: () => {
+    let html = `<style>
+      .color-family { margin-bottom: 24px; }
+      .color-family-title { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: #5b7282; margin: 0 0 8px; }
+      .color-row { display: flex; gap: 8px; }
+      .color-cell { display: flex; flex-direction: column; align-items: center; gap: 4px; width: 72px; }
+      .color-swatch { width: 64px; height: 40px; border-radius: 4px; border: 1px solid rgba(0,0,0,0.06); }
+      .color-label { font-size: 9px; color: #7a909e; font-family: monospace; }
+      .color-var { display: none; font-size: 9px; font-family: monospace; color: #3e5463; text-align: center; user-select: all; cursor: text; white-space: nowrap; }
+      .color-hex { display: none; font-size: 8px; font-family: monospace; color: #9fb1bd; text-align: center; user-select: none; white-space: nowrap; }
+      .color-cell:hover .color-var, .color-cell:hover .color-hex { display: block; }
+    </style>`;
+
+    for (const family of families) {
+      html += `<div class="color-family"><p class="color-family-title">${family}</p><div class="color-row">`;
+      for (const step of steps) {
+        const val = (colors as any)[family]?.[step] || "";
+        html += `<div class="color-cell">
+          <div class="color-swatch" style="background:${val}"></div>
+          <span class="color-label">${step}</span>
+          <span class="color-var">--fd-color-${family}-${step}</span>
+          <span class="color-hex">${val}</span>
+        </div>`;
+      }
+      html += `</div></div>`;
+    }
+    return html;
+  },
+});

--- a/apps/catalog/src/pages/datetime-picker.ts
+++ b/apps/catalog/src/pages/datetime-picker.ts
@@ -1,0 +1,72 @@
+import { registerPage } from "../registry.js";
+
+registerPage("datetime-picker", {
+  title: "Datetime Picker",
+  section: "Calendar & Date",
+  render: () => `
+    <h3>Types</h3>
+    <div class="variant-group stack-m w-320">
+      <div class="variant-col">
+        <span class="variant-label">Single Date</span>
+        <ui-datetime-picker type="single-date" label="Pick a date"></ui-datetime-picker>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Range Date</span>
+        <ui-datetime-picker type="range-date" label="Date range"></ui-datetime-picker>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Time</span>
+        <ui-datetime-picker type="time" label="Select time"></ui-datetime-picker>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Datetime</span>
+        <ui-datetime-picker type="datetime" label="Date &amp; time"></ui-datetime-picker>
+      </div>
+    </div>
+
+    <h3>With Value</h3>
+    <div class="variant-group stack-m w-320">
+      <div class="variant-col">
+        <span class="variant-label">Single Date</span>
+        <ui-datetime-picker type="single-date" label="Select Date" value="2024-06-15"></ui-datetime-picker>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Range Date</span>
+        <ui-datetime-picker type="range-date" label="Date Range" value="2024-06-10/2024-06-20"></ui-datetime-picker>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Time</span>
+        <ui-datetime-picker type="time" label="Select Time" value="14:30"></ui-datetime-picker>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Datetime</span>
+        <ui-datetime-picker type="datetime" label="Date &amp; Time" value="2024-06-15 14:30"></ui-datetime-picker>
+      </div>
+    </div>
+
+    <h3>With Actions</h3>
+    <div class="w-320">
+      <ui-datetime-picker type="single-date" label="Select Date" show-actions value="2024-06-15"></ui-datetime-picker>
+    </div>
+
+    <h3>Disabled</h3>
+    <div class="w-320">
+      <ui-datetime-picker type="single-date" label="Select Date" disabled value="2024-06-15"></ui-datetime-picker>
+    </div>
+
+    <h3>Status Error</h3>
+    <div class="w-320">
+      <ui-datetime-picker type="single-date" label="Select Date" status="error" supportive="This field is required"></ui-datetime-picker>
+    </div>
+
+    <h3>Inline Time Mode</h3>
+    <div class="w-320">
+      <ui-datetime-picker type="datetime" label="Date &amp; Time" time-mode="inline" value="2024-06-15 14:30"></ui-datetime-picker>
+    </div>
+
+    <h3>Match Panel Width</h3>
+    <div class="w-320">
+      <ui-datetime-picker type="single-date" label="Select Date" match-panel value="2024-06-15"></ui-datetime-picker>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/dropdown.ts
+++ b/apps/catalog/src/pages/dropdown.ts
@@ -1,0 +1,152 @@
+import { registerPage } from "../registry.js";
+
+registerPage("dropdown", {
+  title: "Dropdown",
+  section: "Menus & Dropdowns",
+  render: () => `
+    <h3>Sizes</h3>
+    <div class="variant-row">
+      <div class="variant-col">
+        <span class="variant-label">S</span>
+        <ui-dropdown size="s" label="Small">
+          <ui-dropdown-item>Profile</ui-dropdown-item>
+          <ui-dropdown-item>Settings</ui-dropdown-item>
+          <ui-dropdown-item>Log out</ui-dropdown-item>
+        </ui-dropdown>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">M</span>
+        <ui-dropdown size="m" label="Medium">
+          <ui-dropdown-item>Profile</ui-dropdown-item>
+          <ui-dropdown-item>Settings</ui-dropdown-item>
+          <ui-dropdown-item>Log out</ui-dropdown-item>
+        </ui-dropdown>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">L</span>
+        <ui-dropdown size="l" label="Large">
+          <ui-dropdown-item>Profile</ui-dropdown-item>
+          <ui-dropdown-item>Settings</ui-dropdown-item>
+          <ui-dropdown-item>Log out</ui-dropdown-item>
+        </ui-dropdown>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">XL</span>
+        <ui-dropdown size="xl" label="Extra Large">
+          <ui-dropdown-item>Profile</ui-dropdown-item>
+          <ui-dropdown-item>Settings</ui-dropdown-item>
+          <ui-dropdown-item>Log out</ui-dropdown-item>
+        </ui-dropdown>
+      </div>
+    </div>
+
+    <h3>All Actions</h3>
+    <div class="variant-row row-wrap">
+      <ui-dropdown action="primary" label="Primary">
+        <ui-dropdown-item>Item 1</ui-dropdown-item>
+        <ui-dropdown-item>Item 2</ui-dropdown-item>
+      </ui-dropdown>
+      <ui-dropdown action="secondary" label="Secondary">
+        <ui-dropdown-item>Item 1</ui-dropdown-item>
+        <ui-dropdown-item>Item 2</ui-dropdown-item>
+      </ui-dropdown>
+      <ui-dropdown action="destructive" label="Destructive">
+        <ui-dropdown-item>Item 1</ui-dropdown-item>
+        <ui-dropdown-item>Item 2</ui-dropdown-item>
+      </ui-dropdown>
+      <ui-dropdown action="info" label="Info">
+        <ui-dropdown-item>Item 1</ui-dropdown-item>
+        <ui-dropdown-item>Item 2</ui-dropdown-item>
+      </ui-dropdown>
+      <ui-dropdown action="contrast" label="Contrast">
+        <ui-dropdown-item>Item 1</ui-dropdown-item>
+        <ui-dropdown-item>Item 2</ui-dropdown-item>
+      </ui-dropdown>
+    </div>
+
+    <h3>All Emphases</h3>
+    <div class="variant-row">
+      <ui-dropdown emphasis="bold" label="Bold">
+        <ui-dropdown-item>Item 1</ui-dropdown-item>
+        <ui-dropdown-item>Item 2</ui-dropdown-item>
+      </ui-dropdown>
+      <ui-dropdown emphasis="subtle" label="Subtle">
+        <ui-dropdown-item>Item 1</ui-dropdown-item>
+        <ui-dropdown-item>Item 2</ui-dropdown-item>
+      </ui-dropdown>
+      <ui-dropdown emphasis="minimal" label="Minimal">
+        <ui-dropdown-item>Item 1</ui-dropdown-item>
+        <ui-dropdown-item>Item 2</ui-dropdown-item>
+      </ui-dropdown>
+    </div>
+
+    <h3>With Headings &amp; Separators</h3>
+    <div class="variant-row">
+      <ui-dropdown label="Actions">
+        <ui-dropdown-heading>Edit</ui-dropdown-heading>
+        <ui-dropdown-item>Cut</ui-dropdown-item>
+        <ui-dropdown-item>Copy</ui-dropdown-item>
+        <ui-dropdown-item>Paste</ui-dropdown-item>
+        <ui-dropdown-separator></ui-dropdown-separator>
+        <ui-dropdown-heading>View</ui-dropdown-heading>
+        <ui-dropdown-item>Zoom in</ui-dropdown-item>
+        <ui-dropdown-item>Zoom out</ui-dropdown-item>
+        <ui-dropdown-item>Reset</ui-dropdown-item>
+      </ui-dropdown>
+    </div>
+
+    <h3>Disabled</h3>
+    <div class="variant-row">
+      <ui-dropdown disabled label="Disabled">
+        <ui-dropdown-item>Item 1</ui-dropdown-item>
+        <ui-dropdown-item>Item 2</ui-dropdown-item>
+      </ui-dropdown>
+    </div>
+
+    <h3>Rounded Shape</h3>
+    <div class="variant-row">
+      <ui-dropdown shape="rounded" label="Rounded">
+        <ui-dropdown-item>Option A</ui-dropdown-item>
+        <ui-dropdown-item>Option B</ui-dropdown-item>
+        <ui-dropdown-item>Option C</ui-dropdown-item>
+      </ui-dropdown>
+    </div>
+
+    <h3>Selectable (Single)</h3>
+    <div class="variant-row">
+      <ui-dropdown label="Choose fruit" selectable>
+        <ui-dropdown-item value="apple">Apple</ui-dropdown-item>
+        <ui-dropdown-item value="banana" selected>Banana</ui-dropdown-item>
+        <ui-dropdown-item value="cherry">Cherry</ui-dropdown-item>
+        <ui-dropdown-item value="date">Date</ui-dropdown-item>
+      </ui-dropdown>
+    </div>
+
+    <h3>Selectable (Multi)</h3>
+    <div class="variant-row">
+      <ui-dropdown label="Select toppings" multiple selectable>
+        <ui-dropdown-item value="cheese" selected>Cheese</ui-dropdown-item>
+        <ui-dropdown-item value="pepperoni">Pepperoni</ui-dropdown-item>
+        <ui-dropdown-item value="mushrooms" selected>Mushrooms</ui-dropdown-item>
+        <ui-dropdown-item value="olives">Olives</ui-dropdown-item>
+        <ui-dropdown-item value="onions">Onions</ui-dropdown-item>
+      </ui-dropdown>
+    </div>
+
+    <h3>Split Dropdown</h3>
+    <div class="variant-row">
+      <ui-dropdown-split size="m" action="primary" label="Split Primary">
+        <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+        <ui-dropdown-item value="b">Option B</ui-dropdown-item>
+      </ui-dropdown-split>
+      <ui-dropdown-split size="m" action="secondary" emphasis="subtle" label="Split Subtle">
+        <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+        <ui-dropdown-item value="b">Option B</ui-dropdown-item>
+      </ui-dropdown-split>
+      <ui-dropdown-split size="m" action="destructive" label="Split Destructive">
+        <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+        <ui-dropdown-item value="b">Option B</ui-dropdown-item>
+      </ui-dropdown-split>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/elevation.ts
+++ b/apps/catalog/src/pages/elevation.ts
@@ -1,0 +1,37 @@
+import { registerPage } from "../registry.js";
+import { elevation } from "@maneki/foundation";
+
+registerPage("elevation", {
+  title: "Elevation",
+  section: "Foundation",
+  render: () => {
+    const levels = Object.entries(elevation) as [string, { boxShadow: string }][];
+    let html = `
+      <style>
+        .elevation-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 32px; padding: 32px; background: #f2f5f7; border-radius: 12px; }
+        .elevation-card {
+          background: #fff; border-radius: 10px; padding: 24px; min-height: 160px; width: 100%;
+          display: flex; flex-direction: column; justify-content: space-between;
+          transition: transform 0.2s ease; overflow: hidden;
+        }
+        .elevation-card:hover { transform: translateY(-2px); }
+        .elevation-level { font-size: 20px; font-weight: 600; color: #1c2b36; margin-bottom: 8px; }
+        .elevation-var { font-size: 11px; font-family: monospace; color: #5b7282; margin-bottom: 12px; }
+        .elevation-shadow { font-size: 10px; font-family: monospace; color: #5b7282; line-height: 1.5; word-break: break-all; overflow: hidden; max-height: 60px; }
+      </style>
+      <div class="elevation-grid">`;
+
+    for (const [level, token] of levels) {
+      html += `
+        <div class="elevation-card" style="box-shadow:${token.boxShadow}">
+          <div>
+            <div class="elevation-level">${level}</div>
+            <div class="elevation-var">--fd-elevation-${level}</div>
+          </div>
+          <div class="elevation-shadow">${token.boxShadow}</div>
+        </div>`;
+    }
+    html += `</div>`;
+    return html;
+  },
+});

--- a/apps/catalog/src/pages/file-upload.ts
+++ b/apps/catalog/src/pages/file-upload.ts
@@ -1,0 +1,32 @@
+import { registerPage } from "../registry.js";
+
+registerPage("file-upload", {
+  title: "File Upload",
+  section: "Form Controls",
+  render: () => `
+    <h3>Sizes</h3>
+    <div class="stack-m w-320">
+      <ui-file-upload size="s" placeholder="Small upload"></ui-file-upload>
+      <ui-file-upload size="m" placeholder="Medium upload"></ui-file-upload>
+      <ui-file-upload size="l" placeholder="Large upload"></ui-file-upload>
+    </div>
+
+    <h3>Disabled</h3>
+    <div class="stack-m w-320">
+      <ui-file-upload size="s" disabled placeholder="Cannot upload"></ui-file-upload>
+      <ui-file-upload size="m" disabled placeholder="Cannot upload"></ui-file-upload>
+      <ui-file-upload size="l" disabled placeholder="Cannot upload"></ui-file-upload>
+    </div>
+
+    <h3>With Accept Filter</h3>
+    <div class="stack-m w-320">
+      <ui-file-upload size="m" accept="image/*" placeholder="Select an image" button-text="Browse Images"></ui-file-upload>
+      <ui-file-upload size="m" accept=".pdf,.doc,.docx" placeholder="Select a document" button-text="Browse Docs"></ui-file-upload>
+    </div>
+
+    <h3>Multiple Files</h3>
+    <div class="stack-m w-320">
+      <ui-file-upload size="m" multiple placeholder="Select multiple files"></ui-file-upload>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/flex-layout.ts
+++ b/apps/catalog/src/pages/flex-layout.ts
@@ -1,0 +1,95 @@
+import { registerPage } from "../registry.js";
+import "@maneki/flex-layout";
+
+const tabsHtml = `
+  <ui-tab-group slot="tabs" size="s" closable>
+    <ui-tab-item label="Tab 1" selected></ui-tab-item>
+    <ui-tab-item label="Tab 2"></ui-tab-item>
+    <ui-tab-item label="Tab 3"></ui-tab-item>
+  </ui-tab-group>
+`;
+
+function dashboardLayout(size: string): string {
+  return `
+    <div class="demo-frame demo-frame-500">
+      <flex-layout size="${size}">
+        <flex-layout direction="column" size="${size}" class="flex-fill">
+          <flex-panel>
+            <flex-panel-header slot="header" heading="Card Heading" size="${size}" variant="tabs">${tabsHtml}</flex-panel-header>
+            <div class="panel-content">Content</div>
+          </flex-panel>
+          <flex-layout size="${size}" class="flex-fill">
+            <flex-panel>
+              <flex-panel-header slot="header" heading="Card Heading" size="${size}" variant="tabs">${tabsHtml}</flex-panel-header>
+              <div class="panel-content">Content</div>
+            </flex-panel>
+            <flex-panel>
+              <flex-panel-header slot="header" heading="Card Heading" size="${size}" variant="tabs">${tabsHtml}</flex-panel-header>
+              <div class="panel-content">Content</div>
+            </flex-panel>
+          </flex-layout>
+        </flex-layout>
+        <flex-panel width="300">
+          <flex-panel-header slot="header" heading="Card Heading" size="${size}" variant="tabs">${tabsHtml}</flex-panel-header>
+          <div class="panel-content">Content</div>
+        </flex-panel>
+      </flex-layout>
+    </div>`;
+}
+
+registerPage("flex-layout", {
+  title: "Flex Layout",
+  section: "Layouts",
+  render: () => `
+    <h3>Large</h3>
+    ${dashboardLayout("large")}
+
+    <h3>Medium</h3>
+    ${dashboardLayout("medium")}
+
+    <h3>Small</h3>
+    ${dashboardLayout("small")}
+
+    <h3>Header: Tabs Only</h3>
+    <div class="demo-frame demo-frame-400">
+      <flex-layout size="medium">
+        <flex-panel>
+          <flex-panel-header slot="header" size="medium" variant="tabs">${tabsHtml}</flex-panel-header>
+          <div class="panel-content">Content</div>
+        </flex-panel>
+        <flex-panel>
+          <flex-panel-header slot="header" size="medium" variant="tabs">${tabsHtml}</flex-panel-header>
+          <div class="panel-content">Content</div>
+        </flex-panel>
+      </flex-layout>
+    </div>
+
+    <h3>Header: Title Only</h3>
+    <div class="demo-frame demo-frame-400">
+      <flex-layout size="medium">
+        <flex-panel>
+          <flex-panel-header slot="header" heading="Card Heading" size="medium" variant="title"></flex-panel-header>
+          <div class="panel-content">Content</div>
+        </flex-panel>
+        <flex-panel>
+          <flex-panel-header slot="header" heading="Card Heading" size="medium" variant="title"></flex-panel-header>
+          <div class="panel-content">Content</div>
+        </flex-panel>
+      </flex-layout>
+    </div>
+
+    <h3>Header: Title + Tabs</h3>
+    <div class="demo-frame demo-frame-400">
+      <flex-layout size="medium">
+        <flex-panel>
+          <flex-panel-header slot="header" heading="Card Heading" size="medium" variant="title-tabs">${tabsHtml}</flex-panel-header>
+          <div class="panel-content">Content</div>
+        </flex-panel>
+        <flex-panel>
+          <flex-panel-header slot="header" heading="Card Heading" size="medium" variant="title-tabs">${tabsHtml}</flex-panel-header>
+          <div class="panel-content">Content</div>
+        </flex-panel>
+      </flex-layout>
+    </div>
+  `,
+  });

--- a/apps/catalog/src/pages/grid-layout.ts
+++ b/apps/catalog/src/pages/grid-layout.ts
@@ -1,0 +1,238 @@
+import { registerPage } from "../registry.js";
+import "@maneki/grid-layout";
+
+const COLORS = [
+  { bg: "#E8626E", text: "#111820" },
+  { bg: "#186ADE", text: "#fff" },
+  { bg: "#077D55", text: "#111820" },
+  { bg: "#7B61FF", text: "#fff" },
+  { bg: "#FC9162", text: "#111820" },
+  { bg: "#4EBFB9", text: "#111820" },
+];
+
+function itemColor(i: number): string {
+  return `background:${COLORS[i % COLORS.length].bg};border:1px solid #DCE3E8;color:${COLORS[i % COLORS.length].text}`;
+}
+
+registerPage("grid-layout", {
+  title: "Grid Layout",
+  section: "Layouts",
+  render: () => `
+    <style>
+      .grid-container {
+        display: block; width: 100%; min-height: 400px;
+        border-radius: 8px; background: #F2F5F7;
+        margin-bottom: 24px;
+      }
+      grid-item { cursor: grab; }
+      grid-item[dragging] { cursor: grabbing; }
+    </style>
+
+    <h3>Basic Grid</h3>
+    <grid-layout id="gl-basic" class="grid-container">
+      ${["a","b","c","d","e","f"].map((id, i) =>
+        `<grid-item item-id="${id}"><div class="grid-item-cell" style="${itemColor(i)}">${id.toUpperCase()}</div></grid-item>`
+      ).join("")}
+    </grid-layout>
+
+    <h3>Static Items</h3>
+    <grid-layout id="gl-static" class="grid-container">
+      <grid-item item-id="s1" static><div class="grid-item-cell grid-item-static">Header (static)</div></grid-item>
+      <grid-item item-id="d1"><div class="grid-item-cell" style="${itemColor(1)}">Draggable 1</div></grid-item>
+      <grid-item item-id="s2" static><div class="grid-item-cell grid-item-static">Locked</div></grid-item>
+      <grid-item item-id="d2"><div class="grid-item-cell" style="${itemColor(1)}">Draggable 2</div></grid-item>
+      <grid-item item-id="d3"><div class="grid-item-cell" style="${itemColor(1)}">Draggable 3</div></grid-item>
+      <grid-item item-id="d4"><div class="grid-item-cell" style="${itemColor(1)}">Draggable 4</div></grid-item>
+    </grid-layout>
+
+    <h3>Constraints (min/max width &amp; height)</h3>
+    <grid-layout id="gl-constraints" class="grid-container">
+      ${[
+        { id: "c1", label: "C1 w:2\u20136", i: 0 },
+        { id: "c2", label: "C2 h:2\u20134", i: 1 },
+        { id: "c3", label: "C3 w:3\u20135 h:1\u20133", i: 2 },
+        { id: "c4", label: "C4 min-w:4", i: 3 },
+        { id: "c5", label: "C5 max-w:8", i: 4 },
+      ].map(c =>
+        `<grid-item item-id="${c.id}"><div class="grid-item-cell" style="${itemColor(c.i)}">${c.label}</div></grid-item>`
+      ).join("")}
+    </grid-layout>
+
+    <h3>Compaction: Vertical</h3>
+    <grid-layout id="gl-compact-v" class="grid-container">
+      ${["v1","v2","v3","v4","v5"].map((id, i) =>
+        `<grid-item item-id="${id}"><div class="grid-item-cell" style="${itemColor(i)}">${id.toUpperCase()}</div></grid-item>`
+      ).join("")}
+    </grid-layout>
+
+    <h3>Compaction: Horizontal</h3>
+    <grid-layout id="gl-compact-h" class="grid-container">
+      ${["h1","h2","h3","h4","h5"].map((id, i) =>
+        `<grid-item item-id="${id}"><div class="grid-item-cell" style="${itemColor(i)}">${id.toUpperCase()}</div></grid-item>`
+      ).join("")}
+    </grid-layout>
+
+    <h3>Resize Handles (All Directions)</h3>
+    <grid-layout id="gl-resize" class="grid-container" style="min-height:500px">
+      <grid-item item-id="all-handles"><div class="grid-item-cell" style="${itemColor(1)}">Resize from any edge or corner</div></grid-item>
+    </grid-layout>
+
+    <h3>Responsive Breakpoints</h3>
+    <p class="hint">Resize the browser to see layout change at lg/md/sm breakpoints</p>
+    <responsive-grid-layout id="gl-responsive" class="grid-container">
+      ${["r1","r2","r3","r4","r5"].map((id, i) =>
+        `<grid-item item-id="${id}"><div class="grid-item-cell" style="${itemColor(i)}">${id.toUpperCase()}</div></grid-item>`
+      ).join("")}
+    </responsive-grid-layout>
+
+    <h3>Dark Theme</h3>
+    <grid-layout id="gl-dark" class="grid-container" style="background:#0D1826;border:1px solid #3E5463;--grid-placeholder-bg:rgba(255,255,255,0.06);--grid-placeholder-border:2px dashed #5B7282;--grid-placeholder-radius:6px;--grid-handle-color:#7A909E;--grid-focus-ring-color:#4D9EFF">
+      ${["t1","t2","t3","t4","t5","t6"].map(id =>
+        `<grid-item item-id="${id}"><div class="grid-item-cell" style="background:#1C2B36;border:1px solid #3E5463;color:#DCE3E8">${id.toUpperCase()}</div></grid-item>`
+      ).join("")}
+    </grid-layout>
+
+    <h3>Keyboard Accessible</h3>
+    <p class="hint">Tab to focus items, Enter/Space to grab, Arrow keys to move, R for resize mode, Escape to cancel</p>
+    <grid-layout id="gl-a11y" class="grid-container" style="--grid-focus-ring-color:#186ADE">
+      ${["k1","k2","k3","k4"].map((id, i) =>
+        `<grid-item item-id="${id}"><div class="grid-item-cell" style="${itemColor(i)}">${id.toUpperCase()}</div></grid-item>`
+      ).join("")}
+    </grid-layout>
+  `,
+  setup: () => {
+    const cfg = { cols: 12, rowHeight: 80, margin: [10, 10] as [number, number], containerPadding: [10, 10] as [number, number] };
+
+    // Basic
+    const basic = document.getElementById("gl-basic") as any;
+    if (basic) {
+      basic.gridConfig = cfg;
+      basic.layout = [
+        { i: "a", x: 0, y: 0, w: 4, h: 2 },
+        { i: "b", x: 4, y: 0, w: 4, h: 2 },
+        { i: "c", x: 8, y: 0, w: 4, h: 2 },
+        { i: "d", x: 0, y: 2, w: 6, h: 2 },
+        { i: "e", x: 6, y: 2, w: 3, h: 2 },
+        { i: "f", x: 9, y: 2, w: 3, h: 3 },
+      ];
+    }
+
+    // Static
+    const stat = document.getElementById("gl-static") as any;
+    if (stat) {
+      stat.gridConfig = cfg;
+      stat.layout = [
+        { i: "s1", x: 0, y: 0, w: 12, h: 1, static: true },
+        { i: "d1", x: 0, y: 1, w: 4, h: 2 },
+        { i: "s2", x: 4, y: 1, w: 4, h: 2, static: true },
+        { i: "d2", x: 8, y: 1, w: 4, h: 2 },
+        { i: "d3", x: 0, y: 3, w: 6, h: 2 },
+        { i: "d4", x: 6, y: 3, w: 6, h: 2 },
+      ];
+    }
+
+    // Constraints
+    const cons = document.getElementById("gl-constraints") as any;
+    if (cons) {
+      cons.gridConfig = cfg;
+      cons.layout = [
+        { i: "c1", x: 0, y: 0, w: 4, h: 2, minW: 2, maxW: 6 },
+        { i: "c2", x: 4, y: 0, w: 4, h: 2, minH: 2, maxH: 4 },
+        { i: "c3", x: 8, y: 0, w: 4, h: 2, minW: 3, maxW: 5, minH: 1, maxH: 3 },
+        { i: "c4", x: 0, y: 2, w: 6, h: 2, minW: 4 },
+        { i: "c5", x: 6, y: 2, w: 6, h: 2, maxW: 8, maxH: 3 },
+      ];
+    }
+
+    // Compact vertical
+    const compV = document.getElementById("gl-compact-v") as any;
+    if (compV) {
+      compV.gridConfig = { ...cfg, rowHeight: 60 };
+      compV.compactType = "vertical";
+      compV.layout = [
+        { i: "v1", x: 0, y: 0, w: 4, h: 2 },
+        { i: "v2", x: 4, y: 0, w: 4, h: 2 },
+        { i: "v3", x: 0, y: 4, w: 4, h: 2 },
+        { i: "v4", x: 4, y: 6, w: 4, h: 2 },
+        { i: "v5", x: 8, y: 0, w: 4, h: 3 },
+      ];
+    }
+
+    // Compact horizontal
+    const compH = document.getElementById("gl-compact-h") as any;
+    if (compH) {
+      compH.gridConfig = { ...cfg, rowHeight: 60 };
+      compH.compactType = "horizontal";
+      compH.layout = [
+        { i: "h1", x: 0, y: 0, w: 3, h: 2 },
+        { i: "h2", x: 0, y: 2, w: 3, h: 2 },
+        { i: "h3", x: 6, y: 0, w: 3, h: 2 },
+        { i: "h4", x: 6, y: 2, w: 3, h: 2 },
+        { i: "h5", x: 0, y: 4, w: 4, h: 2 },
+      ];
+    }
+
+    // Resize handles
+    const resize = document.getElementById("gl-resize") as any;
+    if (resize) {
+      resize.gridConfig = { cols: 12, rowHeight: 60, margin: [10, 10] as [number, number], containerPadding: [10, 10] as [number, number] };
+      resize.resizeConfig = { enabled: true, handles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"] };
+      resize.layout = [{ i: "all-handles", x: 3, y: 1, w: 6, h: 4 }];
+    }
+
+    // Responsive
+    const responsive = document.getElementById("gl-responsive") as any;
+    if (responsive) {
+      responsive.gridConfig = { rowHeight: 80, margin: [10, 10] as [number, number], containerPadding: [10, 10] as [number, number] };
+      responsive.layouts = {
+        lg: [
+          { i: "r1", x: 0, y: 0, w: 4, h: 2 },
+          { i: "r2", x: 4, y: 0, w: 4, h: 2 },
+          { i: "r3", x: 8, y: 0, w: 4, h: 2 },
+          { i: "r4", x: 0, y: 2, w: 6, h: 2 },
+          { i: "r5", x: 6, y: 2, w: 6, h: 2 },
+        ],
+        md: [
+          { i: "r1", x: 0, y: 0, w: 5, h: 2 },
+          { i: "r2", x: 5, y: 0, w: 5, h: 2 },
+          { i: "r3", x: 0, y: 2, w: 5, h: 2 },
+          { i: "r4", x: 5, y: 2, w: 5, h: 2 },
+          { i: "r5", x: 0, y: 4, w: 10, h: 2 },
+        ],
+        sm: [
+          { i: "r1", x: 0, y: 0, w: 6, h: 2 },
+          { i: "r2", x: 0, y: 2, w: 6, h: 2 },
+          { i: "r3", x: 0, y: 4, w: 6, h: 2 },
+          { i: "r4", x: 0, y: 6, w: 6, h: 2 },
+          { i: "r5", x: 0, y: 8, w: 6, h: 2 },
+        ],
+      };
+    }
+
+    // Dark theme
+    const dark = document.getElementById("gl-dark") as any;
+    if (dark) {
+      dark.gridConfig = { cols: 12, rowHeight: 70, margin: [10, 10] as [number, number], containerPadding: [10, 10] as [number, number] };
+      dark.layout = [
+        { i: "t1", x: 0, y: 0, w: 4, h: 2 },
+        { i: "t2", x: 4, y: 0, w: 4, h: 2 },
+        { i: "t3", x: 8, y: 0, w: 4, h: 2 },
+        { i: "t4", x: 0, y: 2, w: 6, h: 2 },
+        { i: "t5", x: 6, y: 2, w: 3, h: 2 },
+        { i: "t6", x: 9, y: 2, w: 3, h: 3 },
+      ];
+    }
+
+    // Keyboard accessible
+    const a11y = document.getElementById("gl-a11y") as any;
+    if (a11y) {
+      a11y.gridConfig = { cols: 12, rowHeight: 70, margin: [10, 10] as [number, number], containerPadding: [10, 10] as [number, number] };
+      a11y.layout = [
+        { i: "k1", x: 0, y: 0, w: 4, h: 2 },
+        { i: "k2", x: 4, y: 0, w: 4, h: 2 },
+        { i: "k3", x: 8, y: 0, w: 4, h: 2 },
+        { i: "k4", x: 0, y: 2, w: 6, h: 2 },
+      ];
+    }
+  },
+});

--- a/apps/catalog/src/pages/icon.ts
+++ b/apps/catalog/src/pages/icon.ts
@@ -1,0 +1,70 @@
+import { registerPage } from "../registry.js";
+
+registerPage("icon", {
+  title: "Icon",
+  section: "Primitives",
+  render: () => {
+    const icons = ["close", "check_circle", "warning", "error", "info", "search", "settings", "home", "person", "notifications", "expand_more", "expand_less", "chevron_right", "chevron_left", "arrow_back_ios", "arrow_forward_ios", "add_circle", "share", "download", "upload", "more_vert", "bar_chart", "group", "mail", "account_circle", "attach_money", "visibility", "visibility_off", "cancel", "arrow_drop_up", "arrow_drop_down", "check", "calendar_today", "schedule"];
+    return `
+      <h3>All Icons</h3>
+      <div class="variant-group">
+        <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(80px,1fr));gap:16px">
+          ${icons.map(name => `<div class="variant-col" style="align-items:center;padding:12px 4px">
+            <ui-icon name="${name}" size="m"></ui-icon>
+            <span style="font-size:10px;color:#7a909e;text-align:center;word-break:break-all">${name}</span>
+          </div>`).join("")}
+        </div>
+      </div>
+
+      <h3>Sizes</h3>
+      <div class="variant-row">
+        ${[{s:"xxs",px:12},{s:"xs",px:14},{s:"s",px:16},{s:"m",px:20},{s:"l",px:24}].map(v =>
+          `<div class="variant-col items-center">
+            <ui-icon name="home" size="${v.s}"></ui-icon>
+            <span class="variant-label">${v.s} (${v.px})</span>
+          </div>`
+        ).join("")}
+      </div>
+
+      <h3>States</h3>
+      <div class="variant-row">
+        ${["enabled","hover","active","focus","disabled"].map(state =>
+          `<div class="variant-col items-center">
+            <ui-icon name="home" size="m" state="${state}"></ui-icon>
+            <span class="variant-label">${state}</span>
+          </div>`
+        ).join("")}
+      </div>
+
+      <h3>States (Inverse)</h3>
+      <div class="variant-row" style="background:#1C2B36;padding:24px;border-radius:8px">
+        ${["enabled-inverse","hover-inverse","active-inverse","focus-inverse","disabled-inverse"].map(state =>
+          `<div class="variant-col items-center">
+            <ui-icon name="home" size="m" state="${state}"></ui-icon>
+            <span style="font-size:11px;color:rgba(255,255,255,0.6)">${state.replace("-inverse","")}</span>
+          </div>`
+        ).join("")}
+      </div>
+
+      <h3>Filled vs Outlined</h3>
+      <div class="variant-row">
+        ${["home","settings","check_circle","info","warning"].map(name =>
+          `<div class="variant-col items-center">
+            <div class="row-gap-8">
+              <ui-icon name="${name}" size="m"></ui-icon>
+              <ui-icon name="${name}" size="m" filled></ui-icon>
+            </div>
+            <span class="variant-label">${name}</span>
+          </div>`
+        ).join("")}
+      </div>
+
+      <h3>With Label (a11y)</h3>
+      <div class="variant-row">
+        <ui-icon name="home" size="m" label="Home"></ui-icon>
+        <ui-icon name="settings" size="m" label="Settings"></ui-icon>
+        <ui-icon name="person" size="m" label="User profile"></ui-icon>
+      </div>
+    `;
+  },
+});

--- a/apps/catalog/src/pages/image.ts
+++ b/apps/catalog/src/pages/image.ts
@@ -1,0 +1,55 @@
+import { registerPage } from "../registry.js";
+import { landscapeSvg, createLandscapePng } from "../shared.js";
+
+registerPage("image", {
+  title: "Image",
+  section: "Primitives",
+  render: () => `
+    <h3>Aspect Ratios</h3>
+    <div class="stack-l w-600">
+      ${["16:9", "3:2", "1:1", "3:1", "21:9"].map(r => `<div>
+        <p class="mono-label">${r}</p>
+        <ui-image ratio="${r}" src="${landscapeSvg}" alt="landscape"></ui-image>
+      </div>`).join("")}
+    </div>
+
+    <h3>Object Fit</h3>
+    <div id="object-fit-demo" class="variant-row gap-24"></div>
+
+    <h3>Placeholder</h3>
+    <div class="variant-row gap-24">
+      <div class="flex-1">
+        <p class="mono-label">No src (default bg)</p>
+        <ui-image ratio="16:9"></ui-image>
+      </div>
+      <div class="flex-1">
+        <p class="mono-label">Custom placeholder</p>
+        <ui-image ratio="16:9">
+          <div style="display:flex;align-items:center;justify-content:center;height:100%;color:#5b7282;font-size:14px">No image available</div>
+        </ui-image>
+      </div>
+    </div>
+
+    <h3>In Card</h3>
+    <div class="w-320">
+      <ui-card>
+        <ui-image slot="image" ratio="16:9" src="${landscapeSvg}" alt="card image"></ui-image>
+        <div class="card-content">
+          <p class="card-title">Card with Image</p>
+          <p class="card-text">Using ui-image inside a card's image slot.</p>
+        </div>
+      </ui-card>
+    </div>
+  `,
+  setup: () => {
+    const png = createLandscapePng();
+    const container = document.getElementById("object-fit-demo");
+    if (!container) return;
+    for (const f of ["cover", "contain", "fill", "none"]) {
+      const col = document.createElement("div");
+      col.className = "flex-1";
+      col.innerHTML = `<p class="mono-label">${f}</p><ui-image ratio="1:1" fit="${f}" src="${png}" alt="landscape"></ui-image>`;
+      container.appendChild(col);
+    }
+  },
+});

--- a/apps/catalog/src/pages/input.ts
+++ b/apps/catalog/src/pages/input.ts
@@ -1,0 +1,111 @@
+import { registerPage } from "../registry.js";
+
+registerPage("input", {
+  title: "Input",
+  section: "Form Controls",
+  render: () => `
+    <h3>Sizes</h3>
+    <div class="stack-m w-320">
+      <ui-input size="s" label="Small" placeholder="Size S"></ui-input>
+      <ui-input size="m" label="Medium" placeholder="Size M"></ui-input>
+      <ui-input size="l" label="Large" placeholder="Size L"></ui-input>
+    </div>
+
+    <h3>Types</h3>
+    <div class="stack-m w-320">
+      <ui-input type="text" label="Text" placeholder="Enter text..."></ui-input>
+      <ui-input type="numeric" label="Numeric" value="10"></ui-input>
+      <ui-input type="clearable" label="Clearable" value="Clear me"></ui-input>
+      <ui-input type="password" label="Password" value="secret123"></ui-input>
+    </div>
+
+    <h3>States</h3>
+    <div class="stack-m w-320">
+      <ui-input label="Enabled" placeholder="Default state"></ui-input>
+      <ui-input label="Filled" value="Some value"></ui-input>
+      <ui-input label="Disabled" placeholder="Cannot edit" disabled></ui-input>
+      <ui-input label="Disabled filled" value="Cannot edit" disabled></ui-input>
+      <ui-input label="Readonly" value="Read only value" readonly></ui-input>
+    </div>
+
+    <h3>Statuses</h3>
+    <div class="stack-m w-320">
+      <ui-input status="none" label="None" supportive="Default supportive text" placeholder="No status"></ui-input>
+      <ui-input status="warning" label="Warning" supportive="Please double-check this value" value="Might be wrong"></ui-input>
+      <ui-input status="error" label="Error" supportive="This field is required" value="Invalid"></ui-input>
+      <ui-input error label="Error (boolean)" supportive="This field has an error" value="Invalid"></ui-input>
+      <ui-input status="success" label="Success" supportive="Looks good!" value="Valid input"></ui-input>
+      <ui-input status="loading" label="Loading" supportive="Validating..." value="Checking..."></ui-input>
+    </div>
+
+    <h3>With Label &amp; Supportive Text</h3>
+    <div class="stack-m w-320">
+      <ui-input label="Email" supportive="We'll never share your email" placeholder="you@example.com"></ui-input>
+      <ui-input label="Username" secondary-label="Optional" placeholder="johndoe"></ui-input>
+      <ui-input label="Password" placeholder="Enter password" supportive="Must be at least 8 characters"></ui-input>
+    </div>
+
+    <h3>Leading &amp; Trailing Elements</h3>
+    <div class="stack-m w-320">
+      <ui-input label="Search" placeholder="Search...">
+        <ui-icon name="search" size="m" slot="leading"></ui-icon>
+      </ui-input>
+      <ui-input label="Amount" placeholder="0.00">
+        <ui-icon name="attach_money" size="m" slot="leading"></ui-icon>
+      </ui-input>
+      <ui-input label="Weight" placeholder="0" value="72">
+        <span slot="trailing" class="text-secondary">kg</span>
+      </ui-input>
+      <ui-input label="Website" placeholder="example.com">
+        <span slot="trailing" class="text-secondary">.com</span>
+      </ui-input>
+    </div>
+
+    <h3>Full Featured</h3>
+    <div class="stack-l w-400">
+      <ui-input type="clearable" label="Email Address" secondary-label="Required" placeholder="you@example.com" value="john@example.com" status="success" supportive="Email verified successfully">
+        <ui-icon name="mail" size="m" slot="leading"></ui-icon>
+      </ui-input>
+      <ui-input type="numeric" label="Quantity" secondary-label="Max 99" placeholder="0" value="5" supportive="Enter the number of items"></ui-input>
+      <ui-input size="l" label="Description" secondary-label="Optional" placeholder="Enter a description..." supportive="Maximum 200 characters">
+        <span slot="trailing" class="text-secondary">0/200</span>
+      </ui-input>
+    </div>
+
+    <h3>Input Group</h3>
+    <div class="stack-m w-400">
+      <ui-input-group size="m">
+        <span slot="prefix">https://</span>
+        <ui-input placeholder="www.example.com"></ui-input>
+        <span slot="suffix">Open URL</span>
+      </ui-input-group>
+      <ui-input-group size="m">
+        <span slot="prefix">$</span>
+        <ui-input placeholder="0.00"></ui-input>
+      </ui-input-group>
+      <ui-input-group size="m">
+        <ui-input placeholder="Enter email"></ui-input>
+        <span slot="suffix">@gmail.com</span>
+      </ui-input-group>
+    </div>
+
+    <h3>Input Group Sizes</h3>
+    <div class="stack-m w-400">
+      <ui-input-group size="s">
+        <span slot="prefix">https://</span>
+        <ui-input size="s" placeholder="www.example.com"></ui-input>
+        <span slot="suffix">Open URL</span>
+      </ui-input-group>
+      <ui-input-group size="m">
+        <span slot="prefix">https://</span>
+        <ui-input size="m" placeholder="www.example.com"></ui-input>
+        <span slot="suffix">Open URL</span>
+      </ui-input-group>
+      <ui-input-group size="l">
+        <span slot="prefix">https://</span>
+        <ui-input size="l" placeholder="www.example.com"></ui-input>
+        <span slot="suffix">Open URL</span>
+      </ui-input-group>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/label.ts
+++ b/apps/catalog/src/pages/label.ts
@@ -1,0 +1,48 @@
+import { registerPage } from "../registry.js";
+
+registerPage("label", {
+  title: "Label",
+  section: "Primitives",
+  render: () => `
+    <h3>Variants (Size × Emphasis)</h3>
+    <div class="stack-l">
+      <div>
+        <h4 class="section-label">Bold (default)</h4>
+        <div class="variant-row gap-32">
+          <div class="variant-col"><span class="variant-label">S</span><ui-label size="s">Label</ui-label></div>
+          <div class="variant-col"><span class="variant-label">M</span><ui-label size="m">Label</ui-label></div>
+          <div class="variant-col"><span class="variant-label">L</span><ui-label size="l">Label</ui-label></div>
+        </div>
+      </div>
+      <div>
+        <h4 class="section-label">Subtle</h4>
+        <div class="variant-row gap-32">
+          <div class="variant-col"><span class="variant-label">S</span><ui-label size="s" emphasis="subtle">Label</ui-label></div>
+          <div class="variant-col"><span class="variant-label">M</span><ui-label size="m" emphasis="subtle">Label</ui-label></div>
+          <div class="variant-col"><span class="variant-label">L</span><ui-label size="l" emphasis="subtle">Label</ui-label></div>
+        </div>
+      </div>
+    </div>
+
+    <h3>States</h3>
+    <div class="variant-row gap-32">
+      <div class="variant-col"><span class="variant-label">Enabled</span><ui-label>Label</ui-label></div>
+      <div class="variant-col"><span class="variant-label">Disabled</span><ui-label disabled>Label</ui-label></div>
+    </div>
+
+    <h3>Required</h3>
+    <div class="variant-row gap-32">
+      <div class="variant-col"><span class="variant-label">Not required</span><ui-label>Username</ui-label></div>
+      <div class="variant-col"><span class="variant-label">Required</span><ui-label required>Username</ui-label></div>
+      <div class="variant-col"><span class="variant-label">Required + Disabled</span><ui-label required disabled>Username</ui-label></div>
+    </div>
+
+    <h3>Emphasis + Disabled</h3>
+    <div class="variant-row gap-32">
+      <div class="variant-col"><span class="variant-label">Bold</span><ui-label emphasis="bold">Label</ui-label></div>
+      <div class="variant-col"><span class="variant-label">Subtle</span><ui-label emphasis="subtle">Label</ui-label></div>
+      <div class="variant-col"><span class="variant-label">Bold + Disabled</span><ui-label emphasis="bold" disabled>Label</ui-label></div>
+      <div class="variant-col"><span class="variant-label">Subtle + Disabled</span><ui-label emphasis="subtle" disabled>Label</ui-label></div>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/link.ts
+++ b/apps/catalog/src/pages/link.ts
@@ -1,0 +1,48 @@
+import { registerPage } from "../registry.js";
+
+registerPage("link", {
+  title: "Link",
+  section: "Primitives",
+  render: () => `
+    <h3>Sizes × Emphases</h3>
+    <div class="stack-l">
+      <div>
+        <h4 class="section-label">Bold</h4>
+        <div class="variant-row gap-32">
+          <div class="variant-col"><span class="variant-label">S</span><ui-link size="s" emphasis="bold" href="#">Small</ui-link></div>
+          <div class="variant-col"><span class="variant-label">M</span><ui-link size="m" emphasis="bold" href="#">Medium</ui-link></div>
+          <div class="variant-col"><span class="variant-label">L</span><ui-link size="l" emphasis="bold" href="#">Large</ui-link></div>
+        </div>
+      </div>
+      <div>
+        <h4 class="section-label">Subtle</h4>
+        <div class="variant-row gap-32">
+          <div class="variant-col"><span class="variant-label">S</span><ui-link size="s" emphasis="subtle" href="#">Small</ui-link></div>
+          <div class="variant-col"><span class="variant-label">M</span><ui-link size="m" emphasis="subtle" href="#">Medium</ui-link></div>
+          <div class="variant-col"><span class="variant-label">L</span><ui-link size="l" emphasis="subtle" href="#">Large</ui-link></div>
+        </div>
+      </div>
+      <div>
+        <h4 class="section-label">Disabled</h4>
+        <div class="variant-row gap-32">
+          <div class="variant-col"><span class="variant-label">S</span><ui-link size="s" href="#" disabled>Small</ui-link></div>
+          <div class="variant-col"><span class="variant-label">M</span><ui-link size="m" href="#" disabled>Medium</ui-link></div>
+          <div class="variant-col"><span class="variant-label">L</span><ui-link size="l" href="#" disabled>Large</ui-link></div>
+        </div>
+      </div>
+    </div>
+
+    <h3>Inline</h3>
+    <p style="font-family:Inter,sans-serif;font-size:14px;color:#1c2b36;max-width:480px;line-height:1.6">
+      This is a paragraph with an <ui-link href="#" size="m">inline link</ui-link> embedded
+      in the text. Links can also be <ui-link href="#" emphasis="subtle" size="m">subtle emphasis</ui-link>
+      to blend more naturally with surrounding content.
+    </p>
+
+    <h3>With Target</h3>
+    <div class="variant-row gap-32">
+      <ui-link href="#" target="_self">Same window</ui-link>
+      <ui-link href="#" target="_blank" rel="noopener noreferrer">New window</ui-link>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/list.ts
+++ b/apps/catalog/src/pages/list.ts
@@ -1,0 +1,133 @@
+import { registerPage } from "../registry.js";
+
+registerPage("list", {
+  title: "List",
+  section: "List",
+  render: () => `
+    <h3>Sizes</h3>
+    <div class="variant-row row-start-wrap">
+      ${["s", "m", "l"].map(size => `
+        <div class="variant-col" style="min-width:240px">
+          <span class="variant-label">Size ${size}</span>
+          <ui-list-item size="${size}">Basic item</ui-list-item>
+        </div>
+      `).join("")}
+    </div>
+
+    <h3>With Description</h3>
+    <div class="w-360">
+      <ui-list-item size="m" description="Supporting text that describes this item in more detail">Multi-line list item</ui-list-item>
+    </div>
+
+    <h3>Leading Icon</h3>
+    <div class="w-360">
+      <ui-list-item size="m" leading="icon"><ui-icon slot="leading" name="home" size="s"></ui-icon>Home</ui-list-item>
+      <ui-list-item size="m" leading="icon"><ui-icon slot="leading" name="settings" size="s"></ui-icon>Settings</ui-list-item>
+      <ui-list-item size="m" leading="icon"><ui-icon slot="leading" name="person" size="s"></ui-icon>Profile</ui-list-item>
+    </div>
+
+    <h3>Leading Avatar</h3>
+    <div class="w-360">
+      <ui-list-item size="m" leading="avatar"><ui-avatar slot="leading" size="s" type="text" color="blue">AB</ui-avatar>Alice Brown</ui-list-item>
+      <ui-list-item size="m" leading="avatar"><ui-avatar slot="leading" size="s" type="text" color="green">CD</ui-avatar>Charlie Davis</ui-list-item>
+    </div>
+
+    <h3>Selected</h3>
+    <div class="w-360">
+      <ui-list-item size="m" selected>Selected item</ui-list-item>
+      <ui-list-item size="m">Unselected item</ui-list-item>
+    </div>
+
+    <h3>Trailing Icon</h3>
+    <div class="w-360">
+      <ui-list-item size="m" trailing-icon>Navigate<ui-icon slot="trailing" name="chevron_right" size="xs"></ui-icon></ui-list-item>
+      <ui-list-item size="m" trailing-icon>Another item<ui-icon slot="trailing" name="chevron_right" size="xs"></ui-icon></ui-list-item>
+    </div>
+
+    <h3>With Top Border</h3>
+    <div class="w-360">
+      <ui-list-item size="m" top-border>Item with top border</ui-list-item>
+      <ui-list-item size="m" top-border>Another bordered item</ui-list-item>
+      <ui-list-item size="m" top-border>Third bordered item</ui-list-item>
+    </div>
+
+    <h3>Padding Variants</h3>
+    <div class="variant-row row-start-wrap">
+      ${["none", "s", "m"].map(p => `
+        <div class="variant-col">
+          <span class="variant-label">Padding ${p}</span>
+          <ui-list-item size="m" padding="${p}">Padding ${p}</ui-list-item>
+        </div>
+      `).join("")}
+    </div>
+
+    <h3>List Header</h3>
+    <div class="w-360">
+      <ui-list-header size="m">Section Header</ui-list-header>
+      <ui-list-item size="m">Item one</ui-list-item>
+      <ui-list-item size="m">Item two</ui-list-item>
+    </div>
+
+    <h3>List Group</h3>
+    <div class="w-360">
+      <ui-list-group size="m">
+        <ui-list-header slot="header" size="m">Group Header</ui-list-header>
+        <ui-list-item top-border>First item</ui-list-item>
+        <ui-list-item top-border>Second item</ui-list-item>
+        <ui-list-item top-border>Third item</ui-list-item>
+      </ui-list-group>
+    </div>
+
+    <h3>Group with Leading Icons &amp; Description</h3>
+    <div class="w-360">
+      <ui-list-group size="m">
+        <ui-list-header slot="header">Notifications</ui-list-header>
+        <ui-list-item top-border leading="icon" description="You have 3 new messages in your inbox">
+          <ui-icon slot="leading" name="mail" size="s"></ui-icon>
+          New Messages
+        </ui-list-item>
+        <ui-list-item top-border leading="icon" description="Your monthly report is ready to download">
+          <ui-icon slot="leading" name="download" size="s"></ui-icon>
+          Report Ready
+        </ui-list-item>
+        <ui-list-item top-border leading="icon" description="2 team members joined your project">
+          <ui-icon slot="leading" name="group" size="s"></ui-icon>
+          Team Update
+        </ui-list-item>
+        <ui-list-item top-border leading="icon" description="System maintenance scheduled for tonight">
+          <ui-icon slot="leading" name="settings" size="s"></ui-icon>
+          Maintenance
+        </ui-list-item>
+        <ui-list-item top-border leading="icon" description="Your file has been shared with 5 people">
+          <ui-icon slot="leading" name="share" size="s"></ui-icon>
+          File Shared
+        </ui-list-item>
+      </ui-list-group>
+    </div>
+
+    <h3>Group Sizes</h3>
+    <div class="variant-row row-start-wrap">
+      ${["s", "m", "l"].map(size => `
+        <div class="variant-col">
+          <span class="variant-label">Size ${size}</span>
+          <ui-list-group size="${size}">
+            <ui-list-header slot="header">${size.toUpperCase()} Group</ui-list-header>
+            <ui-list-item top-border>Item 1</ui-list-item>
+            <ui-list-item top-border>Item 2</ui-list-item>
+            <ui-list-item top-border>Item 3</ui-list-item>
+          </ui-list-group>
+        </div>
+      `).join("")}
+    </div>
+
+    <h3>Collapsed Group</h3>
+    <div class="w-360">
+      <ui-list-group size="m" collapsed>
+        <ui-list-header slot="header">Collapsed Section</ui-list-header>
+        <ui-list-item top-border>Item 1</ui-list-item>
+        <ui-list-item top-border>Item 2</ui-list-item>
+        <ui-list-item top-border>Item 3</ui-list-item>
+      </ui-list-group>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/menu.ts
+++ b/apps/catalog/src/pages/menu.ts
@@ -1,0 +1,112 @@
+import { registerPage } from "../registry.js";
+
+registerPage("menu", {
+  title: "Menu",
+  section: "Menus & Dropdowns",
+  render: () => `
+    <h3>Sizes</h3>
+    <div class="variant-row" style="position:relative;min-height:200px;gap:48px">
+      ${["s", "m", "l"].map(size =>
+        `<div class="variant-col">
+          <span class="variant-label">${size.toUpperCase()}</span>
+          <ui-menu size="${size}" open class="pos-relative">
+            <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+            <ui-dropdown-item value="b">Option B</ui-dropdown-item>
+            <ui-dropdown-item value="c">Option C</ui-dropdown-item>
+          </ui-menu>
+        </div>`
+      ).join("")}
+    </div>
+
+    <h3>With Headings &amp; Separators</h3>
+    <div class="variant-row" style="position:relative;min-height:320px">
+      <ui-menu size="m" open class="pos-relative">
+        <ui-dropdown-heading>Edit</ui-dropdown-heading>
+        <ui-dropdown-item value="cut">Cut</ui-dropdown-item>
+        <ui-dropdown-item value="copy">Copy</ui-dropdown-item>
+        <ui-dropdown-item value="paste">Paste</ui-dropdown-item>
+        <ui-dropdown-separator></ui-dropdown-separator>
+        <ui-dropdown-heading>File</ui-dropdown-heading>
+        <ui-dropdown-item value="save">Save</ui-dropdown-item>
+        <ui-dropdown-item value="save-as">Save as…</ui-dropdown-item>
+        <ui-dropdown-item value="export">Export</ui-dropdown-item>
+      </ui-menu>
+    </div>
+
+    <h3>With Disabled Items</h3>
+    <div class="variant-row" style="position:relative;min-height:220px">
+      <ui-menu size="m" open class="pos-relative">
+        <ui-dropdown-item value="cut">Cut</ui-dropdown-item>
+        <ui-dropdown-item value="copy">Copy</ui-dropdown-item>
+        <ui-dropdown-item value="paste" disabled>Paste</ui-dropdown-item>
+        <ui-dropdown-separator></ui-dropdown-separator>
+        <ui-dropdown-item value="delete" disabled>Delete</ui-dropdown-item>
+      </ui-menu>
+    </div>
+
+    <h3>Single Select</h3>
+    <div class="variant-row" style="position:relative;min-height:240px">
+      <ui-menu size="m" open selectable class="pos-relative">
+        <ui-dropdown-heading>Sort by</ui-dropdown-heading>
+        <ui-dropdown-item value="name" selected>Name</ui-dropdown-item>
+        <ui-dropdown-item value="date">Date modified</ui-dropdown-item>
+        <ui-dropdown-item value="size">Size</ui-dropdown-item>
+        <ui-dropdown-item value="type">Type</ui-dropdown-item>
+      </ui-menu>
+    </div>
+
+    <h3>Multi Select</h3>
+    <div class="variant-row" style="position:relative;min-height:260px">
+      <ui-menu size="m" open selectable multiple class="pos-relative">
+        <ui-dropdown-heading>Show columns</ui-dropdown-heading>
+        <ui-dropdown-item value="name" selected>Name</ui-dropdown-item>
+        <ui-dropdown-item value="date" selected>Date</ui-dropdown-item>
+        <ui-dropdown-item value="size">Size</ui-dropdown-item>
+        <ui-dropdown-item value="type">Type</ui-dropdown-item>
+        <ui-dropdown-item value="tags">Tags</ui-dropdown-item>
+      </ui-menu>
+    </div>
+
+    <h3>With Secondary Labels</h3>
+    <div class="variant-row" style="position:relative;min-height:260px">
+      <ui-menu size="m" open class="pos-relative">
+        <ui-dropdown-item secondary="Ctrl+N">New File</ui-dropdown-item>
+        <ui-dropdown-item secondary="Ctrl+O">Open File</ui-dropdown-item>
+        <ui-dropdown-item secondary="Ctrl+S">Save</ui-dropdown-item>
+        <ui-dropdown-item secondary="Ctrl+Shift+S">Save As</ui-dropdown-item>
+        <ui-dropdown-separator></ui-dropdown-separator>
+        <ui-dropdown-item secondary="Ctrl+Q">Quit</ui-dropdown-item>
+      </ui-menu>
+    </div>
+
+    <h3>With Descriptions</h3>
+    <div class="variant-row" style="position:relative;min-height:260px">
+      <ui-menu size="m" open class="pos-relative" style="--ui-menu-min-width:300px">
+        <ui-dropdown-item description="Create a new empty document">New File</ui-dropdown-item>
+        <ui-dropdown-item description="Open an existing file from disk">Open File</ui-dropdown-item>
+        <ui-dropdown-item description="Save changes to current file" disabled>Save</ui-dropdown-item>
+      </ui-menu>
+    </div>
+
+    <h3>With Checkboxes</h3>
+    <div class="variant-row" style="position:relative;min-height:220px">
+      <ui-menu size="m" open selectable multiple class="pos-relative">
+        <ui-dropdown-item leading="checkbox" value="bold" selected>Bold</ui-dropdown-item>
+        <ui-dropdown-item leading="checkbox" value="italic">Italic</ui-dropdown-item>
+        <ui-dropdown-item leading="checkbox" value="underline">Underline</ui-dropdown-item>
+        <ui-dropdown-item leading="checkbox" value="strike" disabled>Strikethrough</ui-dropdown-item>
+      </ui-menu>
+    </div>
+
+    <h3>With Radios</h3>
+    <div class="variant-row" style="position:relative;min-height:260px">
+      <ui-menu size="m" open selectable class="pos-relative">
+        <ui-dropdown-heading>Sort By</ui-dropdown-heading>
+        <ui-dropdown-item leading="radio" value="name" selected>Name</ui-dropdown-item>
+        <ui-dropdown-item leading="radio" value="date">Date Modified</ui-dropdown-item>
+        <ui-dropdown-item leading="radio" value="size">Size</ui-dropdown-item>
+        <ui-dropdown-item leading="radio" value="type">Type</ui-dropdown-item>
+      </ui-menu>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/modal.ts
+++ b/apps/catalog/src/pages/modal.ts
@@ -1,0 +1,89 @@
+import { registerPage } from "../registry.js";
+
+registerPage("modal", {
+  title: "Modal",
+  section: "Overlays",
+  render: () => `
+    <h3>Sizes (click to open)</h3>
+    <div class="variant-row">
+      ${["s", "m", "l"].map(size =>
+        `<ui-button size="m" onclick="document.getElementById('modal-${size}').show()">Size ${size.toUpperCase()}</ui-button>
+         <ui-modal id="modal-${size}" size="${size}" dismissible>
+           ${size.toUpperCase()} Modal
+           <div slot="body">${size.toUpperCase()} size body content.</div>
+           <div slot="footer-end" class="row-gap-8">
+             <ui-button action="secondary" size="m">Cancel</ui-button>
+             <ui-button action="primary" size="m">OK</ui-button>
+           </div>
+         </ui-modal>`
+      ).join("")}
+    </div>
+
+    <h3>With Subtitle</h3>
+    <div class="variant-row">
+      <ui-button size="m" onclick="document.getElementById('subtitle-modal').show()">Open Modal</ui-button>
+    </div>
+    <ui-modal id="subtitle-modal" dismissible>
+      <span slot="subtitle">Optional subtitle text</span>
+      Modal Title
+      <div slot="body">Body content with a subtitle above the title.</div>
+      <div slot="footer-end" class="row-gap-8">
+        <ui-button action="secondary" size="m">Cancel</ui-button>
+        <ui-button action="primary" size="m">Save</ui-button>
+      </div>
+    </ui-modal>
+
+    <h3>Fluid Layout</h3>
+    <div class="variant-row">
+      <ui-button size="m" onclick="document.getElementById('fluid-modal').show()">Open Fluid Modal</ui-button>
+    </div>
+    <ui-modal id="fluid-modal" layout="fluid" dismissible>
+      Fluid Layout Modal
+      <div slot="body">
+        <p>This modal has a fixed height and the body area scrolls when content overflows.</p>
+        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+        <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+        <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.</p>
+      </div>
+      <div slot="footer-end" class="row-gap-8">
+        <ui-button action="secondary" size="m">Cancel</ui-button>
+        <ui-button action="primary" size="m">Save</ui-button>
+      </div>
+    </ui-modal>
+
+    <h3>With Tertiary Button</h3>
+    <div class="variant-row">
+      <ui-button size="m" onclick="document.getElementById('tertiary-modal').show()">Open Modal</ui-button>
+    </div>
+    <ui-modal id="tertiary-modal" dismissible>
+      Modal with Tertiary Action
+      <div slot="body">This modal has a tertiary button on the left side of the footer.</div>
+      <ui-button slot="footer-start" action="secondary" emphasis="subtle" size="m">Learn more</ui-button>
+      <div slot="footer-end" class="row-gap-8">
+        <ui-button action="secondary" size="m">Cancel</ui-button>
+        <ui-button action="primary" size="m">Confirm</ui-button>
+      </div>
+    </ui-modal>
+
+    <h3>Non-Dismissible</h3>
+    <div class="variant-row">
+      <ui-button size="m" onclick="document.getElementById('nondismiss-modal').show()">Open Non-Dismissible</ui-button>
+    </div>
+    <ui-modal id="nondismiss-modal">
+      Non-Dismissible Modal
+      <div slot="body">This modal can only be closed by the action button below.</div>
+      <div slot="footer-end" class="row-gap-8">
+        <ui-button action="primary" size="m" onclick="document.getElementById('nondismiss-modal').close()">Accept</ui-button>
+      </div>
+    </ui-modal>
+
+    <h3>No Footer</h3>
+    <div class="variant-row">
+      <ui-button size="m" onclick="document.getElementById('nofooter-modal').show()">Open Modal</ui-button>
+    </div>
+    <ui-modal id="nofooter-modal" dismissible>
+      Information
+      <div slot="body">This modal has no footer buttons. Use the close button to dismiss.</div>
+    </ui-modal>
+  `,
+});

--- a/apps/catalog/src/pages/radio.ts
+++ b/apps/catalog/src/pages/radio.ts
@@ -1,0 +1,91 @@
+import { registerPage } from "../registry.js";
+
+registerPage("radio", {
+  title: "Radio",
+  section: "Form Controls",
+  render: () => `
+    <h3>Sizes</h3>
+    <div class="variant-row">
+      <div class="variant-col"><span class="variant-label">S</span><ui-radio-item size="s" checked label="right">Small</ui-radio-item></div>
+      <div class="variant-col"><span class="variant-label">M</span><ui-radio-item size="m" checked label="right">Medium</ui-radio-item></div>
+      <div class="variant-col"><span class="variant-label">L</span><ui-radio-item size="l" checked label="right">Large</ui-radio-item></div>
+    </div>
+
+    <h3>Check States</h3>
+    <div class="variant-row">
+      <ui-radio-item label="right">Unchecked</ui-radio-item>
+      <ui-radio-item checked label="right">Checked</ui-radio-item>
+    </div>
+
+    <h3>Label Positions</h3>
+    <div class="variant-row">
+      <div class="variant-col"><span class="variant-label">None</span><ui-radio-item checked aria-label="No label radio">No label</ui-radio-item></div>
+      <div class="variant-col"><span class="variant-label">Right</span><ui-radio-item checked label="right">Label right</ui-radio-item></div>
+      <div class="variant-col"><span class="variant-label">Left</span><ui-radio-item checked label="left">Label left</ui-radio-item></div>
+    </div>
+
+    <h3>States</h3>
+    <div class="variant-row">
+      <ui-radio-item label="right">Enabled</ui-radio-item>
+      <ui-radio-item disabled label="right">Disabled</ui-radio-item>
+      <ui-radio-item disabled checked label="right">Disabled checked</ui-radio-item>
+      <ui-radio-item error label="right">Error</ui-radio-item>
+      <ui-radio-item error checked label="right">Error checked</ui-radio-item>
+    </div>
+
+    <h3>With Label (Sizes)</h3>
+    <div class="stack-m">
+      <ui-radio-item size="s" label="right">I agree to the terms and conditions</ui-radio-item>
+      <ui-radio-item size="m" label="right">Subscribe to newsletter</ui-radio-item>
+      <ui-radio-item size="l" label="right">Remember my preferences</ui-radio-item>
+    </div>
+
+    <h3>Group Sizes</h3>
+    <div class="grid-3">
+      <div>
+        <span class="variant-label">S</span>
+        <ui-radio-group size="s" orientation="vertical">
+          <ui-radio-item label="right" value="1">Option 1</ui-radio-item>
+          <ui-radio-item label="right" value="2">Option 2</ui-radio-item>
+          <ui-radio-item label="right" value="3">Option 3</ui-radio-item>
+        </ui-radio-group>
+      </div>
+      <div>
+        <span class="variant-label">M</span>
+        <ui-radio-group size="m" orientation="vertical">
+          <ui-radio-item label="right" value="1">Option 1</ui-radio-item>
+          <ui-radio-item label="right" value="2">Option 2</ui-radio-item>
+          <ui-radio-item label="right" value="3">Option 3</ui-radio-item>
+        </ui-radio-group>
+      </div>
+      <div>
+        <span class="variant-label">L</span>
+        <ui-radio-group size="l" orientation="vertical">
+          <ui-radio-item label="right" value="1">Option 1</ui-radio-item>
+          <ui-radio-item label="right" value="2">Option 2</ui-radio-item>
+          <ui-radio-item label="right" value="3">Option 3</ui-radio-item>
+        </ui-radio-group>
+      </div>
+    </div>
+
+    <h3>Radio Group — Vertical (Preselected)</h3>
+    <div class="variant-row">
+      <ui-radio-group orientation="vertical" size="m">
+        <ui-radio-item label="right" value="a">Option A</ui-radio-item>
+        <ui-radio-item label="right" value="b" checked>Option B (preselected)</ui-radio-item>
+        <ui-radio-item label="right" value="c">Option C</ui-radio-item>
+        <ui-radio-item label="right" value="d">Option D</ui-radio-item>
+      </ui-radio-group>
+    </div>
+
+    <h3>Radio Group — Horizontal</h3>
+    <div class="variant-row">
+      <ui-radio-group orientation="horizontal" size="m">
+        <ui-radio-item label="right" value="1">Option 1</ui-radio-item>
+        <ui-radio-item label="right" value="2">Option 2</ui-radio-item>
+        <ui-radio-item label="right" value="3">Option 3</ui-radio-item>
+        <ui-radio-item label="right" value="4">Option 4</ui-radio-item>
+      </ui-radio-group>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/select.ts
+++ b/apps/catalog/src/pages/select.ts
@@ -1,0 +1,139 @@
+import { registerPage } from "../registry.js";
+
+registerPage("select", {
+  title: "Select",
+  section: "Form Controls",
+  render: () => `
+    <h3>Sizes — Without Labels</h3>
+    <div class="stack-m w-320">
+      <ui-select size="s" placeholder="Small (S)">
+        <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+        <ui-dropdown-item value="b">Option B</ui-dropdown-item>
+      </ui-select>
+      <ui-select size="m" placeholder="Medium (M)">
+        <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+        <ui-dropdown-item value="b">Option B</ui-dropdown-item>
+      </ui-select>
+      <ui-select size="l" placeholder="Large (L)">
+        <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+        <ui-dropdown-item value="b">Option B</ui-dropdown-item>
+      </ui-select>
+    </div>
+
+    <h3>Sizes — With Labels</h3>
+    <div class="stack-m w-320">
+      <ui-select size="s" label="Label" supportive="Supportive Text" placeholder="Small (S)">
+        <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+        <ui-dropdown-item value="b">Option B</ui-dropdown-item>
+      </ui-select>
+      <ui-select size="m" label="Label" supportive="Supportive Text" placeholder="Medium (M)">
+        <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+        <ui-dropdown-item value="b">Option B</ui-dropdown-item>
+      </ui-select>
+      <ui-select size="l" label="Label" supportive="Supportive Text" placeholder="Large (L)">
+        <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+        <ui-dropdown-item value="b">Option B</ui-dropdown-item>
+      </ui-select>
+    </div>
+
+    <h3>States</h3>
+    <div class="grid-3">
+      <div class="card-content">
+        <span class="variant-label">Enabled</span>
+        <ui-select label="Label" supportive="Supportive Text" placeholder="Select an option">
+          <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+          <ui-dropdown-item value="b">Option B</ui-dropdown-item>
+        </ui-select>
+      </div>
+      <div class="card-content">
+        <span class="variant-label">Filled (Single)</span>
+        <ui-select label="Label" supportive="Supportive Text" value="a">
+          <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+          <ui-dropdown-item value="b">Option B</ui-dropdown-item>
+        </ui-select>
+      </div>
+      <div class="card-content">
+        <span class="variant-label">Filled (Multi)</span>
+        <ui-select label="Label" supportive="Supportive Text" multiple value="a,b">
+          <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+          <ui-dropdown-item value="b">Option B</ui-dropdown-item>
+          <ui-dropdown-item value="c">Option C</ui-dropdown-item>
+        </ui-select>
+      </div>
+      <div class="card-content">
+        <span class="variant-label">Disabled</span>
+        <ui-select label="Label" supportive="Supportive Text" disabled placeholder="Select an option">
+          <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+          <ui-dropdown-item value="b">Option B</ui-dropdown-item>
+        </ui-select>
+      </div>
+      <div class="card-content">
+        <span class="variant-label">Read Only</span>
+        <ui-select label="Label" supportive="Supportive Text" readonly value="a">
+          <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+          <ui-dropdown-item value="b">Option B</ui-dropdown-item>
+        </ui-select>
+      </div>
+    </div>
+
+    <h3>Statuses</h3>
+    <div class="stack-m w-320">
+      <ui-select label="Label" supportive="Supportive Text" placeholder="Select an option">
+        <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+      </ui-select>
+      <ui-select label="Label" supportive="Warning message" status="warning" placeholder="Select an option">
+        <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+      </ui-select>
+      <ui-select label="Label" supportive="Error message" status="error" placeholder="Select an option">
+        <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+      </ui-select>
+      <ui-select label="Label" supportive="Success message" status="success" placeholder="Select an option">
+        <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+      </ui-select>
+      <ui-select label="Label" supportive="Loading..." status="loading" placeholder="Select an option">
+        <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+      </ui-select>
+    </div>
+
+    <h3>Leading Icon</h3>
+    <div class="variant-row">
+      <ui-select label="With Leading Icon" supportive="Supportive Text" placeholder="Select an option">
+        <ui-icon name="account_circle" size="m" slot="leading"></ui-icon>
+        <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+        <ui-dropdown-item value="b">Option B</ui-dropdown-item>
+        <ui-dropdown-item value="c">Option C</ui-dropdown-item>
+      </ui-select>
+      <ui-select label="Without Leading Icon" supportive="Supportive Text" placeholder="Select an option">
+        <ui-dropdown-item value="a">Option A</ui-dropdown-item>
+        <ui-dropdown-item value="b">Option B</ui-dropdown-item>
+        <ui-dropdown-item value="c">Option C</ui-dropdown-item>
+      </ui-select>
+    </div>
+
+    <h3>With Headings &amp; Separators</h3>
+    <div class="variant-row">
+      <ui-select label="Country" supportive="Select your country" placeholder="Choose a country" style="width:300px;">
+        <ui-dropdown-heading>North America</ui-dropdown-heading>
+        <ui-dropdown-item value="us">United States</ui-dropdown-item>
+        <ui-dropdown-item value="ca">Canada</ui-dropdown-item>
+        <ui-dropdown-item value="mx">Mexico</ui-dropdown-item>
+        <ui-dropdown-separator></ui-dropdown-separator>
+        <ui-dropdown-heading>Europe</ui-dropdown-heading>
+        <ui-dropdown-item value="uk">United Kingdom</ui-dropdown-item>
+        <ui-dropdown-item value="de">Germany</ui-dropdown-item>
+        <ui-dropdown-item value="fr">France</ui-dropdown-item>
+      </ui-select>
+    </div>
+
+    <h3>Multi-Select</h3>
+    <div class="variant-row">
+      <ui-select label="Tags" supportive="Select multiple tags" multiple style="width:400px;">
+        <ui-dropdown-item value="react">React</ui-dropdown-item>
+        <ui-dropdown-item value="vue">Vue</ui-dropdown-item>
+        <ui-dropdown-item value="angular">Angular</ui-dropdown-item>
+        <ui-dropdown-item value="svelte">Svelte</ui-dropdown-item>
+        <ui-dropdown-item value="solid">Solid</ui-dropdown-item>
+      </ui-select>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/semantic-tokens.ts
+++ b/apps/catalog/src/pages/semantic-tokens.ts
@@ -1,0 +1,60 @@
+import { registerPage } from "../registry.js";
+import {
+  surface, border, text, icon, global,
+  statusSurface, statusText, statusIcon, statusGeneral,
+  resolveSemanticValue,
+} from "@maneki/foundation";
+
+function toKebab(s: string): string {
+  return s.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
+}
+
+function renderSwatch(name: string, cssVar: string, value: any, mode: string): string {
+  const resolved = resolveSemanticValue(value);
+  const isLight = resolved === "#ffffff" || resolved === "rgba(28, 43, 54, 0.8)";
+
+  let swatchHtml = "";
+  if (mode === "surface") {
+    swatchHtml = `<div style="width:44px;height:44px;border-radius:6px;flex-shrink:0;background:${resolved};${isLight ? "border:1px solid #dce3e8;" : ""}"></div>`;
+  } else if (mode === "border") {
+    swatchHtml = `<div style="width:44px;height:44px;border-radius:6px;flex-shrink:0;background:#fff;border:2px solid ${resolved};"></div>`;
+  } else {
+    swatchHtml = `<div style="width:44px;height:44px;border-radius:6px;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-size:20px;font-weight:600;background:#fff;border:1px solid #dce3e8;color:${resolved};">${mode === "icon" ? "\u2605" : "Aa"}</div>`;
+  }
+
+  return `
+    <div style="display:flex;align-items:center;gap:12px;padding:8px;border-radius:8px;background:#f8f9fa;">
+      ${swatchHtml}
+      <div style="min-width:0;">
+        <div style="font-size:12px;font-weight:500;margin-bottom:2px;">${name}</div>
+        <code style="font-size:10px;color:#5b7282;display:block;margin-bottom:1px;">${cssVar}</code>
+        <div style="font-size:10px;color:#5b7282;font-family:monospace;">${resolved}</div>
+      </div>
+    </div>`;
+}
+
+function renderGroup(title: string, tokens: Record<string, any>, prefix: string, mode: string): string {
+  let html = `<h3>${title}</h3><div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:12px;margin-bottom:32px;">`;
+  for (const [name, value] of Object.entries(tokens)) {
+    const cssVar = `--fd-${prefix}-${toKebab(name)}`;
+    html += renderSwatch(name, cssVar, value, mode);
+  }
+  html += `</div>`;
+  return html;
+}
+
+registerPage("semantic-tokens", {
+  title: "Semantic Tokens",
+  section: "Foundation",
+  render: () => {
+    return renderGroup("Surface", surface, "surface", "surface") +
+      renderGroup("Border", border, "border", "border") +
+      renderGroup("Text", text, "text", "text") +
+      renderGroup("Icon", icon, "icon", "icon") +
+      renderGroup("Global", global, "global", "surface") +
+      renderGroup("Status \u2014 General", statusGeneral, "status-general", "surface") +
+      renderGroup("Status \u2014 Surface", statusSurface, "status-surface", "surface") +
+      renderGroup("Status \u2014 Text", statusText, "status-text", "text") +
+      renderGroup("Status \u2014 Icon", statusIcon, "status-icon", "icon");
+  },
+});

--- a/apps/catalog/src/pages/side-panel-menu.ts
+++ b/apps/catalog/src/pages/side-panel-menu.ts
@@ -1,0 +1,143 @@
+import { registerPage } from "../registry.js";
+
+registerPage("side-panel-menu", {
+  title: "Side Panel Menu",
+  section: "Navigation",
+  render: () => `
+    <h3>Expanded (with content area)</h3>
+    <div class="layout-frame layout-frame-400">
+      <ui-side-panel-menu state="expanded" title="Navigation">
+        <ui-side-panel-menu-item leading-icon>
+          <ui-icon slot="icon" name="home" size="m"></ui-icon>
+          Dashboard
+        </ui-side-panel-menu-item>
+        <ui-side-panel-menu-item leading-icon selected>
+          <ui-icon slot="icon" name="person" size="m"></ui-icon>
+          Profile
+        </ui-side-panel-menu-item>
+        <ui-side-panel-menu-item leading-icon>
+          <ui-icon slot="icon" name="bar_chart" size="m"></ui-icon>
+          Analytics
+        </ui-side-panel-menu-item>
+        <ui-side-panel-menu-item leading-icon>
+          <ui-icon slot="icon" name="mail" size="m"></ui-icon>
+          Messages
+        </ui-side-panel-menu-item>
+        <ui-side-panel-menu-item leading-icon>
+          <ui-icon slot="icon" name="settings" size="m"></ui-icon>
+          Settings
+        </ui-side-panel-menu-item>
+      </ui-side-panel-menu>
+      <div class="main-content">
+        <p class="card-text">Main content area</p>
+      </div>
+    </div>
+
+    <h3>Collapsed</h3>
+    <div class="layout-frame layout-frame-400">
+      <ui-side-panel-menu state="collapsed" title="Navigation">
+        <ui-side-panel-menu-item leading-icon>
+          <ui-icon slot="icon" name="home" size="m"></ui-icon>
+          Dashboard
+        </ui-side-panel-menu-item>
+        <ui-side-panel-menu-item leading-icon selected>
+          <ui-icon slot="icon" name="person" size="m"></ui-icon>
+          Profile
+        </ui-side-panel-menu-item>
+        <ui-side-panel-menu-item leading-icon>
+          <ui-icon slot="icon" name="bar_chart" size="m"></ui-icon>
+          Analytics
+        </ui-side-panel-menu-item>
+        <ui-side-panel-menu-item leading-icon>
+          <ui-icon slot="icon" name="settings" size="m"></ui-icon>
+          Settings
+        </ui-side-panel-menu-item>
+      </ui-side-panel-menu>
+      <div class="main-content">
+        <p class="card-text">Main content area</p>
+      </div>
+    </div>
+
+    <h3>With Nested Items</h3>
+    <div class="layout-frame layout-frame-500">
+      <ui-side-panel-menu title="Navigation">
+        <ui-side-panel-menu-item leading-icon>
+          <ui-icon slot="icon" name="home" size="m"></ui-icon>
+          Dashboard
+        </ui-side-panel-menu-item>
+        <ui-side-panel-menu-item leading-icon expandable expanded child-parent-selected>
+          <ui-icon slot="icon" name="group" size="m"></ui-icon>
+          Users
+          <ui-side-panel-menu-item slot="children" level="secondary" child-parent-selected>All Users</ui-side-panel-menu-item>
+          <ui-side-panel-menu-item slot="children" level="secondary" selected>Active Users</ui-side-panel-menu-item>
+          <ui-side-panel-menu-item slot="children" level="secondary">Inactive Users</ui-side-panel-menu-item>
+        </ui-side-panel-menu-item>
+        <ui-side-panel-menu-item leading-icon expandable>
+          <ui-icon slot="icon" name="bar_chart" size="m"></ui-icon>
+          Reports
+          <ui-side-panel-menu-item slot="children" level="secondary">Monthly</ui-side-panel-menu-item>
+          <ui-side-panel-menu-item slot="children" level="secondary">Quarterly</ui-side-panel-menu-item>
+        </ui-side-panel-menu-item>
+        <ui-side-panel-menu-item leading-icon>
+          <ui-icon slot="icon" name="settings" size="m"></ui-icon>
+          Settings
+        </ui-side-panel-menu-item>
+      </ui-side-panel-menu>
+      <div class="main-content">
+        <p class="card-text">Main content area</p>
+      </div>
+    </div>
+
+    <h3>All States</h3>
+    <div class="layout-frame layout-frame-500">
+      <ui-side-panel-menu title="Item States">
+        <ui-side-panel-menu-item leading-icon>
+          <ui-icon slot="icon" name="home" size="m"></ui-icon>
+          Enabled
+        </ui-side-panel-menu-item>
+        <ui-side-panel-menu-item leading-icon selected>
+          <ui-icon slot="icon" name="person" size="m"></ui-icon>
+          Selected
+        </ui-side-panel-menu-item>
+        <ui-side-panel-menu-item leading-icon child-parent-selected>
+          <ui-icon slot="icon" name="bar_chart" size="m"></ui-icon>
+          Child/Parent Selected
+        </ui-side-panel-menu-item>
+        <ui-side-panel-menu-item leading-icon disabled>
+          <ui-icon slot="icon" name="mail" size="m"></ui-icon>
+          Disabled
+        </ui-side-panel-menu-item>
+        <ui-side-panel-menu-item leading-icon expandable expanded child-parent-selected>
+          <ui-icon slot="icon" name="group" size="m"></ui-icon>
+          Expandable (Expanded)
+          <ui-side-panel-menu-item slot="children" level="secondary">Secondary Item</ui-side-panel-menu-item>
+          <ui-side-panel-menu-item slot="children" level="secondary" selected>Secondary Selected</ui-side-panel-menu-item>
+        </ui-side-panel-menu-item>
+      </ui-side-panel-menu>
+      <div class="main-content">
+        <p class="card-text">Main content area</p>
+      </div>
+    </div>
+
+    <h3>Levels</h3>
+    <div class="layout-frame layout-frame-400">
+      <ui-side-panel-menu title="Levels">
+        <ui-side-panel-menu-item leading-icon>
+          <ui-icon slot="icon" name="home" size="m"></ui-icon>
+          Primary Level
+        </ui-side-panel-menu-item>
+        <ui-side-panel-menu-item level="secondary">Secondary Level</ui-side-panel-menu-item>
+        <ui-side-panel-menu-item level="tertiary">Tertiary Level</ui-side-panel-menu-item>
+        <ui-side-panel-menu-item leading-icon>
+          <ui-icon slot="icon" name="person" size="m"></ui-icon>
+          Primary Level
+        </ui-side-panel-menu-item>
+        <ui-side-panel-menu-item level="secondary" selected>Secondary Selected</ui-side-panel-menu-item>
+        <ui-side-panel-menu-item level="tertiary" selected>Tertiary Selected</ui-side-panel-menu-item>
+      </ui-side-panel-menu>
+      <div class="main-content">
+        <p class="card-text">Main content area</p>
+      </div>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/spacing.ts
+++ b/apps/catalog/src/pages/spacing.ts
@@ -1,0 +1,29 @@
+import { registerPage } from "../registry.js";
+import { spacing } from "@maneki/foundation";
+
+registerPage("spacing", {
+  title: "Spacing",
+  section: "Foundation",
+  render: () => {
+    const steps = Object.entries(spacing).sort((a, b) => (a[1] as number) - (b[1] as number)) as [string, number][];
+    let html = `<style>
+      .spacing-row { display: flex; align-items: center; gap: 12px; margin-bottom: 8px; }
+      .spacing-label { width: 48px; text-align: right; font-size: 12px; font-weight: 500; color: #3e5463; }
+      .spacing-bar { height: 24px; background: #186ade; border-radius: 2px; opacity: 0.6; }
+      .spacing-value { font-size: 11px; color: #7a909e; }
+      .spacing-var { font-size: 10px; color: #9fb1bd; font-family: monospace; }
+    </style><div class="variant-group">`;
+
+    for (const [step, val] of steps) {
+      const cssKey = step.replace(".", "-");
+      html += `<div class="spacing-row">
+        <span class="spacing-label">${step}</span>
+        <div class="spacing-bar" style="width:${val}px"></div>
+        <span class="spacing-value">${val}px</span>
+        <span class="spacing-var">--fd-space-${cssKey}</span>
+      </div>`;
+    }
+    html += `</div>`;
+    return html;
+  },
+});

--- a/apps/catalog/src/pages/table.ts
+++ b/apps/catalog/src/pages/table.ts
@@ -1,0 +1,214 @@
+import { registerPage } from "../registry.js";
+
+registerPage("table", {
+  title: "Table",
+  section: "Data Display",
+  render: () => `
+    <div class="stack-l w-720">
+    ${["s", "m", "l"].map(size => `
+      <div>
+        <p class="section-label">Size ${size.toUpperCase()}</p>
+        <ui-table size="${size}">
+          <ui-table-row header>
+            <ui-table-cell header>Name</ui-table-cell>
+            <ui-table-cell header>Email</ui-table-cell>
+            <ui-table-cell header>Role</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>John Doe</ui-table-cell>
+            <ui-table-cell>john@example.com</ui-table-cell>
+            <ui-table-cell>Admin</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>Jane Smith</ui-table-cell>
+            <ui-table-cell>jane@example.com</ui-table-cell>
+            <ui-table-cell>Editor</ui-table-cell>
+          </ui-table-row>
+        </ui-table>
+      </div>
+    `).join("")}
+    </div>
+
+    <h3>Separators</h3>
+    <div class="variant-row row-start gap-24">
+      <div class="variant-col">
+        <span class="variant-label">Minimal</span>
+        <ui-table size="m" separator="minimal" class="w-360">
+          <ui-table-row header>
+            <ui-table-cell header>Name</ui-table-cell>
+            <ui-table-cell header>Role</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>Alice</ui-table-cell>
+            <ui-table-cell>Admin</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>Bob</ui-table-cell>
+            <ui-table-cell>Editor</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>Carol</ui-table-cell>
+            <ui-table-cell>Viewer</ui-table-cell>
+          </ui-table-row>
+        </ui-table>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Moderate</span>
+        <ui-table size="m" separator="moderate" class="w-360">
+          <ui-table-row header>
+            <ui-table-cell header>Name</ui-table-cell>
+            <ui-table-cell header>Role</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>Alice</ui-table-cell>
+            <ui-table-cell>Admin</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>Bob</ui-table-cell>
+            <ui-table-cell>Editor</ui-table-cell>
+          </ui-table-row>
+          <ui-table-row>
+            <ui-table-cell>Carol</ui-table-cell>
+            <ui-table-cell>Viewer</ui-table-cell>
+          </ui-table-row>
+        </ui-table>
+      </div>
+    </div>
+
+    <h3>Zebra Striping</h3>
+    <ui-table size="m" zebra class="w-720">
+      <ui-table-row header>
+        <ui-table-cell header>Name</ui-table-cell>
+        <ui-table-cell header>Email</ui-table-cell>
+        <ui-table-cell header>Role</ui-table-cell>
+        <ui-table-cell header>Status</ui-table-cell>
+      </ui-table-row>
+      <ui-table-row>
+        <ui-table-cell>John Doe</ui-table-cell>
+        <ui-table-cell>john@example.com</ui-table-cell>
+        <ui-table-cell>Admin</ui-table-cell>
+        <ui-table-cell>Active</ui-table-cell>
+      </ui-table-row>
+      <ui-table-row>
+        <ui-table-cell>Jane Smith</ui-table-cell>
+        <ui-table-cell>jane@example.com</ui-table-cell>
+        <ui-table-cell>Editor</ui-table-cell>
+        <ui-table-cell>Active</ui-table-cell>
+      </ui-table-row>
+      <ui-table-row>
+        <ui-table-cell>Bob Wilson</ui-table-cell>
+        <ui-table-cell>bob@example.com</ui-table-cell>
+        <ui-table-cell>Viewer</ui-table-cell>
+        <ui-table-cell>Inactive</ui-table-cell>
+      </ui-table-row>
+      <ui-table-row>
+        <ui-table-cell>Alice Brown</ui-table-cell>
+        <ui-table-cell>alice@example.com</ui-table-cell>
+        <ui-table-cell>Editor</ui-table-cell>
+        <ui-table-cell>Active</ui-table-cell>
+      </ui-table-row>
+      <ui-table-row>
+        <ui-table-cell>Charlie Lee</ui-table-cell>
+        <ui-table-cell>charlie@example.com</ui-table-cell>
+        <ui-table-cell>Admin</ui-table-cell>
+        <ui-table-cell>Active</ui-table-cell>
+      </ui-table-row>
+    </ui-table>
+
+    <h3>Bordered</h3>
+    <ui-table size="m" bordered class="w-720">
+      <ui-table-row header>
+        <ui-table-cell header>Name</ui-table-cell>
+        <ui-table-cell header>Email</ui-table-cell>
+        <ui-table-cell header>Role</ui-table-cell>
+        <ui-table-cell header>Status</ui-table-cell>
+      </ui-table-row>
+      <ui-table-row>
+        <ui-table-cell>John Doe</ui-table-cell>
+        <ui-table-cell>john@example.com</ui-table-cell>
+        <ui-table-cell>Admin</ui-table-cell>
+        <ui-table-cell>Active</ui-table-cell>
+      </ui-table-row>
+      <ui-table-row>
+        <ui-table-cell>Jane Smith</ui-table-cell>
+        <ui-table-cell>jane@example.com</ui-table-cell>
+        <ui-table-cell>Editor</ui-table-cell>
+        <ui-table-cell>Active</ui-table-cell>
+      </ui-table-row>
+      <ui-table-row>
+        <ui-table-cell>Bob Wilson</ui-table-cell>
+        <ui-table-cell>bob@example.com</ui-table-cell>
+        <ui-table-cell>Viewer</ui-table-cell>
+        <ui-table-cell>Inactive</ui-table-cell>
+      </ui-table-row>
+    </ui-table>
+
+    <h3>Row States</h3>
+    <ui-table size="m" class="w-720">
+      <ui-table-row header>
+        <ui-table-cell header>Name</ui-table-cell>
+        <ui-table-cell header>Email</ui-table-cell>
+        <ui-table-cell header>Role</ui-table-cell>
+        <ui-table-cell header>State</ui-table-cell>
+      </ui-table-row>
+      <ui-table-row>
+        <ui-table-cell>John Doe</ui-table-cell>
+        <ui-table-cell>john@example.com</ui-table-cell>
+        <ui-table-cell>Admin</ui-table-cell>
+        <ui-table-cell>Default</ui-table-cell>
+      </ui-table-row>
+      <ui-table-row selected>
+        <ui-table-cell>Bob Wilson</ui-table-cell>
+        <ui-table-cell>bob@example.com</ui-table-cell>
+        <ui-table-cell>Viewer</ui-table-cell>
+        <ui-table-cell>Selected</ui-table-cell>
+      </ui-table-row>
+      <ui-table-row disabled>
+        <ui-table-cell>Alice Brown</ui-table-cell>
+        <ui-table-cell>alice@example.com</ui-table-cell>
+        <ui-table-cell>Editor</ui-table-cell>
+        <ui-table-cell>Disabled</ui-table-cell>
+      </ui-table-row>
+    </ui-table>
+
+    <h3>Full Featured</h3>
+    <ui-table size="m" bordered zebra separator="moderate" class="w-720">
+      <ui-table-row header>
+        <ui-table-cell header>Name</ui-table-cell>
+        <ui-table-cell header>Email</ui-table-cell>
+        <ui-table-cell header>Role</ui-table-cell>
+        <ui-table-cell header>Status</ui-table-cell>
+      </ui-table-row>
+      <ui-table-row>
+        <ui-table-cell>John Doe</ui-table-cell>
+        <ui-table-cell>john@example.com</ui-table-cell>
+        <ui-table-cell>Admin</ui-table-cell>
+        <ui-table-cell>Active</ui-table-cell>
+      </ui-table-row>
+      <ui-table-row>
+        <ui-table-cell>Jane Smith</ui-table-cell>
+        <ui-table-cell>jane@example.com</ui-table-cell>
+        <ui-table-cell>Editor</ui-table-cell>
+        <ui-table-cell>Active</ui-table-cell>
+      </ui-table-row>
+      <ui-table-row>
+        <ui-table-cell>Bob Wilson</ui-table-cell>
+        <ui-table-cell>bob@example.com</ui-table-cell>
+        <ui-table-cell>Viewer</ui-table-cell>
+        <ui-table-cell>Inactive</ui-table-cell>
+      </ui-table-row>
+      <ui-table-row>
+        <ui-table-cell>Alice Brown</ui-table-cell>
+        <ui-table-cell>alice@example.com</ui-table-cell>
+        <ui-table-cell>Editor</ui-table-cell>
+        <ui-table-cell>Active</ui-table-cell>
+      </ui-table-row>
+      <ui-table-row>
+        <ui-table-cell>Charlie Lee</ui-table-cell>
+        <ui-table-cell>charlie@example.com</ui-table-cell>
+        <ui-table-cell>Admin</ui-table-cell>
+        <ui-table-cell>Active</ui-table-cell>
+      </ui-table-row>
+    </ui-table>
+  `,
+});

--- a/apps/catalog/src/pages/tabs.ts
+++ b/apps/catalog/src/pages/tabs.ts
@@ -1,0 +1,159 @@
+import { registerPage } from "../registry.js";
+
+registerPage("tabs", {
+  title: "Tabs",
+  section: "Tabs",
+  render: () => `
+    <h3>Sizes</h3>
+    <div class="variant-group stack-m">
+      <div class="variant-col">
+        <span class="variant-label">Size s</span>
+        <ui-tab-group size="s">
+          <ui-tab-item label="Overview" selected></ui-tab-item>
+          <ui-tab-item label="Details"></ui-tab-item>
+          <ui-tab-item label="Settings"></ui-tab-item>
+        </ui-tab-group>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Size m</span>
+        <ui-tab-group size="m">
+          <ui-tab-item label="Overview" selected></ui-tab-item>
+          <ui-tab-item label="Details"></ui-tab-item>
+          <ui-tab-item label="Settings"></ui-tab-item>
+        </ui-tab-group>
+      </div>
+    </div>
+
+    <h3>Orientation</h3>
+    <div class="variant-row row-start-wrap gap-48">
+      <div class="variant-col">
+        <span class="variant-label">Horizontal</span>
+        <ui-tab-group orientation="horizontal">
+          <ui-tab-item label="Data Grid" selected></ui-tab-item>
+          <ui-tab-item label="Table"></ui-tab-item>
+          <ui-tab-item label="Pie Chart"></ui-tab-item>
+        </ui-tab-group>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Vertical</span>
+        <ui-tab-group orientation="vertical" class="w-200">
+          <ui-tab-item label="Data Grid" selected></ui-tab-item>
+          <ui-tab-item label="Table"></ui-tab-item>
+          <ui-tab-item label="Pie Chart"></ui-tab-item>
+        </ui-tab-group>
+      </div>
+    </div>
+
+    <h3>States</h3>
+    <div class="variant-row row-start-wrap gap-48">
+      <div class="variant-col">
+        <span class="variant-label">Enabled</span>
+        <ui-tab-item label="Label" size="m"></ui-tab-item>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Selected</span>
+        <ui-tab-item label="Label" size="m" selected></ui-tab-item>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Disabled</span>
+        <ui-tab-item label="Label" size="m" disabled></ui-tab-item>
+      </div>
+    </div>
+
+    <h3>With Disabled Tab</h3>
+    <ui-tab-group size="m" orientation="horizontal">
+      <ui-tab-item label="Tab One" selected></ui-tab-item>
+      <ui-tab-item label="Tab Two"></ui-tab-item>
+      <ui-tab-item label="Tab Three"></ui-tab-item>
+      <ui-tab-item label="Disabled" disabled></ui-tab-item>
+    </ui-tab-group>
+
+    <h3>Vertical with Disabled</h3>
+    <ui-tab-group size="m" orientation="vertical" class="w-200 h-180">
+      <ui-tab-item label="Dashboard" selected></ui-tab-item>
+      <ui-tab-item label="Analytics"></ui-tab-item>
+      <ui-tab-item label="Reports"></ui-tab-item>
+      <ui-tab-item label="Disabled" disabled></ui-tab-item>
+    </ui-tab-group>
+
+    <h3>With Leading Icons</h3>
+    <ui-tab-group size="m">
+      <ui-tab-item label="Data Grid" selected>
+        <ui-icon name="bar_chart" size="m" slot="leading-icon"></ui-icon>
+      </ui-tab-item>
+      <ui-tab-item label="Table">
+        <ui-icon name="home" size="m" slot="leading-icon"></ui-icon>
+      </ui-tab-item>
+      <ui-tab-item label="Pie Chart">
+        <ui-icon name="settings" size="m" slot="leading-icon"></ui-icon>
+      </ui-tab-item>
+    </ui-tab-group>
+
+    <h3>Icon Only</h3>
+    <ui-tab-group size="m">
+      <ui-tab-item selected>
+        <ui-icon name="bar_chart" size="m" slot="leading-icon"></ui-icon>
+      </ui-tab-item>
+      <ui-tab-item>
+        <ui-icon name="home" size="m" slot="leading-icon"></ui-icon>
+      </ui-tab-item>
+      <ui-tab-item>
+        <ui-icon name="settings" size="m" slot="leading-icon"></ui-icon>
+      </ui-tab-item>
+    </ui-tab-group>
+
+    <h3>With Trailing Icons</h3>
+    <ui-tab-group size="m">
+      <ui-tab-item label="Data Grid" selected>
+        <ui-icon name="bar_chart" size="m" slot="trailing-icon"></ui-icon>
+      </ui-tab-item>
+      <ui-tab-item label="Table">
+        <ui-icon name="bar_chart" size="m" slot="trailing-icon"></ui-icon>
+      </ui-tab-item>
+    </ui-tab-group>
+
+    <h3>Sub Menu</h3>
+    <ui-tab-group size="m">
+      <ui-tab-item label="Data Grid" sub-menu selected></ui-tab-item>
+      <ui-tab-item label="Table" sub-menu></ui-tab-item>
+    </ui-tab-group>
+
+    <h3>Overflow: Scroll</h3>
+    <div class="w-300">
+      <p class="hint">Constrained width (300px) — scroll overflow</p>
+      <ui-tab-group>
+        <ui-tab-item label="Data Grid" selected></ui-tab-item>
+        <ui-tab-item label="Table"></ui-tab-item>
+        <ui-tab-item label="Pie Chart"></ui-tab-item>
+        <ui-tab-item label="Bar Chart"></ui-tab-item>
+        <ui-tab-item label="Line Chart"></ui-tab-item>
+        <ui-tab-item label="Scatter Plot"></ui-tab-item>
+      </ui-tab-group>
+    </div>
+
+    <h3>Overflow: Menu</h3>
+    <div class="w-300">
+      <p class="hint">Constrained width (300px) — menu overflow with ⋮ button</p>
+      <ui-tab-group overflow="menu">
+        <ui-tab-item label="Data Grid" selected></ui-tab-item>
+        <ui-tab-item label="Table"></ui-tab-item>
+        <ui-tab-item label="Pie Chart"></ui-tab-item>
+        <ui-tab-item label="Bar Chart"></ui-tab-item>
+        <ui-tab-item label="Line Chart"></ui-tab-item>
+        <ui-tab-item label="Scatter Plot"></ui-tab-item>
+      </ui-tab-group>
+    </div>
+
+    <h3>Overflow: Menu (Vertical)</h3>
+    <div class="h-120">
+      <p class="hint">Constrained height (120px) — vertical menu overflow</p>
+      <ui-tab-group orientation="vertical" overflow="menu" class="h-100">
+        <ui-tab-item label="Data Grid" selected></ui-tab-item>
+        <ui-tab-item label="Table"></ui-tab-item>
+        <ui-tab-item label="Pie Chart"></ui-tab-item>
+        <ui-tab-item label="Bar Chart"></ui-tab-item>
+        <ui-tab-item label="Line Chart"></ui-tab-item>
+      </ui-tab-group>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/tag.ts
+++ b/apps/catalog/src/pages/tag.ts
@@ -1,0 +1,115 @@
+import { registerPage } from "../registry.js";
+
+registerPage("tag", {
+  title: "Tag",
+  section: "Primitives",
+  render: () => `
+    <h3>Sizes</h3>
+    <div class="variant-row">
+      <ui-tag size="xs">XS Tag</ui-tag>
+      <ui-tag size="s">S Tag</ui-tag>
+      <ui-tag size="m">M Tag</ui-tag>
+      <ui-tag size="l">L Tag</ui-tag>
+    </div>
+
+    <h3>Types</h3>
+    <div class="variant-row">
+      <ui-tag type="basic">Basic</ui-tag>
+      <ui-tag type="selectable">Selectable</ui-tag>
+      <ui-tag type="toggle">Toggle</ui-tag>
+    </div>
+
+    <h3>Emphases</h3>
+    <div class="variant-row">
+      <ui-tag emphasis="bold">Bold</ui-tag>
+      <ui-tag emphasis="subtle">Subtle</ui-tag>
+      <ui-tag emphasis="minimal">Minimal</ui-tag>
+    </div>
+
+    <h3>States</h3>
+    <div class="variant-row">
+      <ui-tag type="selectable" state="enabled">Enabled</ui-tag>
+      <ui-tag type="selectable" state="selected">Selected</ui-tag>
+      <ui-tag type="selectable" state="disabled">Disabled</ui-tag>
+    </div>
+
+    <h3>Dismissible</h3>
+    <div class="variant-row">
+      <ui-tag dismissible>Dismissible</ui-tag>
+      <ui-tag emphasis="subtle" dismissible>Subtle Dismissible</ui-tag>
+      <ui-tag emphasis="minimal" dismissible>Minimal Dismissible</ui-tag>
+    </div>
+
+    <h3>Check</h3>
+    <div class="variant-row">
+      <ui-tag check>With Check</ui-tag>
+      <ui-tag emphasis="subtle" check>Subtle Check</ui-tag>
+      <ui-tag emphasis="minimal" check>Minimal Check</ui-tag>
+    </div>
+
+    <h3>Check + Dismissible</h3>
+    <div class="variant-row">
+      <ui-tag check dismissible>Bold</ui-tag>
+      <ui-tag emphasis="subtle" check dismissible>Subtle</ui-tag>
+      <ui-tag emphasis="minimal" check dismissible>Minimal</ui-tag>
+    </div>
+
+    <h3>Colors (Bold)</h3>
+    <div class="variant-row row-wrap">
+      ${["red","yellow","green","blue","lime","teal","turquoise","aqua","ultramarine","pink","purple","orange"].map(c =>
+        `<ui-tag color="${c}">${c}</ui-tag>`
+      ).join("")}
+      <ui-tag>None (default)</ui-tag>
+    </div>
+    <h3>Colors (Subtle)</h3>
+    <div class="variant-row row-wrap">
+      ${["red","yellow","green","blue","lime","teal","turquoise","aqua","ultramarine","pink","purple","orange"].map(c =>
+        `<ui-tag color="${c}" emphasis="subtle">${c}</ui-tag>`
+      ).join("")}
+      <ui-tag emphasis="subtle">None (default)</ui-tag>
+    </div>
+    <h3>Colors (Minimal)</h3>
+    <div class="variant-row row-wrap">
+      ${["red","yellow","green","blue","lime","teal","turquoise","aqua","ultramarine","pink","purple","orange"].map(c =>
+        `<ui-tag color="${c}" emphasis="minimal">${c}</ui-tag>`
+      ).join("")}
+      <ui-tag emphasis="minimal">None (default)</ui-tag>
+    </div>
+
+    <h3>Interaction</h3>
+    <div class="stack-m">
+      <div>
+        <p class="hint">Selectable — click to toggle</p>
+        <div class="variant-row">
+          <ui-tag type="selectable">Click me</ui-tag>
+          <ui-tag type="selectable" check>With check</ui-tag>
+          <ui-tag type="selectable" size="s">Small</ui-tag>
+          <ui-tag type="selectable" size="l">Large</ui-tag>
+        </div>
+      </div>
+      <div>
+        <p class="hint">Dismissible — click close icon</p>
+        <div class="variant-row">
+          <ui-tag dismissible>Dismiss me</ui-tag>
+          <ui-tag emphasis="subtle" dismissible>Subtle</ui-tag>
+          <ui-tag emphasis="minimal" dismissible>Minimal</ui-tag>
+        </div>
+      </div>
+      <div>
+        <p class="hint">Disabled selectable — non-interactive</p>
+        <div class="variant-row">
+          <ui-tag type="selectable" state="disabled">Disabled</ui-tag>
+          <ui-tag type="selectable" state="disabled" check>Disabled check</ui-tag>
+          <ui-tag type="selectable" state="disabled" dismissible>Disabled dismiss</ui-tag>
+        </div>
+      </div>
+    </div>
+
+    <h3>Editable</h3>
+    <div class="variant-row">
+      <ui-tag emphasis="subtle">Existing Tag</ui-tag>
+      <ui-tag emphasis="subtle">Another Tag</ui-tag>
+      <ui-tag editable>New tag</ui-tag>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/textarea.ts
+++ b/apps/catalog/src/pages/textarea.ts
@@ -1,0 +1,51 @@
+import { registerPage } from "../registry.js";
+
+registerPage("textarea", {
+  title: "Textarea",
+  section: "Form Controls",
+  render: () => `
+    <h3>Sizes</h3>
+    <div class="stack-m w-320">
+      <ui-textarea size="s" label="Small" placeholder="Size S"></ui-textarea>
+      <ui-textarea size="m" label="Medium" placeholder="Size M"></ui-textarea>
+      <ui-textarea size="l" label="Large" placeholder="Size L"></ui-textarea>
+    </div>
+
+    <h3>States</h3>
+    <div class="stack-m w-320">
+      <ui-textarea label="Enabled" placeholder="Default state"></ui-textarea>
+      <ui-textarea label="Filled" value="Some value entered by the user"></ui-textarea>
+      <ui-textarea label="Disabled" placeholder="Cannot edit" disabled></ui-textarea>
+      <ui-textarea label="Disabled filled" value="Cannot edit this content" disabled></ui-textarea>
+      <ui-textarea label="Readonly" value="Read only value" readonly></ui-textarea>
+    </div>
+
+    <h3>Statuses</h3>
+    <div class="stack-m w-320">
+      <ui-textarea status="none" label="None" secondary-label="Default secondary text" placeholder="No status"></ui-textarea>
+      <ui-textarea status="warning" label="Warning" secondary-label="Please double-check this value" value="Might be wrong"></ui-textarea>
+      <ui-textarea status="error" label="Error" secondary-label="This field is required" value="Invalid"></ui-textarea>
+      <ui-textarea error label="Error (boolean)" secondary-label="This field has an error" value="Invalid"></ui-textarea>
+      <ui-textarea status="success" label="Success" secondary-label="Looks good!" value="Valid input"></ui-textarea>
+      <ui-textarea status="loading" label="Loading" secondary-label="Validating..." value="Checking..."></ui-textarea>
+    </div>
+
+    <h3>With Labels</h3>
+    <div class="stack-m w-320">
+      <ui-textarea label="Description" placeholder="Enter a description..."></ui-textarea>
+      <ui-textarea label="Bio" placeholder="Tell us about yourself..." maxlength="200"></ui-textarea>
+    </div>
+
+    <h3>With Secondary Label</h3>
+    <div class="stack-m w-320">
+      <ui-textarea label="Notes" placeholder="Add notes..." secondary-label="Optional"></ui-textarea>
+      <ui-textarea label="Feedback" placeholder="Share your feedback..." secondary-label="Max 500 characters"></ui-textarea>
+    </div>
+
+    <h3>Full Featured</h3>
+    <div class="stack-l w-400">
+      <ui-textarea size="m" label="Description" secondary-label="Required" placeholder="Enter a detailed description..." value="This is a fully featured textarea with all options enabled." maxlength="300" status="success"></ui-textarea>
+      <ui-textarea size="l" label="Comments" secondary-label="Optional" placeholder="Leave a comment..." rows="6" maxlength="500"></ui-textarea>
+    </div>
+  `,
+});

--- a/apps/catalog/src/pages/typography.ts
+++ b/apps/catalog/src/pages/typography.ts
@@ -1,0 +1,58 @@
+import { registerPage } from "../registry.js";
+import { typography } from "@maneki/foundation";
+
+const groupLabels: Record<string, string> = {
+  display: "Display", heading: "Heading", body: "Body", ui: "UI",
+  caption: "Caption", badge: "Badge", code: "Code",
+};
+
+registerPage("typography", {
+  title: "Typography",
+  section: "Foundation",
+  render: () => {
+    const groups = Object.entries(typography) as [string, Record<string, any>][];
+    let html = `
+      <style>
+        .type-group { margin-bottom: 40px; }
+        .group-header {
+          font-size: 11px; font-weight: 600; text-transform: uppercase;
+          letter-spacing: 0.08em; color: #5b7282; margin: 0 0 16px;
+          padding-bottom: 8px; border-bottom: 1px solid #dce3e8;
+        }
+        .type-row {
+          display: grid; grid-template-columns: 1fr 280px;
+          align-items: baseline; gap: 24px; padding: 12px 0;
+          border-bottom: 1px solid #f2f5f7;
+        }
+        .type-sample { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+        .type-meta { display: flex; gap: 16px; align-items: baseline; font-size: 11px; color: #5b7282; }
+        .meta-key { font-weight: 500; color: #3e5463; min-width: 70px; }
+        .meta-detail { font-family: monospace; font-size: 10px; color: #5b7282; }
+        .meta-var { font-family: monospace; font-size: 10px; color: #7a909e; margin-top: 2px; }
+        .meta-usage { font-size: 10px; color: #5b7282; margin-top: 4px; font-style: italic; }
+      </style>
+    `;
+
+    for (const [group, tokens] of groups) {
+      html += `<div class="type-group"><p class="group-header">${groupLabels[group] ?? group}</p>`;
+      for (const [key, t] of Object.entries(tokens) as [string, any][]) {
+        html += `
+          <div class="type-row">
+            <div class="type-sample" style="font-family:${t.fontFamily};font-size:${t.fontSize}px;line-height:${t.lineHeight}px;font-weight:${t.fontWeight};">
+              The quick brown fox jumps
+            </div>
+            <div>
+              <div class="type-meta">
+                <span class="meta-key">${group}/${key}</span>
+                <span class="meta-detail">${t.fontSize}px / ${t.lineHeight}px \u00b7 ${t.fontWeight}</span>
+              </div>
+              <div class="meta-var">--fd-type-${group}-${key}-font-size</div>
+              ${t.usage ? `<div class="meta-usage">${t.usage}</div>` : ""}
+            </div>
+          </div>`;
+      }
+      html += `</div>`;
+    }
+    return html;
+  },
+});

--- a/apps/catalog/src/registry.ts
+++ b/apps/catalog/src/registry.ts
@@ -1,0 +1,14 @@
+// ─── Page registry ───────────────────────────────────────────────────────────
+
+export interface Page {
+  title: string;
+  section: string;
+  render: () => string;
+  setup?: () => void;
+}
+
+export const pages: Record<string, Page> = {};
+
+export function registerPage(id: string, page: Page): void {
+  pages[id] = page;
+}

--- a/apps/catalog/src/shared.ts
+++ b/apps/catalog/src/shared.ts
@@ -1,0 +1,24 @@
+// Shared inline SVG for deterministic image demos (no external URLs)
+export const landscapeSvg = `data:image/svg+xml,${encodeURIComponent(`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 400"><rect fill="#87CEEB" width="800" height="400"/><circle cx="650" cy="80" r="50" fill="%23FFD700"/><polygon points="100,400 250,150 400,400" fill="%23228B22"/><polygon points="300,400 500,100 700,400" fill="%23006400"/><rect y="350" width="800" height="50" fill="%23654321"/><rect x="350" y="280" width="60" height="70" fill="%238B4513"/><polygon points="350,280 380,240 410,280" fill="%23A0522D"/></svg>`)}`;
+
+// Raster PNG generated from canvas — object-fit works correctly on raster images
+export function createLandscapePng(): string {
+  const c = document.createElement("canvas");
+  c.width = 400; c.height = 200;
+  const ctx = c.getContext("2d")!;
+  // Sky
+  ctx.fillStyle = "#87CEEB"; ctx.fillRect(0, 0, 400, 200);
+  // Sun
+  ctx.fillStyle = "#FFD700"; ctx.beginPath(); ctx.arc(320, 40, 25, 0, Math.PI * 2); ctx.fill();
+  // Mountains
+  ctx.fillStyle = "#228B22"; ctx.beginPath(); ctx.moveTo(50, 200); ctx.lineTo(125, 75); ctx.lineTo(200, 200); ctx.fill();
+  ctx.fillStyle = "#006400"; ctx.beginPath(); ctx.moveTo(150, 200); ctx.lineTo(250, 50); ctx.lineTo(350, 200); ctx.fill();
+  // Ground
+  ctx.fillStyle = "#654321"; ctx.fillRect(0, 175, 400, 25);
+  // House
+  ctx.fillStyle = "#8B4513"; ctx.fillRect(175, 140, 30, 35);
+  ctx.fillStyle = "#A0522D"; ctx.beginPath(); ctx.moveTo(175, 140); ctx.lineTo(190, 120); ctx.lineTo(205, 140); ctx.fill();
+  return c.toDataURL("image/png");
+}
+
+export const gradientPlaceholder = `<div style="width:100%;height:100%;background:linear-gradient(135deg,#186ade 0%,#7ac7e3 100%)"></div>`;

--- a/apps/catalog/tsconfig.json
+++ b/apps/catalog/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/catalog/vite.config.ts
+++ b/apps/catalog/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  root: ".",
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+  },
+  server: {
+    port: 5174,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,21 @@
         "vitest": "^4.0.18"
       }
     },
+    "apps/catalog": {
+      "name": "@maneki/catalog",
+      "version": "0.1.0",
+      "dependencies": {
+        "@maneki/flex-layout": "*",
+        "@maneki/foundation": "*",
+        "@maneki/grid-layout": "*",
+        "@maneki/ui-components": "*"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.58.2",
+        "typescript": "^5.4.0",
+        "vite": "^5.4.0"
+      }
+    },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
@@ -646,6 +661,10 @@
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
+    },
+    "node_modules/@maneki/catalog": {
+      "resolved": "apps/catalog",
+      "link": true
     },
     "node_modules/@maneki/flex-layout": {
       "resolved": "packages/flex-layout",

--- a/packages/grid-layout/src/components/grid-item.ts
+++ b/packages/grid-layout/src/components/grid-item.ts
@@ -108,6 +108,80 @@ const GRID_ITEM_STYLES = `
   border-right: 2px solid var(--grid-handle-color, ${BORDER_BOLD});
   border-bottom: 2px solid var(--grid-handle-color, ${BORDER_BOLD});
 }
+.resize-handle-sw::after {
+  content: "";
+  position: absolute;
+  left: var(--grid-handle-indicator-offset, 3px);
+  bottom: var(--grid-handle-indicator-offset, 3px);
+  width: var(--grid-handle-indicator-size, 5px);
+  height: var(--grid-handle-indicator-size, 5px);
+  border-left: 2px solid var(--grid-handle-color, ${BORDER_BOLD});
+  border-bottom: 2px solid var(--grid-handle-color, ${BORDER_BOLD});
+}
+.resize-handle-ne::after {
+  content: "";
+  position: absolute;
+  right: var(--grid-handle-indicator-offset, 3px);
+  top: var(--grid-handle-indicator-offset, 3px);
+  width: var(--grid-handle-indicator-size, 5px);
+  height: var(--grid-handle-indicator-size, 5px);
+  border-right: 2px solid var(--grid-handle-color, ${BORDER_BOLD});
+  border-top: 2px solid var(--grid-handle-color, ${BORDER_BOLD});
+}
+.resize-handle-nw::after {
+  content: "";
+  position: absolute;
+  left: var(--grid-handle-indicator-offset, 3px);
+  top: var(--grid-handle-indicator-offset, 3px);
+  width: var(--grid-handle-indicator-size, 5px);
+  height: var(--grid-handle-indicator-size, 5px);
+  border-left: 2px solid var(--grid-handle-color, ${BORDER_BOLD});
+  border-top: 2px solid var(--grid-handle-color, ${BORDER_BOLD});
+}
+.resize-handle-s::after {
+  content: "";
+  position: absolute;
+  bottom: var(--grid-handle-indicator-offset, 3px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: 16px;
+  height: 2px;
+  background: var(--grid-handle-color, ${BORDER_BOLD});
+  border-radius: 1px;
+}
+.resize-handle-n::after {
+  content: "";
+  position: absolute;
+  top: var(--grid-handle-indicator-offset, 3px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: 16px;
+  height: 2px;
+  background: var(--grid-handle-color, ${BORDER_BOLD});
+  border-radius: 1px;
+}
+.resize-handle-e::after {
+  content: "";
+  position: absolute;
+  right: var(--grid-handle-indicator-offset, 3px);
+  top: 50%;
+  transform: translateY(-50%);
+  width: 2px;
+  height: 16px;
+  background: var(--grid-handle-color, ${BORDER_BOLD});
+  border-radius: 1px;
+}
+.resize-handle-w::after {
+  content: "";
+  position: absolute;
+  left: var(--grid-handle-indicator-offset, 3px);
+  top: 50%;
+  transform: translateY(-50%);
+  width: 2px;
+  height: 16px;
+  background: var(--grid-handle-color, ${BORDER_BOLD});
+  border-radius: 1px;
+}
 `;
 
 export class GridItemElement extends HTMLElement {
@@ -230,7 +304,11 @@ export class GridItemElement extends HTMLElement {
     if (!this.isResizable) return;
 
     const wrapper = this._shadow.querySelector(".grid-item-content");
-    if (!wrapper) return;
+    if (!wrapper) {
+      // Defer if shadow DOM not ready yet
+      requestAnimationFrame(() => this.updateResizeHandles());
+      return;
+    }
 
     for (const axis of this._resizeHandleAxes) {
       const handle = document.createElement("div");

--- a/packages/grid-layout/src/components/grid-layout.ts
+++ b/packages/grid-layout/src/components/grid-layout.ts
@@ -245,7 +245,7 @@ export class GridLayoutElement extends HTMLElement {
 
   set resizeConfig(value: Partial<ResizeConfig>) {
     this._resizeConfig = { ...DEFAULT_RESIZE_CONFIG, ...value };
-    this.syncResizeHandlesToItems();
+    this.deferredSyncResize();
   }
 
   get compactType(): CompactType {
@@ -323,7 +323,7 @@ export class GridLayoutElement extends HTMLElement {
       this.buildLayoutFromChildren();
     }
 
-    this.syncResizeHandlesToItems();
+    this.deferredSyncResize();
   }
 
   disconnectedCallback(): void {
@@ -380,11 +380,22 @@ export class GridLayoutElement extends HTMLElement {
     }
   }
 
+  private _resizeSyncPending = false;
+
   private syncResizeHandlesToItems(): void {
     const items = this.getGridItems();
     items.forEach((el) => {
       el.resizeHandleAxes = this._resizeConfig.handles;
     });
+  }
+
+  private deferredSyncResize(): void {
+    if (this._resizeSyncPending) return;
+    this._resizeSyncPending = true;
+    setTimeout(() => {
+      this._resizeSyncPending = false;
+      this.syncResizeHandlesToItems();
+    }, 0);
   }
 
   // --- Position rendering ---

--- a/packages/ui-components/AGENTS.md
+++ b/packages/ui-components/AGENTS.md
@@ -130,8 +130,11 @@ ui-components/
 │   │   ├── ui-carousel.ts
 │   │   ├── ui-carousel-item.ts
 │   │   ├── ui-calendar.ts        + ui-calendar.styles.ts
-│   │   ├── ui-calendar-quicklinks.ts + ui-calendar-quicklinks.styles.ts
+- `<ui-calendar-quicklinks>` — composable quicklinks panel: 3 sizes (s/m/l), 2 orientations (side/bottom), section headings, selected state, click events
+- `<ui-calendar-time>` — composable inline time panel: 3 sizes (s/m/l), hour/minute inputs, AM/PM toggle switch, separator line, 12h/24h conversion
+- `<ui-calendar-panel>` — composable wrapper: elevation, slots (default/side/bottom), size propagation, optional actions bar (Cancel/OK)
 │   │   ├── ui-calendar-time.ts    + ui-calendar-time.styles.ts
+│   │   ├── ui-calendar-panel.ts    + ui-calendar-panel.styles.ts
 │   │   ├── ui-datetime-picker-input.ts + ui-datetime-picker-input.styles.ts
 │   │   ├── ui-datetime-picker.ts      + ui-datetime-picker.styles.ts
 │   │   ├── ui-clock.ts            + ui-clock.styles.ts
@@ -336,7 +339,7 @@ After merging a PR that adds/modifies components, icons, or tests, update these 
 ```bash
 moon run ui-components:storybook       # Dev server on port 6006
 moon run ui-components:storybook-build  # Static build
-moon run ui-components:test            # vitest --run (2216 tests)
+moon run ui-components:test            # vitest --run (2235 tests)
 moon run ui-components:build           # vite build + tsc --emitDeclarationOnly
 moon run ui-components:chromatic       # Publish to Chromatic
 ```

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -86,6 +86,7 @@ npm install @maneki/ui-components
 | `<ui-datetime-picker-input>` | Date/time input trigger: 3 types, 3 sizes, 7 states, 5 statuses |
 | `<ui-datetime-picker>` | Datetime picker: input + floating dropdown, 3 types (single-date/range-date/time), actions bar |
 | `<ui-clock>` | Standalone clock: analog face + 24-hour digital, 3 sizes |
+| `<ui-calendar-panel>` | Composable wrapper: elevation, slots (side/bottom), size propagation, actions bar |
 | | **List** |
 | `<ui-list-item>` | List item: 3 sizes, 5 leading elements, 3 paddings, 4 states, trailing icon, description |
 | `<ui-list-header>` | List section header: 3 sizes, collapse button |
@@ -110,7 +111,7 @@ moon run ui-components:storybook        # Dev server on port 6006
 moon run ui-components:storybook-build  # Static build → storybook-static/
 ```
 
-50 components with stories covering all variants, sizes, actions, emphases, shapes, and statuses.
+51 components with stories covering all variants, sizes, actions, emphases, shapes, and statuses.
 
 ---
 
@@ -118,7 +119,7 @@ moon run ui-components:storybook-build  # Static build → storybook-static/
 
 ```bash
 moon run ui-components:build  # vite build + tsc --emitDeclarationOnly → dist/
-moon run ui-components:test   # vitest --run (2216 tests)
+moon run ui-components:test   # vitest --run (2235 tests)
 ```
 
 ---

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "description": "Design system Web Components for the Maneki monorepo",
   "type": "module",
+  "sideEffects": true,
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/ui-components/src/components/ui-calendar-panel.styles.ts
+++ b/packages/ui-components/src/components/ui-calendar-panel.styles.ts
@@ -1,0 +1,59 @@
+import { semanticVar } from "@maneki/foundation";
+
+const ELEVATION_05 = "0px 8px 10px 0px rgba(0,0,0,0.14), 0px 3px 14px 0px rgba(0,0,0,0.12), 0px 5px 5px 0px rgba(0,0,0,0.2)";
+const BORDER_MINIMAL = semanticVar("border", "minimal");
+const SURFACE_PRIMARY = semanticVar("surface", "primary");
+
+export const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: inline-flex;
+    flex-direction: column;
+    border-radius: 2px;
+    box-shadow: var(--ui-calendar-panel-elevation, ${ELEVATION_05});
+    overflow: hidden;
+  }
+
+  .body {
+    display: flex;
+  }
+
+  .main {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .actions {
+    display: none;
+    justify-content: flex-end;
+    gap: 8px;
+    padding: 8px 12px;
+    border-top: 1px solid ${BORDER_MINIMAL};
+    background: ${SURFACE_PRIMARY};
+  }
+
+  :host([show-actions]) .actions {
+    display: flex;
+  }
+
+  /* Reset children elevation + border-radius */
+  ::slotted(ui-calendar) {
+    --ui-calendar-elevation: none;
+    border-radius: 0 !important;
+  }
+
+  ::slotted(ui-calendar-quicklinks) {
+    border-radius: 0 !important;
+  }
+
+  ::slotted(ui-calendar-time) {
+    border-radius: 0 !important;
+  }
+`;

--- a/packages/ui-components/src/components/ui-calendar-panel.test.ts
+++ b/packages/ui-components/src/components/ui-calendar-panel.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, afterEach } from "vitest";
+import "./ui-calendar-panel.js";
+
+function create(attrs = "", inner = ""): HTMLElement {
+  const el = document.createElement("div");
+  el.innerHTML = `<ui-calendar-panel ${attrs}>${inner}</ui-calendar-panel>`;
+  document.body.appendChild(el);
+  return el.querySelector("ui-calendar-panel")!;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("ui-calendar-panel", () => {
+  // ── Default rendering ──────────────────────────────────────────────────
+
+  it("should have shadow DOM", () => {
+    const el = create();
+    expect(el.shadowRoot).toBeTruthy();
+  });
+
+  it("should default to size m", () => {
+    const el = create();
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("should have body and main containers", () => {
+    const el = create();
+    const body = el.shadowRoot!.querySelector(".body");
+    const main = el.shadowRoot!.querySelector(".main");
+    expect(body).toBeTruthy();
+    expect(main).toBeTruthy();
+  });
+
+  it("should have actions bar hidden by default", () => {
+    const el = create();
+    const actions = el.shadowRoot!.querySelector(".actions") as HTMLElement;
+    expect(actions).toBeTruthy();
+    expect(el.hasAttribute("show-actions")).toBe(false);
+  });
+
+  // ── Size attribute ─────────────────────────────────────────────────────
+
+  it("should accept size s", () => {
+    const el = create('size="s"');
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("should accept size l", () => {
+    const el = create('size="l"');
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  it("should update size via property", () => {
+    const el = create() as any;
+    el.size = "l";
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  // ── Size propagation ──────────────────────────────────────────────────
+
+  it("should propagate size to ui-calendar child on attribute change", () => {
+    const el = create("", '<ui-calendar value="2024-06-15"></ui-calendar>');
+    el.setAttribute("size", "l");
+    const cal = el.querySelector("ui-calendar")!;
+    expect(cal.getAttribute("size")).toBe("l");
+  });
+
+  it("should propagate size to ui-calendar-quicklinks child", () => {
+    const el = create("", '<ui-calendar-quicklinks orientation="side"></ui-calendar-quicklinks>');
+    el.setAttribute("size", "s");
+    const ql = el.querySelector("ui-calendar-quicklinks")!;
+    expect(ql.getAttribute("size")).toBe("s");
+  });
+
+  it("should propagate size to ui-calendar-time child", () => {
+    const el = create("", '<ui-calendar-time value="14:30"></ui-calendar-time>');
+    el.setAttribute("size", "l");
+    const ct = el.querySelector("ui-calendar-time")!;
+    expect(ct.getAttribute("size")).toBe("l");
+  });
+
+  // ── show-actions attribute ─────────────────────────────────────────────
+
+  it("should accept show-actions attribute", () => {
+    const el = create("show-actions");
+    expect(el.hasAttribute("show-actions")).toBe(true);
+  });
+
+  it("should toggle show-actions", () => {
+    const el = create();
+    expect(el.hasAttribute("show-actions")).toBe(false);
+    el.setAttribute("show-actions", "");
+    expect(el.hasAttribute("show-actions")).toBe(true);
+    el.removeAttribute("show-actions");
+    expect(el.hasAttribute("show-actions")).toBe(false);
+  });
+
+  // ── Slots ──────────────────────────────────────────────────────────────
+
+  it("should have default slot in main", () => {
+    const el = create();
+    const main = el.shadowRoot!.querySelector(".main");
+    const slot = main!.querySelector("slot:not([name])");
+    expect(slot).toBeTruthy();
+  });
+
+  it("should have side slot in body", () => {
+    const el = create();
+    const body = el.shadowRoot!.querySelector(".body");
+    const slot = body!.querySelector('slot[name="side"]');
+    expect(slot).toBeTruthy();
+  });
+
+  it("should have bottom slot in main", () => {
+    const el = create();
+    const main = el.shadowRoot!.querySelector(".main");
+    const slot = main!.querySelector('slot[name="bottom"]');
+    expect(slot).toBeTruthy();
+  });
+
+  // ── Events ─────────────────────────────────────────────────────────────
+
+  it("should dispatch cancel event from cancel button", () => {
+    const el = create("show-actions");
+    let fired = false;
+    el.addEventListener("cancel", () => { fired = true; });
+    const buttons = el.shadowRoot!.querySelectorAll("ui-button");
+    const cancelBtn = buttons[0] as HTMLElement;
+    cancelBtn.click();
+    expect(fired).toBe(true);
+  });
+
+  it("should dispatch confirm event from OK button", () => {
+    const el = create("show-actions");
+    let fired = false;
+    el.addEventListener("confirm", () => { fired = true; });
+    const buttons = el.shadowRoot!.querySelectorAll("ui-button");
+    const okBtn = buttons[1] as HTMLElement;
+    okBtn.click();
+    expect(fired).toBe(true);
+  });
+
+  // ── Composed usage ─────────────────────────────────────────────────────
+
+  it("should work with calendar + quicklinks side", () => {
+    const el = create('size="m"', `
+      <ui-calendar-quicklinks slot="side" orientation="side"></ui-calendar-quicklinks>
+      <ui-calendar value="2024-06-15"></ui-calendar>
+    `);
+    expect(el.querySelector("ui-calendar")).toBeTruthy();
+    expect(el.querySelector("ui-calendar-quicklinks")).toBeTruthy();
+  });
+
+  it("should work with calendar + time bottom", () => {
+    const el = create('size="m"', `
+      <ui-calendar value="2024-06-15"></ui-calendar>
+      <ui-calendar-time slot="bottom" value="14:30"></ui-calendar-time>
+    `);
+    expect(el.querySelector("ui-calendar")).toBeTruthy();
+    expect(el.querySelector("ui-calendar-time")).toBeTruthy();
+  });
+});

--- a/packages/ui-components/src/components/ui-calendar-panel.ts
+++ b/packages/ui-components/src/components/ui-calendar-panel.ts
@@ -1,0 +1,127 @@
+import { STYLES } from "./ui-calendar-panel.styles.js";
+import "./ui-calendar.js";
+import "./ui-calendar-quicklinks.js";
+import "./ui-calendar-time.js";
+import "./ui-button.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type CalendarPanelSize = "s" | "m" | "l";
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiCalendarPanel extends HTMLElement {
+  static readonly observedAttributes = ["size", "show-actions"];
+
+  #cancelBtn!: HTMLButtonElement;
+  #okBtn!: HTMLButtonElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    // Body: side slot + main column
+    const body = document.createElement("div");
+    body.className = "body";
+
+    // Side slot (for quicklinks orientation="side")
+    const sideSlot = document.createElement("slot");
+    sideSlot.name = "side";
+    body.appendChild(sideSlot);
+
+    // Main column: default slot + bottom slot
+    const main = document.createElement("div");
+    main.className = "main";
+
+    const defaultSlot = document.createElement("slot");
+    main.appendChild(defaultSlot);
+
+    const bottomSlot = document.createElement("slot");
+    bottomSlot.name = "bottom";
+    main.appendChild(bottomSlot);
+
+    body.appendChild(main);
+    shadow.appendChild(body);
+
+    // Actions bar
+    const actions = document.createElement("div");
+    actions.className = "actions";
+
+    this.#cancelBtn = document.createElement("button");
+    this.#cancelBtn.className = "action-btn";
+    this.#cancelBtn.type = "button";
+
+    this.#okBtn = document.createElement("button");
+    this.#okBtn.className = "action-btn";
+    this.#okBtn.type = "button";
+
+    // Use ui-button elements
+    const cancelBtnEl = document.createElement("ui-button");
+    cancelBtnEl.setAttribute("action", "secondary");
+    cancelBtnEl.setAttribute("emphasis", "minimal");
+    cancelBtnEl.setAttribute("size", "m");
+    cancelBtnEl.textContent = "Cancel";
+
+    const okBtnEl = document.createElement("ui-button");
+    okBtnEl.setAttribute("action", "primary");
+    okBtnEl.setAttribute("emphasis", "bold");
+    okBtnEl.setAttribute("size", "m");
+    okBtnEl.textContent = "OK";
+
+    actions.append(cancelBtnEl, okBtnEl);
+    shadow.appendChild(actions);
+
+    // Events
+    cancelBtnEl.addEventListener("click", () => {
+      this.dispatchEvent(new CustomEvent("cancel", { bubbles: true }));
+    });
+    okBtnEl.addEventListener("click", () => {
+      this.dispatchEvent(new CustomEvent("confirm", { bubbles: true }));
+    });
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("size")) {
+      this.setAttribute("size", "m");
+    }
+    this.#propagateSize();
+  }
+
+  attributeChangedCallback(name: string): void {
+    if (!this.isConnected) return;
+    if (name === "size") {
+      this.#propagateSize();
+    }
+  }
+
+  // ─── Properties ────────────────────────────────────────────────────────
+
+  get size(): CalendarPanelSize {
+    return (this.getAttribute("size") as CalendarPanelSize) || "m";
+  }
+
+  set size(v: CalendarPanelSize) {
+    this.setAttribute("size", v);
+  }
+
+  // ─── Internal ──────────────────────────────────────────────────────────
+
+  #propagateSize(): void {
+    const size = this.size;
+    for (const child of this.children) {
+      if (
+        child.tagName === "UI-CALENDAR" ||
+        child.tagName === "UI-CALENDAR-QUICKLINKS" ||
+        child.tagName === "UI-CALENDAR-TIME"
+      ) {
+        child.setAttribute("size", size);
+      }
+    }
+  }
+}
+
+customElements.define("ui-calendar-panel", UiCalendarPanel);

--- a/packages/ui-components/src/components/ui-checkbox-item.ts
+++ b/packages/ui-components/src/components/ui-checkbox-item.ts
@@ -1,6 +1,6 @@
 import { semanticVar, spaceVar } from "@maneki/foundation";
 import "./ui-icon.js";
-import type { UIIcon } from "./ui-icon.js";
+import type { UiIcon } from "./ui-icon.js";
 
 // ─── Type-safe property unions ───────────────────────────────────────────────
 
@@ -315,13 +315,13 @@ export class UiCheckboxItem extends HTMLElement {
     checkbox.className = "checkbox";
 
     // Check icon
-    const checkIcon = document.createElement("ui-icon") as UIIcon;
+    const checkIcon = document.createElement("ui-icon") as UiIcon;
     checkIcon.className = "check-icon";
     checkIcon.setAttribute("name", "check");
     checkbox.appendChild(checkIcon);
 
     // Indeterminate icon
-    const indeterminateIcon = document.createElement("ui-icon") as UIIcon;
+    const indeterminateIcon = document.createElement("ui-icon") as UiIcon;
     indeterminateIcon.className = "indeterminate-icon";
     indeterminateIcon.setAttribute("name", "remove");
     checkbox.appendChild(indeterminateIcon);

--- a/packages/ui-components/src/components/ui-input-group.ts
+++ b/packages/ui-components/src/components/ui-input-group.ts
@@ -13,6 +13,8 @@ const TEXT_SECONDARY = semanticVar("text", "secondary");
 const TEXT_PRIMARY = semanticVar("text", "primary");
 const SP_1 = spaceVar("1");
 const SP_15 = spaceVar("1.5");
+const HOVER_BORDER = semanticVar("stateHover", "borderModerate");
+const FOCUS_BORDER = semanticVar("border", "focus");
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
 
@@ -35,6 +37,15 @@ const STYLES = /* css */ `
     border-radius: 2px;
     overflow: hidden;
     width: 100%;
+    transition: border-color 0.15s ease;
+  }
+
+  :host(:hover:not([disabled]):not([readonly])) .wrapper {
+    border-color: var(--ui-ig-hover-border, ${HOVER_BORDER});
+  }
+
+  :host(:focus-within:not([disabled]):not([readonly])) .wrapper {
+    border-color: var(--ui-ig-focus-border, ${FOCUS_BORDER});
   }
 
   /* ── Prefix / Suffix sections ─────────────────────────────────────────── */
@@ -73,10 +84,19 @@ const STYLES = /* css */ `
     align-self: stretch;
     background-color: var(--ui-ig-separator, ${FORM_INPUT_BORDER});
     flex-shrink: 0;
+    transition: background-color 0.15s ease;
   }
 
   .separator.visible {
     display: block;
+  }
+
+  :host(:hover:not([disabled]):not([readonly])) .separator {
+    background-color: var(--ui-ig-hover-border, ${HOVER_BORDER});
+  }
+
+  :host(:focus-within:not([disabled]):not([readonly])) .separator {
+    background-color: var(--ui-ig-focus-border, ${FOCUS_BORDER});
   }
 
   /* ── Default slot (for ui-input) ──────────────────────────────────────── */
@@ -92,6 +112,8 @@ const STYLES = /* css */ `
     flex: 1;
     min-width: 0;
     --ui-input-border: transparent;
+    --ui-input-hover-border: transparent;
+    --ui-input-focus-border: transparent;
     border: none !important;
     border-radius: 0 !important;
   }

--- a/packages/ui-components/src/components/ui-tag.ts
+++ b/packages/ui-components/src/components/ui-tag.ts
@@ -1,6 +1,6 @@
 import { colorVar, semanticVar, spaceVar } from "@maneki/foundation";
 import "./ui-icon.js";
-import type { UIIcon } from "./ui-icon.js";
+import type { UiIcon } from "./ui-icon.js";
 
 // ─── Type-safe property unions ───────────────────────────────────────────────
 
@@ -598,21 +598,21 @@ export class UiTag extends HTMLElement {
 
     // Create check icon
     const checkWrap = shadow.querySelector(".check-icon")!;
-    const checkIcon = document.createElement("ui-icon") as UIIcon;
+    const checkIcon = document.createElement("ui-icon") as UiIcon;
     checkIcon.setAttribute("name", "check");
     checkWrap.appendChild(checkIcon);
     this._checkIcon = checkIcon as unknown as HTMLElement;
 
     // Create dismiss icon
     const dismissWrap = shadow.querySelector(".dismiss-icon")!;
-    const dismissIcon = document.createElement("ui-icon") as UIIcon;
+    const dismissIcon = document.createElement("ui-icon") as UiIcon;
     dismissIcon.setAttribute("name", "close");
     dismissWrap.appendChild(dismissIcon);
     this._dismissIcon = dismissIcon as unknown as HTMLElement;
 
     // Create add icon (for editable mode)
     const addWrap = shadow.querySelector(".add-icon")!;
-    const addIcon = document.createElement("ui-icon") as UIIcon;
+    const addIcon = document.createElement("ui-icon") as UiIcon;
     addIcon.setAttribute("name", "add");
     addWrap.appendChild(addIcon);
   }

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -30,6 +30,8 @@ export type {
 } from "./components/ui-alert.js";
 export { UiTag } from "./components/ui-tag.js";
 export type { TagSize, TagType, TagEmphasis, TagState, TagColor } from "./components/ui-tag.js";
+export { UiLink } from "./components/ui-link.js";
+export type { LinkSize } from "./components/ui-link.js";
 
 // ─── Form Controls ──────────────────────────────────────────────────────────
 
@@ -127,6 +129,8 @@ export { UiCarouselItem } from "./components/ui-carousel-item.js";
 
 export { UiCalendar } from "./components/ui-calendar.js";
 export type { CalendarSize, CalendarMode, CalendarView, CalendarEvent } from "./components/ui-calendar.js";
+export { UiCalendarPanel } from "./components/ui-calendar-panel.js";
+export type { CalendarPanelSize } from "./components/ui-calendar-panel.js";
 
 // ─── Date Picker Input ───────────────────────────────────────────────────────
 

--- a/packages/ui-components/src/stories/ui-link.stories.ts
+++ b/packages/ui-components/src/stories/ui-link.stories.ts
@@ -1,0 +1,133 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-link.js";
+
+const meta: Meta = {
+  title: "Components/Link",
+  component: "ui-link",
+  argTypes: {
+    size: { control: { type: "select" }, options: ["s", "m", "l"] },
+    emphasis: { control: { type: "select" }, options: ["bold", "subtle"] },
+    href: { control: "text" },
+    disabled: { control: "boolean" },
+  },
+  args: {
+    size: "m",
+    emphasis: "bold",
+    href: "#",
+    disabled: false,
+  },
+  render: (args) => html`
+    <ui-link
+      size=${args.size}
+      emphasis=${args.emphasis}
+      href=${args.href}
+      ?disabled=${args.disabled}
+    >Link text</ui-link>
+  `,
+};
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  render: () => html`<ui-link href="#">Default link</ui-link>`,
+};
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 32px; align-items: baseline;">
+      <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+        <span style="font-family: Inter, sans-serif; font-size: 11px; color: #9fb1bd;">S</span>
+        <ui-link size="s" href="#">Small link</ui-link>
+      </div>
+      <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+        <span style="font-family: Inter, sans-serif; font-size: 11px; color: #9fb1bd;">M</span>
+        <ui-link size="m" href="#">Medium link</ui-link>
+      </div>
+      <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+        <span style="font-family: Inter, sans-serif; font-size: 11px; color: #9fb1bd;">L</span>
+        <ui-link size="l" href="#">Large link</ui-link>
+      </div>
+    </div>
+  `,
+};
+
+export const Emphases: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 32px; align-items: baseline;">
+      <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+        <span style="font-family: Inter, sans-serif; font-size: 11px; color: #9fb1bd;">Bold</span>
+        <ui-link emphasis="bold" href="#">Bold link</ui-link>
+      </div>
+      <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+        <span style="font-family: Inter, sans-serif; font-size: 11px; color: #9fb1bd;">Subtle</span>
+        <ui-link emphasis="subtle" href="#">Subtle link</ui-link>
+      </div>
+    </div>
+  `,
+};
+
+export const States: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 32px; align-items: baseline;">
+      <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+        <span style="font-family: Inter, sans-serif; font-size: 11px; color: #9fb1bd;">Enabled</span>
+        <ui-link href="#">Enabled</ui-link>
+      </div>
+      <div style="display: flex; flex-direction: column; gap: 4px; align-items: flex-start;">
+        <span style="font-family: Inter, sans-serif; font-size: 11px; color: #9fb1bd;">Disabled</span>
+        <ui-link href="#" disabled>Disabled</ui-link>
+      </div>
+    </div>
+  `,
+};
+
+export const Inline: Story = {
+  render: () => html`
+    <p style="font-family: Inter, sans-serif; font-size: 14px; color: #1c2b36; max-width: 480px; line-height: 1.6;">
+      This is a paragraph with an <ui-link href="#" size="m">inline link</ui-link> embedded
+      in the text. Links can also be <ui-link href="#" emphasis="subtle" size="m">subtle emphasis</ui-link>
+      to blend more naturally with surrounding content.
+    </p>
+  `,
+};
+
+export const WithTarget: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 32px; align-items: baseline;">
+      <ui-link href="#" target="_self">Same window</ui-link>
+      <ui-link href="#" target="_blank" rel="noopener noreferrer">New window</ui-link>
+    </div>
+  `,
+};
+
+export const AllSizesEmphases: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 24px;">
+      <div>
+        <h3 style="margin: 0 0 12px; font-family: Inter, sans-serif; font-size: 14px; color: #5b7282;">Bold</h3>
+        <div style="display: flex; gap: 32px; align-items: baseline;">
+          <ui-link size="s" emphasis="bold" href="#">Small</ui-link>
+          <ui-link size="m" emphasis="bold" href="#">Medium</ui-link>
+          <ui-link size="l" emphasis="bold" href="#">Large</ui-link>
+        </div>
+      </div>
+      <div>
+        <h3 style="margin: 0 0 12px; font-family: Inter, sans-serif; font-size: 14px; color: #5b7282;">Subtle</h3>
+        <div style="display: flex; gap: 32px; align-items: baseline;">
+          <ui-link size="s" emphasis="subtle" href="#">Small</ui-link>
+          <ui-link size="m" emphasis="subtle" href="#">Medium</ui-link>
+          <ui-link size="l" emphasis="subtle" href="#">Large</ui-link>
+        </div>
+      </div>
+      <div>
+        <h3 style="margin: 0 0 12px; font-family: Inter, sans-serif; font-size: 14px; color: #5b7282;">Disabled</h3>
+        <div style="display: flex; gap: 32px; align-items: baseline;">
+          <ui-link size="s" href="#" disabled>Small</ui-link>
+          <ui-link size="m" href="#" disabled>Medium</ui-link>
+          <ui-link size="l" href="#" disabled>Large</ui-link>
+        </div>
+      </div>
+    </div>
+  `,
+};


### PR DESCRIPTION
## Summary

- Add `apps/catalog` — a dedicated visual catalog app showcasing all foundation tokens and 50 components
- Sidebar navigation with hash-based routing, 34 pages (5 foundation + 29 component)
- Each page renders key variants (sizes, states, emphases, colors) for visual regression
- Playwright visual test suite: 36 screenshot tests (one per page + sidebar + full layout)
- Baseline snapshots generated for Chromium at 1280×900
- Vite-based build, Moon tasks for `dev`, `build`, `test-visual`, `test-visual-update`