### PR TITLE
feat(ui-components): add ui-separator component

### DIFF
--- a/apps/catalog/e2e/visual.spec.ts
+++ b/apps/catalog/e2e/visual.spec.ts
@@ -18,6 +18,7 @@ const pages = [
   "label",
   "link",
   "tag",
+  "separator",
   "checkbox",
   "radio",
   "input",

--- a/apps/catalog/src/main.ts
+++ b/apps/catalog/src/main.ts
@@ -36,6 +36,7 @@ const pageLoaders: Record<string, () => Promise<unknown>> = {
   "label": () => import("./pages/label.js"),
   "link": () => import("./pages/link.js"),
   "tag": () => import("./pages/tag.js"),
+  "separator": () => import("./pages/separator.js"),
   "checkbox": () => import("./pages/checkbox.js"),
   "radio": () => import("./pages/radio.js"),
   "input": () => import("./pages/input.js"),

--- a/apps/catalog/src/manifest.ts
+++ b/apps/catalog/src/manifest.ts
@@ -41,6 +41,7 @@ export const manifest: PageMeta[] = [
   { id: "label", title: "Label", section: "Primitives" },
   { id: "link", title: "Link", section: "Primitives" },
   { id: "tag", title: "Tag", section: "Primitives" },
+  { id: "separator", title: "Separator", section: "Primitives" },
   // Form Controls
   { id: "checkbox", title: "Checkbox", section: "Form Controls" },
   { id: "radio", title: "Radio", section: "Form Controls" },

--- a/apps/catalog/src/pages/separator.ts
+++ b/apps/catalog/src/pages/separator.ts
@@ -1,0 +1,79 @@
+import { registerPage } from "../registry.js";
+
+registerPage("separator", {
+  title: "Separator",
+  section: "Primitives",
+  render: () => `
+    <h3>Emphasis — Horizontal</h3>
+    <div class="stack-l" style="gap: 24px; max-width: 400px;">
+      <div class="variant-col">
+        <span class="variant-label">Minimal</span>
+        <ui-separator emphasis="minimal"></ui-separator>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Subtle</span>
+        <ui-separator emphasis="subtle"></ui-separator>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Moderate</span>
+        <ui-separator emphasis="moderate"></ui-separator>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Bold</span>
+        <ui-separator emphasis="bold"></ui-separator>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Contrast</span>
+        <ui-separator emphasis="contrast"></ui-separator>
+      </div>
+    </div>
+
+    <h3>Length — Horizontal</h3>
+    <div class="stack-l" style="gap: 24px; max-width: 400px;">
+      <div class="variant-col">
+        <span class="variant-label">Full</span>
+        <ui-separator emphasis="bold" length="full"></ui-separator>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Inset 04</span>
+        <ui-separator emphasis="bold" length="inset-04"></ui-separator>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Inset 08</span>
+        <ui-separator emphasis="bold" length="inset-08"></ui-separator>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Inset 16</span>
+        <ui-separator emphasis="bold" length="inset-16"></ui-separator>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Inset 24</span>
+        <ui-separator emphasis="bold" length="inset-24"></ui-separator>
+      </div>
+    </div>
+
+    <h3>Vertical — Emphasis</h3>
+    <div class="variant-row" style="gap: 40px; height: 80px; align-items: stretch;">
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Minimal</span>
+        <ui-separator orientation="vertical" emphasis="minimal"></ui-separator>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Subtle</span>
+        <ui-separator orientation="vertical" emphasis="subtle"></ui-separator>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Moderate</span>
+        <ui-separator orientation="vertical" emphasis="moderate"></ui-separator>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Bold</span>
+        <ui-separator orientation="vertical" emphasis="bold"></ui-separator>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Contrast</span>
+        <ui-separator orientation="vertical" emphasis="contrast"></ui-separator>
+      </div>
+    </div>
+  `,
+});

--- a/packages/ui-components/src/components/ui-separator.test.ts
+++ b/packages/ui-components/src/components/ui-separator.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "./ui-separator.js";
+import type {
+  SeparatorOrientation,
+  SeparatorEmphasis,
+  SeparatorLength,
+} from "./ui-separator.js";
+import { UiSeparator } from "./ui-separator.js";
+
+describe("ui-separator", () => {
+  let el: UiSeparator;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-separator") as UiSeparator;
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-separator")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("applies adoptedStyleSheets", () => {
+    expect(el.shadowRoot!.adoptedStyleSheets.length).toBe(1);
+  });
+
+  // ── Default rendering ─────────────────────────────────────────────────────
+
+  it("renders a .line element", () => {
+    const line = el.shadowRoot!.querySelector(".line");
+    expect(line).not.toBeNull();
+  });
+
+  it("sets role=separator on the .line element", () => {
+    const line = el.shadowRoot!.querySelector(".line");
+    expect(line!.getAttribute("role")).toBe("separator");
+  });
+
+  // ── Default attributes ────────────────────────────────────────────────────
+
+  it("defaults orientation to horizontal", () => {
+    expect(el.getAttribute("orientation")).toBe("horizontal");
+  });
+
+  it("defaults emphasis to minimal", () => {
+    expect(el.getAttribute("emphasis")).toBe("minimal");
+  });
+
+  it("defaults length to full", () => {
+    expect(el.getAttribute("length")).toBe("full");
+  });
+
+  it("defaults role to separator on host", () => {
+    expect(el.getAttribute("role")).toBe("separator");
+  });
+
+  // ── Orientation attribute ─────────────────────────────────────────────────
+
+  it("accepts orientation=horizontal", () => {
+    el.setAttribute("orientation", "horizontal");
+    expect(el.getAttribute("orientation")).toBe("horizontal");
+  });
+
+  it("accepts orientation=vertical", () => {
+    el.setAttribute("orientation", "vertical");
+    expect(el.getAttribute("orientation")).toBe("vertical");
+  });
+
+  // ── Emphasis attribute ────────────────────────────────────────────────────
+
+  const emphases: SeparatorEmphasis[] = [
+    "minimal",
+    "subtle",
+    "moderate",
+    "bold",
+    "contrast",
+  ];
+
+  for (const emphasis of emphases) {
+    it(`accepts emphasis=${emphasis}`, () => {
+      el.setAttribute("emphasis", emphasis);
+      expect(el.getAttribute("emphasis")).toBe(emphasis);
+    });
+  }
+
+  // ── Length attribute ──────────────────────────────────────────────────────
+
+  const lengths: SeparatorLength[] = [
+    "full",
+    "inset-04",
+    "inset-08",
+    "inset-16",
+    "inset-24",
+  ];
+
+  for (const length of lengths) {
+    it(`accepts length=${length}`, () => {
+      el.setAttribute("length", length);
+      expect(el.getAttribute("length")).toBe(length);
+    });
+  }
+
+  // ── Property accessors ────────────────────────────────────────────────────
+
+  it("orientation getter returns current attribute value", () => {
+    el.setAttribute("orientation", "vertical");
+    expect(el.orientation).toBe("vertical");
+  });
+
+  it("orientation setter updates the attribute", () => {
+    el.orientation = "vertical";
+    expect(el.getAttribute("orientation")).toBe("vertical");
+  });
+
+  it("emphasis getter returns current attribute value", () => {
+    el.setAttribute("emphasis", "bold");
+    expect(el.emphasis).toBe("bold");
+  });
+
+  it("emphasis setter updates the attribute", () => {
+    el.emphasis = "contrast";
+    expect(el.getAttribute("emphasis")).toBe("contrast");
+  });
+
+  it("length getter returns current attribute value", () => {
+    el.setAttribute("length", "inset-16");
+    expect(el.length).toBe("inset-16");
+  });
+
+  it("length setter updates the attribute", () => {
+    el.length = "inset-24";
+    expect(el.getAttribute("length")).toBe("inset-24");
+  });
+
+  // ── ARIA ──────────────────────────────────────────────────────────────────
+
+  it("has role=separator on the host element", () => {
+    expect(el.getAttribute("role")).toBe("separator");
+  });
+
+  it("does not override an existing role on the host", () => {
+    const el2 = document.createElement("ui-separator") as UiSeparator;
+    el2.setAttribute("role", "presentation");
+    document.body.appendChild(el2);
+    expect(el2.getAttribute("role")).toBe("presentation");
+  });
+
+  // ── observedAttributes ────────────────────────────────────────────────────
+
+  it("observes orientation, emphasis, and length", () => {
+    expect(UiSeparator.observedAttributes).toEqual([
+      "orientation",
+      "emphasis",
+      "length",
+    ]);
+  });
+
+  it("observedAttributes has exactly 3 entries", () => {
+    expect(UiSeparator.observedAttributes).toHaveLength(3);
+  });
+});

--- a/packages/ui-components/src/components/ui-separator.ts
+++ b/packages/ui-components/src/components/ui-separator.ts
@@ -1,0 +1,173 @@
+import { semanticVar } from "@maneki/foundation";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const BORDER_MINIMAL = semanticVar("border", "minimal");
+const BORDER_SUBTLE = semanticVar("border", "subtle");
+const BORDER_MODERATE = semanticVar("border", "moderate");
+const BORDER_BOLD = semanticVar("border", "bold");
+const BORDER_CONTRAST = semanticVar("border", "contrast");
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type SeparatorOrientation = "horizontal" | "vertical";
+export type SeparatorEmphasis = "minimal" | "subtle" | "moderate" | "bold" | "contrast";
+export type SeparatorLength = "full" | "inset-04" | "inset-08" | "inset-16" | "inset-24";
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  :host {
+    display: block;
+  }
+
+  .line {
+    border: none;
+    margin: 0;
+  }
+
+  /* ── Horizontal (default) ────────────────────────────────────────────────── */
+
+  :host,
+  :host([orientation="horizontal"]) {
+    width: 100%;
+  }
+
+  :host([orientation="horizontal"]) .line,
+  :host:not([orientation]) .line {
+    height: 1px;
+    width: 100%;
+  }
+
+  /* ── Vertical ────────────────────────────────────────────────────────────── */
+
+  :host([orientation="vertical"]) {
+    display: inline-block;
+    height: 100%;
+    width: auto;
+  }
+
+  :host([orientation="vertical"]) .line {
+    width: 1px;
+    height: 100%;
+  }
+
+  /* ── Emphasis ─────────────────────────────────────────────────────────────── */
+
+  :host([emphasis="minimal"]) .line,
+  :host:not([emphasis]) .line {
+    background: ${BORDER_MINIMAL};
+  }
+
+  :host([emphasis="subtle"]) .line {
+    background: ${BORDER_SUBTLE};
+  }
+
+  :host([emphasis="moderate"]) .line {
+    background: ${BORDER_MODERATE};
+  }
+
+  :host([emphasis="bold"]) .line {
+    background: ${BORDER_BOLD};
+  }
+
+  :host([emphasis="contrast"]) .line {
+    background: ${BORDER_CONTRAST};
+  }
+
+  /* ── Length: horizontal insets ────────────────────────────────────────────── */
+
+  :host([length="inset-04"]:not([orientation="vertical"])) .line {
+    margin-left: 4px;
+    margin-right: 4px;
+  }
+
+  :host([length="inset-08"]:not([orientation="vertical"])) .line {
+    margin-left: 8px;
+    margin-right: 8px;
+  }
+
+  :host([length="inset-16"]:not([orientation="vertical"])) .line {
+    margin-left: 16px;
+    margin-right: 16px;
+  }
+
+  :host([length="inset-24"]:not([orientation="vertical"])) .line {
+    margin-left: 24px;
+    margin-right: 24px;
+  }
+
+  /* ── Length: vertical insets ─────────────────────────────────────────────── */
+
+  :host([orientation="vertical"][length="inset-04"]) .line {
+    margin-top: 4px;
+    margin-bottom: 4px;
+  }
+
+  :host([orientation="vertical"][length="inset-08"]) .line {
+    margin-top: 8px;
+    margin-bottom: 8px;
+  }
+
+  :host([orientation="vertical"][length="inset-16"]) .line {
+    margin-top: 16px;
+    margin-bottom: 16px;
+  }
+
+  :host([orientation="vertical"][length="inset-24"]) .line {
+    margin-top: 24px;
+    margin-bottom: 24px;
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiSeparator extends HTMLElement {
+  static readonly observedAttributes = ["orientation", "emphasis", "length"];
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    const line = document.createElement("div");
+    line.className = "line";
+    line.setAttribute("role", "separator");
+    shadow.appendChild(line);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("orientation")) this.setAttribute("orientation", "horizontal");
+    if (!this.hasAttribute("emphasis")) this.setAttribute("emphasis", "minimal");
+    if (!this.hasAttribute("length")) this.setAttribute("length", "full");
+    if (!this.hasAttribute("role")) this.setAttribute("role", "separator");
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get orientation(): SeparatorOrientation {
+    return (this.getAttribute("orientation") as SeparatorOrientation) ?? "horizontal";
+  }
+  set orientation(v: SeparatorOrientation) {
+    this.setAttribute("orientation", v);
+  }
+
+  get emphasis(): SeparatorEmphasis {
+    return (this.getAttribute("emphasis") as SeparatorEmphasis) ?? "minimal";
+  }
+  set emphasis(v: SeparatorEmphasis) {
+    this.setAttribute("emphasis", v);
+  }
+
+  get length(): SeparatorLength {
+    return (this.getAttribute("length") as SeparatorLength) ?? "full";
+  }
+  set length(v: SeparatorLength) {
+    this.setAttribute("length", v);
+  }
+}
+
+customElements.define("ui-separator", UiSeparator);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -226,3 +226,8 @@ export type {
   SearchSelectDetail,
   SearchShowAllDetail,
 } from "./components/ui-search.js";
+
+// ─── Separator ────────────────────────────────────────────────────────────────
+
+export { UiSeparator } from "./components/ui-separator.js";
+export type { SeparatorOrientation, SeparatorEmphasis, SeparatorLength } from "./components/ui-separator.js";

--- a/packages/ui-components/src/stories/ui-separator.stories.ts
+++ b/packages/ui-components/src/stories/ui-separator.stories.ts
@@ -1,0 +1,103 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-separator.js";
+
+const meta: Meta = {
+  title: "Components/Separator",
+  component: "ui-separator",
+  argTypes: {
+    orientation: {
+      control: { type: "select" },
+      options: ["horizontal", "vertical"],
+    },
+    emphasis: {
+      control: { type: "select" },
+      options: ["minimal", "subtle", "moderate", "bold", "contrast"],
+    },
+    length: {
+      control: { type: "select" },
+      options: ["full", "inset-04", "inset-08", "inset-16", "inset-24"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {
+  args: {
+    orientation: "horizontal",
+    emphasis: "minimal",
+    length: "full",
+  },
+  render: (args) =>
+    html`<ui-separator
+      orientation=${args.orientation}
+      emphasis=${args.emphasis}
+      length=${args.length}
+    ></ui-separator>`,
+};
+
+export const AllEmphases: Story = {
+  render: () => html`
+    <div style="display:flex; flex-direction:column; gap:16px;">
+      ${(["minimal", "subtle", "moderate", "bold", "contrast"] as const).map(
+        (e) => html`
+          <div>
+            <div style="margin-bottom:4px; font-size:12px; color:#666;">${e}</div>
+            <ui-separator emphasis=${e}></ui-separator>
+          </div>
+        `,
+      )}
+    </div>
+  `,
+};
+
+export const AllLengths: Story = {
+  render: () => html`
+    <div style="display:flex; flex-direction:column; gap:16px;">
+      ${(["full", "inset-04", "inset-08", "inset-16", "inset-24"] as const).map(
+        (l) => html`
+          <div>
+            <div style="margin-bottom:4px; font-size:12px; color:#666;">${l}</div>
+            <ui-separator emphasis="bold" length=${l}></ui-separator>
+          </div>
+        `,
+      )}
+    </div>
+  `,
+};
+
+export const Vertical: Story = {
+  render: () => html`
+    <div style="display:flex; flex-direction:row; gap:16px; height:100px;">
+      ${(["minimal", "subtle", "moderate", "bold", "contrast"] as const).map(
+        (e) => html`
+          <div style="display:flex; align-items:center; gap:4px;">
+            <span style="font-size:12px; color:#666;">${e}</span>
+            <ui-separator orientation="vertical" emphasis=${e}></ui-separator>
+          </div>
+        `,
+      )}
+    </div>
+  `,
+};
+
+export const VerticalLengths: Story = {
+  render: () => html`
+    <div style="display:flex; flex-direction:row; gap:16px; height:100px;">
+      ${(["full", "inset-04", "inset-08", "inset-16", "inset-24"] as const).map(
+        (l) => html`
+          <div style="display:flex; align-items:center; gap:4px;">
+            <span style="font-size:12px; color:#666;">${l}</span>
+            <ui-separator
+              orientation="vertical"
+              emphasis="bold"
+              length=${l}
+            ></ui-separator>
+          </div>
+        `,
+      )}
+    </div>
+  `,
+};


### PR DESCRIPTION
## Summary

New `<ui-separator>` Web Component — a horizontal or vertical divider line with configurable emphasis and inset length.

## Features

- 2 orientations: `horizontal` (1px height, full width) and `vertical` (1px width, full height)
- 5 emphases: `minimal` (#DCE3E8), `subtle` (#C1CCD6), `moderate` (#9FB1BD), `bold` (#5B7282), `contrast` (#1C2B36)
- 5 lengths: `full`, `inset-04`, `inset-08`, `inset-16`, `inset-24` (symmetric margin insets)
- ARIA: `role="separator"`

## API

```html
<ui-separator emphasis="bold" length="inset-16"></ui-separator>
<ui-separator orientation="vertical" emphasis="moderate"></ui-separator>
```

## Testing

- 2937 unit tests (31 new)
- 5 Storybook stories
- 48 Playwright visual regression tests (1 new)

## Files

- `packages/ui-components/src/components/ui-separator.ts`
- `packages/ui-components/src/components/ui-separator.test.ts`
- `packages/ui-components/src/stories/ui-separator.stories.ts`
- `packages/ui-components/src/index.ts` — barrel exports
- `apps/catalog/src/pages/separator.ts` — catalog page