### PR TITLE
feat(ui-components): add ui-popover component

### DIFF
--- a/apps/catalog/e2e/visual.spec.ts
+++ b/apps/catalog/e2e/visual.spec.ts
@@ -36,6 +36,7 @@ const pages = [
   "table",
   "metric",
   "person",
+  "popover",
   "carousel",
   "calendar",
   "datetime-picker",

--- a/apps/catalog/src/main.ts
+++ b/apps/catalog/src/main.ts
@@ -54,6 +54,7 @@ const pageLoaders: Record<string, () => Promise<unknown>> = {
   "table": () => import("./pages/table.js"),
   "metric": () => import("./pages/metric.js"),
   "person": () => import("./pages/person.js"),
+  "popover": () => import("./pages/popover.js"),
   "carousel": () => import("./pages/carousel.js"),
   "calendar": () => import("./pages/calendar.js"),
   "datetime-picker": () => import("./pages/datetime-picker.js"),

--- a/apps/catalog/src/manifest.ts
+++ b/apps/catalog/src/manifest.ts
@@ -62,6 +62,7 @@ export const manifest: PageMeta[] = [
   { id: "menu", title: "Menu", section: "Menus & Dropdowns" },
   // Overlays
   { id: "modal", title: "Modal", section: "Overlays" },
+  { id: "popover", title: "Popover", section: "Overlays" },
   // Tabs
   { id: "tabs", title: "Tabs", section: "Tabs" },
   // Data Display

--- a/apps/catalog/src/pages/popover.ts
+++ b/apps/catalog/src/pages/popover.ts
@@ -1,0 +1,103 @@
+import { registerPage } from "../registry.js";
+
+registerPage("popover", {
+  title: "Popover",
+  section: "Overlays",
+  render: () => `
+    <h3>Variants</h3>
+    <div style="display: flex; gap: 40px; padding: 20px 0 120px;">
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Size S</span>
+        <ui-popover size="s" placement="bottom-left" title-text="Title" description="Description" open>
+          <ui-button slot="trigger" size="s">Trigger S</ui-button>
+        </ui-popover>
+      </div>
+      <div class="variant-col" style="align-items: center; margin-left: 380px;">
+        <span class="variant-label">Size M</span>
+        <ui-popover size="m" placement="bottom-left" title-text="Title" description="Description" open>
+          <ui-button slot="trigger" size="m">Trigger M</ui-button>
+        </ui-popover>
+      </div>
+    </div>
+
+    <h3>Dismissable</h3>
+    <div style="display: flex; gap: 40px; padding: 20px 0 120px;">
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Off</span>
+        <ui-popover size="m" placement="bottom-left" title-text="Title" description="Description" open>
+          <ui-button slot="trigger" size="m">Trigger</ui-button>
+        </ui-popover>
+      </div>
+      <div class="variant-col" style="align-items: center; margin-left: 380px;">
+        <span class="variant-label">On</span>
+        <ui-popover size="m" placement="bottom-left" title-text="Title" description="Description" dismissable open>
+          <ui-button slot="trigger" size="m">Trigger</ui-button>
+        </ui-popover>
+      </div>
+    </div>
+
+    <h3>Placement — Top</h3>
+    <div style="display: flex; padding: 140px 0 20px;">
+      <div style="margin-left: 20px;">
+        <ui-popover placement="top-left" title-text="Top Left" description="Arrow points down" open>
+          <ui-button slot="trigger" size="s">Trigger</ui-button>
+        </ui-popover>
+      </div>
+      <div style="margin-left: 420px;">
+        <ui-popover placement="top-center" title-text="Top Center" description="Arrow points down" open>
+          <ui-button slot="trigger" size="s">Trigger</ui-button>
+        </ui-popover>
+      </div>
+      <div style="margin-left: 420px;">
+        <ui-popover placement="top-right" title-text="Top Right" description="Arrow points down" open>
+          <ui-button slot="trigger" size="s">Trigger</ui-button>
+        </ui-popover>
+      </div>
+    </div>
+
+    <h3>Placement — Bottom</h3>
+    <div style="display: flex; padding: 20px 0 140px;">
+      <div style="margin-left: 20px;">
+        <ui-popover placement="bottom-left" title-text="Bottom Left" description="Arrow points up" open>
+          <ui-button slot="trigger" size="s">Trigger</ui-button>
+        </ui-popover>
+      </div>
+      <div style="margin-left: 420px;">
+        <ui-popover placement="bottom-center" title-text="Bottom Center" description="Arrow points up" open>
+          <ui-button slot="trigger" size="s">Trigger</ui-button>
+        </ui-popover>
+      </div>
+      <div style="margin-left: 420px;">
+        <ui-popover placement="bottom-right" title-text="Bottom Right" description="Arrow points up" open>
+          <ui-button slot="trigger" size="s">Trigger</ui-button>
+        </ui-popover>
+      </div>
+    </div>
+
+    <h3>Placement — Left</h3>
+    <div style="display: flex; flex-direction: column; gap: 120px; padding: 20px 0 20px 400px;">
+      <ui-popover placement="left-top" title-text="Left Top" description="Arrow points right" open>
+        <ui-button slot="trigger" size="s">Trigger</ui-button>
+      </ui-popover>
+      <ui-popover placement="left-center" title-text="Left Center" description="Arrow points right" open>
+        <ui-button slot="trigger" size="s">Trigger</ui-button>
+      </ui-popover>
+      <ui-popover placement="left-bottom" title-text="Left Bottom" description="Arrow points right" open>
+        <ui-button slot="trigger" size="s">Trigger</ui-button>
+      </ui-popover>
+    </div>
+
+    <h3>Placement — Right</h3>
+    <div style="display: flex; flex-direction: column; gap: 120px; padding: 20px 0 20px 20px;">
+      <ui-popover placement="right-top" title-text="Right Top" description="Arrow points left" open>
+        <ui-button slot="trigger" size="s">Trigger</ui-button>
+      </ui-popover>
+      <ui-popover placement="right-center" title-text="Right Center" description="Arrow points left" open>
+        <ui-button slot="trigger" size="s">Trigger</ui-button>
+      </ui-popover>
+      <ui-popover placement="right-bottom" title-text="Right Bottom" description="Arrow points left" open>
+        <ui-button slot="trigger" size="s">Trigger</ui-button>
+      </ui-popover>
+    </div>
+  `,
+});

--- a/packages/ui-components/src/components/ui-popover.styles.ts
+++ b/packages/ui-components/src/components/ui-popover.styles.ts
@@ -1,0 +1,356 @@
+import { semanticVar } from "@maneki/foundation";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const SURFACE_CONTRAST = semanticVar("surface", "contrast");
+const ICON_REVERSED = semanticVar("icon", "reversed");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+export const STYLES = /* css */ `
+  @font-face {
+    font-family: "Material Symbols Outlined";
+    font-style: normal;
+    src: local("Material Symbols Outlined");
+  }
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: inline-flex;
+    position: relative;
+    width: fit-content;
+    font-family: "Geist", sans-serif;
+  }
+
+  /* ── Popover panel ───────────────────────────────────────────────────────── */
+
+  .panel {
+    position: absolute;
+    z-index: 1000;
+    display: none;
+    flex-direction: column;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+  }
+
+  :host([open]) .panel {
+    display: flex;
+    opacity: 1;
+  }
+
+  .base {
+    display: flex;
+    align-items: flex-start;
+    background: ${SURFACE_CONTRAST};
+    border-radius: 2px;
+    color: #ffffff;
+  }
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .title-text {
+    font-weight: 500;
+    color: #ffffff;
+  }
+
+  .description-text {
+    font-weight: 400;
+    color: #ffffff;
+  }
+
+  /* ── Close button ────────────────────────────────────────────────────────── */
+
+  .close {
+    display: none;
+    align-items: flex-start;
+    flex-shrink: 0;
+    border: none;
+    background: transparent;
+    color: ${ICON_REVERSED};
+    cursor: pointer;
+    padding: 0;
+  }
+
+  :host([dismissable]) .close {
+    display: flex;
+  }
+
+  .close .material-symbols-outlined {
+    font-family: "Material Symbols Outlined";
+    font-weight: normal;
+    font-style: normal;
+    line-height: 1;
+    letter-spacing: normal;
+    text-transform: none;
+    display: inline-block;
+    white-space: nowrap;
+    word-wrap: normal;
+    direction: ltr;
+    -webkit-font-smoothing: antialiased;
+    font-variation-settings: "FILL" 0;
+  }
+
+  /* ── Arrow ───────────────────────────────────────────────────────────────── */
+
+  .arrow {
+    position: absolute;
+    width: 10px;
+    height: 10px;
+    background: ${SURFACE_CONTRAST};
+    transform: rotate(45deg);
+  }
+
+  /* ── Size: M (default) ───────────────────────────────────────────────────── */
+
+  :host,
+  :host([size="m"]) {
+    --_popover-width: 320px;
+  }
+
+  :host .base,
+  :host([size="m"]) .base {
+    padding: 20px 16px;
+    gap: 8px;
+  }
+
+  :host .content,
+  :host([size="m"]) .content {
+    gap: 12px;
+  }
+
+  :host .title-text,
+  :host([size="m"]) .title-text {
+    font-size: 20px;
+    line-height: 28px;
+  }
+
+  :host .description-text,
+  :host([size="m"]) .description-text {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  :host .close .material-symbols-outlined,
+  :host([size="m"]) .close .material-symbols-outlined {
+    font-size: 20px;
+  }
+
+  /* ── Size: S ─────────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) {
+    --_popover-width: 320px;
+  }
+
+  :host([size="s"]) .base {
+    padding: 16px;
+    gap: 8px;
+  }
+
+  :host([size="s"]) .content {
+    gap: 8px;
+  }
+
+  :host([size="s"]) .title-text {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  :host([size="s"]) .description-text {
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  :host([size="s"]) .close .material-symbols-outlined {
+    font-size: 16px;
+  }
+
+  /* ── Placement: positioning ──────────────────────────────────────────────── */
+
+  /* Top placements: popover above trigger */
+  :host([placement="top-left"]) .panel,
+  :host([placement="top-center"]) .panel,
+  :host([placement="top-right"]) .panel {
+    bottom: 100%;
+    margin-bottom: 8px;
+  }
+
+  :host([placement="top-left"]) .panel {
+    left: 0;
+  }
+
+  :host([placement="top-center"]) .panel {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  :host([placement="top-right"]) .panel {
+    right: 0;
+  }
+
+  /* Bottom placements: popover below trigger */
+  :host([placement="bottom-left"]) .panel,
+  :host([placement="bottom-center"]) .panel,
+  :host([placement="bottom-right"]) .panel {
+    top: 100%;
+    margin-top: 8px;
+  }
+
+  :host([placement="bottom-left"]) .panel {
+    left: 0;
+  }
+
+  :host([placement="bottom-center"]) .panel {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  :host([placement="bottom-right"]) .panel {
+    right: 0;
+  }
+
+  /* Left placements: popover to the left of trigger */
+  :host([placement="left-top"]) .panel,
+  :host([placement="left-center"]) .panel,
+  :host([placement="left-bottom"]) .panel {
+    right: 100%;
+    margin-right: 8px;
+  }
+
+  :host([placement="left-top"]) .panel {
+    top: 0;
+  }
+
+  :host([placement="left-center"]) .panel {
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  :host([placement="left-bottom"]) .panel {
+    bottom: 0;
+  }
+
+  /* Right placements: popover to the right of trigger */
+  :host([placement="right-top"]) .panel,
+  :host([placement="right-center"]) .panel,
+  :host([placement="right-bottom"]) .panel {
+    left: 100%;
+    margin-left: 8px;
+  }
+
+  :host([placement="right-top"]) .panel {
+    top: 0;
+  }
+
+  :host([placement="right-center"]) .panel {
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  :host([placement="right-bottom"]) .panel {
+    bottom: 0;
+  }
+
+  /* ── Arrow positioning ───────────────────────────────────────────────────── */
+
+  /* Top placements: arrow at bottom of panel */
+  :host([placement="top-left"]) .arrow,
+  :host([placement="top-center"]) .arrow,
+  :host([placement="top-right"]) .arrow {
+    bottom: -5px;
+  }
+
+  :host([placement="top-left"]) .arrow {
+    left: 20px;
+  }
+
+  :host([placement="top-center"]) .arrow {
+    left: 50%;
+    margin-left: -5px;
+  }
+
+  :host([placement="top-right"]) .arrow {
+    right: 20px;
+  }
+
+  /* Bottom placements: arrow at top of panel */
+  :host([placement="bottom-left"]) .arrow,
+  :host([placement="bottom-center"]) .arrow,
+  :host([placement="bottom-right"]) .arrow {
+    top: -5px;
+  }
+
+  :host([placement="bottom-left"]) .arrow {
+    left: 20px;
+  }
+
+  :host([placement="bottom-center"]) .arrow {
+    left: 50%;
+    margin-left: -5px;
+  }
+
+  :host([placement="bottom-right"]) .arrow {
+    right: 20px;
+  }
+
+  /* Left placements: arrow at right of panel */
+  :host([placement="left-top"]) .arrow,
+  :host([placement="left-center"]) .arrow,
+  :host([placement="left-bottom"]) .arrow {
+    right: -5px;
+  }
+
+  :host([placement="left-top"]) .arrow {
+    top: 16px;
+  }
+
+  :host([placement="left-center"]) .arrow {
+    top: 50%;
+    margin-top: -5px;
+  }
+
+  :host([placement="left-bottom"]) .arrow {
+    bottom: 16px;
+  }
+
+  /* Right placements: arrow at left of panel */
+  :host([placement="right-top"]) .arrow,
+  :host([placement="right-center"]) .arrow,
+  :host([placement="right-bottom"]) .arrow {
+    left: -5px;
+  }
+
+  :host([placement="right-top"]) .arrow {
+    top: 16px;
+  }
+
+  :host([placement="right-center"]) .arrow {
+    top: 50%;
+    margin-top: -5px;
+  }
+
+  :host([placement="right-bottom"]) .arrow {
+    bottom: 16px;
+  }
+
+  /* ── Panel width ─────────────────────────────────────────────────────────── */
+
+  .panel {
+    width: var(--_popover-width, 320px);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .panel {
+      transition-duration: 0.01ms !important;
+    }
+  }
+`;

--- a/packages/ui-components/src/components/ui-popover.test.ts
+++ b/packages/ui-components/src/components/ui-popover.test.ts
@@ -1,0 +1,441 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import "./ui-popover.js";
+import type { PopoverSize, PopoverPlacement } from "./ui-popover.js";
+import { STYLES } from "./ui-popover.styles.js";
+
+describe("ui-popover", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-popover");
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-popover")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("applies adoptedStyleSheets", () => {
+    expect(el.shadowRoot!.adoptedStyleSheets.length).toBe(1);
+  });
+
+  // ── Default rendering ─────────────────────────────────────────────────────
+
+  it("renders a trigger slot", () => {
+    const slot = el.shadowRoot!.querySelector("slot[name='trigger']");
+    expect(slot).not.toBeNull();
+  });
+
+  it("renders a .panel element", () => {
+    expect(el.shadowRoot!.querySelector(".panel")).not.toBeNull();
+  });
+
+  it("renders a .base element", () => {
+    expect(el.shadowRoot!.querySelector(".base")).not.toBeNull();
+  });
+
+  it("renders a .content element", () => {
+    expect(el.shadowRoot!.querySelector(".content")).not.toBeNull();
+  });
+
+  it("renders an .arrow element", () => {
+    expect(el.shadowRoot!.querySelector(".arrow")).not.toBeNull();
+  });
+
+  it("renders a .title-text element", () => {
+    expect(el.shadowRoot!.querySelector(".title-text")).not.toBeNull();
+  });
+
+  it("renders a .description-text element", () => {
+    expect(el.shadowRoot!.querySelector(".description-text")).not.toBeNull();
+  });
+
+  it("renders a .close button", () => {
+    expect(el.shadowRoot!.querySelector("button.close")).not.toBeNull();
+  });
+
+  it("renders a default slot for custom content", () => {
+    const slots = el.shadowRoot!.querySelectorAll("slot");
+    const defaultSlot = Array.from(slots).find((s) => !s.name);
+    expect(defaultSlot).not.toBeNull();
+  });
+
+  it("panel is hidden by default", () => {
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  it("sets default placement to top-center", () => {
+    expect(el.getAttribute("placement")).toBe("top-center");
+  });
+
+  // ── observedAttributes ────────────────────────────────────────────────────
+
+  it("observes the correct attributes", () => {
+    const Ctor = customElements.get("ui-popover") as unknown as {
+      observedAttributes: string[];
+    };
+    expect(Ctor.observedAttributes).toEqual([
+      "size",
+      "placement",
+      "dismissable",
+      "open",
+      "title-text",
+      "description",
+    ]);
+  });
+
+  // ── Attributes ────────────────────────────────────────────────────────────
+
+  it("reflects size attribute", () => {
+    el.setAttribute("size", "s");
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("reflects placement attribute", () => {
+    el.setAttribute("placement", "bottom-left");
+    expect(el.getAttribute("placement")).toBe("bottom-left");
+  });
+
+  it("reflects dismissable attribute", () => {
+    el.setAttribute("dismissable", "");
+    expect(el.hasAttribute("dismissable")).toBe(true);
+  });
+
+  it("reflects open attribute", () => {
+    el.setAttribute("open", "");
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  it("sets title-text content via attribute", () => {
+    el.setAttribute("title-text", "Hello");
+    const titleEl = el.shadowRoot!.querySelector(".title-text");
+    expect(titleEl!.textContent).toBe("Hello");
+  });
+
+  it("sets description content via attribute", () => {
+    el.setAttribute("description", "Some description");
+    const descEl = el.shadowRoot!.querySelector(".description-text");
+    expect(descEl!.textContent).toBe("Some description");
+  });
+
+  it("clears title-text when attribute removed", () => {
+    el.setAttribute("title-text", "Hello");
+    el.removeAttribute("title-text");
+    const titleEl = el.shadowRoot!.querySelector(".title-text");
+    expect(titleEl!.textContent).toBe("");
+  });
+
+  it("clears description when attribute removed", () => {
+    el.setAttribute("description", "Desc");
+    el.removeAttribute("description");
+    const descEl = el.shadowRoot!.querySelector(".description-text");
+    expect(descEl!.textContent).toBe("");
+  });
+
+  // ── Property accessors ────────────────────────────────────────────────────
+
+  it("size getter returns default m", () => {
+    expect((el as unknown as { size: PopoverSize }).size).toBe("m");
+  });
+
+  it("size setter sets attribute", () => {
+    (el as unknown as { size: PopoverSize }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("placement getter returns default top-center", () => {
+    expect(
+      (el as unknown as { placement: PopoverPlacement }).placement,
+    ).toBe("top-center");
+  });
+
+  it("placement setter sets attribute", () => {
+    (el as unknown as { placement: PopoverPlacement }).placement =
+      "bottom-right";
+    expect(el.getAttribute("placement")).toBe("bottom-right");
+  });
+
+  it("dismissable getter returns false by default", () => {
+    expect((el as unknown as { dismissable: boolean }).dismissable).toBe(
+      false,
+    );
+  });
+
+  it("dismissable setter adds attribute when true", () => {
+    (el as unknown as { dismissable: boolean }).dismissable = true;
+    expect(el.hasAttribute("dismissable")).toBe(true);
+  });
+
+  it("dismissable setter removes attribute when false", () => {
+    el.setAttribute("dismissable", "");
+    (el as unknown as { dismissable: boolean }).dismissable = false;
+    expect(el.hasAttribute("dismissable")).toBe(false);
+  });
+
+  it("open getter returns false by default", () => {
+    expect((el as unknown as { open: boolean }).open).toBe(false);
+  });
+
+  it("open setter adds attribute when true", () => {
+    (el as unknown as { open: boolean }).open = true;
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  it("open setter removes attribute when false", () => {
+    el.setAttribute("open", "");
+    (el as unknown as { open: boolean }).open = false;
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  it("titleText getter returns empty string by default", () => {
+    expect((el as unknown as { titleText: string }).titleText).toBe("");
+  });
+
+  it("titleText setter sets title-text attribute", () => {
+    (el as unknown as { titleText: string }).titleText = "My Title";
+    expect(el.getAttribute("title-text")).toBe("My Title");
+  });
+
+  it("description getter returns empty string by default", () => {
+    expect((el as unknown as { description: string }).description).toBe("");
+  });
+
+  it("description setter sets description attribute", () => {
+    (el as unknown as { description: string }).description = "My Desc";
+    expect(el.getAttribute("description")).toBe("My Desc");
+  });
+
+  // ── Sizes ─────────────────────────────────────────────────────────────────
+
+  it("styles contain size m title font-size 20px", () => {
+    expect(STYLES).toContain("font-size: 20px");
+  });
+
+  it("styles contain size m description font-size 14px", () => {
+    expect(STYLES).toContain("font-size: 14px");
+  });
+
+  it("styles contain size s title font-size 16px", () => {
+    expect(STYLES).toContain("font-size: 16px");
+  });
+
+  it("styles contain size s description font-size 12px", () => {
+    expect(STYLES).toContain("font-size: 12px");
+  });
+
+  // ── Placements ────────────────────────────────────────────────────────────
+
+  const ALL_PLACEMENTS: PopoverPlacement[] = [
+    "top-left",
+    "top-center",
+    "top-right",
+    "bottom-left",
+    "bottom-center",
+    "bottom-right",
+    "left-top",
+    "left-center",
+    "left-bottom",
+    "right-top",
+    "right-center",
+    "right-bottom",
+  ];
+
+  for (const p of ALL_PLACEMENTS) {
+    it(`accepts placement "${p}"`, () => {
+      (el as unknown as { placement: PopoverPlacement }).placement = p;
+      expect(el.getAttribute("placement")).toBe(p);
+    });
+  }
+
+  // ── Open / Close ──────────────────────────────────────────────────────────
+
+  it("setting open attribute shows panel", () => {
+    el.setAttribute("open", "");
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  it("removing open attribute hides panel", () => {
+    el.setAttribute("open", "");
+    el.removeAttribute("open");
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  // ── Dismissable ───────────────────────────────────────────────────────────
+
+  it("close button has aria-label Close", () => {
+    const btn = el.shadowRoot!.querySelector("button.close");
+    expect(btn!.getAttribute("aria-label")).toBe("Close");
+  });
+
+  it("close button has type button", () => {
+    const btn = el.shadowRoot!.querySelector("button.close") as HTMLButtonElement;
+    expect(btn.type).toBe("button");
+  });
+
+  it("styles hide close button by default", () => {
+    expect(STYLES).toContain(".close {");
+    expect(STYLES).toContain("display: none");
+  });
+
+  it("styles show close button when dismissable", () => {
+    expect(STYLES).toContain(":host([dismissable]) .close");
+    expect(STYLES).toContain("display: flex");
+  });
+
+  // ── Close button click ────────────────────────────────────────────────────
+
+  it("close button click dispatches popover-close event", () => {
+    el.setAttribute("open", "");
+    el.setAttribute("dismissable", "");
+    const spy = vi.fn();
+    el.addEventListener("popover-close", spy);
+    const btn = el.shadowRoot!.querySelector("button.close") as HTMLButtonElement;
+    btn.click();
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it("close button click removes open attribute", () => {
+    el.setAttribute("open", "");
+    el.setAttribute("dismissable", "");
+    const btn = el.shadowRoot!.querySelector("button.close") as HTMLButtonElement;
+    btn.click();
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  // ── Trigger click ─────────────────────────────────────────────────────────
+
+  it("trigger click opens popover", () => {
+    const trigger = document.createElement("button");
+    trigger.slot = "trigger";
+    el.appendChild(trigger);
+    trigger.click();
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  it("trigger click toggles popover closed", () => {
+    const trigger = document.createElement("button");
+    trigger.slot = "trigger";
+    el.appendChild(trigger);
+    trigger.click();
+    expect(el.hasAttribute("open")).toBe(true);
+    trigger.click();
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  // ── Escape key ────────────────────────────────────────────────────────────
+
+  it("Escape key closes open popover", () => {
+    el.setAttribute("open", "");
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  it("Escape key dispatches popover-close event", () => {
+    el.setAttribute("open", "");
+    const spy = vi.fn();
+    el.addEventListener("popover-close", spy);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it("Escape key does nothing when popover is closed", () => {
+    const spy = vi.fn();
+    el.addEventListener("popover-close", spy);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  // ── Outside click ─────────────────────────────────────────────────────────
+
+  it("outside click closes open popover", () => {
+    el.setAttribute("open", "");
+    document.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  it("outside click dispatches popover-close event", () => {
+    el.setAttribute("open", "");
+    const spy = vi.fn();
+    el.addEventListener("popover-close", spy);
+    document.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it("outside click does nothing when popover is closed", () => {
+    const spy = vi.fn();
+    el.addEventListener("popover-close", spy);
+    document.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  // ── Events ────────────────────────────────────────────────────────────────
+
+  it("popover-open event bubbles", () => {
+    const spy = vi.fn();
+    document.addEventListener("popover-open", spy);
+    const trigger = document.createElement("button");
+    trigger.slot = "trigger";
+    el.appendChild(trigger);
+    trigger.click();
+    expect(spy).toHaveBeenCalledOnce();
+    document.removeEventListener("popover-open", spy);
+  });
+
+  it("popover-open event is composed", () => {
+    let composed = false;
+    const handler = (e: Event) => {
+      composed = e.composed;
+    };
+    document.addEventListener("popover-open", handler);
+    const trigger = document.createElement("button");
+    trigger.slot = "trigger";
+    el.appendChild(trigger);
+    trigger.click();
+    expect(composed).toBe(true);
+    document.removeEventListener("popover-open", handler);
+  });
+
+  it("popover-close event bubbles", () => {
+    el.setAttribute("open", "");
+    const spy = vi.fn();
+    document.addEventListener("popover-close", spy);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(spy).toHaveBeenCalledOnce();
+    document.removeEventListener("popover-close", spy);
+  });
+
+  it("popover-close event is composed", () => {
+    el.setAttribute("open", "");
+    let composed = false;
+    const handler = (e: Event) => {
+      composed = e.composed;
+    };
+    document.addEventListener("popover-close", handler);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(composed).toBe(true);
+    document.removeEventListener("popover-close", handler);
+  });
+
+  // ── Cleanup on disconnect ─────────────────────────────────────────────────
+
+  it("removes document listeners on disconnect", () => {
+    el.setAttribute("open", "");
+    el.remove();
+    // After removal, outside click should not throw or close
+    document.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    // No error means listeners were cleaned up
+    expect(true).toBe(true);
+  });
+});

--- a/packages/ui-components/src/components/ui-popover.ts
+++ b/packages/ui-components/src/components/ui-popover.ts
@@ -1,0 +1,220 @@
+import { STYLES } from "./ui-popover.styles.js";
+import { ICON_CLOSE } from "@maneki/foundation";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type PopoverSize = "s" | "m";
+export type PopoverPlacement =
+  | "top-left"
+  | "top-center"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-center"
+  | "bottom-right"
+  | "left-top"
+  | "left-center"
+  | "left-bottom"
+  | "right-top"
+  | "right-center"
+  | "right-bottom";
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiPopover extends HTMLElement {
+  static readonly observedAttributes = [
+    "size",
+    "placement",
+    "dismissable",
+    "open",
+    "title-text",
+    "description",
+  ];
+
+  #titleEl!: HTMLElement;
+  #descriptionEl!: HTMLElement;
+  #closeBtn!: HTMLButtonElement;
+  #panel!: HTMLElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    // Trigger slot
+    const triggerSlot = document.createElement("slot");
+    triggerSlot.name = "trigger";
+
+    // Panel
+    this.#panel = document.createElement("div");
+    this.#panel.className = "panel";
+
+    // Arrow
+    const arrow = document.createElement("div");
+    arrow.className = "arrow";
+
+    // Base
+    const base = document.createElement("div");
+    base.className = "base";
+
+    // Content
+    const content = document.createElement("div");
+    content.className = "content";
+
+    this.#titleEl = document.createElement("div");
+    this.#titleEl.className = "title-text";
+
+    this.#descriptionEl = document.createElement("div");
+    this.#descriptionEl.className = "description-text";
+
+    // Default slot for custom content
+    const defaultSlot = document.createElement("slot");
+
+    content.append(this.#titleEl, this.#descriptionEl, defaultSlot);
+
+    // Close button
+    this.#closeBtn = document.createElement("button");
+    this.#closeBtn.className = "close";
+    this.#closeBtn.type = "button";
+    this.#closeBtn.setAttribute("aria-label", "Close");
+    const closeIcon = document.createElement("span");
+    closeIcon.className = "material-symbols-outlined";
+    closeIcon.textContent = ICON_CLOSE;
+    this.#closeBtn.appendChild(closeIcon);
+
+    base.append(content, this.#closeBtn);
+    this.#panel.append(arrow, base);
+
+    shadow.append(triggerSlot, this.#panel);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("placement")) {
+      this.setAttribute("placement", "top-center");
+    }
+
+    this.#closeBtn.addEventListener("click", (e) => { e.stopPropagation(); this._close(); });
+
+    // Click on trigger toggles popover
+    this.addEventListener("click", (e) => {
+      const trigger = (e.target as HTMLElement).closest("[slot='trigger']");
+      if (trigger) {
+        e.stopPropagation();
+        this._toggle();
+      }
+    });
+
+    // Close on outside click
+    this._onDocumentClick = this._onDocumentClick.bind(this);
+    document.addEventListener("click", this._onDocumentClick);
+
+    // Close on Escape
+    this._onKeyDown = this._onKeyDown.bind(this);
+    document.addEventListener("keydown", this._onKeyDown);
+  }
+
+  disconnectedCallback(): void {
+    document.removeEventListener("click", this._onDocumentClick);
+    document.removeEventListener("keydown", this._onKeyDown);
+  }
+
+  attributeChangedCallback(
+    name: string,
+    _oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    switch (name) {
+      case "title-text":
+        this.#titleEl.textContent = newValue ?? "";
+        break;
+      case "description":
+        this.#descriptionEl.textContent = newValue ?? "";
+        break;
+    }
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): PopoverSize {
+    return (this.getAttribute("size") as PopoverSize) ?? "m";
+  }
+  set size(v: PopoverSize) {
+    this.setAttribute("size", v);
+  }
+
+  get placement(): PopoverPlacement {
+    return (this.getAttribute("placement") as PopoverPlacement) ?? "top-center";
+  }
+  set placement(v: PopoverPlacement) {
+    this.setAttribute("placement", v);
+  }
+
+  get dismissable(): boolean {
+    return this.hasAttribute("dismissable");
+  }
+  set dismissable(v: boolean) {
+    if (v) this.setAttribute("dismissable", "");
+    else this.removeAttribute("dismissable");
+  }
+
+  get open(): boolean {
+    return this.hasAttribute("open");
+  }
+  set open(v: boolean) {
+    if (v) this.setAttribute("open", "");
+    else this.removeAttribute("open");
+  }
+
+  get titleText(): string {
+    return this.getAttribute("title-text") ?? "";
+  }
+  set titleText(v: string) {
+    this.setAttribute("title-text", v);
+  }
+
+  get description(): string {
+    return this.getAttribute("description") ?? "";
+  }
+  set description(v: string) {
+    this.setAttribute("description", v);
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private _toggle(): void {
+    if (this.open) this._close();
+    else this._open();
+  }
+
+  private _open(): void {
+    this.setAttribute("open", "");
+    this.dispatchEvent(
+      new CustomEvent("popover-open", { bubbles: true, composed: true }),
+    );
+  }
+
+  private _close(): void {
+    this.removeAttribute("open");
+    this.dispatchEvent(
+      new CustomEvent("popover-close", { bubbles: true, composed: true }),
+    );
+  }
+
+  private _onDocumentClick(e: MouseEvent): void {
+    if (!this.open) return;
+    if (this.contains(e.target as Node)) return;
+    this._close();
+  }
+
+  private _onKeyDown(e: KeyboardEvent): void {
+    if (!this.open) return;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      this._close();
+    }
+  }
+}
+
+customElements.define("ui-popover", UiPopover);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -179,3 +179,8 @@ export type { PaginationSize, PaginationType } from "./components/ui-pagination.
 export { UiPersonItem } from "./components/ui-person-item.js";
 export type { PersonItemSize } from "./components/ui-person-item.js";
 export { UiPersonGroup } from "./components/ui-person-group.js";
+
+// ─── Popover ─────────────────────────────────────────────────────────────────
+
+export { UiPopover } from "./components/ui-popover.js";
+export type { PopoverSize, PopoverPlacement } from "./components/ui-popover.js";

--- a/packages/ui-components/src/stories/ui-popover.stories.ts
+++ b/packages/ui-components/src/stories/ui-popover.stories.ts
@@ -1,0 +1,188 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-popover.js";
+
+const placements = [
+  "top-left",
+  "top-center",
+  "top-right",
+  "bottom-left",
+  "bottom-center",
+  "bottom-right",
+  "left-top",
+  "left-center",
+  "left-bottom",
+  "right-top",
+  "right-center",
+  "right-bottom",
+] as const;
+
+const meta: Meta = {
+  title: "Components/Popover",
+  component: "ui-popover",
+  argTypes: {
+    size: {
+      control: { type: "select" },
+      options: ["s", "m"],
+    },
+    placement: {
+      control: { type: "select" },
+      options: [...placements],
+    },
+    dismissable: {
+      control: { type: "boolean" },
+    },
+    open: {
+      control: { type: "boolean" },
+    },
+    titleText: {
+      control: { type: "text" },
+    },
+    description: {
+      control: { type: "text" },
+    },
+  },
+  args: {
+    size: "m",
+    placement: "top-center",
+    dismissable: false,
+    open: true,
+    titleText: "Popover Title",
+    description: "This is a popover description with helpful context.",
+  },
+  render: (args) => html`
+    <div style="padding: 120px 200px; display: inline-block;">
+      <ui-popover
+        size=${args.size}
+        placement=${args.placement}
+        ?dismissable=${args.dismissable}
+        ?open=${args.open}
+        title-text=${args.titleText}
+        description=${args.description}
+      >
+        <ui-button slot="trigger" size="s">Trigger</ui-button>
+      </ui-popover>
+    </div>
+  `,
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {};
+
+export const SizeS: Story = {
+  args: {
+    size: "s",
+    open: true,
+  },
+};
+
+export const Dismissable: Story = {
+  args: {
+    dismissable: true,
+    open: true,
+  },
+};
+
+export const TopPlacements: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 80px; padding: 140px 60px 40px;">
+      ${(["top-left", "top-center", "top-right"] as const).map(
+        (p) => html`
+          <ui-popover
+            placement=${p}
+            open
+            title-text=${p}
+            description="Placement demo"
+          >
+            <ui-button slot="trigger" size="s">${p}</ui-button>
+          </ui-popover>
+        `,
+      )}
+    </div>
+  `,
+};
+
+export const BottomPlacements: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 80px; padding: 40px 60px 140px;">
+      ${(["bottom-left", "bottom-center", "bottom-right"] as const).map(
+        (p) => html`
+          <ui-popover
+            placement=${p}
+            open
+            title-text=${p}
+            description="Placement demo"
+          >
+            <ui-button slot="trigger" size="s">${p}</ui-button>
+          </ui-popover>
+        `,
+      )}
+    </div>
+  `,
+};
+
+export const LeftPlacements: Story = {
+  render: () => html`
+    <div
+      style="display: flex; flex-direction: column; gap: 60px; padding: 40px 40px 40px 220px;"
+    >
+      ${(["left-top", "left-center", "left-bottom"] as const).map(
+        (p) => html`
+          <ui-popover
+            placement=${p}
+            open
+            title-text=${p}
+            description="Placement demo"
+          >
+            <ui-button slot="trigger" size="s">${p}</ui-button>
+          </ui-popover>
+        `,
+      )}
+    </div>
+  `,
+};
+
+export const RightPlacements: Story = {
+  render: () => html`
+    <div
+      style="display: flex; flex-direction: column; gap: 60px; padding: 40px 220px 40px 40px;"
+    >
+      ${(["right-top", "right-center", "right-bottom"] as const).map(
+        (p) => html`
+          <ui-popover
+            placement=${p}
+            open
+            title-text=${p}
+            description="Placement demo"
+          >
+            <ui-button slot="trigger" size="s">${p}</ui-button>
+          </ui-popover>
+        `,
+      )}
+    </div>
+  `,
+};
+
+export const WithTrigger: Story = {
+  args: {
+    open: false,
+  },
+  render: (args) => html`
+    <div style="padding: 120px 200px; display: inline-block;">
+      <ui-popover
+        size=${args.size}
+        placement=${args.placement}
+        ?dismissable=${args.dismissable}
+        ?open=${args.open}
+        title-text=${args.titleText}
+        description=${args.description}
+      >
+        <ui-button slot="trigger" action="primary" emphasis="bold" size="m">
+          Click to toggle
+        </ui-button>
+      </ui-popover>
+    </div>
+  `,
+};


### PR DESCRIPTION
## Summary

New `<ui-popover>` Web Component — a tooltip/popover with dark background, arrow indicator, and 12 placement options.

## Features

- 2 sizes: `s` (16px padding, 16/12px title/description) and `m` (20px padding, 20/14px)
- 12 placements: `top-left`, `top-center`, `top-right`, `bottom-left`, `bottom-center`, `bottom-right`, `left-top`, `left-center`, `left-bottom`, `right-top`, `right-center`, `right-bottom`
- Dark background (`surface-contrast`), white text, CSS rotated-square arrow
- Dismissable mode with close button (X icon)
- Trigger slot: click to toggle open/close
- Outside click + Escape key dismiss
- Events: `popover-open`, `popover-close` (bubbles + composed)
- Reduced motion support

## API

```html
<ui-popover size="m" placement="top-center" title-text="Title" description="Description" dismissable>
  <ui-button slot="trigger">Click me</ui-button>
</ui-popover>
```

## Testing

- 2550 unit tests (74 new for popover)
- Storybook stories covering all sizes, placements, dismissable
- 42 Playwright visual regression tests (1 new)

## Files

- `packages/ui-components/src/components/ui-popover.ts` + `ui-popover.styles.ts`
- `packages/ui-components/src/components/ui-popover.test.ts`
- `packages/ui-components/src/stories/ui-popover.stories.ts`
- `packages/ui-components/src/index.ts` — barrel exports
- `apps/catalog/src/pages/popover.ts` — catalog page