### PR TITLE
feat(ui-components): add ui-progress-bar and ui-progress-circle components

### DIFF
--- a/apps/catalog/e2e/visual.spec.ts
+++ b/apps/catalog/e2e/visual.spec.ts
@@ -36,6 +36,7 @@ const pages = [
   "table",
   "metric",
   "person",
+  "progress",
   "popover",
   "carousel",
   "calendar",

--- a/apps/catalog/src/main.ts
+++ b/apps/catalog/src/main.ts
@@ -54,6 +54,7 @@ const pageLoaders: Record<string, () => Promise<unknown>> = {
   "table": () => import("./pages/table.js"),
   "metric": () => import("./pages/metric.js"),
   "person": () => import("./pages/person.js"),
+  "progress": () => import("./pages/progress.js"),
   "popover": () => import("./pages/popover.js"),
   "carousel": () => import("./pages/carousel.js"),
   "calendar": () => import("./pages/calendar.js"),

--- a/apps/catalog/src/manifest.ts
+++ b/apps/catalog/src/manifest.ts
@@ -69,6 +69,7 @@ export const manifest: PageMeta[] = [
   { id: "table", title: "Table", section: "Data Display" },
   { id: "metric", title: "Metric", section: "Data Display" },
   { id: "person", title: "Person", section: "Data Display" },
+  { id: "progress", title: "Progress", section: "Data Display" },
   // Calendar & Date
   { id: "calendar", title: "Calendar", section: "Calendar & Date" },
   { id: "datetime-picker", title: "Datetime Picker", section: "Calendar & Date" },

--- a/apps/catalog/src/pages/progress.ts
+++ b/apps/catalog/src/pages/progress.ts
@@ -1,0 +1,187 @@
+import { registerPage } from "../registry.js";
+
+registerPage("progress", {
+  title: "Progress",
+  section: "Data Display",
+  render: () => `
+    <h3>Progress Bar — Sizes</h3>
+    <div class="stack-l" style="gap: 24px; max-width: 400px;">
+      <div class="variant-col">
+        <span class="variant-label">S</span>
+        <ui-progress-bar size="s" label="top-label" status="information" value="50" label-text="Label"></ui-progress-bar>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">M</span>
+        <ui-progress-bar size="m" label="top-label" status="information" value="50" label-text="Label"></ui-progress-bar>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">L</span>
+        <ui-progress-bar size="l" label="top-label" status="information" value="50" label-text="Label"></ui-progress-bar>
+      </div>
+    </div>
+
+    <h3>Progress Bar — Label Modes</h3>
+    <div class="stack-l" style="gap: 24px; max-width: 400px;">
+      <div class="variant-col">
+        <span class="variant-label">Top Label</span>
+        <ui-progress-bar size="m" label="top-label" status="information" value="50" label-text="Label"></ui-progress-bar>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Inner Label</span>
+        <ui-progress-bar size="m" label="inner-label" status="information" value="50" label-text="Label"></ui-progress-bar>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">None</span>
+        <ui-progress-bar size="m" label="none" status="information" value="50"></ui-progress-bar>
+      </div>
+    </div>
+
+    <h3>Progress Bar — Statuses</h3>
+    <div class="stack-l" style="gap: 16px; max-width: 400px;">
+      <div class="variant-col">
+        <span class="variant-label">None</span>
+        <ui-progress-bar size="m" label="top-label" status="none" value="50" label-text="Label"></ui-progress-bar>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Information</span>
+        <ui-progress-bar size="m" label="top-label" status="information" value="50" label-text="Label"></ui-progress-bar>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Success</span>
+        <ui-progress-bar size="m" label="top-label" status="success" value="50" label-text="Label"></ui-progress-bar>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Warning</span>
+        <ui-progress-bar size="m" label="top-label" status="warning" value="50" label-text="Label"></ui-progress-bar>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Error</span>
+        <ui-progress-bar size="m" label="top-label" status="error" value="50" label-text="Label"></ui-progress-bar>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Open</span>
+        <ui-progress-bar size="m" label="top-label" status="open" value="50" label-text="Label"></ui-progress-bar>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Complete</span>
+        <ui-progress-bar size="m" label="top-label" status="complete" value="100" label-text="Complete"></ui-progress-bar>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Suspended</span>
+        <ui-progress-bar size="m" label="top-label" status="suspended" value="50" label-text="Suspended"></ui-progress-bar>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Cancelled</span>
+        <ui-progress-bar size="m" label="top-label" status="cancelled" value="50" label-text="Cancelled"></ui-progress-bar>
+      </div>
+    </div>
+
+    <h3>Progress Bar — Amounts</h3>
+    <div class="stack-l" style="gap: 16px; max-width: 400px;">
+      <div class="variant-col">
+        <span class="variant-label">10%</span>
+        <ui-progress-bar size="m" label="top-label" status="information" value="10" label-text="Label"></ui-progress-bar>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">50%</span>
+        <ui-progress-bar size="m" label="top-label" status="information" value="50" label-text="Label"></ui-progress-bar>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">75%</span>
+        <ui-progress-bar size="m" label="top-label" status="information" value="75" label-text="Label"></ui-progress-bar>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">100%</span>
+        <ui-progress-bar size="m" label="top-label" status="information" value="100" label-text="Label"></ui-progress-bar>
+      </div>
+    </div>
+
+    <h3>Progress Circle — Sizes</h3>
+    <div class="variant-row" style="gap: 40px;">
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">S</span>
+        <ui-progress-circle size="s" label-position="bottom" status="information" value="25" label-text="Label"></ui-progress-circle>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">M</span>
+        <ui-progress-circle size="m" label-position="bottom" status="information" value="25" label-text="Label"></ui-progress-circle>
+      </div>
+    </div>
+
+    <h3>Progress Circle — Label Positions</h3>
+    <div class="variant-row" style="gap: 40px;">
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Bottom</span>
+        <ui-progress-circle size="m" label-position="bottom" status="information" value="25" label-text="Label"></ui-progress-circle>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Right (S)</span>
+        <ui-progress-circle size="s" label-position="right" status="information" value="25" label-text="Label"></ui-progress-circle>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">None</span>
+        <ui-progress-circle size="m" label-position="none" status="information" value="25"></ui-progress-circle>
+      </div>
+    </div>
+
+    <h3>Progress Circle — Statuses</h3>
+    <div class="variant-row" style="gap: 24px; flex-wrap: wrap;">
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">None</span>
+        <ui-progress-circle size="m" status="none" value="25" label-text="Label"></ui-progress-circle>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Information</span>
+        <ui-progress-circle size="m" status="information" value="25" label-text="Label"></ui-progress-circle>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Success</span>
+        <ui-progress-circle size="m" status="success" value="25" label-text="Label"></ui-progress-circle>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Warning</span>
+        <ui-progress-circle size="m" status="warning" value="25" label-text="Label"></ui-progress-circle>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Error</span>
+        <ui-progress-circle size="m" status="error" value="25" label-text="Label"></ui-progress-circle>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Open</span>
+        <ui-progress-circle size="m" status="open" value="25" label-text="Open"></ui-progress-circle>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Complete</span>
+        <ui-progress-circle size="m" status="complete" value="100" label-text="Complete"></ui-progress-circle>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Suspended</span>
+        <ui-progress-circle size="m" status="suspended" value="25" label-text="Suspended"></ui-progress-circle>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Cancelled</span>
+        <ui-progress-circle size="m" status="cancelled" value="25" label-text="Cancelled"></ui-progress-circle>
+      </div>
+    </div>
+
+    <h3>Progress Circle — Amounts</h3>
+    <div class="variant-row" style="gap: 24px;">
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">25%</span>
+        <ui-progress-circle size="m" status="information" value="25" label-text="Label"></ui-progress-circle>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">50%</span>
+        <ui-progress-circle size="m" status="information" value="50" label-text="Label"></ui-progress-circle>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">75%</span>
+        <ui-progress-circle size="m" status="information" value="75" label-text="Label"></ui-progress-circle>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">100%</span>
+        <ui-progress-circle size="m" status="information" value="100" label-text="Label"></ui-progress-circle>
+      </div>
+    </div>
+  `,
+});

--- a/packages/ui-components/src/components/ui-progress-bar.styles.ts
+++ b/packages/ui-components/src/components/ui-progress-bar.styles.ts
@@ -1,0 +1,245 @@
+import { semanticVar, colorVar } from "@maneki/foundation";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const SURFACE_TERTIARY = semanticVar("surface", "tertiary");
+
+// ─── Status color maps ───────────────────────────────────────────────────────
+
+// Fill colors (the progress indicator)
+const STATUS_FILL: Record<string, string> = {
+  none: "#5B7282",
+  information: "#186ADE",
+  success: "#077D55",
+  warning: "#F5C518",
+  error: "#D91F11",
+  open: "#43C478",
+  complete: "#077D55",
+  suspended: "#F7E379",
+  cancelled: "#FABBB4",
+};
+
+// Track colors (the background)
+const STATUS_TRACK: Record<string, string> = {
+  none: "#DCE3E8",
+  information: "#DCE3E8",
+  success: "#DCE3E8",
+  warning: "#DCE3E8",
+  error: "#DCE3E8",
+  open: "#C7EBD1",
+  complete: "#DCE3E8",
+  suspended: "#FAF6CF",
+  cancelled: "#FADCD9",
+};
+
+// Inner label fill (lighter shades for inner-label mode)
+const STATUS_INNER_FILL: Record<string, string> = {
+  none: "#9FB1BD",
+  information: "#75B1FF",
+  success: "#077D55",
+  warning: "#F5C518",
+  error: "#D91F11",
+  open: "#43C478",
+  complete: "#077D55",
+  suspended: "#F7E379",
+  cancelled: "#FABBB4",
+};
+
+const STATUS_INNER_TRACK: Record<string, string> = {
+  none: "#DCE3E8",
+  information: "#D4E4FA",
+  success: "#DCE3E8",
+  warning: "#DCE3E8",
+  error: "#DCE3E8",
+  open: "#C7EBD1",
+  complete: "#DCE3E8",
+  suspended: "#FAF6CF",
+  cancelled: "#FADCD9",
+};
+
+export {
+  TEXT_PRIMARY,
+  SURFACE_TERTIARY,
+  STATUS_FILL,
+  STATUS_TRACK,
+  STATUS_INNER_FILL,
+  STATUS_INNER_TRACK,
+};
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+export const BAR_STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: block;
+    width: 100%;
+    font-family: "Geist", sans-serif;
+  }
+
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  /* ── Top label ───────────────────────────────────────────────────────────── */
+
+  .top-label {
+    display: none;
+    align-items: center;
+    gap: 8px;
+    overflow: hidden;
+    color: ${TEXT_PRIMARY};
+  }
+
+  :host([label="top-label"]) .top-label {
+    display: flex;
+  }
+
+  .top-label .label-text {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .top-label .value-text {
+    flex-shrink: 0;
+    text-align: right;
+    white-space: nowrap;
+  }
+
+  /* ── Bar ──────────────────────────────────────────────────────────────────── */
+
+  .bar {
+    position: relative;
+    width: 100%;
+    overflow: hidden;
+  }
+
+  .track {
+    position: absolute;
+    inset: 0;
+  }
+
+  .fill {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    transition: width 0.3s ease;
+  }
+
+  /* ── Inner label ─────────────────────────────────────────────────────────── */
+
+  .inner-label {
+    display: none;
+    position: absolute;
+    inset: 0;
+    align-items: center;
+    gap: 8px;
+    overflow: hidden;
+    color: ${TEXT_PRIMARY};
+  }
+
+  :host([label="inner-label"]) .inner-label {
+    display: flex;
+  }
+
+  :host([label="inner-label"]) .bar-wrapper {
+    position: relative;
+  }
+
+  .inner-label .label-text {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .inner-label .value-text {
+    flex-shrink: 0;
+    text-align: right;
+    white-space: nowrap;
+  }
+
+  /* ── Size: S ─────────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) .wrapper {
+    gap: 4px;
+  }
+
+  :host([size="s"]) .top-label {
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  :host([size="s"]) .bar {
+    height: 2px;
+  }
+
+  /* S has no inner-label mode */
+
+  /* ── Size: M (default) ───────────────────────────────────────────────────── */
+
+  :host .wrapper,
+  :host([size="m"]) .wrapper {
+    gap: 8px;
+  }
+
+  :host .top-label,
+  :host([size="m"]) .top-label {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  :host .bar,
+  :host([size="m"]) .bar {
+    height: 4px;
+  }
+
+  :host([size="m"][label="inner-label"]) .bar,
+  :host([label="inner-label"]) .bar {
+    height: 24px;
+  }
+
+  :host .inner-label,
+  :host([size="m"]) .inner-label {
+    font-size: 12px;
+    line-height: 16px;
+    padding: 4px 8px;
+  }
+
+  /* ── Size: L ─────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) .wrapper {
+    gap: 8px;
+  }
+
+  :host([size="l"]) .top-label {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  :host([size="l"]) .bar {
+    height: 8px;
+  }
+
+  :host([size="l"][label="inner-label"]) .bar {
+    height: 30px;
+  }
+
+  :host([size="l"]) .inner-label {
+    font-size: 14px;
+    line-height: 20px;
+    padding: 4px 8px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .fill {
+      transition-duration: 0.01ms !important;
+    }
+  }
+`;

--- a/packages/ui-components/src/components/ui-progress-bar.test.ts
+++ b/packages/ui-components/src/components/ui-progress-bar.test.ts
@@ -1,0 +1,415 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "./ui-progress-bar.js";
+import type { ProgressBarSize, ProgressBarLabel, ProgressStatus } from "./ui-progress-bar.js";
+import {
+  STATUS_FILL,
+  STATUS_TRACK,
+  STATUS_INNER_FILL,
+  STATUS_INNER_TRACK,
+} from "./ui-progress-bar.styles.js";
+
+describe("ui-progress-bar", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    el = document.createElement("ui-progress-bar");
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-progress-bar")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("applies adoptedStyleSheets", () => {
+    expect(el.shadowRoot!.adoptedStyleSheets.length).toBe(1);
+  });
+
+  // ── Default rendering ─────────────────────────────────────────────────────
+
+  it("renders a .wrapper element", () => {
+    expect(el.shadowRoot!.querySelector(".wrapper")).not.toBeNull();
+  });
+
+  it("renders a .bar element", () => {
+    expect(el.shadowRoot!.querySelector(".bar")).not.toBeNull();
+  });
+
+  it("renders a .track element", () => {
+    expect(el.shadowRoot!.querySelector(".track")).not.toBeNull();
+  });
+
+  it("renders a .fill element", () => {
+    expect(el.shadowRoot!.querySelector(".fill")).not.toBeNull();
+  });
+
+  it("renders a .top-label element", () => {
+    expect(el.shadowRoot!.querySelector(".top-label")).not.toBeNull();
+  });
+
+  it("renders a .inner-label element", () => {
+    expect(el.shadowRoot!.querySelector(".inner-label")).not.toBeNull();
+  });
+
+  // ── Default attribute values ──────────────────────────────────────────────
+
+  it("defaults size to m", () => {
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("defaults label to top-label", () => {
+    expect(el.getAttribute("label")).toBe("top-label");
+  });
+
+  it("defaults status to information", () => {
+    expect(el.getAttribute("status")).toBe("information");
+  });
+
+  it("defaults value to 0", () => {
+    expect(el.getAttribute("value")).toBe("0");
+  });
+
+  // ── Attribute: size ───────────────────────────────────────────────────────
+
+  it("accepts size=s", () => {
+    el.setAttribute("size", "s");
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("accepts size=m", () => {
+    el.setAttribute("size", "m");
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("accepts size=l", () => {
+    el.setAttribute("size", "l");
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  // ── Attribute: label ──────────────────────────────────────────────────────
+
+  it("accepts label=none", () => {
+    el.setAttribute("label", "none");
+    expect(el.getAttribute("label")).toBe("none");
+  });
+
+  it("accepts label=top-label", () => {
+    el.setAttribute("label", "top-label");
+    expect(el.getAttribute("label")).toBe("top-label");
+  });
+
+  it("accepts label=inner-label", () => {
+    el.setAttribute("label", "inner-label");
+    expect(el.getAttribute("label")).toBe("inner-label");
+  });
+
+  // ── Attribute: status ─────────────────────────────────────────────────────
+
+  const ALL_STATUSES: ProgressStatus[] = [
+    "none",
+    "information",
+    "success",
+    "warning",
+    "error",
+    "open",
+    "complete",
+    "suspended",
+    "cancelled",
+  ];
+
+  for (const status of ALL_STATUSES) {
+    it(`accepts status=${status}`, () => {
+      el.setAttribute("status", status);
+      expect(el.getAttribute("status")).toBe(status);
+    });
+  }
+
+  // ── Attribute: value ──────────────────────────────────────────────────────
+
+  it("accepts value=50", () => {
+    el.setAttribute("value", "50");
+    expect(el.getAttribute("value")).toBe("50");
+  });
+
+  it("accepts value=100", () => {
+    el.setAttribute("value", "100");
+    expect(el.getAttribute("value")).toBe("100");
+  });
+
+  // ── Attribute: label-text ─────────────────────────────────────────────────
+
+  it("accepts label-text attribute", () => {
+    el.setAttribute("label-text", "Loading…");
+    expect(el.getAttribute("label-text")).toBe("Loading…");
+  });
+
+  // ── Property accessors ────────────────────────────────────────────────────
+
+  it("size getter returns current attribute", () => {
+    el.setAttribute("size", "l");
+    expect((el as unknown as { size: ProgressBarSize }).size).toBe("l");
+  });
+
+  it("size setter updates attribute", () => {
+    (el as unknown as { size: ProgressBarSize }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("label getter returns current attribute", () => {
+    el.setAttribute("label", "inner-label");
+    expect((el as unknown as { label: ProgressBarLabel }).label).toBe("inner-label");
+  });
+
+  it("label setter updates attribute", () => {
+    (el as unknown as { label: ProgressBarLabel }).label = "none";
+    expect(el.getAttribute("label")).toBe("none");
+  });
+
+  it("status getter returns current attribute", () => {
+    el.setAttribute("status", "error");
+    expect((el as unknown as { status: ProgressStatus }).status).toBe("error");
+  });
+
+  it("status setter updates attribute", () => {
+    (el as unknown as { status: ProgressStatus }).status = "success";
+    expect(el.getAttribute("status")).toBe("success");
+  });
+
+  it("value getter returns numeric value", () => {
+    el.setAttribute("value", "75");
+    expect((el as unknown as { value: number }).value).toBe(75);
+  });
+
+  it("value setter updates attribute", () => {
+    (el as unknown as { value: number }).value = 42;
+    expect(el.getAttribute("value")).toBe("42");
+  });
+
+  it("labelText getter returns current attribute", () => {
+    el.setAttribute("label-text", "Progress");
+    expect((el as unknown as { labelText: string }).labelText).toBe("Progress");
+  });
+
+  it("labelText setter updates attribute", () => {
+    (el as unknown as { labelText: string }).labelText = "Uploading";
+    expect(el.getAttribute("label-text")).toBe("Uploading");
+  });
+
+  // ── Value clamping ────────────────────────────────────────────────────────
+
+  it("clamps value below 0 to 0 via getter", () => {
+    el.setAttribute("value", "-10");
+    expect((el as unknown as { value: number }).value).toBe(0);
+  });
+
+  it("clamps value above 100 to 100 via getter", () => {
+    el.setAttribute("value", "200");
+    expect((el as unknown as { value: number }).value).toBe(100);
+  });
+
+  it("clamps value below 0 to 0 via setter", () => {
+    (el as unknown as { value: number }).value = -50;
+    expect(el.getAttribute("value")).toBe("0");
+  });
+
+  it("clamps value above 100 to 100 via setter", () => {
+    (el as unknown as { value: number }).value = 150;
+    expect(el.getAttribute("value")).toBe("100");
+  });
+
+  it("treats non-numeric value as 0", () => {
+    el.setAttribute("value", "abc");
+    expect((el as unknown as { value: number }).value).toBe(0);
+  });
+
+  // ── Fill width ────────────────────────────────────────────────────────────
+
+  it("sets fill width to 0% for value=0", () => {
+    el.setAttribute("value", "0");
+    const fill = el.shadowRoot!.querySelector(".fill") as HTMLElement;
+    expect(fill.style.width).toBe("0%");
+  });
+
+  it("sets fill width to 50% for value=50", () => {
+    el.setAttribute("value", "50");
+    const fill = el.shadowRoot!.querySelector(".fill") as HTMLElement;
+    expect(fill.style.width).toBe("50%");
+  });
+
+  it("sets fill width to 100% for value=100", () => {
+    el.setAttribute("value", "100");
+    const fill = el.shadowRoot!.querySelector(".fill") as HTMLElement;
+    expect(fill.style.width).toBe("100%");
+  });
+
+  // ── Colors: default (non-inner) mode ──────────────────────────────────────
+
+  it("applies correct track color for information status", () => {
+    el.setAttribute("status", "information");
+    const track = el.shadowRoot!.querySelector(".track") as HTMLElement;
+    expect(track.style.backgroundColor).toBe(STATUS_TRACK.information);
+  });
+
+  it("applies correct fill color for information status", () => {
+    el.setAttribute("status", "information");
+    const fill = el.shadowRoot!.querySelector(".fill") as HTMLElement;
+    expect(fill.style.backgroundColor).toBe(STATUS_FILL.information);
+  });
+
+  it("applies correct fill color for success status", () => {
+    el.setAttribute("status", "success");
+    const fill = el.shadowRoot!.querySelector(".fill") as HTMLElement;
+    expect(fill.style.backgroundColor).toBe(STATUS_FILL.success);
+  });
+
+  it("applies correct fill color for error status", () => {
+    el.setAttribute("status", "error");
+    const fill = el.shadowRoot!.querySelector(".fill") as HTMLElement;
+    expect(fill.style.backgroundColor).toBe(STATUS_FILL.error);
+  });
+
+  it("applies correct track color for open status", () => {
+    el.setAttribute("status", "open");
+    const track = el.shadowRoot!.querySelector(".track") as HTMLElement;
+    expect(track.style.backgroundColor).toBe(STATUS_TRACK.open);
+  });
+
+  it("applies correct fill color for cancelled status", () => {
+    el.setAttribute("status", "cancelled");
+    const fill = el.shadowRoot!.querySelector(".fill") as HTMLElement;
+    expect(fill.style.backgroundColor).toBe(STATUS_FILL.cancelled);
+  });
+
+  // ── Colors: inner-label mode ──────────────────────────────────────────────
+
+  it("applies inner track color in inner-label mode", () => {
+    el.setAttribute("label", "inner-label");
+    el.setAttribute("status", "information");
+    const track = el.shadowRoot!.querySelector(".track") as HTMLElement;
+    expect(track.style.backgroundColor).toBe(STATUS_INNER_TRACK.information);
+  });
+
+  it("applies inner fill color in inner-label mode", () => {
+    el.setAttribute("label", "inner-label");
+    el.setAttribute("status", "information");
+    const fill = el.shadowRoot!.querySelector(".fill") as HTMLElement;
+    expect(fill.style.backgroundColor).toBe(STATUS_INNER_FILL.information);
+  });
+
+  it("switches from inner to normal colors when label changes", () => {
+    el.setAttribute("label", "inner-label");
+    el.setAttribute("status", "information");
+    el.setAttribute("label", "top-label");
+    const track = el.shadowRoot!.querySelector(".track") as HTMLElement;
+    expect(track.style.backgroundColor).toBe(STATUS_TRACK.information);
+  });
+
+  // ── Top label mode ────────────────────────────────────────────────────────
+
+  it("shows label-text in top label", () => {
+    el.setAttribute("label", "top-label");
+    el.setAttribute("label-text", "Uploading");
+    const labelText = el.shadowRoot!.querySelector(".top-label .label-text") as HTMLElement;
+    expect(labelText.textContent).toBe("Uploading");
+  });
+
+  it("shows value% in top label", () => {
+    el.setAttribute("label", "top-label");
+    el.setAttribute("value", "65");
+    const valueText = el.shadowRoot!.querySelector(".top-label .value-text") as HTMLElement;
+    expect(valueText.textContent).toBe("65%");
+  });
+
+  // ── Inner label mode ──────────────────────────────────────────────────────
+
+  it("shows label-text in inner label", () => {
+    el.setAttribute("label", "inner-label");
+    el.setAttribute("label-text", "Processing");
+    const labelText = el.shadowRoot!.querySelector(".inner-label .label-text") as HTMLElement;
+    expect(labelText.textContent).toBe("Processing");
+  });
+
+  it("shows value% in inner label", () => {
+    el.setAttribute("label", "inner-label");
+    el.setAttribute("value", "30");
+    const valueText = el.shadowRoot!.querySelector(".inner-label .value-text") as HTMLElement;
+    expect(valueText.textContent).toBe("30%");
+  });
+
+  // ── ARIA ──────────────────────────────────────────────────────────────────
+
+  it("sets role=progressbar on .bar", () => {
+    const bar = el.shadowRoot!.querySelector(".bar") as HTMLElement;
+    expect(bar.getAttribute("role")).toBe("progressbar");
+  });
+
+  it("sets aria-valuemin=0", () => {
+    const bar = el.shadowRoot!.querySelector(".bar") as HTMLElement;
+    expect(bar.getAttribute("aria-valuemin")).toBe("0");
+  });
+
+  it("sets aria-valuemax=100", () => {
+    const bar = el.shadowRoot!.querySelector(".bar") as HTMLElement;
+    expect(bar.getAttribute("aria-valuemax")).toBe("100");
+  });
+
+  it("sets aria-valuenow to current value", () => {
+    el.setAttribute("value", "42");
+    const bar = el.shadowRoot!.querySelector(".bar") as HTMLElement;
+    expect(bar.getAttribute("aria-valuenow")).toBe("42");
+  });
+
+  it("updates aria-valuenow when value changes", () => {
+    el.setAttribute("value", "10");
+    el.setAttribute("value", "90");
+    const bar = el.shadowRoot!.querySelector(".bar") as HTMLElement;
+    expect(bar.getAttribute("aria-valuenow")).toBe("90");
+  });
+
+  it("sets aria-label when label-text is provided", () => {
+    el.setAttribute("label-text", "Upload progress");
+    const bar = el.shadowRoot!.querySelector(".bar") as HTMLElement;
+    expect(bar.getAttribute("aria-label")).toBe("Upload progress");
+  });
+
+  // ── observedAttributes ────────────────────────────────────────────────────
+
+  it("observes size attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("size");
+  });
+
+  it("observes label attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("label");
+  });
+
+  it("observes status attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("status");
+  });
+
+  it("observes value attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("value");
+  });
+
+  it("observes label-text attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("label-text");
+  });
+
+  it("has exactly 5 observed attributes", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed.length).toBe(5);
+  });
+});

--- a/packages/ui-components/src/components/ui-progress-bar.ts
+++ b/packages/ui-components/src/components/ui-progress-bar.ts
@@ -1,0 +1,182 @@
+import {
+  BAR_STYLES,
+  STATUS_FILL,
+  STATUS_TRACK,
+  STATUS_INNER_FILL,
+  STATUS_INNER_TRACK,
+} from "./ui-progress-bar.styles.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type ProgressBarSize = "s" | "m" | "l";
+export type ProgressBarLabel = "none" | "top-label" | "inner-label";
+export type ProgressStatus =
+  | "none"
+  | "information"
+  | "success"
+  | "warning"
+  | "error"
+  | "open"
+  | "complete"
+  | "suspended"
+  | "cancelled";
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(BAR_STYLES);
+
+export class UiProgressBar extends HTMLElement {
+  static readonly observedAttributes = [
+    "size",
+    "label",
+    "status",
+    "value",
+    "label-text",
+  ];
+
+  #topLabel!: HTMLElement;
+  #topLabelText!: HTMLElement;
+  #topValueText!: HTMLElement;
+  #bar!: HTMLElement;
+  #track!: HTMLElement;
+  #fill!: HTMLElement;
+  #innerLabel!: HTMLElement;
+  #innerLabelText!: HTMLElement;
+  #innerValueText!: HTMLElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    const wrapper = document.createElement("div");
+    wrapper.className = "wrapper";
+
+    // Top label
+    this.#topLabel = document.createElement("div");
+    this.#topLabel.className = "top-label";
+
+    this.#topLabelText = document.createElement("span");
+    this.#topLabelText.className = "label-text";
+
+    this.#topValueText = document.createElement("span");
+    this.#topValueText.className = "value-text";
+
+    this.#topLabel.append(this.#topLabelText, this.#topValueText);
+
+    // Bar
+    this.#bar = document.createElement("div");
+    this.#bar.className = "bar";
+    this.#bar.setAttribute("role", "progressbar");
+    this.#bar.setAttribute("aria-valuemin", "0");
+    this.#bar.setAttribute("aria-valuemax", "100");
+
+    this.#track = document.createElement("div");
+    this.#track.className = "track";
+
+    this.#fill = document.createElement("div");
+    this.#fill.className = "fill";
+
+    // Inner label
+    this.#innerLabel = document.createElement("div");
+    this.#innerLabel.className = "inner-label";
+
+    this.#innerLabelText = document.createElement("span");
+    this.#innerLabelText.className = "label-text";
+
+    this.#innerValueText = document.createElement("span");
+    this.#innerValueText.className = "value-text";
+
+    this.#innerLabel.append(this.#innerLabelText, this.#innerValueText);
+
+    this.#bar.append(this.#track, this.#fill, this.#innerLabel);
+    wrapper.append(this.#topLabel, this.#bar);
+    shadow.appendChild(wrapper);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("size")) this.setAttribute("size", "m");
+    if (!this.hasAttribute("label")) this.setAttribute("label", "top-label");
+    if (!this.hasAttribute("status")) this.setAttribute("status", "information");
+    if (!this.hasAttribute("value")) this.setAttribute("value", "0");
+    this._syncAll();
+  }
+
+  attributeChangedCallback(): void {
+    if (this.isConnected) this._syncAll();
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): ProgressBarSize {
+    return (this.getAttribute("size") as ProgressBarSize) ?? "m";
+  }
+  set size(v: ProgressBarSize) {
+    this.setAttribute("size", v);
+  }
+
+  get label(): ProgressBarLabel {
+    return (this.getAttribute("label") as ProgressBarLabel) ?? "top-label";
+  }
+  set label(v: ProgressBarLabel) {
+    this.setAttribute("label", v);
+  }
+
+  get status(): ProgressStatus {
+    return (this.getAttribute("status") as ProgressStatus) ?? "information";
+  }
+  set status(v: ProgressStatus) {
+    this.setAttribute("status", v);
+  }
+
+  get value(): number {
+    return Math.max(0, Math.min(100, parseInt(this.getAttribute("value") ?? "0", 10) || 0));
+  }
+  set value(v: number) {
+    this.setAttribute("value", String(Math.max(0, Math.min(100, v))));
+  }
+
+  get labelText(): string {
+    return this.getAttribute("label-text") ?? "";
+  }
+  set labelText(v: string) {
+    this.setAttribute("label-text", v);
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private _syncAll(): void {
+    const val = this.value;
+    const status = this.status;
+    const labelMode = this.label;
+    const text = this.labelText;
+
+    // Value text
+    const valueStr = `${val}%`;
+    this.#topValueText.textContent = valueStr;
+    this.#innerValueText.textContent = valueStr;
+
+    // Label text
+    this.#topLabelText.textContent = text;
+    this.#innerLabelText.textContent = text;
+
+    // Fill width
+    this.#fill.style.width = `${val}%`;
+
+    // ARIA
+    this.#bar.setAttribute("aria-valuenow", String(val));
+    if (text) this.#bar.setAttribute("aria-label", text);
+
+    // Colors
+    if (labelMode === "inner-label") {
+      this.#track.style.backgroundColor = STATUS_INNER_TRACK[status] ?? STATUS_INNER_TRACK.none;
+      this.#fill.style.backgroundColor = STATUS_INNER_FILL[status] ?? STATUS_INNER_FILL.none;
+    } else {
+      this.#track.style.backgroundColor = STATUS_TRACK[status] ?? STATUS_TRACK.none;
+      this.#fill.style.backgroundColor = STATUS_FILL[status] ?? STATUS_FILL.none;
+    }
+  }
+}
+
+customElements.define("ui-progress-bar", UiProgressBar);

--- a/packages/ui-components/src/components/ui-progress-circle.test.ts
+++ b/packages/ui-components/src/components/ui-progress-circle.test.ts
@@ -1,0 +1,441 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "./ui-progress-circle.js";
+import type { ProgressCircleSize, ProgressCircleLabelPosition } from "./ui-progress-circle.js";
+import { STATUS_FILL, STATUS_TRACK } from "./ui-progress-bar.styles.js";
+
+describe("ui-progress-circle", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    el = document.createElement("ui-progress-circle");
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-progress-circle")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("applies adoptedStyleSheets", () => {
+    expect(el.shadowRoot!.adoptedStyleSheets.length).toBe(1);
+  });
+
+  // ── Default rendering ─────────────────────────────────────────────────────
+
+  it("renders a .container element", () => {
+    expect(el.shadowRoot!.querySelector(".container")).not.toBeNull();
+  });
+
+  it("renders an SVG element", () => {
+    expect(el.shadowRoot!.querySelector("svg")).not.toBeNull();
+  });
+
+  it("renders a .track-circle element", () => {
+    expect(el.shadowRoot!.querySelector(".track-circle")).not.toBeNull();
+  });
+
+  it("renders a .fill-circle element", () => {
+    expect(el.shadowRoot!.querySelector(".fill-circle")).not.toBeNull();
+  });
+
+  it("renders a .percentage element", () => {
+    expect(el.shadowRoot!.querySelector(".percentage")).not.toBeNull();
+  });
+
+  it("renders a .label element", () => {
+    expect(el.shadowRoot!.querySelector(".label")).not.toBeNull();
+  });
+
+  // ── Default attribute values ──────────────────────────────────────────────
+
+  it("defaults size to m", () => {
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("defaults label-position to bottom", () => {
+    expect(el.getAttribute("label-position")).toBe("bottom");
+  });
+
+  it("defaults status to information", () => {
+    expect(el.getAttribute("status")).toBe("information");
+  });
+
+  it("defaults value to 0", () => {
+    expect(el.getAttribute("value")).toBe("0");
+  });
+
+  // ── Attribute: size ───────────────────────────────────────────────────────
+
+  it("accepts size=s", () => {
+    el.setAttribute("size", "s");
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("accepts size=m", () => {
+    el.setAttribute("size", "m");
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  // ── Attribute: label-position ─────────────────────────────────────────────
+
+  it("accepts label-position=none", () => {
+    el.setAttribute("label-position", "none");
+    expect(el.getAttribute("label-position")).toBe("none");
+  });
+
+  it("accepts label-position=bottom", () => {
+    el.setAttribute("label-position", "bottom");
+    expect(el.getAttribute("label-position")).toBe("bottom");
+  });
+
+  it("accepts label-position=right", () => {
+    el.setAttribute("label-position", "right");
+    expect(el.getAttribute("label-position")).toBe("right");
+  });
+
+  // ── Attribute: status ─────────────────────────────────────────────────────
+
+  it("accepts status=success", () => {
+    el.setAttribute("status", "success");
+    expect(el.getAttribute("status")).toBe("success");
+  });
+
+  it("accepts status=error", () => {
+    el.setAttribute("status", "error");
+    expect(el.getAttribute("status")).toBe("error");
+  });
+
+  it("accepts status=warning", () => {
+    el.setAttribute("status", "warning");
+    expect(el.getAttribute("status")).toBe("warning");
+  });
+
+  it("accepts status=none", () => {
+    el.setAttribute("status", "none");
+    expect(el.getAttribute("status")).toBe("none");
+  });
+
+  // ── Attribute: value & label-text ─────────────────────────────────────────
+
+  it("accepts value=75", () => {
+    el.setAttribute("value", "75");
+    expect(el.getAttribute("value")).toBe("75");
+  });
+
+  it("accepts label-text attribute", () => {
+    el.setAttribute("label-text", "CPU Usage");
+    expect(el.getAttribute("label-text")).toBe("CPU Usage");
+  });
+
+  // ── Property accessors ────────────────────────────────────────────────────
+
+  it("size getter returns current attribute", () => {
+    el.setAttribute("size", "s");
+    expect((el as unknown as { size: ProgressCircleSize }).size).toBe("s");
+  });
+
+  it("size setter updates attribute", () => {
+    (el as unknown as { size: ProgressCircleSize }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("labelPosition getter returns current attribute", () => {
+    el.setAttribute("label-position", "right");
+    expect((el as unknown as { labelPosition: ProgressCircleLabelPosition }).labelPosition).toBe("right");
+  });
+
+  it("labelPosition setter updates attribute", () => {
+    (el as unknown as { labelPosition: ProgressCircleLabelPosition }).labelPosition = "none";
+    expect(el.getAttribute("label-position")).toBe("none");
+  });
+
+  it("status getter returns current attribute", () => {
+    el.setAttribute("status", "error");
+    expect((el as unknown as { status: string }).status).toBe("error");
+  });
+
+  it("status setter updates attribute", () => {
+    (el as unknown as { status: string }).status = "success";
+    expect(el.getAttribute("status")).toBe("success");
+  });
+
+  it("value getter returns numeric value", () => {
+    el.setAttribute("value", "60");
+    expect((el as unknown as { value: number }).value).toBe(60);
+  });
+
+  it("value setter updates attribute", () => {
+    (el as unknown as { value: number }).value = 88;
+    expect(el.getAttribute("value")).toBe("88");
+  });
+
+  it("labelText getter returns current attribute", () => {
+    el.setAttribute("label-text", "Memory");
+    expect((el as unknown as { labelText: string }).labelText).toBe("Memory");
+  });
+
+  it("labelText setter updates attribute", () => {
+    (el as unknown as { labelText: string }).labelText = "Disk";
+    expect(el.getAttribute("label-text")).toBe("Disk");
+  });
+
+  // ── Value clamping ────────────────────────────────────────────────────────
+
+  it("clamps value below 0 to 0 via getter", () => {
+    el.setAttribute("value", "-20");
+    expect((el as unknown as { value: number }).value).toBe(0);
+  });
+
+  it("clamps value above 100 to 100 via getter", () => {
+    el.setAttribute("value", "999");
+    expect((el as unknown as { value: number }).value).toBe(100);
+  });
+
+  it("clamps value below 0 to 0 via setter", () => {
+    (el as unknown as { value: number }).value = -5;
+    expect(el.getAttribute("value")).toBe("0");
+  });
+
+  it("clamps value above 100 to 100 via setter", () => {
+    (el as unknown as { value: number }).value = 200;
+    expect(el.getAttribute("value")).toBe("100");
+  });
+
+  it("treats non-numeric value as 0", () => {
+    el.setAttribute("value", "xyz");
+    expect((el as unknown as { value: number }).value).toBe(0);
+  });
+
+  // ── SVG dimensions ────────────────────────────────────────────────────────
+
+  it("renders 52px SVG for size=m", () => {
+    el.setAttribute("size", "m");
+    const svg = el.shadowRoot!.querySelector("svg") as SVGSVGElement;
+    expect(svg.getAttribute("width")).toBe("52");
+    expect(svg.getAttribute("height")).toBe("52");
+  });
+
+  it("renders 24px SVG for size=s", () => {
+    el.setAttribute("size", "s");
+    const svg = el.shadowRoot!.querySelector("svg") as SVGSVGElement;
+    expect(svg.getAttribute("width")).toBe("24");
+    expect(svg.getAttribute("height")).toBe("24");
+  });
+
+  it("sets correct viewBox for size=m", () => {
+    el.setAttribute("size", "m");
+    const svg = el.shadowRoot!.querySelector("svg") as SVGSVGElement;
+    expect(svg.getAttribute("viewBox")).toBe("0 0 52 52");
+  });
+
+  it("sets correct viewBox for size=s", () => {
+    el.setAttribute("size", "s");
+    const svg = el.shadowRoot!.querySelector("svg") as SVGSVGElement;
+    expect(svg.getAttribute("viewBox")).toBe("0 0 24 24");
+  });
+
+  // ── SVG circle attributes ─────────────────────────────────────────────────
+
+  it("sets track circle cx/cy to center for size=m", () => {
+    el.setAttribute("size", "m");
+    const track = el.shadowRoot!.querySelector(".track-circle") as SVGCircleElement;
+    expect(track.getAttribute("cx")).toBe("26");
+    expect(track.getAttribute("cy")).toBe("26");
+  });
+
+  it("sets track circle radius for size=m (r = (52-4)/2 = 24)", () => {
+    el.setAttribute("size", "m");
+    const track = el.shadowRoot!.querySelector(".track-circle") as SVGCircleElement;
+    expect(track.getAttribute("r")).toBe("24");
+  });
+
+  it("sets track circle stroke-width for size=m", () => {
+    el.setAttribute("size", "m");
+    const track = el.shadowRoot!.querySelector(".track-circle") as SVGCircleElement;
+    expect(track.getAttribute("stroke-width")).toBe("4");
+  });
+
+  it("sets fill circle radius for size=s (r = (24-3)/2 = 10.5)", () => {
+    el.setAttribute("size", "s");
+    const fill = el.shadowRoot!.querySelector(".fill-circle") as SVGCircleElement;
+    expect(fill.getAttribute("r")).toBe("10.5");
+  });
+
+  it("sets fill circle stroke-linecap to round", () => {
+    const fill = el.shadowRoot!.querySelector(".fill-circle") as SVGCircleElement;
+    expect(fill.getAttribute("stroke-linecap")).toBe("round");
+  });
+
+  // ── Percentage text ───────────────────────────────────────────────────────
+
+  it("shows percentage text for size=m", () => {
+    el.setAttribute("size", "m");
+    el.setAttribute("value", "42");
+    const pct = el.shadowRoot!.querySelector(".percentage") as HTMLElement;
+    expect(pct.textContent).toBe("42%");
+  });
+
+  it("updates percentage text when value changes", () => {
+    el.setAttribute("value", "10");
+    el.setAttribute("value", "99");
+    const pct = el.shadowRoot!.querySelector(".percentage") as HTMLElement;
+    expect(pct.textContent).toBe("99%");
+  });
+
+  it("shows 0% for default value", () => {
+    const pct = el.shadowRoot!.querySelector(".percentage") as HTMLElement;
+    expect(pct.textContent).toBe("0%");
+  });
+
+  // ── Label text ────────────────────────────────────────────────────────────
+
+  it("renders label-text in .label element", () => {
+    el.setAttribute("label-text", "CPU");
+    const label = el.shadowRoot!.querySelector(".label") as HTMLElement;
+    expect(label.textContent).toBe("CPU");
+  });
+
+  it("updates label when label-text changes", () => {
+    el.setAttribute("label-text", "CPU");
+    el.setAttribute("label-text", "Memory");
+    const label = el.shadowRoot!.querySelector(".label") as HTMLElement;
+    expect(label.textContent).toBe("Memory");
+  });
+
+  it("renders empty label when no label-text", () => {
+    const label = el.shadowRoot!.querySelector(".label") as HTMLElement;
+    expect(label.textContent).toBe("");
+  });
+
+  // ── Status colors ─────────────────────────────────────────────────────────
+
+  it("applies track stroke color for information status", () => {
+    el.setAttribute("status", "information");
+    const track = el.shadowRoot!.querySelector(".track-circle") as SVGCircleElement;
+    expect(track.style.stroke).toBe(STATUS_TRACK.information);
+  });
+
+  it("applies fill stroke color for information status", () => {
+    el.setAttribute("status", "information");
+    const fill = el.shadowRoot!.querySelector(".fill-circle") as SVGCircleElement;
+    expect(fill.style.stroke).toBe(STATUS_FILL.information);
+  });
+
+  it("applies fill stroke color for error status", () => {
+    el.setAttribute("status", "error");
+    const fill = el.shadowRoot!.querySelector(".fill-circle") as SVGCircleElement;
+    expect(fill.style.stroke).toBe(STATUS_FILL.error);
+  });
+
+  it("applies track stroke color for open status", () => {
+    el.setAttribute("status", "open");
+    const track = el.shadowRoot!.querySelector(".track-circle") as SVGCircleElement;
+    expect(track.style.stroke).toBe(STATUS_TRACK.open);
+  });
+
+  // ── Stroke dash ───────────────────────────────────────────────────────────
+
+  it("sets strokeDasharray on fill circle", () => {
+    const fill = el.shadowRoot!.querySelector(".fill-circle") as SVGCircleElement;
+    expect(fill.style.strokeDasharray).not.toBe("");
+  });
+
+  it("sets strokeDashoffset based on value", () => {
+    el.setAttribute("value", "50");
+    const fill = el.shadowRoot!.querySelector(".fill-circle") as SVGCircleElement;
+    // For m: radius=24, circumference=2*PI*24≈150.796, offset=circumference*0.5≈75.398
+    const circumference = 2 * Math.PI * 24;
+    const expectedOffset = circumference - (50 / 100) * circumference;
+    expect(fill.style.strokeDashoffset).toBe(String(expectedOffset));
+  });
+
+  it("sets full offset (no fill) for value=0", () => {
+    el.setAttribute("value", "0");
+    const fill = el.shadowRoot!.querySelector(".fill-circle") as SVGCircleElement;
+    const circumference = 2 * Math.PI * 24;
+    expect(fill.style.strokeDashoffset).toBe(String(circumference));
+  });
+
+  it("sets zero offset (full fill) for value=100", () => {
+    el.setAttribute("value", "100");
+    const fill = el.shadowRoot!.querySelector(".fill-circle") as SVGCircleElement;
+    expect(fill.style.strokeDashoffset).toBe("0");
+  });
+
+  // ── ARIA ──────────────────────────────────────────────────────────────────
+
+  it("sets role=progressbar on .container", () => {
+    const container = el.shadowRoot!.querySelector(".container") as HTMLElement;
+    expect(container.getAttribute("role")).toBe("progressbar");
+  });
+
+  it("sets aria-valuemin=0", () => {
+    const container = el.shadowRoot!.querySelector(".container") as HTMLElement;
+    expect(container.getAttribute("aria-valuemin")).toBe("0");
+  });
+
+  it("sets aria-valuemax=100", () => {
+    const container = el.shadowRoot!.querySelector(".container") as HTMLElement;
+    expect(container.getAttribute("aria-valuemax")).toBe("100");
+  });
+
+  it("sets aria-valuenow to current value", () => {
+    el.setAttribute("value", "55");
+    const container = el.shadowRoot!.querySelector(".container") as HTMLElement;
+    expect(container.getAttribute("aria-valuenow")).toBe("55");
+  });
+
+  it("updates aria-valuenow when value changes", () => {
+    el.setAttribute("value", "10");
+    el.setAttribute("value", "80");
+    const container = el.shadowRoot!.querySelector(".container") as HTMLElement;
+    expect(container.getAttribute("aria-valuenow")).toBe("80");
+  });
+
+  it("sets aria-label when label-text is provided", () => {
+    el.setAttribute("label-text", "Upload progress");
+    const container = el.shadowRoot!.querySelector(".container") as HTMLElement;
+    expect(container.getAttribute("aria-label")).toBe("Upload progress");
+  });
+
+  // ── observedAttributes ────────────────────────────────────────────────────
+
+  it("observes size attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("size");
+  });
+
+  it("observes label-position attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("label-position");
+  });
+
+  it("observes status attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("status");
+  });
+
+  it("observes value attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("value");
+  });
+
+  it("observes label-text attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("label-text");
+  });
+
+  it("has exactly 5 observed attributes", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed.length).toBe(5);
+  });
+});

--- a/packages/ui-components/src/components/ui-progress-circle.ts
+++ b/packages/ui-components/src/components/ui-progress-circle.ts
@@ -1,0 +1,288 @@
+import { semanticVar } from "@maneki/foundation";
+import { STATUS_FILL, STATUS_TRACK } from "./ui-progress-bar.styles.js";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const TEXT_PRIMARY = semanticVar("text", "primary");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+export const CIRCLE_STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    font-family: "Geist", sans-serif;
+  }
+
+  .container {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  svg {
+    display: block;
+    transform: rotate(-90deg);
+  }
+
+  .track-circle {
+    fill: none;
+  }
+
+  .fill-circle {
+    fill: none;
+    transition: stroke-dashoffset 0.3s ease;
+  }
+
+  .percentage {
+    position: absolute;
+    font-weight: 500;
+    color: ${TEXT_PRIMARY};
+    text-align: center;
+  }
+
+  .label {
+    font-weight: 400;
+    color: ${TEXT_PRIMARY};
+    text-align: center;
+    white-space: nowrap;
+  }
+
+  /* ── Size: S (24px) ──────────────────────────────────────────────────────── */
+
+  :host([size="s"]) .container {
+    width: 24px;
+    height: 24px;
+  }
+
+  :host([size="s"]) .percentage {
+    display: none;
+  }
+
+  :host([size="s"]) .label {
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  /* ── Size: M (default, 52px) ─────────────────────────────────────────────── */
+
+  :host .container,
+  :host([size="m"]) .container {
+    width: 52px;
+    height: 52px;
+  }
+
+  :host .percentage,
+  :host([size="m"]) .percentage {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  :host .label,
+  :host([size="m"]) .label {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  /* ── Label positions ─────────────────────────────────────────────────────── */
+
+  :host([label-position="bottom"]) {
+    gap: 8px;
+  }
+
+  :host([label-position="bottom"]) .label {
+    display: block;
+  }
+
+  :host([size="s"][label-position="bottom"]) {
+    gap: 4px;
+  }
+
+  :host([label-position="right"]) {
+    flex-direction: row;
+    gap: 8px;
+  }
+
+  :host([label-position="right"]) .label {
+    display: block;
+  }
+
+  :host([label-position="none"]) .label {
+    display: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .fill-circle {
+      transition-duration: 0.01ms !important;
+    }
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export type ProgressCircleSize = "s" | "m";
+export type ProgressCircleLabelPosition = "none" | "bottom" | "right";
+
+const circleSheet = new CSSStyleSheet();
+circleSheet.replaceSync(CIRCLE_STYLES);
+
+// SVG dimensions per size
+const SIZE_CONFIG: Record<string, { diameter: number; strokeWidth: number }> = {
+  s: { diameter: 24, strokeWidth: 3 },
+  m: { diameter: 52, strokeWidth: 4 },
+};
+
+export class UiProgressCircle extends HTMLElement {
+  static readonly observedAttributes = [
+    "size",
+    "label-position",
+    "status",
+    "value",
+    "label-text",
+  ];
+
+  #container!: HTMLElement;
+  #svg!: SVGSVGElement;
+  #trackCircle!: SVGCircleElement;
+  #fillCircle!: SVGCircleElement;
+  #percentage!: HTMLElement;
+  #label!: HTMLElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [circleSheet];
+
+    this.#container = document.createElement("div");
+    this.#container.className = "container";
+    this.#container.setAttribute("role", "progressbar");
+    this.#container.setAttribute("aria-valuemin", "0");
+    this.#container.setAttribute("aria-valuemax", "100");
+
+    // SVG
+    this.#svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    this.#trackCircle = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+    this.#trackCircle.classList.add("track-circle");
+    this.#fillCircle = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+    this.#fillCircle.classList.add("fill-circle");
+    this.#svg.append(this.#trackCircle, this.#fillCircle);
+
+    // Percentage text overlay
+    this.#percentage = document.createElement("div");
+    this.#percentage.className = "percentage";
+
+    this.#container.append(this.#svg, this.#percentage);
+
+    // Label
+    this.#label = document.createElement("div");
+    this.#label.className = "label";
+
+    shadow.append(this.#container, this.#label);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("size")) this.setAttribute("size", "m");
+    if (!this.hasAttribute("label-position")) this.setAttribute("label-position", "bottom");
+    if (!this.hasAttribute("status")) this.setAttribute("status", "information");
+    if (!this.hasAttribute("value")) this.setAttribute("value", "0");
+    this._syncAll();
+  }
+
+  attributeChangedCallback(): void {
+    if (this.isConnected) this._syncAll();
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): ProgressCircleSize {
+    return (this.getAttribute("size") as ProgressCircleSize) ?? "m";
+  }
+  set size(v: ProgressCircleSize) {
+    this.setAttribute("size", v);
+  }
+
+  get labelPosition(): ProgressCircleLabelPosition {
+    return (this.getAttribute("label-position") as ProgressCircleLabelPosition) ?? "bottom";
+  }
+  set labelPosition(v: ProgressCircleLabelPosition) {
+    this.setAttribute("label-position", v);
+  }
+
+  get status(): string {
+    return this.getAttribute("status") ?? "information";
+  }
+  set status(v: string) {
+    this.setAttribute("status", v);
+  }
+
+  get value(): number {
+    return Math.max(0, Math.min(100, parseInt(this.getAttribute("value") ?? "0", 10) || 0));
+  }
+  set value(v: number) {
+    this.setAttribute("value", String(Math.max(0, Math.min(100, v))));
+  }
+
+  get labelText(): string {
+    return this.getAttribute("label-text") ?? "";
+  }
+  set labelText(v: string) {
+    this.setAttribute("label-text", v);
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private _syncAll(): void {
+    const val = this.value;
+    const status = this.status;
+    const size = this.size;
+    const config = SIZE_CONFIG[size] ?? SIZE_CONFIG.m;
+    const { diameter, strokeWidth } = config;
+    const radius = (diameter - strokeWidth) / 2;
+    const circumference = 2 * Math.PI * radius;
+    const offset = circumference - (val / 100) * circumference;
+
+    // SVG attributes
+    this.#svg.setAttribute("width", String(diameter));
+    this.#svg.setAttribute("height", String(diameter));
+    this.#svg.setAttribute("viewBox", `0 0 ${diameter} ${diameter}`);
+
+    const cx = String(diameter / 2);
+    const cy = String(diameter / 2);
+    const r = String(radius);
+
+    this.#trackCircle.setAttribute("cx", cx);
+    this.#trackCircle.setAttribute("cy", cy);
+    this.#trackCircle.setAttribute("r", r);
+    this.#trackCircle.setAttribute("stroke-width", String(strokeWidth));
+    this.#trackCircle.style.stroke = STATUS_TRACK[status] ?? STATUS_TRACK.none;
+
+    this.#fillCircle.setAttribute("cx", cx);
+    this.#fillCircle.setAttribute("cy", cy);
+    this.#fillCircle.setAttribute("r", r);
+    this.#fillCircle.setAttribute("stroke-width", String(strokeWidth));
+    this.#fillCircle.setAttribute("stroke-linecap", "round");
+    this.#fillCircle.style.stroke = STATUS_FILL[status] ?? STATUS_FILL.none;
+    this.#fillCircle.style.strokeDasharray = String(circumference);
+    this.#fillCircle.style.strokeDashoffset = String(offset);
+
+    // Percentage text
+    this.#percentage.textContent = `${val}%`;
+
+    // Label
+    this.#label.textContent = this.labelText;
+
+    // ARIA
+    this.#container.setAttribute("aria-valuenow", String(val));
+    if (this.labelText) this.#container.setAttribute("aria-label", this.labelText);
+  }
+}
+
+customElements.define("ui-progress-circle", UiProgressCircle);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -184,3 +184,10 @@ export { UiPersonGroup } from "./components/ui-person-group.js";
 
 export { UiPopover } from "./components/ui-popover.js";
 export type { PopoverSize, PopoverPlacement } from "./components/ui-popover.js";
+
+// ─── Progress ────────────────────────────────────────────────────────────────
+
+export { UiProgressBar } from "./components/ui-progress-bar.js";
+export type { ProgressBarSize, ProgressBarLabel, ProgressStatus } from "./components/ui-progress-bar.js";
+export { UiProgressCircle } from "./components/ui-progress-circle.js";
+export type { ProgressCircleSize, ProgressCircleLabelPosition } from "./components/ui-progress-circle.js";

--- a/packages/ui-components/src/stories/ui-progress-bar.stories.ts
+++ b/packages/ui-components/src/stories/ui-progress-bar.stories.ts
@@ -1,0 +1,142 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-progress-bar.js";
+
+const meta: Meta = {
+  title: "Components/Progress Bar",
+  component: "ui-progress-bar",
+  argTypes: {
+    size: {
+      control: { type: "select" },
+      options: ["s", "m", "l"],
+    },
+    label: {
+      control: { type: "select" },
+      options: ["none", "top-label", "inner-label"],
+    },
+    status: {
+      control: { type: "select" },
+      options: [
+        "none",
+        "information",
+        "success",
+        "warning",
+        "error",
+        "open",
+        "complete",
+        "suspended",
+        "cancelled",
+      ],
+    },
+    value: {
+      control: { type: "range", min: 0, max: 100, step: 1 },
+    },
+    labelText: {
+      control: { type: "text" },
+    },
+  },
+  args: {
+    size: "m",
+    label: "top-label",
+    status: "information",
+    value: 50,
+    labelText: "Progress",
+  },
+  render: (args) => html`
+    <ui-progress-bar
+      size=${args.size}
+      label=${args.label}
+      status=${args.status}
+      value=${args.value}
+      label-text=${args.labelText}
+    ></ui-progress-bar>
+  `,
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {};
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 24px; max-width: 400px;">
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Size S</div>
+        <ui-progress-bar size="s" label="top-label" status="information" value="50" label-text="Small"></ui-progress-bar>
+      </div>
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Size M</div>
+        <ui-progress-bar size="m" label="top-label" status="information" value="50" label-text="Medium"></ui-progress-bar>
+      </div>
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Size L</div>
+        <ui-progress-bar size="l" label="top-label" status="information" value="50" label-text="Large"></ui-progress-bar>
+      </div>
+    </div>
+  `,
+};
+
+export const LabelModes: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 24px; max-width: 400px;">
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">None</div>
+        <ui-progress-bar label="none" status="information" value="50" label-text="Hidden"></ui-progress-bar>
+      </div>
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Top Label</div>
+        <ui-progress-bar label="top-label" status="information" value="50" label-text="Top label"></ui-progress-bar>
+      </div>
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Inner Label</div>
+        <ui-progress-bar label="inner-label" status="information" value="50" label-text="Inner label"></ui-progress-bar>
+      </div>
+    </div>
+  `,
+};
+
+export const AllStatuses: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 16px; max-width: 400px;">
+      ${(
+        [
+          "information",
+          "success",
+          "warning",
+          "error",
+          "open",
+          "complete",
+          "suspended",
+          "cancelled",
+        ] as const
+      ).map(
+        (status) => html`
+          <ui-progress-bar
+            label="top-label"
+            status=${status}
+            value="65"
+            label-text=${status}
+          ></ui-progress-bar>
+        `,
+      )}
+    </div>
+  `,
+};
+
+export const ProgressAmounts: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 16px; max-width: 400px;">
+      ${([10, 25, 50, 75, 100] as const).map(
+        (val) => html`
+          <ui-progress-bar
+            label="top-label"
+            status="information"
+            value=${val}
+            label-text="${val}% complete"
+          ></ui-progress-bar>
+        `,
+      )}
+    </div>
+  `,
+};

--- a/packages/ui-components/src/stories/ui-progress-circle.stories.ts
+++ b/packages/ui-components/src/stories/ui-progress-circle.stories.ts
@@ -1,0 +1,139 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-progress-circle.js";
+
+const meta: Meta = {
+  title: "Components/Progress Circle",
+  component: "ui-progress-circle",
+  argTypes: {
+    size: {
+      control: { type: "select" },
+      options: ["s", "m"],
+    },
+    labelPosition: {
+      control: { type: "select" },
+      options: ["none", "bottom", "right"],
+    },
+    status: {
+      control: { type: "select" },
+      options: [
+        "none",
+        "information",
+        "success",
+        "warning",
+        "error",
+        "open",
+        "complete",
+        "suspended",
+        "cancelled",
+      ],
+    },
+    value: {
+      control: { type: "range", min: 0, max: 100, step: 1 },
+    },
+    labelText: {
+      control: { type: "text" },
+    },
+  },
+  args: {
+    size: "m",
+    labelPosition: "bottom",
+    status: "information",
+    value: 25,
+    labelText: "Progress",
+  },
+  render: (args) => html`
+    <ui-progress-circle
+      size=${args.size}
+      label-position=${args.labelPosition}
+      status=${args.status}
+      value=${args.value}
+      label-text=${args.labelText}
+    ></ui-progress-circle>
+  `,
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {};
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 32px; align-items: flex-end;">
+      <div style="text-align: center;">
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Size S</div>
+        <ui-progress-circle size="s" label-position="bottom" status="information" value="50" label-text="Small"></ui-progress-circle>
+      </div>
+      <div style="text-align: center;">
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Size M</div>
+        <ui-progress-circle size="m" label-position="bottom" status="information" value="50" label-text="Medium"></ui-progress-circle>
+      </div>
+    </div>
+  `,
+};
+
+export const LabelPositions: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 48px; align-items: flex-start;">
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">None</div>
+        <ui-progress-circle label-position="none" status="information" value="50" label-text="Hidden"></ui-progress-circle>
+      </div>
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Bottom</div>
+        <ui-progress-circle label-position="bottom" status="information" value="50" label-text="Bottom"></ui-progress-circle>
+      </div>
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Right</div>
+        <ui-progress-circle label-position="right" status="information" value="50" label-text="Right"></ui-progress-circle>
+      </div>
+    </div>
+  `,
+};
+
+export const AllStatuses: Story = {
+  render: () => html`
+    <div style="display: flex; flex-wrap: wrap; gap: 24px;">
+      ${(
+        [
+          "none",
+          "information",
+          "success",
+          "warning",
+          "error",
+          "open",
+          "complete",
+          "suspended",
+          "cancelled",
+        ] as const
+      ).map(
+        (status) => html`
+          <ui-progress-circle
+            label-position="bottom"
+            status=${status}
+            value="65"
+            label-text=${status}
+          ></ui-progress-circle>
+        `,
+      )}
+    </div>
+  `,
+};
+
+export const ProgressAmounts: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 32px;">
+      ${([25, 50, 75, 100] as const).map(
+        (val) => html`
+          <ui-progress-circle
+            label-position="bottom"
+            status="information"
+            value=${val}
+            label-text="${val}%"
+          ></ui-progress-circle>
+        `,
+      )}
+    </div>
+  `,
+};


### PR DESCRIPTION
## Summary

New `<ui-progress-bar>` and `<ui-progress-circle>` Web Components for displaying progress indicators with status colors.

## `<ui-progress-bar>`

- 3 sizes: `s` (2px bar), `m` (4px bar), `l` (8px bar)
- 3 label modes: `none`, `top-label` (label + percentage above bar), `inner-label` (label + percentage inside bar)
- 9 statuses: none, information, success, warning, error, open, complete, suspended, cancelled
- `value` attribute (0-100) with clamping
- Status-specific track/fill colors (e.g., information = blue, error = red, suspended = yellow)
- Inner-label mode uses lighter fill/track colors

## `<ui-progress-circle>`

- 2 sizes: `s` (24px) and `m` (52px with percentage text inside)
- 3 label positions: `none`, `bottom`, `right` (S only)
- SVG circle with `stroke-dasharray`/`stroke-dashoffset` for progress arc
- Same 9 statuses as progress bar
- `value` attribute (0-100) with clamping

## Accessibility

- `role="progressbar"` with `aria-valuenow`, `aria-valuemin`, `aria-valuemax`
- `prefers-reduced-motion` support

## Testing

- 2698 unit tests (148 new: 74 bar + 74 circle)
- Storybook stories for both components
- 43 Playwright visual regression tests (1 new)

## Files

- `packages/ui-components/src/components/ui-progress-bar.ts` + `ui-progress-bar.styles.ts`
- `packages/ui-components/src/components/ui-progress-circle.ts`
- `packages/ui-components/src/components/ui-progress-bar.test.ts` + `ui-progress-circle.test.ts`
- `packages/ui-components/src/stories/ui-progress-bar.stories.ts` + `ui-progress-circle.stories.ts`
- `packages/ui-components/src/index.ts` — barrel exports
- `apps/catalog/src/pages/progress.ts` — catalog page