### PR TITLE
feat(ui-components): add ui-pull-to-refresh component

### DIFF
--- a/apps/catalog/e2e/visual.spec.ts
+++ b/apps/catalog/e2e/visual.spec.ts
@@ -37,6 +37,7 @@ const pages = [
   "metric",
   "person",
   "progress",
+  "pull-to-refresh",
   "popover",
   "carousel",
   "calendar",

--- a/apps/catalog/src/main.ts
+++ b/apps/catalog/src/main.ts
@@ -55,6 +55,7 @@ const pageLoaders: Record<string, () => Promise<unknown>> = {
   "metric": () => import("./pages/metric.js"),
   "person": () => import("./pages/person.js"),
   "progress": () => import("./pages/progress.js"),
+  "pull-to-refresh": () => import("./pages/pull-to-refresh.js"),
   "popover": () => import("./pages/popover.js"),
   "carousel": () => import("./pages/carousel.js"),
   "calendar": () => import("./pages/calendar.js"),

--- a/apps/catalog/src/manifest.ts
+++ b/apps/catalog/src/manifest.ts
@@ -70,6 +70,7 @@ export const manifest: PageMeta[] = [
   { id: "metric", title: "Metric", section: "Data Display" },
   { id: "person", title: "Person", section: "Data Display" },
   { id: "progress", title: "Progress", section: "Data Display" },
+  { id: "pull-to-refresh", title: "Pull to Refresh", section: "Data Display" },
   // Calendar & Date
   { id: "calendar", title: "Calendar", section: "Calendar & Date" },
   { id: "datetime-picker", title: "Datetime Picker", section: "Calendar & Date" },

--- a/apps/catalog/src/pages/pull-to-refresh.ts
+++ b/apps/catalog/src/pages/pull-to-refresh.ts
@@ -1,0 +1,62 @@
+import { registerPage } from "../registry.js";
+
+registerPage("pull-to-refresh", {
+  title: "Pull to Refresh",
+  section: "Data Display",
+  render: () => `
+    <h3>Sizes — Light</h3>
+    <div class="stack-l" style="gap: 16px;">
+      <div class="variant-col">
+        <span class="variant-label">S</span>
+        <div style="border: 1px solid var(--fd-border-minimal, #dce3e8); border-radius: 4px;">
+          <ui-pull-to-refresh active size="s"></ui-pull-to-refresh>
+        </div>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">M</span>
+        <div style="border: 1px solid var(--fd-border-minimal, #dce3e8); border-radius: 4px;">
+          <ui-pull-to-refresh active size="m"></ui-pull-to-refresh>
+        </div>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">L</span>
+        <div style="border: 1px solid var(--fd-border-minimal, #dce3e8); border-radius: 4px;">
+          <ui-pull-to-refresh active size="l"></ui-pull-to-refresh>
+        </div>
+      </div>
+    </div>
+
+    <h3>Sizes — Dark</h3>
+    <div class="stack-l" style="gap: 16px;">
+      <div class="variant-col">
+        <span class="variant-label">S</span>
+        <div style="background: #11294d; border-radius: 4px;">
+          <ui-pull-to-refresh active size="s" variant="dark"></ui-pull-to-refresh>
+        </div>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">M</span>
+        <div style="background: #11294d; border-radius: 4px;">
+          <ui-pull-to-refresh active size="m" variant="dark"></ui-pull-to-refresh>
+        </div>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">L</span>
+        <div style="background: #11294d; border-radius: 4px;">
+          <ui-pull-to-refresh active size="l" variant="dark"></ui-pull-to-refresh>
+        </div>
+      </div>
+    </div>
+
+    <h3>Custom Text</h3>
+    <div style="border: 1px solid var(--fd-border-minimal, #dce3e8); border-radius: 4px;">
+      <ui-pull-to-refresh active text="Loading data..."></ui-pull-to-refresh>
+    </div>
+
+    <h3>Inactive (Hidden)</h3>
+    <div style="border: 1px solid var(--fd-border-minimal, #dce3e8); border-radius: 4px; min-height: 60px;">
+      <ui-pull-to-refresh></ui-pull-to-refresh>
+      <p style="text-align: center; color: var(--fd-text-tertiary, #7a909e); font-size: 14px; padding: 20px;">Component is hidden when not active</p>
+    </div>
+  `,
+});

--- a/packages/ui-components/src/components/ui-pull-to-refresh.styles.ts
+++ b/packages/ui-components/src/components/ui-pull-to-refresh.styles.ts
@@ -1,0 +1,182 @@
+import { semanticVar } from "@maneki/foundation";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const TEXT_PRIMARY = semanticVar("text", "primary");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+export const STYLES = /* css */ `
+  @font-face {
+    font-family: "Material Symbols Outlined";
+    font-style: normal;
+    src: local("Material Symbols Outlined");
+  }
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 12px;
+    font-family: "Geist", sans-serif;
+    width: 100%;
+  }
+
+  :host(:not([active])) {
+    display: none;
+  }
+
+  .loading-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .spinner {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    animation: spin 1s linear infinite;
+  }
+
+  .spinner .material-symbols-outlined {
+    font-family: "Material Symbols Outlined";
+    font-weight: normal;
+    font-style: normal;
+    font-size: 20px;
+    line-height: 1;
+    letter-spacing: normal;
+    text-transform: none;
+    display: inline-block;
+    white-space: nowrap;
+    word-wrap: normal;
+    direction: ltr;
+    -webkit-font-smoothing: antialiased;
+    font-variation-settings: "FILL" 0;
+  }
+
+  /* ── Size: S ─────────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) {
+    padding: 8px;
+  }
+
+  :host([size="s"]) .loading-info {
+    gap: 6px;
+  }
+
+  :host([size="s"]) .spinner {
+    width: 16px;
+    height: 16px;
+  }
+
+  :host([size="s"]) .spinner .material-symbols-outlined {
+    font-size: 16px;
+  }
+
+  :host([size="s"]) .text {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  /* ── Size: M (default) ───────────────────────────────────────────────────── */
+
+  :host,
+  :host([size="m"]) {
+    padding: 12px;
+  }
+
+  :host .loading-info,
+  :host([size="m"]) .loading-info {
+    gap: 8px;
+  }
+
+  :host .spinner,
+  :host([size="m"]) .spinner {
+    width: 20px;
+    height: 20px;
+  }
+
+  :host .spinner .material-symbols-outlined,
+  :host([size="m"]) .spinner .material-symbols-outlined {
+    font-size: 20px;
+  }
+
+  :host .text,
+  :host([size="m"]) .text {
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  /* ── Size: L ─────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) {
+    padding: 16px;
+  }
+
+  :host([size="l"]) .loading-info {
+    gap: 10px;
+  }
+
+  :host([size="l"]) .spinner {
+    width: 24px;
+    height: 24px;
+  }
+
+  :host([size="l"]) .spinner .material-symbols-outlined {
+    font-size: 24px;
+  }
+
+  :host([size="l"]) .text {
+    font-size: 18px;
+    line-height: 28px;
+  }
+
+  /* ── Light variant (default) ─────────────────────────────────────────────── */
+
+  :host,
+  :host([variant="light"]) {
+    background: transparent;
+  }
+
+  :host .spinner,
+  :host([variant="light"]) .spinner {
+    color: ${TEXT_PRIMARY};
+  }
+
+  :host .text,
+  :host([variant="light"]) .text {
+    color: ${TEXT_PRIMARY};
+  }
+
+  /* ── Dark variant ────────────────────────────────────────────────────────── */
+
+  :host([variant="dark"]) .spinner {
+    color: #ffffff;
+  }
+
+  :host([variant="dark"]) .text {
+    color: #ffffff;
+  }
+
+  @keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .spinner {
+      animation-duration: 4s;
+    }
+  }
+`;

--- a/packages/ui-components/src/components/ui-pull-to-refresh.test.ts
+++ b/packages/ui-components/src/components/ui-pull-to-refresh.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "./ui-pull-to-refresh.js";
+import type { PullToRefreshVariant } from "./ui-pull-to-refresh.js";
+import { STYLES } from "./ui-pull-to-refresh.styles.js";
+
+describe("ui-pull-to-refresh", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-pull-to-refresh");
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-pull-to-refresh")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("applies adoptedStyleSheets", () => {
+    expect(el.shadowRoot!.adoptedStyleSheets.length).toBe(1);
+  });
+
+  // ── Default rendering ─────────────────────────────────────────────────────
+
+  it("renders a .loading-info container", () => {
+    const info = el.shadowRoot!.querySelector(".loading-info");
+    expect(info).not.toBeNull();
+  });
+
+  it("renders a .spinner element", () => {
+    const spinner = el.shadowRoot!.querySelector(".spinner");
+    expect(spinner).not.toBeNull();
+  });
+
+  it("renders a .text element", () => {
+    const text = el.shadowRoot!.querySelector(".text");
+    expect(text).not.toBeNull();
+  });
+
+  it("renders a material-symbols-outlined icon inside spinner", () => {
+    const icon = el.shadowRoot!.querySelector(".spinner .material-symbols-outlined");
+    expect(icon).not.toBeNull();
+  });
+
+  it("spinner icon contains the progress_activity codepoint", () => {
+    const icon = el.shadowRoot!.querySelector(".spinner .material-symbols-outlined");
+    expect(icon!.textContent).toBeTruthy();
+  });
+
+  it("default text is 'Refreshing content'", () => {
+    const text = el.shadowRoot!.querySelector(".text");
+    expect(text!.textContent).toBe("Refreshing content");
+  });
+
+  // ── Active attribute ──────────────────────────────────────────────────────
+
+  it("is hidden when no active attribute is set", () => {
+    expect(el.hasAttribute("active")).toBe(false);
+  });
+
+  it("is visible when active attribute is set", () => {
+    el.setAttribute("active", "");
+    expect(el.hasAttribute("active")).toBe(true);
+  });
+
+  it("active property getter returns false by default", () => {
+    expect((el as any).active).toBe(false);
+  });
+
+  it("active property getter returns true when attribute is set", () => {
+    el.setAttribute("active", "");
+    expect((el as any).active).toBe(true);
+  });
+
+  it("active property setter adds the attribute", () => {
+    (el as any).active = true;
+    expect(el.hasAttribute("active")).toBe(true);
+  });
+
+  it("active property setter removes the attribute", () => {
+    el.setAttribute("active", "");
+    (el as any).active = false;
+    expect(el.hasAttribute("active")).toBe(false);
+  });
+
+  // ── Variant attribute ─────────────────────────────────────────────────────
+
+  it("defaults to light variant", () => {
+    expect((el as any).variant).toBe("light");
+  });
+
+  it("reflects variant attribute via property getter", () => {
+    el.setAttribute("variant", "dark");
+    expect((el as any).variant).toBe("dark");
+  });
+
+  it("variant property setter updates the attribute", () => {
+    (el as any).variant = "dark";
+    expect(el.getAttribute("variant")).toBe("dark");
+  });
+
+  it("variant property setter sets light", () => {
+    (el as any).variant = "light" as PullToRefreshVariant;
+    expect(el.getAttribute("variant")).toBe("light");
+  });
+
+  // ── Text attribute ────────────────────────────────────────────────────────
+
+  it("default text property is 'Refreshing content'", () => {
+    expect((el as any).text).toBe("Refreshing content");
+  });
+
+  it("text attribute updates the displayed text", () => {
+    el.setAttribute("text", "Loading data...");
+    const text = el.shadowRoot!.querySelector(".text");
+    expect(text!.textContent).toBe("Loading data...");
+  });
+
+  it("text property getter reflects the attribute", () => {
+    el.setAttribute("text", "Please wait");
+    expect((el as any).text).toBe("Please wait");
+  });
+
+  it("text property setter updates the attribute", () => {
+    (el as any).text = "Syncing";
+    expect(el.getAttribute("text")).toBe("Syncing");
+  });
+
+  it("text property setter updates the displayed text", () => {
+    (el as any).text = "Syncing";
+    const text = el.shadowRoot!.querySelector(".text");
+    expect(text!.textContent).toBe("Syncing");
+  });
+
+  it("removing text attribute resets to default", () => {
+    el.setAttribute("text", "Custom");
+    el.removeAttribute("text");
+    const text = el.shadowRoot!.querySelector(".text");
+    expect(text!.textContent).toBe("Refreshing content");
+  });
+
+  // ── ARIA ──────────────────────────────────────────────────────────────────
+
+  it("sets role=status on connectedCallback", () => {
+    expect(el.getAttribute("role")).toBe("status");
+  });
+
+  it("sets aria-live=polite on connectedCallback", () => {
+    expect(el.getAttribute("aria-live")).toBe("polite");
+  });
+
+  // ── observedAttributes ────────────────────────────────────────────────────
+
+  it("observes active, variant, and text attributes", () => {
+    const Ctor = customElements.get("ui-pull-to-refresh") as any;
+    expect(Ctor.observedAttributes).toEqual(["active", "variant", "text", "size"]);
+  });
+
+  // ── STYLES ────────────────────────────────────────────────────────────────
+
+  it("STYLES contains @keyframes spin", () => {
+    expect(STYLES).toContain("@keyframes spin");
+  });
+
+  it("STYLES contains :host(:not([active])) hide rule", () => {
+    expect(STYLES).toContain(":host(:not([active]))");
+    expect(STYLES).toContain("display: none");
+  });
+
+  it("STYLES contains light variant rules", () => {
+    expect(STYLES).toContain(':host([variant="light"])');
+  });
+
+  it("STYLES contains dark variant rules", () => {
+    expect(STYLES).toContain(':host([variant="dark"])');
+  });
+
+  it("STYLES contains prefers-reduced-motion media query", () => {
+    expect(STYLES).toContain("prefers-reduced-motion: reduce");
+  });
+
+  it("STYLES contains .loading-info styles", () => {
+    expect(STYLES).toContain(".loading-info");
+  });
+
+  it("STYLES contains .spinner styles", () => {
+    expect(STYLES).toContain(".spinner");
+  });
+
+  it("STYLES contains .text styles", () => {
+    expect(STYLES).toContain(".text");
+  });
+});

--- a/packages/ui-components/src/components/ui-pull-to-refresh.ts
+++ b/packages/ui-components/src/components/ui-pull-to-refresh.ts
@@ -1,0 +1,94 @@
+import { STYLES } from "./ui-pull-to-refresh.styles.js";
+import { ICON_PROGRESS_ACTIVITY } from "@maneki/foundation";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type PullToRefreshVariant = "light" | "dark";
+export type PullToRefreshSize = "s" | "m" | "l";
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiPullToRefresh extends HTMLElement {
+  static readonly observedAttributes = ["active", "variant", "text", "size"];
+
+  #spinner!: HTMLElement;
+  #textEl!: HTMLElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    const loadingInfo = document.createElement("div");
+    loadingInfo.className = "loading-info";
+
+    // Spinner
+    this.#spinner = document.createElement("span");
+    this.#spinner.className = "spinner";
+    const icon = document.createElement("span");
+    icon.className = "material-symbols-outlined";
+    icon.textContent = ICON_PROGRESS_ACTIVITY;
+    this.#spinner.appendChild(icon);
+
+    // Text
+    this.#textEl = document.createElement("span");
+    this.#textEl.className = "text";
+    this.#textEl.textContent = "Refreshing content";
+
+    loadingInfo.append(this.#spinner, this.#textEl);
+    shadow.appendChild(loadingInfo);
+  }
+
+  connectedCallback(): void {
+    this.setAttribute("role", "status");
+    this.setAttribute("aria-live", "polite");
+  }
+
+  attributeChangedCallback(
+    name: string,
+    _oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    switch (name) {
+      case "text":
+        this.#textEl.textContent = newValue ?? "Refreshing content";
+        break;
+    }
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get active(): boolean {
+    return this.hasAttribute("active");
+  }
+  set active(v: boolean) {
+    if (v) this.setAttribute("active", "");
+    else this.removeAttribute("active");
+  }
+
+  get variant(): PullToRefreshVariant {
+    return (this.getAttribute("variant") as PullToRefreshVariant) ?? "light";
+  }
+  set variant(v: PullToRefreshVariant) {
+    this.setAttribute("variant", v);
+  }
+
+  get text(): string {
+    return this.getAttribute("text") ?? "Refreshing content";
+  }
+  set text(v: string) {
+    this.setAttribute("text", v);
+  }
+
+  get size(): PullToRefreshSize {
+    return (this.getAttribute("size") as PullToRefreshSize) ?? "m";
+  }
+  set size(v: PullToRefreshSize) {
+    this.setAttribute("size", v);
+  }
+}
+
+customElements.define("ui-pull-to-refresh", UiPullToRefresh);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -191,3 +191,8 @@ export { UiProgressBar } from "./components/ui-progress-bar.js";
 export type { ProgressBarSize, ProgressBarLabel, ProgressStatus } from "./components/ui-progress-bar.js";
 export { UiProgressCircle } from "./components/ui-progress-circle.js";
 export type { ProgressCircleSize, ProgressCircleLabelPosition } from "./components/ui-progress-circle.js";
+
+// ─── Pull to Refresh ──────────────────────────────────────────────────────────
+
+export { UiPullToRefresh } from "./components/ui-pull-to-refresh.js";
+export type { PullToRefreshVariant, PullToRefreshSize } from "./components/ui-pull-to-refresh.js";

--- a/packages/ui-components/src/stories/ui-pull-to-refresh.stories.ts
+++ b/packages/ui-components/src/stories/ui-pull-to-refresh.stories.ts
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-pull-to-refresh.js";
+
+const meta: Meta = {
+  title: "Components/Pull To Refresh",
+  component: "ui-pull-to-refresh",
+  argTypes: {
+    active: {
+      control: { type: "boolean" },
+    },
+    variant: {
+      control: { type: "select" },
+      options: ["light", "dark"],
+    },
+    text: {
+      control: { type: "text" },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  args: {
+    active: true,
+    variant: "light",
+    text: "Refreshing content",
+  },
+  render: (args) =>
+    html`<ui-pull-to-refresh
+      ?active=${args.active}
+      variant=${args.variant}
+      text=${args.text}
+    ></ui-pull-to-refresh>`,
+};
+
+export const Dark: Story = {
+  args: {
+    active: true,
+    variant: "dark",
+    text: "Refreshing content",
+  },
+  render: (args) =>
+    html`<div
+      style="background: #1c2b36; padding: 24px; border-radius: 8px;"
+    >
+      <ui-pull-to-refresh
+        ?active=${args.active}
+        variant=${args.variant}
+        text=${args.text}
+      ></ui-pull-to-refresh>
+    </div>`,
+};
+
+export const CustomText: Story = {
+  args: {
+    active: true,
+    variant: "light",
+    text: "Loading data...",
+  },
+  render: (args) =>
+    html`<ui-pull-to-refresh
+      ?active=${args.active}
+      variant=${args.variant}
+      text=${args.text}
+    ></ui-pull-to-refresh>`,
+};
+
+export const Inactive: Story = {
+  args: {
+    active: false,
+    variant: "light",
+    text: "Refreshing content",
+  },
+  render: (args) =>
+    html`<ui-pull-to-refresh
+      variant=${args.variant}
+      text=${args.text}
+    ></ui-pull-to-refresh>`,
+};


### PR DESCRIPTION
## Summary

New `<ui-pull-to-refresh>` Web Component — a loading indicator bar with spinning icon and text label.

## Features

- 2 variants: `light` (dark text on transparent bg) and `dark` (white text for dark backgrounds)
- `active` boolean attribute to show/hide the component
- Customizable text via `text` attribute (default: "Refreshing content")
- CSS `@keyframes spin` animation with `prefers-reduced-motion` support
- ARIA: `role="status"`, `aria-live="polite"`

## API

```html
<ui-pull-to-refresh active variant="light" text="Refreshing content"></ui-pull-to-refresh>
<ui-pull-to-refresh active variant="dark"></ui-pull-to-refresh>
```

## Testing

- 2734 unit tests (36 new)
- Storybook stories (light, dark, custom text, inactive)
- 44 Playwright visual regression tests (1 new)

## Files

- `packages/ui-components/src/components/ui-pull-to-refresh.ts` + `ui-pull-to-refresh.styles.ts`
- `packages/ui-components/src/components/ui-pull-to-refresh.test.ts`
- `packages/ui-components/src/stories/ui-pull-to-refresh.stories.ts`
- `packages/ui-components/src/index.ts` — barrel exports
- `apps/catalog/src/pages/pull-to-refresh.ts` — catalog page