### PR TITLE
feat(ui-components): add ui-scrollbar component

### DIFF
--- a/apps/catalog/e2e/visual.spec.ts
+++ b/apps/catalog/e2e/visual.spec.ts
@@ -39,6 +39,7 @@ const pages = [
   "person",
   "progress",
   "pull-to-refresh",
+  "scrollbar",
   "popover",
   "carousel",
   "calendar",

--- a/apps/catalog/src/main.ts
+++ b/apps/catalog/src/main.ts
@@ -57,6 +57,7 @@ const pageLoaders: Record<string, () => Promise<unknown>> = {
   "person": () => import("./pages/person.js"),
   "progress": () => import("./pages/progress.js"),
   "pull-to-refresh": () => import("./pages/pull-to-refresh.js"),
+  "scrollbar": () => import("./pages/scrollbar.js"),
   "popover": () => import("./pages/popover.js"),
   "carousel": () => import("./pages/carousel.js"),
   "calendar": () => import("./pages/calendar.js"),

--- a/apps/catalog/src/manifest.ts
+++ b/apps/catalog/src/manifest.ts
@@ -72,6 +72,7 @@ export const manifest: PageMeta[] = [
   { id: "person", title: "Person", section: "Data Display" },
   { id: "progress", title: "Progress", section: "Data Display" },
   { id: "pull-to-refresh", title: "Pull to Refresh", section: "Data Display" },
+  { id: "scrollbar", title: "Scrollbar", section: "Data Display" },
   // Calendar & Date
   { id: "calendar", title: "Calendar", section: "Calendar & Date" },
   { id: "datetime-picker", title: "Datetime Picker", section: "Calendar & Date" },

--- a/apps/catalog/src/pages/scrollbar.ts
+++ b/apps/catalog/src/pages/scrollbar.ts
@@ -1,0 +1,58 @@
+import { registerPage } from "../registry.js";
+
+registerPage("scrollbar", {
+  title: "Scrollbar",
+  section: "Data Display",
+  render: () => `
+    <h3>Emphasis</h3>
+    <div class="variant-row" style="gap: 60px;">
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Bold</span>
+        <ui-scrollbar emphasis="bold" orientation="vertical" style="width: 200px; height: 200px; border: 1px solid var(--fd-border-minimal, #dce3e8);">
+          <div style="padding: 12px; font-size: 14px; line-height: 1.6; color: var(--fd-text-primary, #1c2b36);">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+            <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+            <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+            <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.</p>
+          </div>
+        </ui-scrollbar>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Minimal</span>
+        <ui-scrollbar emphasis="minimal" orientation="vertical" style="width: 200px; height: 200px; border: 1px solid var(--fd-border-minimal, #dce3e8);">
+          <div style="padding: 12px; font-size: 14px; line-height: 1.6; color: var(--fd-text-primary, #1c2b36);">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+            <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+            <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+            <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            <p>Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.</p>
+          </div>
+        </ui-scrollbar>
+      </div>
+    </div>
+
+    <h3>Orientation</h3>
+    <div class="variant-row" style="gap: 60px;">
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Vertical</span>
+        <ui-scrollbar emphasis="bold" orientation="vertical" style="width: 200px; height: 200px; border: 1px solid var(--fd-border-minimal, #dce3e8);">
+          <div style="padding: 12px; font-size: 14px; line-height: 1.6; color: var(--fd-text-primary, #1c2b36);">
+            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+            <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+            <p>Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</p>
+            <p>Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+          </div>
+        </ui-scrollbar>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Horizontal</span>
+        <ui-scrollbar emphasis="bold" orientation="horizontal" style="width: 300px; height: 80px; border: 1px solid var(--fd-border-minimal, #dce3e8);">
+          <div style="padding: 12px; font-size: 14px; line-height: 1.6; color: var(--fd-text-primary, #1c2b36); white-space: nowrap; width: 800px;">
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit.
+          </div>
+        </ui-scrollbar>
+      </div>
+    </div>
+  `,
+});

--- a/packages/ui-components/src/components/ui-scrollbar.styles.ts
+++ b/packages/ui-components/src/components/ui-scrollbar.styles.ts
@@ -1,0 +1,124 @@
+import { semanticVar } from "@maneki/foundation";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const SURFACE_SECONDARY = semanticVar("surface", "secondary");
+const BORDER_MINIMAL = semanticVar("border", "minimal");
+const SURFACE_BOLD = semanticVar("surface", "bold");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+export const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: block;
+    overflow: hidden;
+    position: relative;
+  }
+
+  .container {
+    width: 100%;
+    height: 100%;
+  }
+
+  /* ── Bold emphasis (default) ─────────────────────────────────────────────── */
+
+  :host,
+  :host([emphasis="bold"]) {
+    --_track-bg: ${SURFACE_SECONDARY};
+    --_thumb-bg: ${SURFACE_BOLD};
+    --_thumb-radius: 12px;
+    --_thumb-size: 5px;
+    --_track-size: 12px;
+    --_border-color: ${BORDER_MINIMAL};
+  }
+
+  /* ── Minimal emphasis ────────────────────────────────────────────────────── */
+
+  :host([emphasis="minimal"]) {
+    --_track-bg: transparent;
+    --_thumb-bg: ${SURFACE_BOLD};
+    --_thumb-radius: 12px;
+    --_thumb-size: 5px;
+    --_track-size: 8px;
+    --_border-color: transparent;
+  }
+
+  /* ── Vertical (default) ──────────────────────────────────────────────────── */
+
+  :host,
+  :host([orientation="vertical"]) {
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  :host([orientation="vertical"]) .container {
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  /* ── Horizontal ──────────────────────────────────────────────────────────── */
+
+  :host([orientation="horizontal"]) {
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  :host([orientation="horizontal"]) .container {
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  /* ── Webkit scrollbar styling ────────────────────────────────────────────── */
+
+  .container::-webkit-scrollbar {
+    width: var(--_track-size);
+    height: var(--_track-size);
+  }
+
+  .container::-webkit-scrollbar-track {
+    background: var(--_track-bg);
+  }
+
+  .container::-webkit-scrollbar-thumb {
+    background: var(--_thumb-bg);
+    border-radius: var(--_thumb-radius);
+    border: 3px solid transparent;
+    background-clip: content-box;
+  }
+
+  /* Bold: vertical border on left side of track */
+  :host([emphasis="bold"][orientation="vertical"]) .container::-webkit-scrollbar-track,
+  :host([emphasis="bold"]:not([orientation])) .container::-webkit-scrollbar-track {
+    border-left: 1px solid var(--_border-color);
+  }
+
+  /* Bold: horizontal border on top of track */
+  :host([emphasis="bold"][orientation="horizontal"]) .container::-webkit-scrollbar-track {
+    border-top: 1px solid var(--_border-color);
+  }
+
+  /* Minimal: thinner thumb, no border */
+  :host([emphasis="minimal"]) .container::-webkit-scrollbar-thumb {
+    border: 2px solid transparent;
+    background-clip: content-box;
+  }
+
+  /* ── Firefox scrollbar styling ─────────────────────────────────────────── */
+
+  :host([emphasis="bold"]) .container,
+  :host(:not([emphasis])) .container {
+    scrollbar-width: auto;
+    scrollbar-color: var(--_thumb-bg) var(--_track-bg);
+  }
+
+  :host([emphasis="minimal"]) .container {
+    scrollbar-width: thin;
+    scrollbar-color: var(--_thumb-bg) transparent;
+  }
+`;

--- a/packages/ui-components/src/components/ui-scrollbar.test.ts
+++ b/packages/ui-components/src/components/ui-scrollbar.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "./ui-scrollbar.js";
+import type { ScrollbarEmphasis, ScrollbarOrientation } from "./ui-scrollbar.js";
+import { STYLES } from "./ui-scrollbar.styles.js";
+
+describe("ui-scrollbar", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-scrollbar");
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-scrollbar")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("applies adoptedStyleSheets", () => {
+    expect(el.shadowRoot!.adoptedStyleSheets.length).toBe(1);
+  });
+
+  // ── Default rendering ─────────────────────────────────────────────────────
+
+  it("renders a .container element", () => {
+    const container = el.shadowRoot!.querySelector(".container");
+    expect(container).not.toBeNull();
+  });
+
+  it("renders a <slot> inside the container", () => {
+    const slot = el.shadowRoot!.querySelector(".container slot");
+    expect(slot).not.toBeNull();
+  });
+
+  // ── Default attributes ─────────────────────────────────────────────────────
+
+  it("defaults emphasis to 'bold'", () => {
+    expect(el.getAttribute("emphasis")).toBe("bold");
+  });
+
+  it("defaults orientation to 'vertical'", () => {
+    expect(el.getAttribute("orientation")).toBe("vertical");
+  });
+
+  // ── Emphasis attribute ─────────────────────────────────────────────────────
+
+  it("accepts emphasis='bold'", () => {
+    el.setAttribute("emphasis", "bold");
+    expect(el.getAttribute("emphasis")).toBe("bold");
+  });
+
+  it("accepts emphasis='minimal'", () => {
+    el.setAttribute("emphasis", "minimal");
+    expect(el.getAttribute("emphasis")).toBe("minimal");
+  });
+
+  // ── Orientation attribute ──────────────────────────────────────────────────
+
+  it("accepts orientation='vertical'", () => {
+    el.setAttribute("orientation", "vertical");
+    expect(el.getAttribute("orientation")).toBe("vertical");
+  });
+
+  it("accepts orientation='horizontal'", () => {
+    el.setAttribute("orientation", "horizontal");
+    expect(el.getAttribute("orientation")).toBe("horizontal");
+  });
+
+  // ── Property accessors ─────────────────────────────────────────────────────
+
+  it("emphasis getter returns the attribute value", () => {
+    el.setAttribute("emphasis", "minimal");
+    expect((el as any).emphasis).toBe("minimal");
+  });
+
+  it("emphasis setter updates the attribute", () => {
+    (el as any).emphasis = "minimal";
+    expect(el.getAttribute("emphasis")).toBe("minimal");
+  });
+
+  it("emphasis getter defaults to 'bold'", () => {
+    expect((el as any).emphasis).toBe("bold");
+  });
+
+  it("orientation getter returns the attribute value", () => {
+    el.setAttribute("orientation", "horizontal");
+    expect((el as any).orientation).toBe("horizontal");
+  });
+
+  it("orientation setter updates the attribute", () => {
+    (el as any).orientation = "horizontal";
+    expect(el.getAttribute("orientation")).toBe("horizontal");
+  });
+
+  it("orientation getter defaults to 'vertical'", () => {
+    expect((el as any).orientation).toBe("vertical");
+  });
+
+  // ── observedAttributes ─────────────────────────────────────────────────────
+
+  it("observes 'emphasis' attribute", () => {
+    const observed = (customElements.get("ui-scrollbar") as any).observedAttributes;
+    expect(observed).toContain("emphasis");
+  });
+
+  it("observes 'orientation' attribute", () => {
+    const observed = (customElements.get("ui-scrollbar") as any).observedAttributes;
+    expect(observed).toContain("orientation");
+  });
+
+  it("observedAttributes has exactly 2 entries", () => {
+    const observed = (customElements.get("ui-scrollbar") as any).observedAttributes;
+    expect(observed).toHaveLength(2);
+  });
+
+  // ── STYLES ─────────────────────────────────────────────────────────────────
+
+  it("STYLES contains ::-webkit-scrollbar rule", () => {
+    expect(STYLES).toContain("::-webkit-scrollbar");
+  });
+
+  it("STYLES contains ::-webkit-scrollbar-track rule", () => {
+    expect(STYLES).toContain("::-webkit-scrollbar-track");
+  });
+
+  it("STYLES contains ::-webkit-scrollbar-thumb rule", () => {
+    expect(STYLES).toContain("::-webkit-scrollbar-thumb");
+  });
+
+  it("STYLES contains scrollbar-color for Firefox", () => {
+    expect(STYLES).toContain("scrollbar-color");
+  });
+
+  it("STYLES contains scrollbar-width for Firefox", () => {
+    expect(STYLES).toContain("scrollbar-width");
+  });
+
+  // ── Slotted content ────────────────────────────────────────────────────────
+
+  it("projects slotted content through the default slot", () => {
+    const child = document.createElement("div");
+    child.textContent = "scrollable content";
+    el.appendChild(child);
+    const slot = el.shadowRoot!.querySelector("slot") as HTMLSlotElement;
+    const assigned = slot.assignedNodes();
+    expect(assigned).toContain(child);
+  });
+
+  // ── No default attributes before connectedCallback ─────────────────────────
+
+  it("does not set defaults before being added to DOM", () => {
+    const detached = document.createElement("ui-scrollbar");
+    expect(detached.hasAttribute("emphasis")).toBe(false);
+    expect(detached.hasAttribute("orientation")).toBe(false);
+  });
+
+  // ── Preserves user-set attributes ──────────────────────────────────────────
+
+  it("preserves emphasis if already set before connection", () => {
+    const fresh = document.createElement("ui-scrollbar");
+    fresh.setAttribute("emphasis", "minimal");
+    document.body.appendChild(fresh);
+    expect(fresh.getAttribute("emphasis")).toBe("minimal");
+  });
+
+  it("preserves orientation if already set before connection", () => {
+    const fresh = document.createElement("ui-scrollbar");
+    fresh.setAttribute("orientation", "horizontal");
+    document.body.appendChild(fresh);
+    expect(fresh.getAttribute("orientation")).toBe("horizontal");
+  });
+});

--- a/packages/ui-components/src/components/ui-scrollbar.ts
+++ b/packages/ui-components/src/components/ui-scrollbar.ts
@@ -1,0 +1,50 @@
+import { STYLES } from "./ui-scrollbar.styles.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type ScrollbarEmphasis = "bold" | "minimal";
+export type ScrollbarOrientation = "vertical" | "horizontal";
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiScrollbar extends HTMLElement {
+  static readonly observedAttributes = ["emphasis", "orientation"];
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    const container = document.createElement("div");
+    container.className = "container";
+    const slot = document.createElement("slot");
+    container.appendChild(slot);
+    shadow.appendChild(container);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("emphasis")) this.setAttribute("emphasis", "bold");
+    if (!this.hasAttribute("orientation")) this.setAttribute("orientation", "vertical");
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get emphasis(): ScrollbarEmphasis {
+    return (this.getAttribute("emphasis") as ScrollbarEmphasis) ?? "bold";
+  }
+  set emphasis(v: ScrollbarEmphasis) {
+    this.setAttribute("emphasis", v);
+  }
+
+  get orientation(): ScrollbarOrientation {
+    return (this.getAttribute("orientation") as ScrollbarOrientation) ?? "vertical";
+  }
+  set orientation(v: ScrollbarOrientation) {
+    this.setAttribute("orientation", v);
+  }
+}
+
+customElements.define("ui-scrollbar", UiScrollbar);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -210,3 +210,8 @@ export type {
   QueryfieldSubmitDetail,
   QueryfieldInputDetail,
 } from "./components/ui-queryfield.js";
+
+// ─── Scrollbar ───────────────────────────────────────────────────────────────
+
+export { UiScrollbar } from "./components/ui-scrollbar.js";
+export type { ScrollbarEmphasis, ScrollbarOrientation } from "./components/ui-scrollbar.js";

--- a/packages/ui-components/src/stories/ui-scrollbar.stories.ts
+++ b/packages/ui-components/src/stories/ui-scrollbar.stories.ts
@@ -1,0 +1,127 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-scrollbar.js";
+
+const meta: Meta = {
+  title: "Components/Scrollbar",
+  component: "ui-scrollbar",
+  argTypes: {
+    emphasis: {
+      control: { type: "select" },
+      options: ["bold", "minimal"],
+    },
+    orientation: {
+      control: { type: "select" },
+      options: ["vertical", "horizontal"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+const TALL_CONTENT = html`
+  <div style="padding: 16px;">
+    ${Array.from(
+      { length: 20 },
+      (_, i) => html`<p style="margin: 0 0 12px;">Line ${i + 1} — Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>`,
+    )}
+  </div>
+`;
+
+const WIDE_CONTENT = html`
+  <div style="white-space: nowrap; padding: 16px;">
+    ${Array.from(
+      { length: 10 },
+      (_, i) =>
+        html`<p style="margin: 0 0 12px;">
+          Row ${i + 1} — Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.
+        </p>`,
+    )}
+  </div>
+`;
+
+const wrapperStyle = "width: 300px; height: 200px; border: 1px solid #dce3e8; border-radius: 4px;";
+
+export const BoldVertical: Story = {
+  args: {
+    emphasis: "bold",
+    orientation: "vertical",
+  },
+  render: (args) =>
+    html`<ui-scrollbar
+      emphasis=${args.emphasis}
+      orientation=${args.orientation}
+      style=${wrapperStyle}
+    >${TALL_CONTENT}</ui-scrollbar>`,
+};
+
+export const BoldHorizontal: Story = {
+  args: {
+    emphasis: "bold",
+    orientation: "horizontal",
+  },
+  render: (args) =>
+    html`<ui-scrollbar
+      emphasis=${args.emphasis}
+      orientation=${args.orientation}
+      style=${wrapperStyle}
+    >${WIDE_CONTENT}</ui-scrollbar>`,
+};
+
+export const MinimalVertical: Story = {
+  args: {
+    emphasis: "minimal",
+    orientation: "vertical",
+  },
+  render: (args) =>
+    html`<ui-scrollbar
+      emphasis=${args.emphasis}
+      orientation=${args.orientation}
+      style=${wrapperStyle}
+    >${TALL_CONTENT}</ui-scrollbar>`,
+};
+
+export const MinimalHorizontal: Story = {
+  args: {
+    emphasis: "minimal",
+    orientation: "horizontal",
+  },
+  render: (args) =>
+    html`<ui-scrollbar
+      emphasis=${args.emphasis}
+      orientation=${args.orientation}
+      style=${wrapperStyle}
+    >${WIDE_CONTENT}</ui-scrollbar>`,
+};
+
+export const AllVariants: Story = {
+  render: () => html`
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 24px; max-width: 700px;">
+      <div>
+        <p style="margin: 0 0 8px; font-weight: 600;">Bold / Vertical</p>
+        <ui-scrollbar emphasis="bold" orientation="vertical" style=${wrapperStyle}>
+          ${TALL_CONTENT}
+        </ui-scrollbar>
+      </div>
+      <div>
+        <p style="margin: 0 0 8px; font-weight: 600;">Bold / Horizontal</p>
+        <ui-scrollbar emphasis="bold" orientation="horizontal" style=${wrapperStyle}>
+          ${WIDE_CONTENT}
+        </ui-scrollbar>
+      </div>
+      <div>
+        <p style="margin: 0 0 8px; font-weight: 600;">Minimal / Vertical</p>
+        <ui-scrollbar emphasis="minimal" orientation="vertical" style=${wrapperStyle}>
+          ${TALL_CONTENT}
+        </ui-scrollbar>
+      </div>
+      <div>
+        <p style="margin: 0 0 8px; font-weight: 600;">Minimal / Horizontal</p>
+        <ui-scrollbar emphasis="minimal" orientation="horizontal" style=${wrapperStyle}>
+          ${WIDE_CONTENT}
+        </ui-scrollbar>
+      </div>
+    </div>
+  `,
+};


### PR DESCRIPTION
## Summary

New `<ui-scrollbar>` Web Component — a wrapper that applies custom scrollbar styling to slotted content.

## Features

- 2 emphases: `bold` (gray track background + border) and `minimal` (transparent track, just the thumb)
- 2 orientations: `vertical` and `horizontal`
- Webkit: custom `::-webkit-scrollbar`, `::-webkit-scrollbar-track`, `::-webkit-scrollbar-thumb`
- Firefox: `scrollbar-width: thin`, `scrollbar-color`
- 12px track width, 5px rounded thumb, semantic token colors

## API

```html
<ui-scrollbar emphasis="bold" orientation="vertical" style="width: 200px; height: 200px;">
  <div>Overflowing content here...</div>
</ui-scrollbar>
```

## Testing

- 2843 unit tests (29 new)
- Storybook stories (bold/minimal × vertical/horizontal)
- 46 Playwright visual regression tests (1 new)

## Files

- `packages/ui-components/src/components/ui-scrollbar.ts` + `ui-scrollbar.styles.ts`
- `packages/ui-components/src/components/ui-scrollbar.test.ts`
- `packages/ui-components/src/stories/ui-scrollbar.stories.ts`
- `packages/ui-components/src/index.ts` — barrel exports
- `apps/catalog/src/pages/scrollbar.ts` — catalog page