### PR TITLE
feat(ui-components): add ui-queryfield-tag and ui-queryfield components

### DIFF
--- a/apps/catalog/e2e/visual.spec.ts
+++ b/apps/catalog/e2e/visual.spec.ts
@@ -24,6 +24,7 @@ const pages = [
   "textarea",
   "file-upload",
   "select",
+  "queryfield",
   "card",
   "breadcrumb",
   "accordion",

--- a/apps/catalog/src/main.ts
+++ b/apps/catalog/src/main.ts
@@ -42,6 +42,7 @@ const pageLoaders: Record<string, () => Promise<unknown>> = {
   "textarea": () => import("./pages/textarea.js"),
   "file-upload": () => import("./pages/file-upload.js"),
   "select": () => import("./pages/select.js"),
+  "queryfield": () => import("./pages/queryfield.js"),
   "card": () => import("./pages/card.js"),
   "breadcrumb": () => import("./pages/breadcrumb.js"),
   "accordion": () => import("./pages/accordion.js"),

--- a/apps/catalog/src/manifest.ts
+++ b/apps/catalog/src/manifest.ts
@@ -48,6 +48,7 @@ export const manifest: PageMeta[] = [
   { id: "textarea", title: "Textarea", section: "Form Controls" },
   { id: "file-upload", title: "File Upload", section: "Form Controls" },
   { id: "select", title: "Select", section: "Form Controls" },
+  { id: "queryfield", title: "Queryfield", section: "Form Controls" },
   // Containers
   { id: "card", title: "Card", section: "Containers" },
   { id: "carousel", title: "Carousel", section: "Containers" },

--- a/apps/catalog/src/pages/queryfield.ts
+++ b/apps/catalog/src/pages/queryfield.ts
@@ -1,0 +1,106 @@
+import { registerPage } from "../registry.js";
+
+registerPage("queryfield", {
+  title: "Queryfield",
+  section: "Form Controls",
+  render: () => `
+    <h3>Interactive (click input to try)</h3>
+    <p style="font-size: 13px; color: var(--fd-text-tertiary, #7a909e); margin: 0 0 8px;">Pick from suggestions, type custom values + Enter, click tags to edit, X to dismiss</p>
+    <div class="stack-l" style="gap: 16px; max-width: 600px;">
+      <ui-queryfield id="interactive-qf" size="m" placeholder="Click to add filters...">
+        <ui-queryfield-tag slot="tags" category="CITY" expression="equals London or Mumbai" filter-name="city" operator="equals" values="London,Mumbai"></ui-queryfield-tag>
+        <ui-queryfield-tag slot="tags" category="TITLE" expression="contains VP" filter-name="title" operator="contains" values="VP"></ui-queryfield-tag>
+      </ui-queryfield>
+    </div>
+
+    <h3>Queryfield Tag — Sizes</h3>
+    <div class="stack-l" style="gap: 16px;">
+      <div class="variant-col">
+        <span class="variant-label">S</span>
+        <ui-queryfield-tag size="s" category="CITY" expression="equals London or Bengaluru"></ui-queryfield-tag>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">M</span>
+        <ui-queryfield-tag size="m" category="CITY" expression="equals London or Bengaluru"></ui-queryfield-tag>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">L</span>
+        <ui-queryfield-tag size="l" category="CITY" expression="equals London or Bengaluru"></ui-queryfield-tag>
+      </div>
+    </div>
+
+    <h3>Queryfield — Sizes</h3>
+    <div class="stack-l" style="gap: 16px; max-width: 600px;">
+      <div class="variant-col">
+        <span class="variant-label">S</span>
+        <ui-queryfield size="s" placeholder="Search...">
+          <ui-queryfield-tag slot="tags" category="CITY" expression="equals London"></ui-queryfield-tag>
+        </ui-queryfield>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">M</span>
+        <ui-queryfield size="m" placeholder="Search...">
+          <ui-queryfield-tag slot="tags" category="CITY" expression="equals London or Bengaluru"></ui-queryfield-tag>
+          <ui-queryfield-tag slot="tags" category="STATUS" expression="equals Active"></ui-queryfield-tag>
+        </ui-queryfield>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">L</span>
+        <ui-queryfield size="l" placeholder="Search...">
+          <ui-queryfield-tag slot="tags" category="CITY" expression="equals London or Bengaluru"></ui-queryfield-tag>
+          <ui-queryfield-tag slot="tags" category="ROLE" expression="contains Manager"></ui-queryfield-tag>
+        </ui-queryfield>
+      </div>
+    </div>
+
+    <h3>Queryfield — Empty</h3>
+    <div class="stack-l" style="gap: 16px; max-width: 600px;">
+      <ui-queryfield size="m" placeholder="Type to search or add filters..."></ui-queryfield>
+    </div>
+
+    <h3>Queryfield — Disabled</h3>
+    <div class="stack-l" style="gap: 16px; max-width: 600px;">
+      <ui-queryfield size="m" placeholder="Search..." disabled>
+        <ui-queryfield-tag slot="tags" category="CITY" expression="equals London"></ui-queryfield-tag>
+      </ui-queryfield>
+    </div>
+
+    <h3>Queryfield — Multiple Tags</h3>
+    <div class="stack-l" style="gap: 16px; max-width: 600px;">
+      <ui-queryfield size="m" placeholder="Add more filters...">
+        <ui-queryfield-tag slot="tags" category="CITY" expression="equals London or Bengaluru"></ui-queryfield-tag>
+        <ui-queryfield-tag slot="tags" category="STATUS" expression="equals Active"></ui-queryfield-tag>
+        <ui-queryfield-tag slot="tags" category="ROLE" expression="contains Manager"></ui-queryfield-tag>
+        <ui-queryfield-tag slot="tags" category="DEPT" expression="equals Engineering"></ui-queryfield-tag>
+      </ui-queryfield>
+    </div>
+  `,
+  setup: () => {
+    const qf = document.getElementById("interactive-qf") as HTMLElement & { filters: Array<{ name: string; label: string; operators: string[]; values: string[] }> };
+    if (!qf) return;
+    qf.filters = [
+      { name: "city", label: "City", operators: ["equals", "not", "contains"], values: ["London", "Bengaluru", "New York", "Tokyo"] },
+      { name: "title", label: "Title", operators: ["equals", "contains", "starts with"], values: ["Vice President", "Managing Director", "Associate", "Analyst"] },
+      { name: "age", label: "Age", operators: ["equals", "not"], values: ["25", "30", "35", "40", "45"] },
+      { name: "name", label: "Name", operators: ["equals", "contains", "starts with"], values: ["Jess Smith", "John Doe", "Jane Roe"] },
+    ];
+
+    // Wire up dismiss on pre-existing tags
+    qf.querySelectorAll("ui-queryfield-tag").forEach((tag) => {
+      tag.addEventListener("dismiss", () => tag.remove());
+    });
+
+    qf.addEventListener("queryfield-filter-add", ((e: CustomEvent) => {
+      const { filter, operator, values } = e.detail;
+      const tag = document.createElement("ui-queryfield-tag");
+      tag.setAttribute("slot", "tags");
+      tag.setAttribute("category", filter.toUpperCase());
+      tag.setAttribute("expression", `${operator} ${values.join(" or ")}`);
+      tag.setAttribute("filter-name", filter);
+      tag.setAttribute("operator", operator);
+      tag.setAttribute("values", values.join(","));
+      tag.addEventListener("dismiss", () => tag.remove());
+      qf.appendChild(tag);
+    }) as EventListener);
+  },
+});

--- a/packages/ui-components/src/components/ui-queryfield-tag.styles.ts
+++ b/packages/ui-components/src/components/ui-queryfield-tag.styles.ts
@@ -1,0 +1,199 @@
+import { semanticVar } from "@maneki/foundation";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const TAG_SUBTLE_BG = semanticVar("tag", "subtle");
+const TAG_TEXT_SUBTLE = semanticVar("tag", "textSubtle");
+const TEXT_SECONDARY = semanticVar("text", "secondary");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+export const TAG_STYLES = /* css */ `
+  @font-face {
+    font-family: "Material Symbols Outlined";
+    font-style: normal;
+    src: local("Material Symbols Outlined");
+  }
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: inline-flex;
+    align-items: center;
+    font-family: "Geist", sans-serif;
+  }
+
+  .category {
+    display: flex;
+    align-items: center;
+    background: ${TAG_SUBTLE_BG};
+    border: 1px solid ${TAG_SUBTLE_BG};
+    border-right: none;
+    border-radius: 200px 0 0 200px;
+    color: ${TAG_TEXT_SUBTLE};
+    text-transform: uppercase;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .value {
+    display: flex;
+    align-items: center;
+    background: transparent;
+    border: 1px solid ${TAG_SUBTLE_BG};
+    border-left: none;
+    border-radius: 0 200px 200px 0;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  /* Editing state */
+  :host([editing]) .category {
+    background: ${TAG_TEXT_SUBTLE};
+    border-color: ${TAG_TEXT_SUBTLE};
+    color: #ffffff;
+  }
+
+  :host([editing]) .value {
+    border-color: ${TAG_TEXT_SUBTLE};
+  }
+
+  .value-text {
+    display: inline;
+  }
+
+  .operator {
+    display: inline;
+    font-weight: 500;
+    color: ${TEXT_SECONDARY};
+  }
+
+  .filter-value {
+    display: inline;
+    font-weight: 400;
+    color: ${TAG_TEXT_SUBTLE};
+  }
+
+  .conjunction {
+    display: inline;
+    font-weight: 400;
+    color: ${TEXT_SECONDARY};
+  }
+
+  .dismiss {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    padding: 0;
+    cursor: pointer;
+    color: ${TEXT_SECONDARY};
+    flex-shrink: 0;
+  }
+
+  .dismiss .material-symbols-outlined {
+    font-family: "Material Symbols Outlined";
+    font-weight: normal;
+    font-style: normal;
+    line-height: 1;
+    letter-spacing: normal;
+    text-transform: none;
+    display: inline-block;
+    white-space: nowrap;
+    word-wrap: normal;
+    direction: ltr;
+    -webkit-font-smoothing: antialiased;
+    font-variation-settings: "FILL" 1;
+  }
+
+  /* ── Size: S ─────────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) .category {
+    padding: 0 8px;
+    font-size: 11px;
+    line-height: 16px;
+  }
+
+  :host([size="s"]) .value {
+    padding: 0 6px;
+    gap: 2px;
+  }
+
+  :host([size="s"]) .value-text {
+    font-size: 11px;
+    line-height: 16px;
+  }
+
+  :host([size="s"]) .dismiss {
+    width: 12px;
+    height: 12px;
+  }
+
+  :host([size="s"]) .dismiss .material-symbols-outlined {
+    font-size: 12px;
+  }
+
+  /* ── Size: M (default) ───────────────────────────────────────────────────── */
+
+  :host .category,
+  :host([size="m"]) .category {
+    padding: 2px 12px;
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  :host .value,
+  :host([size="m"]) .value {
+    padding: 2px 8px;
+    gap: 4px;
+  }
+
+  :host .value-text,
+  :host([size="m"]) .value-text {
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  :host .dismiss,
+  :host([size="m"]) .dismiss {
+    width: 12px;
+    height: 12px;
+  }
+
+  :host .dismiss .material-symbols-outlined,
+  :host([size="m"]) .dismiss .material-symbols-outlined {
+    font-size: 12px;
+  }
+
+  /* ── Size: L ─────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) .category {
+    padding: 2px 12px;
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  :host([size="l"]) .value {
+    padding: 2px 8px;
+    gap: 4px;
+  }
+
+  :host([size="l"]) .value-text {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  :host([size="l"]) .dismiss {
+    width: 12px;
+    height: 12px;
+  }
+
+  :host([size="l"]) .dismiss .material-symbols-outlined {
+    font-size: 12px;
+  }
+`;

--- a/packages/ui-components/src/components/ui-queryfield-tag.test.ts
+++ b/packages/ui-components/src/components/ui-queryfield-tag.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import "./ui-queryfield-tag.js";
+import type { QueryfieldTagSize } from "./ui-queryfield-tag.js";
+import { TAG_STYLES } from "./ui-queryfield-tag.styles.js";
+
+describe("ui-queryfield-tag", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-queryfield-tag");
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-queryfield-tag")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("applies adoptedStyleSheets", () => {
+    expect(el.shadowRoot!.adoptedStyleSheets.length).toBe(1);
+  });
+
+  it("exports TAG_STYLES string", () => {
+    expect(typeof TAG_STYLES).toBe("string");
+    expect(TAG_STYLES.length).toBeGreaterThan(0);
+  });
+
+  // ── Default rendering ─────────────────────────────────────────────────────
+
+  it("renders a .category element", () => {
+    const cat = el.shadowRoot!.querySelector(".category");
+    expect(cat).not.toBeNull();
+  });
+
+  it("renders a .value element", () => {
+    const val = el.shadowRoot!.querySelector(".value");
+    expect(val).not.toBeNull();
+  });
+
+  it("renders a .value-text element", () => {
+    const vt = el.shadowRoot!.querySelector(".value-text");
+    expect(vt).not.toBeNull();
+  });
+
+  it("renders a dismiss button", () => {
+    const btn = el.shadowRoot!.querySelector("button.dismiss");
+    expect(btn).not.toBeNull();
+  });
+
+  it("dismiss button has aria-label", () => {
+    const btn = el.shadowRoot!.querySelector("button.dismiss") as HTMLButtonElement;
+    expect(btn.getAttribute("aria-label")).toBe("Remove filter");
+  });
+
+  it("dismiss button has type=button", () => {
+    const btn = el.shadowRoot!.querySelector("button.dismiss") as HTMLButtonElement;
+    expect(btn.type).toBe("button");
+  });
+
+  it("defaults size to m", () => {
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  // ── observedAttributes ─────────────────────────────────────────────────────
+
+  it("observes size, category, expression", () => {
+    const Ctor = customElements.get("ui-queryfield-tag") as unknown as {
+      observedAttributes: string[];
+    };
+    expect(Ctor.observedAttributes).toEqual(["size", "category", "expression", "filter-name", "operator", "values"]);
+  });
+
+  // ── Attributes: size ──────────────────────────────────────────────────────
+
+  it("reflects size=s as attribute", () => {
+    el.setAttribute("size", "s");
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("reflects size=m as attribute", () => {
+    el.setAttribute("size", "m");
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("reflects size=l as attribute", () => {
+    el.setAttribute("size", "l");
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  // ── Attributes: category ──────────────────────────────────────────────────
+
+  it("renders category text from attribute", () => {
+    el.setAttribute("category", "City");
+    const cat = el.shadowRoot!.querySelector(".category");
+    expect(cat!.textContent).toBe("City");
+  });
+
+  it("clears category text when attribute removed", () => {
+    el.setAttribute("category", "City");
+    el.removeAttribute("category");
+    const cat = el.shadowRoot!.querySelector(".category");
+    expect(cat!.textContent).toBe("");
+  });
+
+  // ── Attributes: expression ────────────────────────────────────────────────
+
+  it("renders expression text from attribute", () => {
+    el.setAttribute("expression", "equals London");
+    const vt = el.shadowRoot!.querySelector(".value-text");
+    expect(vt!.textContent!.trim()).toBe("equals London");
+  });
+
+  it("clears expression when attribute removed", () => {
+    el.setAttribute("expression", "equals London");
+    el.removeAttribute("expression");
+    const vt = el.shadowRoot!.querySelector(".value-text");
+    expect(vt!.textContent!.trim()).toBe("");
+  });
+
+  // ── Property accessors ────────────────────────────────────────────────────
+
+  it("size getter returns current attribute", () => {
+    el.setAttribute("size", "l");
+    expect((el as unknown as { size: QueryfieldTagSize }).size).toBe("l");
+  });
+
+  it("size setter updates attribute", () => {
+    (el as unknown as { size: QueryfieldTagSize }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("category getter returns current attribute", () => {
+    el.setAttribute("category", "Status");
+    expect((el as unknown as { category: string }).category).toBe("Status");
+  });
+
+  it("category setter updates attribute", () => {
+    (el as unknown as { category: string }).category = "Region";
+    expect(el.getAttribute("category")).toBe("Region");
+  });
+
+  it("expression getter returns current attribute", () => {
+    el.setAttribute("expression", "contains foo");
+    expect((el as unknown as { expression: string }).expression).toBe(
+      "contains foo",
+    );
+  });
+
+  it("expression setter updates attribute", () => {
+    (el as unknown as { expression: string }).expression = "not bar";
+    expect(el.getAttribute("expression")).toBe("not bar");
+  });
+
+  it("category getter defaults to empty string", () => {
+    expect((el as unknown as { category: string }).category).toBe("");
+  });
+
+  it("expression getter defaults to empty string", () => {
+    expect((el as unknown as { expression: string }).expression).toBe("");
+  });
+
+  // ── Expression parsing ────────────────────────────────────────────────────
+
+  it("parses operator 'equals' with .operator class", () => {
+    el.setAttribute("expression", "equals London");
+    const ops = el.shadowRoot!.querySelectorAll(".operator");
+    expect(ops.length).toBe(1);
+    expect(ops[0].textContent!.trim()).toBe("equals");
+  });
+
+  it("parses operator 'contains' with .operator class", () => {
+    el.setAttribute("expression", "contains test");
+    const ops = el.shadowRoot!.querySelectorAll(".operator");
+    expect(ops.length).toBe(1);
+    expect(ops[0].textContent!.trim()).toBe("contains");
+  });
+
+  it("parses multi-word operator 'starts with'", () => {
+    el.setAttribute("expression", "starts with foo");
+    const ops = el.shadowRoot!.querySelectorAll(".operator");
+    expect(ops.length).toBe(1);
+    expect(ops[0].textContent!.trim()).toBe("starts with");
+  });
+
+  it("parses multi-word operator 'ends with'", () => {
+    el.setAttribute("expression", "ends with bar");
+    const ops = el.shadowRoot!.querySelectorAll(".operator");
+    expect(ops.length).toBe(1);
+    expect(ops[0].textContent!.trim()).toBe("ends with");
+  });
+
+  it("parses operator 'not'", () => {
+    el.setAttribute("expression", "not baz");
+    const ops = el.shadowRoot!.querySelectorAll(".operator");
+    expect(ops.length).toBe(1);
+    expect(ops[0].textContent!.trim()).toBe("not");
+  });
+
+  it("parses values with .filter-value class", () => {
+    el.setAttribute("expression", "equals London");
+    const vals = el.shadowRoot!.querySelectorAll(".filter-value");
+    expect(vals.length).toBe(1);
+    expect(vals[0].textContent!.trim()).toBe("London");
+  });
+
+  it("parses conjunction 'or' with .conjunction class", () => {
+    el.setAttribute("expression", "equals London or Bengaluru");
+    const conj = el.shadowRoot!.querySelectorAll(".conjunction");
+    expect(conj.length).toBe(1);
+    expect(conj[0].textContent!.trim()).toBe("or");
+  });
+
+  it("parses conjunction 'and' with .conjunction class", () => {
+    el.setAttribute("expression", "equals A and B");
+    const conj = el.shadowRoot!.querySelectorAll(".conjunction");
+    expect(conj.length).toBe(1);
+    expect(conj[0].textContent!.trim()).toBe("and");
+  });
+
+  it("parses complex expression with operator, values, and conjunction", () => {
+    el.setAttribute("expression", "equals London or Bengaluru");
+    const vt = el.shadowRoot!.querySelector(".value-text")!;
+    const children = vt.children;
+    expect(children.length).toBe(4);
+    expect(children[0].className).toBe("operator");
+    expect(children[1].className).toBe("filter-value");
+    expect(children[2].className).toBe("conjunction");
+    expect(children[3].className).toBe("filter-value");
+  });
+
+  it("re-renders expression when attribute changes", () => {
+    el.setAttribute("expression", "equals A");
+    expect(el.shadowRoot!.querySelectorAll(".filter-value").length).toBe(1);
+    el.setAttribute("expression", "equals A or B");
+    expect(el.shadowRoot!.querySelectorAll(".filter-value").length).toBe(2);
+  });
+
+  // ── Dismiss event ─────────────────────────────────────────────────────────
+
+  it("dispatches dismiss event on button click", () => {
+    const handler = vi.fn();
+    el.addEventListener("dismiss", handler);
+    const btn = el.shadowRoot!.querySelector("button.dismiss") as HTMLButtonElement;
+    btn.click();
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("dismiss event bubbles", () => {
+    const handler = vi.fn();
+    document.body.addEventListener("dismiss", handler);
+    const btn = el.shadowRoot!.querySelector("button.dismiss") as HTMLButtonElement;
+    btn.click();
+    expect(handler).toHaveBeenCalledOnce();
+    document.body.removeEventListener("dismiss", handler);
+  });
+
+  it("dismiss event is composed", () => {
+    let composed = false;
+    el.addEventListener("dismiss", (e) => {
+      composed = e.composed;
+    });
+    const btn = el.shadowRoot!.querySelector("button.dismiss") as HTMLButtonElement;
+    btn.click();
+    expect(composed).toBe(true);
+  });
+});

--- a/packages/ui-components/src/components/ui-queryfield-tag.ts
+++ b/packages/ui-components/src/components/ui-queryfield-tag.ts
@@ -1,0 +1,185 @@
+import { TAG_STYLES } from "./ui-queryfield-tag.styles.js";
+import { ICON_CANCEL } from "@maneki/foundation";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type QueryfieldTagSize = "s" | "m" | "l";
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(TAG_STYLES);
+
+export class UiQueryfieldTag extends HTMLElement {
+  static readonly observedAttributes = ["size", "category", "expression", "filter-name", "operator", "values"];
+
+  #categoryEl!: HTMLElement;
+  #valueText!: HTMLElement;
+  #dismissBtn!: HTMLButtonElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    // Category (left pill)
+    this.#categoryEl = document.createElement("span");
+    this.#categoryEl.className = "category";
+
+    // Value (right pill)
+    const value = document.createElement("span");
+    value.className = "value";
+
+    this.#valueText = document.createElement("span");
+    this.#valueText.className = "value-text";
+
+    // Dismiss button
+    this.#dismissBtn = document.createElement("button");
+    this.#dismissBtn.className = "dismiss";
+    this.#dismissBtn.type = "button";
+    this.#dismissBtn.setAttribute("aria-label", "Remove filter");
+    const icon = document.createElement("span");
+    icon.className = "material-symbols-outlined";
+    icon.textContent = ICON_CANCEL;
+    this.#dismissBtn.appendChild(icon);
+
+    value.append(this.#valueText, this.#dismissBtn);
+    shadow.append(this.#categoryEl, value);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("size")) this.setAttribute("size", "m");
+    this.#dismissBtn.addEventListener("click", (e) => { e.stopPropagation(); this._dismiss(); });
+    this.addEventListener("click", () => this._edit());
+  }
+
+  attributeChangedCallback(
+    name: string,
+    _oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    switch (name) {
+      case "category":
+        this.#categoryEl.textContent = newValue ?? "";
+        break;
+      case "expression":
+        this._renderExpression(newValue ?? "");
+        break;
+    }
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): QueryfieldTagSize {
+    return (this.getAttribute("size") as QueryfieldTagSize) ?? "m";
+  }
+  set size(v: QueryfieldTagSize) {
+    this.setAttribute("size", v);
+  }
+
+  get category(): string {
+    return this.getAttribute("category") ?? "";
+  }
+  set category(v: string) {
+    this.setAttribute("category", v);
+  }
+
+  get expression(): string {
+    return this.getAttribute("expression") ?? "";
+  }
+  set expression(v: string) {
+    this.setAttribute("expression", v);
+  }
+
+  get filterName(): string {
+    return this.getAttribute("filter-name") ?? "";
+  }
+  set filterName(v: string) {
+    this.setAttribute("filter-name", v);
+  }
+
+  get operator(): string {
+    return this.getAttribute("operator") ?? "";
+  }
+  set operator(v: string) {
+    this.setAttribute("operator", v);
+  }
+
+  get values(): string[] {
+    const raw = this.getAttribute("values");
+    if (!raw) return [];
+    return raw.split(",").map((s) => s.trim()).filter(Boolean);
+  }
+  set values(v: string[]) {
+    this.setAttribute("values", v.join(","));
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private _renderExpression(expr: string): void {
+    this.#valueText.innerHTML = "";
+
+    // Parse expression: "equals London or Bengaluru"
+    // Operators: equals, contains, starts with, ends with, not, and, or
+    const operators = ["equals", "contains", "starts with", "ends with", "not"];
+    const conjunctions = ["or", "and"];
+    const words = expr.split(/\s+/);
+    let i = 0;
+
+    while (i < words.length) {
+      // Check for multi-word operators
+      const twoWord = words.slice(i, i + 2).join(" ").toLowerCase();
+      const oneWord = words[i].toLowerCase();
+
+      if (operators.includes(twoWord)) {
+        const span = document.createElement("span");
+        span.className = "operator";
+        span.textContent = words.slice(i, i + 2).join(" ") + " ";
+        this.#valueText.appendChild(span);
+        i += 2;
+      } else if (operators.includes(oneWord)) {
+        const span = document.createElement("span");
+        span.className = "operator";
+        span.textContent = words[i] + " ";
+        this.#valueText.appendChild(span);
+        i++;
+      } else if (conjunctions.includes(oneWord)) {
+        const span = document.createElement("span");
+        span.className = "conjunction";
+        span.textContent = words[i] + " ";
+        this.#valueText.appendChild(span);
+        i++;
+      } else {
+        const span = document.createElement("span");
+        span.className = "filter-value";
+        span.textContent = words[i] + " ";
+        this.#valueText.appendChild(span);
+        i++;
+      }
+    }
+  }
+
+  private _dismiss(): void {
+    this.dispatchEvent(
+      new CustomEvent("dismiss", { bubbles: true, composed: true }),
+    );
+  }
+
+  private _edit(): void {
+    this.dispatchEvent(
+      new CustomEvent("tag-edit", {
+        detail: {
+          tag: this,
+          filterName: this.filterName,
+          operator: this.operator,
+          values: this.values,
+        },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+}
+
+
+customElements.define("ui-queryfield-tag", UiQueryfieldTag);

--- a/packages/ui-components/src/components/ui-queryfield.styles.ts
+++ b/packages/ui-components/src/components/ui-queryfield.styles.ts
@@ -1,0 +1,249 @@
+import { semanticVar } from "@maneki/foundation";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const TEXT_SECONDARY = semanticVar("text", "secondary");
+const TEXT_TERTIARY = semanticVar("text", "tertiary");
+const BORDER_MODERATE = semanticVar("border", "moderate");
+const SURFACE_PRIMARY = semanticVar("surface", "primary");
+const ICON_SECONDARY = semanticVar("icon", "secondary");
+const HOVER_BORDER = semanticVar("stateHover", "borderModerate");
+const FOCUS_BORDER = semanticVar("border", "focus");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+export const FIELD_STYLES = /* css */ `
+  @font-face {
+    font-family: "Material Symbols Outlined";
+    font-style: normal;
+    src: local("Material Symbols Outlined");
+  }
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: block;
+    width: 100%;
+    font-family: "Geist", sans-serif;
+  }
+
+  .wrapper {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 4px 8px;
+    border: 1px solid ${BORDER_MODERATE};
+    background: ${SURFACE_PRIMARY};
+    transition: border-color 0.15s ease;
+  }
+
+  .wrapper:hover {
+    border-color: ${HOVER_BORDER};
+  }
+
+  .wrapper:focus-within {
+    border-color: ${FOCUS_BORDER};
+    outline: 1px solid ${FOCUS_BORDER};
+    outline-offset: -1px;
+  }
+
+  .search-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    color: ${ICON_SECONDARY};
+  }
+
+  .search-icon .material-symbols-outlined {
+    font-family: "Material Symbols Outlined";
+    font-weight: normal;
+    font-style: normal;
+    line-height: 1;
+    letter-spacing: normal;
+    text-transform: none;
+    display: inline-block;
+    white-space: nowrap;
+    word-wrap: normal;
+    direction: ltr;
+    -webkit-font-smoothing: antialiased;
+    font-variation-settings: "FILL" 0;
+  }
+
+  .tags {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-wrap: wrap;
+  }
+
+  .input {
+    flex: 1;
+    min-width: 80px;
+    border: none;
+    background: transparent;
+    font-family: "Geist", sans-serif;
+    color: ${TEXT_PRIMARY};
+    outline: none;
+  }
+
+  .input::placeholder {
+    color: ${TEXT_TERTIARY};
+  }
+
+  /* ── Size: S ─────────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) .wrapper {
+    padding: 2px 8px;
+    min-height: 24px;
+    border-radius: 2px;
+  }
+
+  :host([size="s"]) .search-icon {
+    width: 16px;
+    height: 16px;
+  }
+
+  :host([size="s"]) .search-icon .material-symbols-outlined {
+    font-size: 16px;
+  }
+
+  :host([size="s"]) .input {
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  /* ── Size: M (default) ───────────────────────────────────────────────────── */
+
+  :host .wrapper,
+  :host([size="m"]) .wrapper {
+    padding: 4px 12px;
+    min-height: 32px;
+    border-radius: 2px;
+  }
+
+  :host .search-icon,
+  :host([size="m"]) .search-icon {
+    width: 20px;
+    height: 20px;
+  }
+
+  :host .search-icon .material-symbols-outlined,
+  :host([size="m"]) .search-icon .material-symbols-outlined {
+    font-size: 20px;
+  }
+
+  :host .input,
+  :host([size="m"]) .input {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  /* ── Size: L ─────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) .wrapper {
+    padding: 6px 12px;
+    min-height: 40px;
+    border-radius: 2px;
+  }
+
+  :host([size="l"]) .search-icon {
+    width: 24px;
+    height: 24px;
+  }
+
+  :host([size="l"]) .search-icon .material-symbols-outlined {
+    font-size: 24px;
+  }
+
+  :host([size="l"]) .input {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  /* ── Disabled ────────────────────────────────────────────────────────────── */
+
+  :host([disabled]) .wrapper {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+
+  /* ── Floating menu ───────────────────────────────────────────────────────── */
+
+  .menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 1000;
+    display: none;
+    flex-direction: column;
+    min-width: 168px;
+    max-width: 280px;
+    background: ${SURFACE_PRIMARY};
+    border-radius: 2px;
+    box-shadow: 0px 8px 10px 0px rgba(0,0,0,0.14), 0px 3px 14px 0px rgba(0,0,0,0.12), 0px 5px 5px 0px rgba(0,0,0,0.2);
+    padding: 4px 0;
+    margin-top: 2px;
+    opacity: 0;
+    transform: translateY(-4px);
+    transition: opacity 0.15s ease, transform 0.15s ease;
+  }
+
+  :host([menu-open]) .menu {
+    display: flex;
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  :host {
+    position: relative;
+  }
+
+  .menu-heading {
+    padding: 4px 16px;
+    font-size: 12px;
+    line-height: 16px;
+    font-weight: 500;
+    color: ${TEXT_SECONDARY};
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .menu-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 16px;
+    font-size: 14px;
+    line-height: 20px;
+    font-weight: 400;
+    color: ${TEXT_PRIMARY};
+    cursor: pointer;
+    white-space: nowrap;
+    border: none;
+    background: transparent;
+    width: 100%;
+    text-align: left;
+    font-family: "Geist", sans-serif;
+  }
+
+  .menu-item:hover {
+    background: rgba(159, 177, 189, 0.1);
+  }
+
+  .menu-item.selected {
+    font-weight: 500;
+    color: ${FOCUS_BORDER};
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .menu {
+      transition-duration: 0.01ms !important;
+    }
+  }
+`;

--- a/packages/ui-components/src/components/ui-queryfield.test.ts
+++ b/packages/ui-components/src/components/ui-queryfield.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import "./ui-queryfield.js";
+import "./ui-queryfield-tag.js";
+import type { QueryfieldSize } from "./ui-queryfield.js";
+import { FIELD_STYLES } from "./ui-queryfield.styles.js";
+
+describe("ui-queryfield", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-queryfield");
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-queryfield")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("applies adoptedStyleSheets", () => {
+    expect(el.shadowRoot!.adoptedStyleSheets.length).toBe(1);
+  });
+
+  it("exports FIELD_STYLES string", () => {
+    expect(typeof FIELD_STYLES).toBe("string");
+    expect(FIELD_STYLES.length).toBeGreaterThan(0);
+  });
+
+  // ── Default rendering ─────────────────────────────────────────────────────
+
+  it("renders a .wrapper element", () => {
+    const wrapper = el.shadowRoot!.querySelector(".wrapper");
+    expect(wrapper).not.toBeNull();
+  });
+
+  it("renders a .search-icon element", () => {
+    const icon = el.shadowRoot!.querySelector(".search-icon");
+    expect(icon).not.toBeNull();
+  });
+
+  it("renders a material-symbols-outlined icon inside search-icon", () => {
+    const icon = el.shadowRoot!.querySelector(
+      ".search-icon .material-symbols-outlined",
+    );
+    expect(icon).not.toBeNull();
+  });
+
+  it("renders a .tags container", () => {
+    const tags = el.shadowRoot!.querySelector(".tags");
+    expect(tags).not.toBeNull();
+  });
+
+  it("renders a slot[name=tags] inside .tags", () => {
+    const slot = el.shadowRoot!.querySelector(".tags slot[name='tags']");
+    expect(slot).not.toBeNull();
+  });
+
+  it("renders an input element", () => {
+    const input = el.shadowRoot!.querySelector("input.input");
+    expect(input).not.toBeNull();
+  });
+
+  it("input has type=text", () => {
+    const input = el.shadowRoot!.querySelector("input.input") as HTMLInputElement;
+    expect(input.type).toBe("text");
+  });
+
+  it("defaults size to m", () => {
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("defaults placeholder to Search...", () => {
+    const input = el.shadowRoot!.querySelector("input.input") as HTMLInputElement;
+    expect(input.placeholder).toBe("Search...");
+  });
+
+  // ── observedAttributes ─────────────────────────────────────────────────────
+
+  it("observes size, placeholder, disabled, value", () => {
+    const Ctor = customElements.get("ui-queryfield") as unknown as {
+      observedAttributes: string[];
+    };
+    expect(Ctor.observedAttributes).toEqual([
+      "size",
+      "placeholder",
+      "disabled",
+      "value",
+    ]);
+  });
+
+  // ── Attributes: size ──────────────────────────────────────────────────────
+
+  it("reflects size=s as attribute", () => {
+    el.setAttribute("size", "s");
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("reflects size=m as attribute", () => {
+    el.setAttribute("size", "m");
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("reflects size=l as attribute", () => {
+    el.setAttribute("size", "l");
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  // ── Attributes: placeholder ───────────────────────────────────────────────
+
+  it("sets input placeholder from attribute", () => {
+    el.setAttribute("placeholder", "Type here...");
+    const input = el.shadowRoot!.querySelector("input.input") as HTMLInputElement;
+    expect(input.placeholder).toBe("Type here...");
+  });
+
+  it("resets placeholder to default when attribute removed", () => {
+    el.setAttribute("placeholder", "Custom");
+    el.removeAttribute("placeholder");
+    const input = el.shadowRoot!.querySelector("input.input") as HTMLInputElement;
+    expect(input.placeholder).toBe("Search...");
+  });
+
+  // ── Attributes: disabled ──────────────────────────────────────────────────
+
+  it("disables input when disabled attribute set", () => {
+    el.setAttribute("disabled", "");
+    const input = el.shadowRoot!.querySelector("input.input") as HTMLInputElement;
+    expect(input.disabled).toBe(true);
+  });
+
+  it("enables input when disabled attribute removed", () => {
+    el.setAttribute("disabled", "");
+    el.removeAttribute("disabled");
+    const input = el.shadowRoot!.querySelector("input.input") as HTMLInputElement;
+    expect(input.disabled).toBe(false);
+  });
+
+  // ── Attributes: value ─────────────────────────────────────────────────────
+
+  it("sets input value from attribute", () => {
+    el.setAttribute("value", "hello");
+    const input = el.shadowRoot!.querySelector("input.input") as HTMLInputElement;
+    expect(input.value).toBe("hello");
+  });
+
+  it("clears input value when attribute removed", () => {
+    el.setAttribute("value", "hello");
+    el.removeAttribute("value");
+    const input = el.shadowRoot!.querySelector("input.input") as HTMLInputElement;
+    expect(input.value).toBe("");
+  });
+
+  // ── Property accessors ────────────────────────────────────────────────────
+
+  it("size getter returns current attribute", () => {
+    el.setAttribute("size", "l");
+    expect((el as unknown as { size: QueryfieldSize }).size).toBe("l");
+  });
+
+  it("size setter updates attribute", () => {
+    (el as unknown as { size: QueryfieldSize }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("placeholder getter returns current attribute", () => {
+    el.setAttribute("placeholder", "Find...");
+    expect((el as unknown as { placeholder: string }).placeholder).toBe("Find...");
+  });
+
+  it("placeholder setter updates attribute", () => {
+    (el as unknown as { placeholder: string }).placeholder = "Query...";
+    expect(el.getAttribute("placeholder")).toBe("Query...");
+  });
+
+  it("placeholder getter defaults to Search...", () => {
+    expect((el as unknown as { placeholder: string }).placeholder).toBe(
+      "Search...",
+    );
+  });
+
+  it("disabled getter returns false by default", () => {
+    expect((el as unknown as { disabled: boolean }).disabled).toBe(false);
+  });
+
+  it("disabled setter sets attribute", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    expect(el.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("disabled setter removes attribute when false", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    (el as unknown as { disabled: boolean }).disabled = false;
+    expect(el.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("value getter returns input value", () => {
+    const input = el.shadowRoot!.querySelector("input.input") as HTMLInputElement;
+    input.value = "test";
+    expect((el as unknown as { value: string }).value).toBe("test");
+  });
+
+  it("value setter updates input value", () => {
+    (el as unknown as { value: string }).value = "hello";
+    const input = el.shadowRoot!.querySelector("input.input") as HTMLInputElement;
+    expect(input.value).toBe("hello");
+  });
+
+  // ── Input events ──────────────────────────────────────────────────────────
+
+  it("dispatches queryfield-input on typing", () => {
+    const handler = vi.fn();
+    el.addEventListener("queryfield-input", handler);
+    const input = el.shadowRoot!.querySelector("input.input") as HTMLInputElement;
+    input.value = "abc";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("queryfield-input detail contains value", () => {
+    let detail: { value: string } | undefined;
+    el.addEventListener("queryfield-input", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+    const input = el.shadowRoot!.querySelector("input.input") as HTMLInputElement;
+    input.value = "xyz";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(detail).toEqual({ value: "xyz" });
+  });
+
+  it("dispatches queryfield-submit on Enter", () => {
+    const handler = vi.fn();
+    el.addEventListener("queryfield-submit", handler);
+    const input = el.shadowRoot!.querySelector("input.input") as HTMLInputElement;
+    input.value = "search term";
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("queryfield-submit detail contains value", () => {
+    let detail: { value: string } | undefined;
+    el.addEventListener("queryfield-submit", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+    const input = el.shadowRoot!.querySelector("input.input") as HTMLInputElement;
+    input.value = "query";
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    expect(detail).toEqual({ value: "query" });
+  });
+
+  it("does not dispatch queryfield-submit on non-Enter keys", () => {
+    const handler = vi.fn();
+    el.addEventListener("queryfield-submit", handler);
+    const input = el.shadowRoot!.querySelector("input.input") as HTMLInputElement;
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  // ── Size propagation ──────────────────────────────────────────────────────
+
+  it("propagates size to slotted tags on slotchange", async () => {
+    el.setAttribute("size", "l");
+    const tag = document.createElement("ui-queryfield-tag");
+    tag.slot = "tags";
+    el.appendChild(tag);
+    // Wait for slotchange microtask
+    await new Promise((r) => setTimeout(r, 0));
+    expect(tag.getAttribute("size")).toBe("l");
+  });
+
+  it("propagates size when size attribute changes", async () => {
+    const tag = document.createElement("ui-queryfield-tag");
+    tag.slot = "tags";
+    el.appendChild(tag);
+    await new Promise((r) => setTimeout(r, 0));
+    el.setAttribute("size", "s");
+    expect(tag.getAttribute("size")).toBe("s");
+  });
+});

--- a/packages/ui-components/src/components/ui-queryfield.ts
+++ b/packages/ui-components/src/components/ui-queryfield.ts
@@ -1,0 +1,504 @@
+import { FIELD_STYLES } from "./ui-queryfield.styles.js";
+import { ICON_SEARCH } from "@maneki/foundation";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type QueryfieldSize = "s" | "m" | "l";
+
+export interface QueryfieldFilter {
+  name: string;
+  label: string;
+  operators: string[];
+  values: string[];
+}
+
+export interface QueryfieldFilterAddDetail {
+  filter: string;
+  label: string;
+  operator: string;
+  values: string[];
+  expression: string;
+}
+
+export interface QueryfieldFilterUpdateDetail {
+  tag: HTMLElement;
+  filter: string;
+  label: string;
+  operator: string;
+  values: string[];
+  expression: string;
+}
+
+export interface QueryfieldSubmitDetail {
+  value: string;
+}
+
+export interface QueryfieldInputDetail {
+  value: string;
+}
+
+type FlowState = "idle" | "selecting-filter" | "selecting-operator" | "selecting-value";
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(FIELD_STYLES);
+
+export class UiQueryfield extends HTMLElement {
+  static readonly observedAttributes = ["size", "placeholder", "disabled", "value"];
+
+  #input!: HTMLInputElement;
+  #tags!: HTMLElement;
+  #menu!: HTMLElement;
+  #wrapper!: HTMLElement;
+
+  // State machine
+  #state: FlowState = "idle";
+  #filters: QueryfieldFilter[] = [];
+  #selectedFilter: QueryfieldFilter | null = null;
+  #selectedOperator: string | null = null;
+  #selectedValues: string[] = [];
+  #editingTag: HTMLElement | null = null;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    this.#wrapper = document.createElement("div");
+    this.#wrapper.className = "wrapper";
+
+    // Search icon
+    const searchIcon = document.createElement("span");
+    searchIcon.className = "search-icon";
+    const icon = document.createElement("span");
+    icon.className = "material-symbols-outlined";
+    icon.textContent = ICON_SEARCH;
+    searchIcon.appendChild(icon);
+
+    // Tags container (slot for queryfield-tag elements)
+    this.#tags = document.createElement("div");
+    this.#tags.className = "tags";
+    const tagSlot = document.createElement("slot");
+    tagSlot.name = "tags";
+    this.#tags.appendChild(tagSlot);
+
+    // Input
+    this.#input = document.createElement("input");
+    this.#input.className = "input";
+    this.#input.type = "text";
+    this.#input.placeholder = "Search...";
+
+    // Floating menu
+    this.#menu = document.createElement("div");
+    this.#menu.className = "menu";
+
+    this.#wrapper.append(searchIcon, this.#tags, this.#input);
+    shadow.append(this.#wrapper, this.#menu);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("size")) this.setAttribute("size", "m");
+
+    this.#input.addEventListener("input", () => {
+      this.dispatchEvent(
+        new CustomEvent("queryfield-input", {
+          detail: { value: this.#input.value },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+      // If we have filters and user is typing, show filter suggestions
+      if (this.#filters.length > 0 && this.#state === "idle") {
+        this._transitionTo("selecting-filter");
+      }
+      this._filterMenuItems();
+    });
+
+    this.#input.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        if (this.#state === "selecting-value") {
+          // Add free-text value if input has text
+          const freeText = this.#input.value.trim();
+          if (freeText) {
+            if (!this.#selectedValues.includes(freeText)) {
+              this.#selectedValues.push(freeText);
+            }
+            this.#input.value = "";
+            this._renderValueMenu();
+            this._openMenu();
+          }
+          // Commit if we have values
+          if (this.#selectedValues.length > 0) {
+            this._commitFilter();
+          }
+        } else if (this.#state === "idle") {
+          this.dispatchEvent(
+            new CustomEvent("queryfield-submit", {
+              detail: { value: this.#input.value },
+              bubbles: true,
+              composed: true,
+            }),
+          );
+        }
+      } else if (e.key === "Escape") {
+        if (this.#state === "selecting-value" && this.#selectedValues.length > 0) {
+          this._commitFilter();
+        } else {
+          this._closeMenu();
+        }
+      }
+    });
+
+    this.#input.addEventListener("focus", () => {
+      if (this.#filters.length > 0 && this.#state === "idle") {
+        this._transitionTo("selecting-filter");
+      }
+    });
+
+    // Listen for tag edit events
+    this.addEventListener("tag-edit", ((e: CustomEvent) => {
+      e.stopPropagation();
+      const { tag, filterName, operator, values } = e.detail;
+      this._editTag(tag, filterName, operator, values);
+    }) as EventListener);
+
+    // Close on outside click
+    this._onDocumentClick = this._onDocumentClick.bind(this);
+    document.addEventListener("click", this._onDocumentClick);
+
+    // Propagate size to slotted tags
+    const slot = this.#tags.querySelector("slot") as HTMLSlotElement;
+    slot.addEventListener("slotchange", () => this._propagateSize());
+    this._propagateSize();
+  }
+
+  disconnectedCallback(): void {
+    document.removeEventListener("click", this._onDocumentClick);
+  }
+
+  attributeChangedCallback(
+    name: string,
+    _oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    switch (name) {
+      case "placeholder":
+        this.#input.placeholder = newValue ?? "Search...";
+        break;
+      case "disabled":
+        this.#input.disabled = newValue !== null;
+        break;
+      case "value":
+        this.#input.value = newValue ?? "";
+        break;
+      case "size":
+        this._propagateSize();
+        break;
+    }
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): QueryfieldSize {
+    return (this.getAttribute("size") as QueryfieldSize) ?? "m";
+  }
+  set size(v: QueryfieldSize) {
+    this.setAttribute("size", v);
+  }
+
+  get placeholder(): string {
+    return this.getAttribute("placeholder") ?? "Search...";
+  }
+  set placeholder(v: string) {
+    this.setAttribute("placeholder", v);
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute("disabled");
+  }
+  set disabled(v: boolean) {
+    if (v) this.setAttribute("disabled", "");
+    else this.removeAttribute("disabled");
+  }
+
+  get value(): string {
+    return this.#input.value;
+  }
+  set value(v: string) {
+    this.#input.value = v;
+  }
+
+  get filters(): QueryfieldFilter[] {
+    return this.#filters;
+  }
+  set filters(v: QueryfieldFilter[]) {
+    this.#filters = v;
+  }
+
+  // ── State machine ───────────────────────────────────────────────────────
+
+  private _transitionTo(state: FlowState): void {
+    this.#state = state;
+
+    switch (state) {
+      case "idle":
+        this._closeMenu();
+        this.#selectedFilter = null;
+        this.#selectedOperator = null;
+        this.#selectedValues = [];
+        this.#input.placeholder = this.getAttribute("placeholder") ?? "Search...";
+        break;
+
+      case "selecting-filter":
+        this.#input.value = "";
+        this.#input.placeholder = "Search filters";
+        this._renderFilterMenu();
+        this._openMenu();
+        break;
+
+      case "selecting-operator":
+        this.#input.value = "";
+        this.#input.placeholder = "Search operators";
+        this._renderOperatorMenu();
+        this._openMenu();
+        break;
+
+      case "selecting-value":
+        this.#input.value = "";
+        this.#input.placeholder = this.#selectedValues.length > 0 ? "or type a value..." : "Search values";
+        this._renderValueMenu();
+        this._openMenu();
+        break;
+    }
+  }
+
+  // ── Menu rendering ──────────────────────────────────────────────────────
+
+  private _renderFilterMenu(): void {
+    this.#menu.innerHTML = "";
+
+    const heading = document.createElement("div");
+    heading.className = "menu-heading";
+    heading.textContent = "SUGGESTED FILTERS";
+    this.#menu.appendChild(heading);
+
+    for (const filter of this.#filters) {
+      const item = document.createElement("button");
+      item.className = "menu-item";
+      item.type = "button";
+      item.textContent = filter.label;
+      item.dataset.filterName = filter.name;
+      item.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this.#selectedFilter = filter;
+        this._transitionTo("selecting-operator");
+      });
+      this.#menu.appendChild(item);
+    }
+  }
+
+  private _renderOperatorMenu(): void {
+    if (!this.#selectedFilter) return;
+    this.#menu.innerHTML = "";
+
+    const heading = document.createElement("div");
+    heading.className = "menu-heading";
+    heading.textContent = this.#selectedFilter.label.toUpperCase();
+    this.#menu.appendChild(heading);
+
+    for (const op of this.#selectedFilter.operators) {
+      const item = document.createElement("button");
+      item.className = "menu-item";
+      item.type = "button";
+      item.textContent = op;
+      item.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this.#selectedOperator = op;
+        this._transitionTo("selecting-value");
+      });
+      this.#menu.appendChild(item);
+    }
+  }
+
+  private _renderValueMenu(): void {
+    if (!this.#selectedFilter) return;
+    this.#menu.innerHTML = "";
+
+    const heading = document.createElement("div");
+    heading.className = "menu-heading";
+    heading.textContent = `${this.#selectedFilter.label.toUpperCase()} ${(this.#selectedOperator ?? "").toUpperCase()}`;
+    this.#menu.appendChild(heading);
+
+    // Show custom values first (values not in the predefined list)
+    const predefined = new Set(this.#selectedFilter.values);
+    const customValues = this.#selectedValues.filter((v) => !predefined.has(v));
+    for (const val of customValues) {
+      const item = document.createElement("button");
+      item.className = "menu-item selected";
+      item.type = "button";
+      item.textContent = `${val} (custom)`;
+      item.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this._toggleValue(val);
+      });
+      this.#menu.appendChild(item);
+    }
+
+    // Show predefined values
+    for (const val of this.#selectedFilter.values) {
+      const item = document.createElement("button");
+      item.className = "menu-item";
+      item.type = "button";
+      item.textContent = val;
+      if (this.#selectedValues.includes(val)) {
+        item.classList.add("selected");
+      }
+      item.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this._toggleValue(val);
+      });
+      this.#menu.appendChild(item);
+    }
+  }
+
+  private _toggleValue(val: string): void {
+    const idx = this.#selectedValues.indexOf(val);
+    if (idx >= 0) {
+      this.#selectedValues.splice(idx, 1);
+    } else {
+      this.#selectedValues.push(val);
+    }
+
+    // Update placeholder to hint "or"
+    this.#input.placeholder = this.#selectedValues.length > 0 ? "or type a value..." : "Search values";
+
+    // Re-render to update selected state
+    this._renderValueMenu();
+    this._openMenu();
+  }
+
+  private _commitFilter(): void {
+    if (!this.#selectedFilter || !this.#selectedOperator || this.#selectedValues.length === 0) return;
+
+    const expression = `${this.#selectedOperator} ${this.#selectedValues.join(" or ")}`;
+
+    if (this.#editingTag) {
+      // Update existing tag
+      this.#editingTag.setAttribute("category", this.#selectedFilter.name.toUpperCase());
+      this.#editingTag.setAttribute("expression", expression);
+      this.#editingTag.setAttribute("filter-name", this.#selectedFilter.name);
+      this.#editingTag.setAttribute("operator", this.#selectedOperator);
+      this.#editingTag.setAttribute("values", this.#selectedValues.join(","));
+
+      this.dispatchEvent(
+        new CustomEvent("queryfield-filter-update", {
+          detail: {
+            tag: this.#editingTag,
+            filter: this.#selectedFilter.name,
+            label: this.#selectedFilter.label,
+            operator: this.#selectedOperator,
+            values: [...this.#selectedValues],
+            expression,
+          },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    } else {
+      // Create new tag
+      this.dispatchEvent(
+        new CustomEvent("queryfield-filter-add", {
+          detail: {
+            filter: this.#selectedFilter.name,
+            label: this.#selectedFilter.label,
+            operator: this.#selectedOperator,
+            values: [...this.#selectedValues],
+            expression,
+          },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    }
+
+    setTimeout(() => {
+      if (this.#editingTag) this.#editingTag.removeAttribute("editing");
+      this.#editingTag = null;
+      this._transitionTo("idle");
+    }, 200);
+  }
+
+  // ── Menu open/close ─────────────────────────────────────────────────────
+
+  private _openMenu(): void {
+    this.setAttribute("menu-open", "");
+  }
+
+  private _closeMenu(): void {
+    this.removeAttribute("menu-open");
+    if (this.#editingTag) this.#editingTag.removeAttribute("editing");
+    this.#editingTag = null;
+    this.#state = "idle";
+  }
+
+  private _filterMenuItems(): void {
+    const query = this.#input.value.toLowerCase();
+    const items = this.#menu.querySelectorAll(".menu-item");
+    for (const item of items) {
+      const text = (item as HTMLElement).textContent?.toLowerCase() ?? "";
+      (item as HTMLElement).style.display = text.includes(query) ? "" : "none";
+    }
+  }
+
+  private _onDocumentClick(e: MouseEvent): void {
+    if (!this.hasAttribute("menu-open")) return;
+    if (this.contains(e.target as Node)) return;
+    const path = e.composedPath();
+    if (path.includes(this)) return;
+    // Commit if values were selected
+    if (this.#state === "selecting-value" && this.#selectedValues.length > 0) {
+      this._commitFilter();
+    } else {
+      this._closeMenu();
+    }
+  }
+
+  // ── Edit existing tag ───────────────────────────────────────────────────
+
+  private _editTag(tag: HTMLElement, filterName: string, operator: string, values: string[]): void {
+    const filter = this.#filters.find((f) => f.name === filterName);
+    if (!filter) return;
+
+    // Clear previous editing state
+    if (this.#editingTag) this.#editingTag.removeAttribute("editing");
+
+    this.#editingTag = tag;
+    tag.setAttribute("editing", "");
+    this.#selectedFilter = filter;
+    this.#selectedOperator = operator;
+    this.#selectedValues = [...values];
+
+    // Jump straight to value selection with existing values pre-selected
+    this.#input.value = "";
+    this.#input.placeholder = values.length > 0 ? `or type a value...` : "Search values";
+    this.#state = "selecting-value";
+    this._renderValueMenu();
+    this._openMenu();
+    this.#input.focus();
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+  private _propagateSize(): void {
+    const size = this.getAttribute("size");
+    if (!size) return;
+    const slot = this.#tags.querySelector("slot") as HTMLSlotElement;
+    for (const node of slot.assignedElements()) {
+      if (node.tagName === "UI-QUERYFIELD-TAG") {
+        node.setAttribute("size", size);
+      }
+    }
+  }
+}
+
+customElements.define("ui-queryfield", UiQueryfield);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -196,3 +196,17 @@ export type { ProgressCircleSize, ProgressCircleLabelPosition } from "./componen
 
 export { UiPullToRefresh } from "./components/ui-pull-to-refresh.js";
 export type { PullToRefreshVariant, PullToRefreshSize } from "./components/ui-pull-to-refresh.js";
+
+// ─── Queryfield ─────────────────────────────────────────────────────────────
+
+export { UiQueryfieldTag } from "./components/ui-queryfield-tag.js";
+export type { QueryfieldTagSize } from "./components/ui-queryfield-tag.js";
+export { UiQueryfield } from "./components/ui-queryfield.js";
+export type {
+  QueryfieldSize,
+  QueryfieldFilter,
+  QueryfieldFilterAddDetail,
+  QueryfieldFilterUpdateDetail,
+  QueryfieldSubmitDetail,
+  QueryfieldInputDetail,
+} from "./components/ui-queryfield.js";

--- a/packages/ui-components/src/stories/ui-queryfield.stories.ts
+++ b/packages/ui-components/src/stories/ui-queryfield.stories.ts
@@ -1,0 +1,133 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-queryfield.js";
+import "../components/ui-queryfield-tag.js";
+
+const meta: Meta = {
+  title: "Components/Queryfield",
+  component: "ui-queryfield",
+  argTypes: {
+    size: {
+      control: { type: "select" },
+      options: ["s", "m", "l"],
+    },
+    placeholder: {
+      control: { type: "text" },
+    },
+    disabled: {
+      control: { type: "boolean" },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+// ── Default ─────────────────────────────────────────────────────────────────
+
+export const Default: Story = {
+  args: { size: "m" },
+  render: ({ size }) => html`
+    <ui-queryfield size=${size}>
+      <ui-queryfield-tag
+        slot="tags"
+        category="City"
+        expression="equals London or Bengaluru"
+      ></ui-queryfield-tag>
+      <ui-queryfield-tag
+        slot="tags"
+        category="Status"
+        expression="equals Active"
+      ></ui-queryfield-tag>
+    </ui-queryfield>
+  `,
+};
+
+// ── All Sizes ───────────────────────────────────────────────────────────────
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display:flex;flex-direction:column;gap:16px;max-width:600px">
+      ${(["s", "m", "l"] as const).map(
+        (size) => html`
+          <ui-queryfield size=${size}>
+            <ui-queryfield-tag
+              slot="tags"
+              category="City"
+              expression="equals London"
+            ></ui-queryfield-tag>
+            <ui-queryfield-tag
+              slot="tags"
+              category="Status"
+              expression="contains Active"
+            ></ui-queryfield-tag>
+          </ui-queryfield>
+        `,
+      )}
+    </div>
+  `,
+};
+
+// ── Tag Only ────────────────────────────────────────────────────────────────
+
+export const TagOnly: Story = {
+  render: () => html`
+    <div style="display:flex;flex-direction:column;gap:12px">
+      ${(["s", "m", "l"] as const).map(
+        (size) => html`
+          <div style="display:flex;gap:8px;align-items:center">
+            <ui-queryfield-tag
+              size=${size}
+              category="City"
+              expression="equals London or Bengaluru"
+            ></ui-queryfield-tag>
+            <ui-queryfield-tag
+              size=${size}
+              category="Status"
+              expression="starts with Act"
+            ></ui-queryfield-tag>
+          </div>
+        `,
+      )}
+    </div>
+  `,
+};
+
+// ── With Placeholder ────────────────────────────────────────────────────────
+
+export const WithPlaceholder: Story = {
+  args: { size: "m", placeholder: "Filter by name, city, or status..." },
+  render: ({ size, placeholder }) => html`
+    <ui-queryfield size=${size} placeholder=${placeholder}>
+      <ui-queryfield-tag
+        slot="tags"
+        category="Region"
+        expression="equals EMEA"
+      ></ui-queryfield-tag>
+    </ui-queryfield>
+  `,
+};
+
+// ── Disabled ────────────────────────────────────────────────────────────────
+
+export const Disabled: Story = {
+  args: { size: "m" },
+  render: ({ size }) => html`
+    <ui-queryfield size=${size} disabled>
+      <ui-queryfield-tag
+        slot="tags"
+        category="City"
+        expression="equals London"
+      ></ui-queryfield-tag>
+    </ui-queryfield>
+  `,
+};
+
+// ── Empty ───────────────────────────────────────────────────────────────────
+
+export const Empty: Story = {
+  args: { size: "m" },
+  render: ({ size }) => html`
+    <ui-queryfield size=${size}></ui-queryfield>
+  `,
+};


### PR DESCRIPTION
## Summary

New `<ui-queryfield-tag>` and `<ui-queryfield>` Web Components for building search/filter interfaces with structured query tags.

## `<ui-queryfield-tag>`

- 3 sizes: `s` (11px), `m` (12px), `l` (14px)
- Two-part pill: left (category label, blue bg, left-rounded) + right (value expression, blue border, right-rounded)
- Expression parsing with semantic color coding: operators (`equals`, `contains`) in secondary text, values in blue, conjunctions (`or`, `and`) in secondary
- Dismissible via X icon, dispatches `dismiss` event

## `<ui-queryfield>`

- Search input with slotted filter tags (`slot="tags"`)
- 3 sizes: `s` (24px), `m` (32px), `l` (40px)
- Search icon, customizable placeholder, disabled state
- Size propagation to slotted `<ui-queryfield-tag>` elements
- Events: `queryfield-input` (on typing), `queryfield-submit` (on Enter)
- Hover/focus border states

## API

```html
<ui-queryfield size="m" placeholder="Search...">
  <ui-queryfield-tag slot="tags" category="CITY" expression="equals London or Bengaluru"></ui-queryfield-tag>
  <ui-queryfield-tag slot="tags" category="STATUS" expression="equals Active"></ui-queryfield-tag>
</ui-queryfield>
```

## Testing

- 2814 unit tests (80 new: 40 tag + 40 field)
- 6 Storybook stories
- 45 Playwright visual regression tests (1 new)

## Files

- `packages/ui-components/src/components/ui-queryfield-tag.ts` + `ui-queryfield-tag.styles.ts`
- `packages/ui-components/src/components/ui-queryfield.ts` + `ui-queryfield.styles.ts`
- `packages/ui-components/src/components/ui-queryfield-tag.test.ts` + `ui-queryfield.test.ts`
- `packages/ui-components/src/stories/ui-queryfield.stories.ts`
- `packages/ui-components/src/index.ts` — barrel exports
- `apps/catalog/src/pages/queryfield.ts` — catalog page