### PR TITLE
feat(ui-components): add ui-metric and ui-metric-group components

### DIFF
--- a/apps/catalog/e2e/visual.spec.ts
+++ b/apps/catalog/e2e/visual.spec.ts
@@ -33,6 +33,7 @@ const pages = [
   "side-panel-menu",
   "tabs",
   "table",
+  "metric",
   "carousel",
   "calendar",
   "datetime-picker",

--- a/apps/catalog/src/main.ts
+++ b/apps/catalog/src/main.ts
@@ -48,6 +48,7 @@ const pageLoaders: Record<string, () => Promise<unknown>> = {
   "side-panel-menu": () => import("./pages/side-panel-menu.js"),
   "tabs": () => import("./pages/tabs.js"),
   "table": () => import("./pages/table.js"),
+  "metric": () => import("./pages/metric.js"),
   "carousel": () => import("./pages/carousel.js"),
   "calendar": () => import("./pages/calendar.js"),
   "datetime-picker": () => import("./pages/datetime-picker.js"),

--- a/apps/catalog/src/manifest.ts
+++ b/apps/catalog/src/manifest.ts
@@ -65,6 +65,7 @@ export const manifest: PageMeta[] = [
   { id: "tabs", title: "Tabs", section: "Tabs" },
   // Data Display
   { id: "table", title: "Table", section: "Data Display" },
+  { id: "metric", title: "Metric", section: "Data Display" },
   // Calendar & Date
   { id: "calendar", title: "Calendar", section: "Calendar & Date" },
   { id: "datetime-picker", title: "Datetime Picker", section: "Calendar & Date" },

--- a/apps/catalog/src/pages/metric.ts
+++ b/apps/catalog/src/pages/metric.ts
@@ -1,0 +1,113 @@
+import { registerPage } from "../registry.js";
+
+registerPage("metric", {
+  title: "Metric",
+  section: "Data Display",
+  render: () => `
+    <h3>Sizes</h3>
+    <div class="variant-row">
+      <div class="variant-col">
+        <span class="variant-label">XS</span>
+        <ui-metric size="xs" label="Revenue" value="$1.2M"></ui-metric>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">S</span>
+        <ui-metric size="s" label="Revenue" value="$1.2M"></ui-metric>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">M</span>
+        <ui-metric size="m" label="Revenue" value="$1.2M"></ui-metric>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">L</span>
+        <ui-metric size="l" label="Revenue" value="$1.2M"></ui-metric>
+      </div>
+    </div>
+
+    <h3>Delta Up</h3>
+    <div class="variant-row">
+      <ui-metric size="xs" label="Users" value="24.5K" delta="up" delta-text="+1.2K (5.1%)"></ui-metric>
+      <ui-metric size="s" label="Users" value="24.5K" delta="up" delta-text="+1.2K (5.1%)"></ui-metric>
+      <ui-metric size="m" label="Users" value="24.5K" delta="up" delta-text="+1.2K (5.1%)"></ui-metric>
+      <ui-metric size="l" label="Users" value="24.5K" delta="up" delta-text="+1.2K (5.1%)"></ui-metric>
+    </div>
+
+    <h3>Delta Down</h3>
+    <div class="variant-row">
+      <ui-metric size="xs" label="Churn" value="3.2%" delta="down" delta-text="-0.5% (2.1%)"></ui-metric>
+      <ui-metric size="s" label="Churn" value="3.2%" delta="down" delta-text="-0.5% (2.1%)"></ui-metric>
+      <ui-metric size="m" label="Churn" value="3.2%" delta="down" delta-text="-0.5% (2.1%)"></ui-metric>
+      <ui-metric size="l" label="Churn" value="3.2%" delta="down" delta-text="-0.5% (2.1%)"></ui-metric>
+    </div>
+
+    <h3>With Legend</h3>
+    <div class="variant-row">
+      <ui-metric size="m" label="Series A" value="$450K" legend-color="#cc1d92"></ui-metric>
+      <ui-metric size="m" label="Series B" value="$780K" legend-color="#0d4ea6"></ui-metric>
+      <ui-metric size="m" label="Series C" value="$120K" legend-color="#077d55"></ui-metric>
+    </div>
+
+    <h3>With Secondary Label</h3>
+    <div class="variant-row">
+      <ui-metric size="s" label="Revenue" value="$1.2M" secondary-label="vs last month"></ui-metric>
+      <ui-metric size="m" label="Revenue" value="$1.2M" secondary-label="vs last quarter"></ui-metric>
+      <ui-metric size="l" label="Revenue" value="$1.2M" secondary-label="vs last year"></ui-metric>
+    </div>
+
+    <h3>Full Variant (Legend + Delta + Secondary)</h3>
+    <div class="variant-row">
+      <ui-metric size="xs" label="Revenue" value="$1.2M" delta="up" delta-text="+12.5K (3.2%)" secondary-label="vs last month" legend-color="#cc1d92"></ui-metric>
+      <ui-metric size="s" label="Revenue" value="$1.2M" delta="up" delta-text="+12.5K (3.2%)" secondary-label="vs last month" legend-color="#cc1d92"></ui-metric>
+      <ui-metric size="m" label="Revenue" value="$1.2M" delta="up" delta-text="+12.5K (3.2%)" secondary-label="vs last month" legend-color="#cc1d92"></ui-metric>
+      <ui-metric size="l" label="Revenue" value="$1.2M" delta="up" delta-text="+12.5K (3.2%)" secondary-label="vs last month" legend-color="#cc1d92"></ui-metric>
+    </div>
+
+    <h3>Horizontal (M only)</h3>
+    <div class="stack-m">
+      <ui-metric size="m" orientation="horizontal" label="Total Revenue" value="$1.2M"></ui-metric>
+      <ui-metric size="m" orientation="horizontal" label="Active Users" value="24.5K"></ui-metric>
+      <ui-metric size="m" orientation="horizontal" label="Conversion" value="3.2%"></ui-metric>
+    </div>
+
+    <h3>Clickable</h3>
+    <div class="variant-row">
+      <ui-metric size="m" label="Revenue" value="$1.2M" clickable></ui-metric>
+      <ui-metric size="m" label="Users" value="24.5K" clickable delta="up" delta-text="+1.2K"></ui-metric>
+    </div>
+
+    <h3>Metric Group</h3>
+    <div class="stack-l">
+      <ui-metric-group size="xs" title="Performance">
+        <ui-metric label="Revenue" value="$1.2M"></ui-metric>
+        <ui-metric label="Users" value="24.5K"></ui-metric>
+        <ui-metric label="Orders" value="8.3K"></ui-metric>
+        <ui-metric label="AOV" value="$142"></ui-metric>
+        <ui-metric label="Conv." value="3.2%"></ui-metric>
+      </ui-metric-group>
+
+      <ui-metric-group size="s" title="Performance">
+        <ui-metric label="Revenue" value="$1.2M"></ui-metric>
+        <ui-metric label="Users" value="24.5K"></ui-metric>
+        <ui-metric label="Orders" value="8.3K"></ui-metric>
+        <ui-metric label="AOV" value="$142"></ui-metric>
+        <ui-metric label="Conv." value="3.2%"></ui-metric>
+      </ui-metric-group>
+
+      <ui-metric-group size="m" title="Performance">
+        <ui-metric label="Revenue" value="$1.2M"></ui-metric>
+        <ui-metric label="Users" value="24.5K"></ui-metric>
+        <ui-metric label="Orders" value="8.3K"></ui-metric>
+        <ui-metric label="AOV" value="$142"></ui-metric>
+        <ui-metric label="Conv." value="3.2%"></ui-metric>
+      </ui-metric-group>
+
+      <ui-metric-group size="l" title="Performance">
+        <ui-metric label="Revenue" value="$1.2M" secondary-label="YTD"></ui-metric>
+        <ui-metric label="Users" value="24.5K" secondary-label="YTD"></ui-metric>
+        <ui-metric label="Orders" value="8.3K" secondary-label="YTD"></ui-metric>
+        <ui-metric label="AOV" value="$142" secondary-label="YTD"></ui-metric>
+        <ui-metric label="Conv." value="3.2%" secondary-label="YTD"></ui-metric>
+      </ui-metric-group>
+    </div>
+  `,
+});

--- a/packages/ui-components/src/components/ui-metric-group.test.ts
+++ b/packages/ui-components/src/components/ui-metric-group.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "./ui-metric.js";
+import "./ui-metric-group.js";
+import type { MetricSize } from "./ui-metric.js";
+
+describe("ui-metric-group", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-metric-group");
+    document.body.appendChild(el);
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-metric-group")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("applies adoptedStyleSheets", () => {
+    expect(el.shadowRoot!.adoptedStyleSheets.length).toBe(1);
+  });
+
+  // ── Default rendering ─────────────────────────────────────────────────────
+
+  it("renders a .wrapper element", () => {
+    expect(el.shadowRoot!.querySelector(".wrapper")).not.toBeNull();
+  });
+
+  it("renders a .separator element", () => {
+    expect(el.shadowRoot!.querySelector(".separator")).not.toBeNull();
+  });
+
+  it("renders a .group element", () => {
+    expect(el.shadowRoot!.querySelector(".group")).not.toBeNull();
+  });
+
+  it("renders a .title element", () => {
+    expect(el.shadowRoot!.querySelector(".title")).not.toBeNull();
+  });
+
+  it("renders a .metrics element", () => {
+    expect(el.shadowRoot!.querySelector(".metrics")).not.toBeNull();
+  });
+
+  it("renders a slot inside .metrics", () => {
+    const metrics = el.shadowRoot!.querySelector(".metrics");
+    expect(metrics!.querySelector("slot")).not.toBeNull();
+  });
+
+  it("title element is empty by default", () => {
+    expect(el.shadowRoot!.querySelector(".title")!.textContent).toBe("");
+  });
+
+  // ── Title attribute ───────────────────────────────────────────────────────
+
+  it("sets title text from attribute", () => {
+    el.setAttribute("title", "Revenue Metrics");
+    expect(el.shadowRoot!.querySelector(".title")!.textContent).toBe(
+      "Revenue Metrics",
+    );
+  });
+
+  it("clears title text when attribute removed", () => {
+    el.setAttribute("title", "Revenue Metrics");
+    el.removeAttribute("title");
+    expect(el.shadowRoot!.querySelector(".title")!.textContent).toBe("");
+  });
+
+  it("updates title text when attribute changes", () => {
+    el.setAttribute("title", "Old Title");
+    el.setAttribute("title", "New Title");
+    expect(el.shadowRoot!.querySelector(".title")!.textContent).toBe("New Title");
+  });
+
+  // ── Size property accessor ────────────────────────────────────────────────
+
+  it("defaults size to 's'", () => {
+    expect((el as unknown as { size: MetricSize }).size).toBe("s");
+  });
+
+  it("reflects size to attribute via setter", () => {
+    (el as unknown as { size: MetricSize }).size = "m";
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("reads size from attribute via getter", () => {
+    el.setAttribute("size", "l");
+    expect((el as unknown as { size: MetricSize }).size).toBe("l");
+  });
+
+  // ── Size propagation ─────────────────────────────────────────────────────
+
+  it("propagates size to slotted ui-metric children", async () => {
+    const metric = document.createElement("ui-metric");
+    el.appendChild(metric);
+    el.setAttribute("size", "l");
+
+    // Wait for slotchange event to fire
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(metric.getAttribute("size")).toBe("l");
+  });
+
+  it("propagates size to multiple slotted ui-metric children", async () => {
+    const m1 = document.createElement("ui-metric");
+    const m2 = document.createElement("ui-metric");
+    el.appendChild(m1);
+    el.appendChild(m2);
+    el.setAttribute("size", "m");
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(m1.getAttribute("size")).toBe("m");
+    expect(m2.getAttribute("size")).toBe("m");
+  });
+
+  it("does not propagate size to non-ui-metric children", async () => {
+    const div = document.createElement("div");
+    el.appendChild(div);
+    el.setAttribute("size", "l");
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(div.hasAttribute("size")).toBe(false);
+  });
+
+  it("does not propagate when size attribute is absent", async () => {
+    const metric = document.createElement("ui-metric");
+    el.appendChild(metric);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    // No size attribute on group → no propagation
+    expect(metric.hasAttribute("size")).toBe(false);
+  });
+
+  // ── observedAttributes ────────────────────────────────────────────────────
+
+  it("observes size and title attributes", () => {
+    const Ctor = customElements.get("ui-metric-group") as unknown as {
+      observedAttributes: string[];
+    };
+    expect(Ctor.observedAttributes).toEqual(
+      expect.arrayContaining(["size", "title"]),
+    );
+  });
+
+  // ── DOM structure ─────────────────────────────────────────────────────────
+
+  it("separator is first child of wrapper", () => {
+    const wrapper = el.shadowRoot!.querySelector(".wrapper")!;
+    expect((wrapper.firstElementChild as HTMLElement).className).toBe("separator");
+  });
+
+  it("group is second child of wrapper", () => {
+    const wrapper = el.shadowRoot!.querySelector(".wrapper")!;
+    const children = Array.from(wrapper.children);
+    expect((children[1] as HTMLElement).className).toBe("group");
+  });
+
+  it("title is first child of group", () => {
+    const group = el.shadowRoot!.querySelector(".group")!;
+    expect((group.firstElementChild as HTMLElement).className).toBe("title");
+  });
+
+  it("metrics is second child of group", () => {
+    const group = el.shadowRoot!.querySelector(".group")!;
+    const children = Array.from(group.children);
+    expect((children[1] as HTMLElement).className).toBe("metrics");
+  });
+});

--- a/packages/ui-components/src/components/ui-metric-group.ts
+++ b/packages/ui-components/src/components/ui-metric-group.ts
@@ -1,0 +1,201 @@
+import { semanticVar } from "@maneki/foundation";
+import type { MetricSize } from "./ui-metric.js";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const TEXT_SECONDARY = semanticVar("text", "secondary");
+const BORDER_MODERATE = semanticVar("border", "moderate");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: flex;
+    align-items: center;
+  }
+
+  .wrapper {
+    display: flex;
+    gap: 8px;
+    align-items: stretch;
+    height: 100%;
+  }
+
+  /* ── Separator ───────────────────────────────────────────────────────────── */
+
+  .separator {
+    width: 1px;
+    align-self: stretch;
+    background: ${BORDER_MODERATE};
+    flex-shrink: 0;
+  }
+
+  /* ── Group container ─────────────────────────────────────────────────────── */
+
+  .group {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    align-items: flex-start;
+    padding-top: 8px;
+  }
+
+  /* ── Title ───────────────────────────────────────────────────────────────── */
+
+  .title {
+    display: none;
+    font-family: "Inter", sans-serif;
+    font-size: 12px;
+    line-height: 16px;
+    font-weight: 500;
+    text-transform: uppercase;
+    color: ${TEXT_SECONDARY};
+    white-space: nowrap;
+  }
+
+  :host([title]) .title {
+    display: flex;
+  }
+
+  /* ── Metric container ────────────────────────────────────────────────────── */
+
+  .metrics {
+    display: flex;
+    align-items: flex-start;
+  }
+
+  /* ── Size-dependent gaps and title padding ────────────────────────────────── */
+
+  :host .metrics,
+  :host([size="s"]) .metrics {
+    gap: 20px;
+  }
+
+  :host .title,
+  :host([size="s"]) .title {
+    padding-left: 8px;
+  }
+
+  :host([size="xs"]) .metrics {
+    gap: 16px;
+  }
+
+  :host([size="xs"]) .title {
+    padding-left: 8px;
+  }
+
+  :host([size="m"]) .metrics {
+    gap: 24px;
+  }
+
+  :host([size="m"]) .title {
+    padding-left: 12px;
+  }
+
+  :host([size="l"]) .metrics {
+    gap: 32px;
+  }
+
+  :host([size="l"]) .title {
+    padding-left: 16px;
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiMetricGroup extends HTMLElement {
+  static readonly observedAttributes = ["size", "title"];
+
+  #titleEl!: HTMLElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    const wrapper = document.createElement("div");
+    wrapper.className = "wrapper";
+
+    // Separator
+    const separator = document.createElement("div");
+    separator.className = "separator";
+
+    // Group container
+    const group = document.createElement("div");
+    group.className = "group";
+
+    // Title
+    this.#titleEl = document.createElement("div");
+    this.#titleEl.className = "title";
+
+    // Metrics slot
+    const metrics = document.createElement("div");
+    metrics.className = "metrics";
+    const slot = document.createElement("slot");
+    metrics.appendChild(slot);
+
+    group.appendChild(this.#titleEl);
+    group.appendChild(metrics);
+
+    wrapper.appendChild(separator);
+    wrapper.appendChild(group);
+
+    shadow.appendChild(wrapper);
+  }
+
+  connectedCallback(): void {
+    this.shadowRoot!.querySelector("slot")!.addEventListener(
+      "slotchange",
+      () => this._propagateSize(),
+    );
+    this._propagateSize();
+  }
+
+  attributeChangedCallback(
+    name: string,
+    _oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    switch (name) {
+      case "title":
+        this.#titleEl.textContent = newValue ?? "";
+        break;
+      case "size":
+        this._propagateSize();
+        break;
+    }
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): MetricSize {
+    return (this.getAttribute("size") as MetricSize) ?? "s";
+  }
+  set size(v: MetricSize) {
+    this.setAttribute("size", v);
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private _propagateSize(): void {
+    const size = this.getAttribute("size");
+    if (!size) return;
+    const slot = this.shadowRoot!.querySelector("slot")!;
+    for (const node of slot.assignedElements()) {
+      if (node.tagName === "UI-METRIC") {
+        node.setAttribute("size", size);
+      }
+    }
+  }
+}
+
+customElements.define("ui-metric-group", UiMetricGroup);

--- a/packages/ui-components/src/components/ui-metric.styles.ts
+++ b/packages/ui-components/src/components/ui-metric.styles.ts
@@ -1,0 +1,358 @@
+import { semanticVar, colorVar, spaceVar } from "@maneki/foundation";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const TEXT_SECONDARY = semanticVar("text", "secondary");
+const GREEN_60 = colorVar("green", 60);
+const RED_60 = colorVar("red", 60);
+const DISABLED_MINIMAL = semanticVar("stateDisabled", "minimal");
+const HOVER_SURFACE = semanticVar("stateHover", "surfaceMinimal");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+export const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: inline-flex;
+  }
+
+  /* ── Base wrapper ────────────────────────────────────────────────────────── */
+
+  .base {
+    display: flex;
+    align-items: flex-start;
+    border-radius: 2px;
+    font-family: "Inter", sans-serif;
+  }
+
+  /* Vertical orientation (default) */
+  :host(:not([orientation="horizontal"])) .base {
+    flex-direction: row;
+  }
+
+  /* Horizontal orientation */
+  :host([orientation="horizontal"]) .base {
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+    white-space: nowrap;
+  }
+
+  :host([orientation="horizontal"]) .content {
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+  }
+
+  :host([orientation="horizontal"]) .value-container {
+    gap: 0;
+  }
+
+  /* ── Legend bar ───────────────────────────────────────────────────────────── */
+
+  .legend {
+    display: none;
+    width: 2px;
+    align-self: stretch;
+    border-radius: 1px;
+    flex-shrink: 0;
+  }
+
+  :host([legend-color]) .legend {
+    display: block;
+  }
+
+  :host([legend-color]) .base {
+    gap: 8px;
+  }
+
+  /* ── Content ─────────────────────────────────────────────────────────────── */
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 2px;
+  }
+
+  .label {
+    font-size: 12px;
+    line-height: 16px;
+    font-weight: 400;
+    color: ${TEXT_SECONDARY};
+    white-space: nowrap;
+  }
+
+  .value-container {
+    display: flex;
+    align-items: center;
+  }
+
+  .value {
+    font-weight: 500;
+    color: ${TEXT_PRIMARY};
+    white-space: nowrap;
+  }
+
+  /* ── Delta arrow ─────────────────────────────────────────────────────────── */
+
+  .delta-arrow {
+    display: none;
+    flex-shrink: 0;
+  }
+
+  :host([delta="up"]) .delta-arrow,
+  :host([delta="down"]) .delta-arrow {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  :host([delta="up"]) .delta-arrow {
+    color: ${GREEN_60};
+  }
+
+  :host([delta="down"]) .delta-arrow {
+    color: ${RED_60};
+  }
+
+  :host([delta="down"]) .delta-arrow .arrow {
+    transform: rotate(180deg);
+  }
+
+  .arrow {
+    display: block;
+    width: 0;
+    height: 0;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-bottom: 5px solid currentColor;
+  }
+
+  /* ── Delta content row ───────────────────────────────────────────────────── */
+
+  .delta-content {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    line-height: 16px;
+    font-weight: 400;
+    white-space: nowrap;
+  }
+
+  .delta-text {
+    display: none;
+  }
+
+  :host([delta="up"]) .delta-text {
+    display: inline;
+    color: ${GREEN_60};
+  }
+
+  :host([delta="down"]) .delta-text {
+    display: inline;
+    color: ${RED_60};
+  }
+
+  .secondary-label {
+    display: none;
+    color: ${TEXT_SECONDARY};
+  }
+
+  :host([secondary-label]) .secondary-label {
+    display: inline;
+  }
+
+  /* Hide delta content row when no delta and no secondary label */
+  :host(:not([delta="up"]):not([delta="down"]):not([secondary-label])) .delta-content {
+    display: none;
+  }
+
+  /* Show delta content when only secondary label (no delta) */
+  :host([secondary-label]:not([delta="up"]):not([delta="down"])) .delta-content {
+    display: flex;
+  }
+
+  /* ── Clickable ───────────────────────────────────────────────────────────── */
+
+  :host([clickable]) .base {
+    cursor: pointer;
+  }
+
+  :host([clickable]) .base:hover {
+    background: ${HOVER_SURFACE};
+  }
+
+  :host([clickable]) .base:active {
+    background: ${DISABLED_MINIMAL};
+  }
+
+  /* ── Size: xs ────────────────────────────────────────────────────────────── */
+
+  :host([size="xs"]) .base {
+    padding: 4px 8px;
+  }
+
+  :host([size="xs"][legend-color]) .base {
+    padding: 4px 8px 4px 6px;
+  }
+
+  :host([size="xs"]) .content {
+    gap: 0;
+  }
+
+  :host([size="xs"]) .value {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  :host([size="xs"]) .delta-arrow {
+    width: 16px;
+    height: 16px;
+  }
+
+  :host([size="xs"]) .arrow {
+    border-left-width: 3px;
+    border-right-width: 3px;
+    border-bottom-width: 4px;
+  }
+
+  :host([size="xs"]) .value-container {
+    gap: 4px;
+  }
+
+  /* ── Size: s (default) ───────────────────────────────────────────────────── */
+
+  :host .base,
+  :host([size="s"]) .base {
+    padding: 4px 8px;
+  }
+
+  :host([legend-color]) .base,
+  :host([size="s"][legend-color]) .base {
+    padding: 4px 8px 4px 6px;
+  }
+
+  :host .content,
+  :host([size="s"]) .content {
+    gap: 2px;
+  }
+
+  :host .value,
+  :host([size="s"]) .value {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  :host .delta-arrow,
+  :host([size="s"]) .delta-arrow {
+    width: 16px;
+    height: 16px;
+  }
+
+  :host .arrow,
+  :host([size="s"]) .arrow {
+    border-left-width: 3px;
+    border-right-width: 3px;
+    border-bottom-width: 4px;
+  }
+
+  :host .value-container,
+  :host([size="s"]) .value-container {
+    gap: 4px;
+  }
+
+  /* ── Size: m ─────────────────────────────────────────────────────────────── */
+
+  :host([size="m"]) .base {
+    padding: 6px 12px;
+  }
+
+  :host([size="m"][legend-color]) .base {
+    padding: 6px 12px 6px 8px;
+  }
+
+  :host([size="m"]) .content {
+    gap: 2px;
+  }
+
+  :host([size="m"]) .value {
+    font-size: 20px;
+    line-height: 28px;
+  }
+
+  :host([size="m"]) .delta-arrow {
+    width: 20px;
+    height: 20px;
+  }
+
+  :host([size="m"]) .arrow {
+    border-left-width: 4px;
+    border-right-width: 4px;
+    border-bottom-width: 5px;
+  }
+
+  :host([size="m"]) .value-container {
+    gap: 4px;
+  }
+
+  :host([size="m"][orientation="horizontal"]) .base {
+    padding: 0;
+  }
+
+  :host([size="m"][orientation="horizontal"]) .label {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  /* ── Size: l ─────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) .base {
+    padding: 8px 16px;
+  }
+
+  :host([size="l"][legend-color]) .base {
+    padding: 8px 16px 8px 8px;
+  }
+
+  :host([size="l"]) .content {
+    gap: 2px;
+  }
+
+  :host([size="l"]) .value {
+    font-size: 32px;
+    line-height: 40px;
+  }
+
+  :host([size="l"]) .delta-arrow {
+    width: 20px;
+    height: 20px;
+  }
+
+  :host([size="l"]) .arrow {
+    border-left-width: 4px;
+    border-right-width: 4px;
+    border-bottom-width: 5px;
+  }
+
+  :host([size="l"]) .value-container {
+    gap: 4px;
+  }
+
+  /* ── Clickable hover bg for m size ───────────────────────────────────────── */
+
+  :host([size="m"][clickable]) .base {
+    background: ${DISABLED_MINIMAL};
+  }
+
+  :host([size="m"][clickable]) .base:hover {
+    background: ${HOVER_SURFACE};
+  }
+`;

--- a/packages/ui-components/src/components/ui-metric.test.ts
+++ b/packages/ui-components/src/components/ui-metric.test.ts
@@ -1,0 +1,432 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "./ui-metric.js";
+import type { MetricSize, MetricOrientation, MetricDelta } from "./ui-metric.js";
+import { STYLES } from "./ui-metric.styles.js";
+
+describe("ui-metric", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-metric");
+    document.body.appendChild(el);
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-metric")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("applies adoptedStyleSheets", () => {
+    expect(el.shadowRoot!.adoptedStyleSheets.length).toBe(1);
+  });
+
+  // ── Default rendering ─────────────────────────────────────────────────────
+
+  it("renders a .base wrapper", () => {
+    expect(el.shadowRoot!.querySelector(".base")).not.toBeNull();
+  });
+
+  it("renders a .label element", () => {
+    expect(el.shadowRoot!.querySelector(".label")).not.toBeNull();
+  });
+
+  it("renders a .value element", () => {
+    expect(el.shadowRoot!.querySelector(".value")).not.toBeNull();
+  });
+
+  it("renders a .legend element", () => {
+    expect(el.shadowRoot!.querySelector(".legend")).not.toBeNull();
+  });
+
+  it("renders a .delta-arrow element", () => {
+    expect(el.shadowRoot!.querySelector(".delta-arrow")).not.toBeNull();
+  });
+
+  it("renders a .delta-text element", () => {
+    expect(el.shadowRoot!.querySelector(".delta-text")).not.toBeNull();
+  });
+
+  it("renders a .secondary-label element", () => {
+    expect(el.shadowRoot!.querySelector(".secondary-label")).not.toBeNull();
+  });
+
+  it("renders a .content wrapper", () => {
+    expect(el.shadowRoot!.querySelector(".content")).not.toBeNull();
+  });
+
+  it("renders a .value-container wrapper", () => {
+    expect(el.shadowRoot!.querySelector(".value-container")).not.toBeNull();
+  });
+
+  it("renders a .delta-content wrapper", () => {
+    expect(el.shadowRoot!.querySelector(".delta-content")).not.toBeNull();
+  });
+
+  // ── Label attribute ───────────────────────────────────────────────────────
+
+  it("sets label text from attribute", () => {
+    el.setAttribute("label", "Revenue");
+    expect(el.shadowRoot!.querySelector(".label")!.textContent).toBe("Revenue");
+  });
+
+  it("clears label text when attribute removed", () => {
+    el.setAttribute("label", "Revenue");
+    el.removeAttribute("label");
+    expect(el.shadowRoot!.querySelector(".label")!.textContent).toBe("");
+  });
+
+  // ── Value attribute ───────────────────────────────────────────────────────
+
+  it("sets value text from attribute", () => {
+    el.setAttribute("value", "$12,345");
+    expect(el.shadowRoot!.querySelector(".value")!.textContent).toBe("$12,345");
+  });
+
+  it("clears value text when attribute removed", () => {
+    el.setAttribute("value", "100");
+    el.removeAttribute("value");
+    expect(el.shadowRoot!.querySelector(".value")!.textContent).toBe("");
+  });
+
+  // ── Delta attribute ───────────────────────────────────────────────────────
+
+  it("defaults delta to 'none'", () => {
+    expect((el as unknown as { delta: MetricDelta }).delta).toBe("none");
+  });
+
+  it("sets delta='up' attribute", () => {
+    el.setAttribute("delta", "up");
+    expect(el.getAttribute("delta")).toBe("up");
+  });
+
+  it("sets delta='down' attribute", () => {
+    el.setAttribute("delta", "down");
+    expect(el.getAttribute("delta")).toBe("down");
+  });
+
+  it("CSS shows delta-arrow for delta='up'", () => {
+    expect(STYLES).toContain(':host([delta="up"]) .delta-arrow');
+  });
+
+  it("CSS shows delta-arrow for delta='down'", () => {
+    expect(STYLES).toContain(':host([delta="down"]) .delta-arrow');
+  });
+
+  it("CSS colors delta='up' arrow green", () => {
+    expect(STYLES).toContain(':host([delta="up"]) .delta-arrow');
+  });
+
+  it("CSS colors delta='down' arrow red", () => {
+    expect(STYLES).toContain(':host([delta="down"]) .delta-arrow');
+  });
+
+  it("CSS rotates delta='down' arrow 180deg", () => {
+    expect(STYLES).toContain(':host([delta="down"]) .delta-arrow .arrow');
+    expect(STYLES).toContain("rotate(180deg)");
+  });
+
+  // ── Delta-text attribute ──────────────────────────────────────────────────
+
+  it("sets delta-text from attribute", () => {
+    el.setAttribute("delta-text", "+12%");
+    expect(el.shadowRoot!.querySelector(".delta-text")!.textContent).toBe("+12%");
+  });
+
+  it("clears delta-text when attribute removed", () => {
+    el.setAttribute("delta-text", "+12%");
+    el.removeAttribute("delta-text");
+    expect(el.shadowRoot!.querySelector(".delta-text")!.textContent).toBe("");
+  });
+
+  it("CSS shows delta-text for delta='up'", () => {
+    expect(STYLES).toContain(':host([delta="up"]) .delta-text');
+  });
+
+  it("CSS shows delta-text for delta='down'", () => {
+    expect(STYLES).toContain(':host([delta="down"]) .delta-text');
+  });
+
+  // ── Secondary-label attribute ─────────────────────────────────────────────
+
+  it("sets secondary-label text from attribute", () => {
+    el.setAttribute("secondary-label", "vs last month");
+    expect(el.shadowRoot!.querySelector(".secondary-label")!.textContent).toBe(
+      "vs last month",
+    );
+  });
+
+  it("clears secondary-label when attribute removed", () => {
+    el.setAttribute("secondary-label", "vs last month");
+    el.removeAttribute("secondary-label");
+    expect(el.shadowRoot!.querySelector(".secondary-label")!.textContent).toBe("");
+  });
+
+  it("CSS shows secondary-label when attribute present", () => {
+    expect(STYLES).toContain(":host([secondary-label]) .secondary-label");
+  });
+
+  // ── Legend-color attribute ────────────────────────────────────────────────
+
+  it("sets legend background-color from attribute", () => {
+    el.setAttribute("legend-color", "#ff0000");
+    const legend = el.shadowRoot!.querySelector(".legend") as HTMLElement;
+    expect(legend.style.backgroundColor).toBe("#ff0000");
+  });
+
+  it("clears legend background-color when attribute removed", () => {
+    el.setAttribute("legend-color", "#ff0000");
+    el.removeAttribute("legend-color");
+    const legend = el.shadowRoot!.querySelector(".legend") as HTMLElement;
+    expect(legend.style.backgroundColor).toBe("");
+  });
+
+  it("CSS shows legend when legend-color attribute present", () => {
+    expect(STYLES).toContain(":host([legend-color]) .legend");
+  });
+
+  // ── Clickable attribute ───────────────────────────────────────────────────
+
+  it("adds role='button' when clickable", () => {
+    el.setAttribute("clickable", "");
+    expect(el.getAttribute("role")).toBe("button");
+  });
+
+  it("adds tabindex='0' when clickable", () => {
+    el.setAttribute("clickable", "");
+    expect(el.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("sets cursor pointer when clickable", () => {
+    el.setAttribute("clickable", "");
+    expect(el.style.cursor).toBe("pointer");
+  });
+
+  it("removes role when clickable removed", () => {
+    el.setAttribute("clickable", "");
+    el.removeAttribute("clickable");
+    expect(el.getAttribute("role")).toBeNull();
+  });
+
+  it("removes tabindex when clickable removed", () => {
+    el.setAttribute("clickable", "");
+    el.removeAttribute("clickable");
+    expect(el.getAttribute("tabindex")).toBeNull();
+  });
+
+  it("clears cursor when clickable removed", () => {
+    el.setAttribute("clickable", "");
+    el.removeAttribute("clickable");
+    expect(el.style.cursor).toBe("");
+  });
+
+  // ── Size attribute ────────────────────────────────────────────────────────
+
+  it("defaults size to 's'", () => {
+    expect((el as unknown as { size: MetricSize }).size).toBe("s");
+  });
+
+  it("reflects size='xs' to attribute", () => {
+    (el as unknown as { size: MetricSize }).size = "xs";
+    expect(el.getAttribute("size")).toBe("xs");
+  });
+
+  it("reflects size='s' to attribute", () => {
+    (el as unknown as { size: MetricSize }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("reflects size='m' to attribute", () => {
+    (el as unknown as { size: MetricSize }).size = "m";
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("reflects size='l' to attribute", () => {
+    (el as unknown as { size: MetricSize }).size = "l";
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  // ── Size CSS: xs ──────────────────────────────────────────────────────────
+
+  it("CSS sets xs value font-size to 14px", () => {
+    expect(STYLES).toContain(':host([size="xs"]) .value');
+    expect(STYLES).toMatch(/\:host\(\[size="xs"\]\) \.value\s*\{[^}]*font-size:\s*14px/);
+  });
+
+  it("CSS sets xs value line-height to 20px", () => {
+    expect(STYLES).toMatch(/\:host\(\[size="xs"\]\) \.value\s*\{[^}]*line-height:\s*20px/);
+  });
+
+  // ── Size CSS: s ───────────────────────────────────────────────────────────
+
+  it("CSS sets s value font-size to 16px", () => {
+    expect(STYLES).toMatch(/\:host\(\[size="s"\]\) \.value\s*\{[^}]*font-size:\s*16px/);
+  });
+
+  it("CSS sets s value line-height to 24px", () => {
+    expect(STYLES).toMatch(/\:host\(\[size="s"\]\) \.value\s*\{[^}]*line-height:\s*24px/);
+  });
+
+  // ── Size CSS: m ───────────────────────────────────────────────────────────
+
+  it("CSS sets m value font-size to 20px", () => {
+    expect(STYLES).toMatch(/\:host\(\[size="m"\]\) \.value\s*\{[^}]*font-size:\s*20px/);
+  });
+
+  it("CSS sets m value line-height to 28px", () => {
+    expect(STYLES).toMatch(/\:host\(\[size="m"\]\) \.value\s*\{[^}]*line-height:\s*28px/);
+  });
+
+  // ── Size CSS: l ───────────────────────────────────────────────────────────
+
+  it("CSS sets l value font-size to 32px", () => {
+    expect(STYLES).toMatch(/\:host\(\[size="l"\]\) \.value\s*\{[^}]*font-size:\s*32px/);
+  });
+
+  it("CSS sets l value line-height to 40px", () => {
+    expect(STYLES).toMatch(/\:host\(\[size="l"\]\) \.value\s*\{[^}]*line-height:\s*40px/);
+  });
+
+  // ── Orientation attribute ─────────────────────────────────────────────────
+
+  it("defaults orientation to 'vertical'", () => {
+    expect((el as unknown as { orientation: MetricOrientation }).orientation).toBe(
+      "vertical",
+    );
+  });
+
+  it("reflects orientation='horizontal' to attribute", () => {
+    (el as unknown as { orientation: MetricOrientation }).orientation = "horizontal";
+    expect(el.getAttribute("orientation")).toBe("horizontal");
+  });
+
+  it("CSS applies horizontal layout", () => {
+    expect(STYLES).toContain(':host([orientation="horizontal"]) .base');
+  });
+
+  // ── Property accessors ────────────────────────────────────────────────────
+
+  it("get/set label property", () => {
+    const typed = el as unknown as { label: string };
+    typed.label = "Users";
+    expect(typed.label).toBe("Users");
+    expect(el.getAttribute("label")).toBe("Users");
+  });
+
+  it("get/set value property", () => {
+    const typed = el as unknown as { value: string };
+    typed.value = "42";
+    expect(typed.value).toBe("42");
+    expect(el.getAttribute("value")).toBe("42");
+  });
+
+  it("get/set delta property", () => {
+    const typed = el as unknown as { delta: MetricDelta };
+    typed.delta = "up";
+    expect(typed.delta).toBe("up");
+    expect(el.getAttribute("delta")).toBe("up");
+  });
+
+  it("get/set deltaText property", () => {
+    const typed = el as unknown as { deltaText: string };
+    typed.deltaText = "+5%";
+    expect(typed.deltaText).toBe("+5%");
+    expect(el.getAttribute("delta-text")).toBe("+5%");
+  });
+
+  it("get/set secondaryLabel property", () => {
+    const typed = el as unknown as { secondaryLabel: string };
+    typed.secondaryLabel = "vs last week";
+    expect(typed.secondaryLabel).toBe("vs last week");
+    expect(el.getAttribute("secondary-label")).toBe("vs last week");
+  });
+
+  it("get/set legendColor property", () => {
+    const typed = el as unknown as { legendColor: string | null };
+    typed.legendColor = "#00ff00";
+    expect(typed.legendColor).toBe("#00ff00");
+    expect(el.getAttribute("legend-color")).toBe("#00ff00");
+  });
+
+  it("legendColor property removes attribute when set to null", () => {
+    const typed = el as unknown as { legendColor: string | null };
+    typed.legendColor = "#00ff00";
+    typed.legendColor = null;
+    expect(el.hasAttribute("legend-color")).toBe(false);
+  });
+
+  it("get/set clickable property", () => {
+    const typed = el as unknown as { clickable: boolean };
+    typed.clickable = true;
+    expect(typed.clickable).toBe(true);
+    expect(el.hasAttribute("clickable")).toBe(true);
+  });
+
+  it("clickable property removes attribute when set to false", () => {
+    const typed = el as unknown as { clickable: boolean };
+    typed.clickable = true;
+    typed.clickable = false;
+    expect(typed.clickable).toBe(false);
+    expect(el.hasAttribute("clickable")).toBe(false);
+  });
+
+  it("get/set size property", () => {
+    const typed = el as unknown as { size: MetricSize };
+    typed.size = "l";
+    expect(typed.size).toBe("l");
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  it("get/set orientation property", () => {
+    const typed = el as unknown as { orientation: MetricOrientation };
+    typed.orientation = "horizontal";
+    expect(typed.orientation).toBe("horizontal");
+    expect(el.getAttribute("orientation")).toBe("horizontal");
+  });
+
+  // ── observedAttributes ────────────────────────────────────────────────────
+
+  it("observes all expected attributes", () => {
+    const Ctor = customElements.get("ui-metric") as unknown as {
+      observedAttributes: string[];
+    };
+    expect(Ctor.observedAttributes).toEqual(
+      expect.arrayContaining([
+        "size",
+        "orientation",
+        "label",
+        "value",
+        "delta",
+        "delta-text",
+        "secondary-label",
+        "legend-color",
+        "clickable",
+      ]),
+    );
+  });
+
+  // ── CSS structure ─────────────────────────────────────────────────────────
+
+  it("CSS sets host display to inline-flex", () => {
+    expect(STYLES).toContain("display: inline-flex");
+  });
+
+  it("CSS includes clickable hover styles", () => {
+    expect(STYLES).toContain(":host([clickable]) .base:hover");
+  });
+
+  it("CSS includes clickable active styles", () => {
+    expect(STYLES).toContain(":host([clickable]) .base:active");
+  });
+
+  it("CSS hides delta-content when no delta and no secondary-label", () => {
+    expect(STYLES).toContain(
+      ":host(:not([delta=\"up\"]):not([delta=\"down\"]):not([secondary-label])) .delta-content",
+    );
+  });
+});

--- a/packages/ui-components/src/components/ui-metric.ts
+++ b/packages/ui-components/src/components/ui-metric.ts
@@ -1,0 +1,215 @@
+import { STYLES } from "./ui-metric.styles.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type MetricSize = "xs" | "s" | "m" | "l";
+export type MetricOrientation = "vertical" | "horizontal";
+export type MetricDelta = "none" | "up" | "down";
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiMetric extends HTMLElement {
+  static readonly observedAttributes = [
+    "size",
+    "orientation",
+    "label",
+    "value",
+    "delta",
+    "delta-text",
+    "secondary-label",
+    "legend-color",
+    "clickable",
+  ];
+
+  #label!: HTMLElement;
+  #value!: HTMLElement;
+  #deltaArrow!: HTMLElement;
+  #deltaText!: HTMLElement;
+  #secondaryLabel!: HTMLElement;
+  #legend!: HTMLElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    // Legend bar
+    this.#legend = document.createElement("div");
+    this.#legend.className = "legend";
+
+    // Content wrapper
+    const content = document.createElement("div");
+    content.className = "content";
+
+    // Label
+    this.#label = document.createElement("div");
+    this.#label.className = "label";
+
+    // Value container
+    const valueContainer = document.createElement("div");
+    valueContainer.className = "value-container";
+
+    this.#value = document.createElement("span");
+    this.#value.className = "value";
+
+    // Delta arrow
+    this.#deltaArrow = document.createElement("span");
+    this.#deltaArrow.className = "delta-arrow";
+    const arrow = document.createElement("span");
+    arrow.className = "arrow";
+    this.#deltaArrow.appendChild(arrow);
+
+    valueContainer.appendChild(this.#value);
+    valueContainer.appendChild(this.#deltaArrow);
+
+    // Delta content row
+    const deltaContent = document.createElement("div");
+    deltaContent.className = "delta-content";
+
+    this.#deltaText = document.createElement("span");
+    this.#deltaText.className = "delta-text";
+
+    this.#secondaryLabel = document.createElement("span");
+    this.#secondaryLabel.className = "secondary-label";
+
+    deltaContent.appendChild(this.#deltaText);
+    deltaContent.appendChild(this.#secondaryLabel);
+
+    content.appendChild(this.#label);
+    content.appendChild(valueContainer);
+    content.appendChild(deltaContent);
+
+    // Base wrapper
+    const base = document.createElement("div");
+    base.className = "base";
+    base.appendChild(this.#legend);
+    base.appendChild(content);
+
+    shadow.appendChild(base);
+  }
+
+  connectedCallback(): void {
+    this._syncLegendColor();
+    if (this.hasAttribute("clickable")) {
+      this._setupClickable();
+    }
+  }
+
+  attributeChangedCallback(
+    name: string,
+    _oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    switch (name) {
+      case "label":
+        this.#label.textContent = newValue ?? "";
+        break;
+      case "value":
+        this.#value.textContent = newValue ?? "";
+        break;
+      case "delta-text":
+        this.#deltaText.textContent = newValue ?? "";
+        break;
+      case "secondary-label":
+        this.#secondaryLabel.textContent = newValue ?? "";
+        break;
+      case "legend-color":
+        this._syncLegendColor();
+        break;
+      case "clickable":
+        this._setupClickable();
+        break;
+    }
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): MetricSize {
+    return (this.getAttribute("size") as MetricSize) ?? "s";
+  }
+  set size(v: MetricSize) {
+    this.setAttribute("size", v);
+  }
+
+  get orientation(): MetricOrientation {
+    return (this.getAttribute("orientation") as MetricOrientation) ?? "vertical";
+  }
+  set orientation(v: MetricOrientation) {
+    this.setAttribute("orientation", v);
+  }
+
+  get label(): string {
+    return this.getAttribute("label") ?? "";
+  }
+  set label(v: string) {
+    this.setAttribute("label", v);
+  }
+
+  get value(): string {
+    return this.getAttribute("value") ?? "";
+  }
+  set value(v: string) {
+    this.setAttribute("value", v);
+  }
+
+  get delta(): MetricDelta {
+    return (this.getAttribute("delta") as MetricDelta) ?? "none";
+  }
+  set delta(v: MetricDelta) {
+    this.setAttribute("delta", v);
+  }
+
+  get deltaText(): string {
+    return this.getAttribute("delta-text") ?? "";
+  }
+  set deltaText(v: string) {
+    this.setAttribute("delta-text", v);
+  }
+
+  get secondaryLabel(): string {
+    return this.getAttribute("secondary-label") ?? "";
+  }
+  set secondaryLabel(v: string) {
+    this.setAttribute("secondary-label", v);
+  }
+
+  get legendColor(): string | null {
+    return this.getAttribute("legend-color");
+  }
+  set legendColor(v: string | null) {
+    if (v) this.setAttribute("legend-color", v);
+    else this.removeAttribute("legend-color");
+  }
+
+  get clickable(): boolean {
+    return this.hasAttribute("clickable");
+  }
+  set clickable(v: boolean) {
+    if (v) this.setAttribute("clickable", "");
+    else this.removeAttribute("clickable");
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private _syncLegendColor(): void {
+    const color = this.getAttribute("legend-color");
+    this.#legend.style.backgroundColor = color ?? "";
+  }
+
+  private _setupClickable(): void {
+    if (this.hasAttribute("clickable")) {
+      this.style.cursor = "pointer";
+      this.setAttribute("role", "button");
+      this.setAttribute("tabindex", "0");
+    } else {
+      this.style.cursor = "";
+      this.removeAttribute("role");
+      this.removeAttribute("tabindex");
+    }
+  }
+}
+
+customElements.define("ui-metric", UiMetric);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -162,3 +162,9 @@ export { UiListHeader } from "./components/ui-list-header.js";
 export type { ListHeaderSize } from "./components/ui-list-header.js";
 export { UiListGroup } from "./components/ui-list-group.js";
 export type { ListGroupSize } from "./components/ui-list-group.js";
+
+// ─── Metric ─────────────────────────────────────────────────────────────────
+
+export { UiMetric } from "./components/ui-metric.js";
+export type { MetricSize, MetricOrientation, MetricDelta } from "./components/ui-metric.js";
+export { UiMetricGroup } from "./components/ui-metric-group.js";

--- a/packages/ui-components/src/stories/ui-metric.stories.ts
+++ b/packages/ui-components/src/stories/ui-metric.stories.ts
@@ -1,0 +1,203 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-metric.js";
+import "../components/ui-metric-group.js";
+
+const meta: Meta = {
+  title: "Components/Metric",
+  component: "ui-metric",
+  argTypes: {
+    size: {
+      control: { type: "select" },
+      options: ["xs", "s", "m", "l"],
+    },
+    orientation: {
+      control: { type: "select" },
+      options: ["vertical", "horizontal"],
+    },
+    delta: {
+      control: { type: "select" },
+      options: ["none", "up", "down"],
+    },
+    label: {
+      control: { type: "text" },
+    },
+    value: {
+      control: { type: "text" },
+    },
+    deltaText: {
+      control: { type: "text" },
+    },
+    secondaryLabel: {
+      control: { type: "text" },
+    },
+    legendColor: {
+      control: { type: "color" },
+    },
+    clickable: {
+      control: { type: "boolean" },
+    },
+  },
+  args: {
+    size: "s",
+    orientation: "vertical",
+    delta: "none",
+    label: "Total Revenue",
+    value: "$45.2K",
+    deltaText: "",
+    secondaryLabel: "",
+    legendColor: "",
+    clickable: false,
+  },
+  render: (args) => html`
+    <ui-metric
+      size=${args.size}
+      orientation=${args.orientation}
+      label=${args.label}
+      value=${args.value}
+      delta=${args.delta}
+      delta-text=${args.deltaText}
+      secondary-label=${args.secondaryLabel}
+      legend-color=${args.legendColor}
+      ?clickable=${args.clickable}
+    ></ui-metric>
+  `,
+};
+
+export default meta;
+type Story = StoryObj;
+
+// ─── Individual metric stories ───────────────────────────────────────────────
+
+export const Default: Story = {};
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 32px; align-items: flex-start;">
+      <ui-metric size="xs" label="XS Metric" value="1,234"></ui-metric>
+      <ui-metric size="s" label="S Metric" value="$45.2K"></ui-metric>
+      <ui-metric size="m" label="M Metric" value="89,102"></ui-metric>
+      <ui-metric size="l" label="L Metric" value="$1.2M"></ui-metric>
+    </div>
+  `,
+};
+
+export const DeltaUp: Story = {
+  args: {
+    delta: "up",
+    deltaText: "+12.5K (3.2%)",
+  },
+};
+
+export const DeltaDown: Story = {
+  args: {
+    delta: "down",
+    deltaText: "-5.2K (1.1%)",
+  },
+};
+
+export const WithLegend: Story = {
+  args: {
+    legendColor: "#cc1d92",
+  },
+};
+
+export const WithSecondaryLabel: Story = {
+  args: {
+    secondaryLabel: "vs last month",
+  },
+};
+
+export const FullVariant: Story = {
+  args: {
+    legendColor: "#cc1d92",
+    delta: "up",
+    deltaText: "+12.5K (3.2%)",
+    secondaryLabel: "vs last month",
+  },
+};
+
+export const Horizontal: Story = {
+  args: {
+    orientation: "horizontal",
+    size: "m",
+  },
+};
+
+export const Clickable: Story = {
+  args: {
+    clickable: true,
+  },
+};
+
+// ─── Group stories ───────────────────────────────────────────────────────────
+
+export const MetricGroup: Story = {
+  render: () => html`
+    <ui-metric-group title="Revenue Overview" size="s">
+      <ui-metric
+        label="Total Revenue"
+        value="$45.2K"
+        delta="up"
+        delta-text="+12.5K (3.2%)"
+        legend-color="#186ADE"
+      ></ui-metric>
+      <ui-metric
+        label="New Customers"
+        value="1,234"
+        delta="up"
+        delta-text="+89 (7.8%)"
+        legend-color="#0D9488"
+      ></ui-metric>
+      <ui-metric
+        label="Churn Rate"
+        value="2.4%"
+        delta="down"
+        delta-text="-0.3% (11%)"
+        legend-color="#D91F11"
+      ></ui-metric>
+      <ui-metric
+        label="Avg Order"
+        value="$128"
+        legend-color="#cc1d92"
+      ></ui-metric>
+      <ui-metric
+        label="Conversion"
+        value="3.6%"
+        delta="up"
+        delta-text="+0.4%"
+        legend-color="#F59E0B"
+      ></ui-metric>
+    </ui-metric-group>
+  `,
+};
+
+export const MetricGroupSizes: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 40px;">
+      <ui-metric-group title="XS Group" size="xs">
+        <ui-metric label="Users" value="1,200" legend-color="#186ADE"></ui-metric>
+        <ui-metric label="Sessions" value="3,400" legend-color="#0D9488"></ui-metric>
+        <ui-metric label="Bounce" value="42%" legend-color="#D91F11"></ui-metric>
+      </ui-metric-group>
+
+      <ui-metric-group title="S Group" size="s">
+        <ui-metric label="Users" value="1,200" legend-color="#186ADE"></ui-metric>
+        <ui-metric label="Sessions" value="3,400" legend-color="#0D9488"></ui-metric>
+        <ui-metric label="Bounce" value="42%" legend-color="#D91F11"></ui-metric>
+      </ui-metric-group>
+
+      <ui-metric-group title="M Group" size="m">
+        <ui-metric label="Users" value="1,200" legend-color="#186ADE"></ui-metric>
+        <ui-metric label="Sessions" value="3,400" legend-color="#0D9488"></ui-metric>
+        <ui-metric label="Bounce" value="42%" legend-color="#D91F11"></ui-metric>
+      </ui-metric-group>
+
+      <ui-metric-group title="L Group" size="l">
+        <ui-metric label="Users" value="1,200" legend-color="#186ADE"></ui-metric>
+        <ui-metric label="Sessions" value="3,400" legend-color="#0D9488"></ui-metric>
+        <ui-metric label="Bounce" value="42%" legend-color="#D91F11"></ui-metric>
+      </ui-metric-group>
+    </div>
+  `,
+};


### PR DESCRIPTION
## Summary

New `<ui-metric>` and `<ui-metric-group>` Web Components for displaying KPI/metric values with delta indicators.

## `<ui-metric>`

- 4 sizes: `xs` (14px), `s` (16px), `m` (20px), `l` (32px)
- 2 orientations: `vertical` (stacked), `horizontal` (inline)
- Delta: `up` (green arrow), `down` (red arrow), `none`
- Optional: legend color bar, secondary label, clickable state
- Attributes: `size`, `orientation`, `label`, `value`, `delta`, `delta-text`, `secondary-label`, `legend-color`, `clickable`

## `<ui-metric-group>`

- Vertical separator on left
- Uppercase group title
- Size propagation to child `<ui-metric>` elements
- Size-dependent gaps (16px xs, 20px s, 24px m, 32px l)

## Testing

- 2333 unit tests (98 new: 73 metric + 25 group)
- 11 Storybook stories
- 39 Playwright visual regression tests (1 new)

## Files

- `packages/ui-components/src/components/ui-metric.ts` + `ui-metric.styles.ts`
- `packages/ui-components/src/components/ui-metric-group.ts`
- `packages/ui-components/src/components/ui-metric.test.ts` + `ui-metric-group.test.ts`
- `packages/ui-components/src/stories/ui-metric.stories.ts`
- `packages/ui-components/src/index.ts` — barrel exports
- `apps/catalog/src/pages/metric.ts` — catalog page
- `apps/catalog/src/manifest.ts` + `src/main.ts` — page registration
- `apps/catalog/e2e/visual.spec.ts` — visual test entry