### PR TITLE
feat(ui-components): add ui-slider component

### DIFF
--- a/apps/catalog/e2e/visual.spec.ts
+++ b/apps/catalog/e2e/visual.spec.ts
@@ -27,6 +27,7 @@ const pages = [
   "select",
   "queryfield",
   "search",
+  "slider",
   "card",
   "breadcrumb",
   "accordion",

--- a/apps/catalog/src/main.ts
+++ b/apps/catalog/src/main.ts
@@ -45,6 +45,7 @@ const pageLoaders: Record<string, () => Promise<unknown>> = {
   "select": () => import("./pages/select.js"),
   "queryfield": () => import("./pages/queryfield.js"),
   "search": () => import("./pages/search.js"),
+  "slider": () => import("./pages/slider.js"),
   "card": () => import("./pages/card.js"),
   "breadcrumb": () => import("./pages/breadcrumb.js"),
   "accordion": () => import("./pages/accordion.js"),

--- a/apps/catalog/src/manifest.ts
+++ b/apps/catalog/src/manifest.ts
@@ -51,6 +51,7 @@ export const manifest: PageMeta[] = [
   { id: "select", title: "Select", section: "Form Controls" },
   { id: "queryfield", title: "Queryfield", section: "Form Controls" },
   { id: "search", title: "Search", section: "Form Controls" },
+  { id: "slider", title: "Slider", section: "Form Controls" },
   // Containers
   { id: "card", title: "Card", section: "Containers" },
   { id: "carousel", title: "Carousel", section: "Containers" },

--- a/apps/catalog/src/pages/slider.ts
+++ b/apps/catalog/src/pages/slider.ts
@@ -1,0 +1,84 @@
+import { registerPage } from "../registry.js";
+
+registerPage("slider", {
+  title: "Slider",
+  section: "Form Controls",
+  render: () => `
+    <h3>Sizes</h3>
+    <div class="stack-l" style="gap: 24px; max-width: 400px;">
+      <div class="variant-col">
+        <span class="variant-label">S</span>
+        <ui-slider size="s" value="50"></ui-slider>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">M</span>
+        <ui-slider size="m" value="50"></ui-slider>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">L</span>
+        <ui-slider size="l" value="50"></ui-slider>
+      </div>
+    </div>
+
+    <h3>With Labels</h3>
+    <div class="stack-l" style="gap: 24px; max-width: 400px;">
+      <div class="variant-col">
+        <span class="variant-label">S</span>
+        <ui-slider size="s" value="50" labels></ui-slider>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">M</span>
+        <ui-slider size="m" value="50" labels></ui-slider>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">L</span>
+        <ui-slider size="l" value="50" labels></ui-slider>
+      </div>
+    </div>
+
+    <h3>Range</h3>
+    <div class="stack-l" style="gap: 24px; max-width: 400px;">
+      <div class="variant-col">
+        <span class="variant-label">Range 0\u201350</span>
+        <ui-slider size="m" range value="0" value-high="50" labels></ui-slider>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Range 25\u201375</span>
+        <ui-slider size="m" range value="25" value-high="75" labels></ui-slider>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Range 50\u2013100</span>
+        <ui-slider size="m" range value="50" value-high="100" labels></ui-slider>
+      </div>
+    </div>
+
+    <h3>Steps</h3>
+    <div class="stack-l" style="gap: 24px; max-width: 400px;">
+      <div class="variant-col">
+        <span class="variant-label">Step 10</span>
+        <ui-slider size="m" value="50" step="10" labels></ui-slider>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Step 25</span>
+        <ui-slider size="m" value="50" step="25" labels></ui-slider>
+      </div>
+    </div>
+
+    <h3>Disabled</h3>
+    <div class="stack-l" style="gap: 24px; max-width: 400px;">
+      <ui-slider size="m" value="50" labels disabled></ui-slider>
+    </div>
+
+    <h3>Interactive (drag or use arrow keys)</h3>
+    <div class="stack-l" style="gap: 24px; max-width: 400px;">
+      <div class="variant-col">
+        <span class="variant-label">Single</span>
+        <ui-slider id="slider-single" size="l" value="30" labels tooltip></ui-slider>
+      </div>
+      <div class="variant-col">
+        <span class="variant-label">Range</span>
+        <ui-slider id="slider-range" size="l" range value="20" value-high="80" labels tooltip></ui-slider>
+      </div>
+    </div>
+  `,
+});

--- a/packages/ui-components/src/components/ui-slider.styles.ts
+++ b/packages/ui-components/src/components/ui-slider.styles.ts
@@ -1,0 +1,230 @@
+import { semanticVar, colorVar } from "@maneki/foundation";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const BLUE_60 = colorVar("blue", 60);
+const SURFACE_BOLD = semanticVar("surface", "bold");
+const DISABLED_TEXT = semanticVar("stateDisabled", "text");
+const BORDER_FOCUS = semanticVar("border", "focus");
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type SliderSize = "s" | "m" | "l";
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+export const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: block;
+    width: 100%;
+    font-family: "Geist", sans-serif;
+    position: relative;
+    user-select: none;
+    -webkit-user-select: none;
+  }
+
+  .wrapper {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  /* ── Track area ──────────────────────────────────────────────────────────── */
+
+  .track-area {
+    position: relative;
+    width: 100%;
+    cursor: pointer;
+  }
+
+  .track {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 2px;
+    background: ${SURFACE_BOLD};
+  }
+
+  .fill {
+    position: absolute;
+    height: 2px;
+    background: ${BLUE_60};
+  }
+
+  /* ── Handle ──────────────────────────────────────────────────────────────── */
+
+  .handle {
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    border-radius: 999px;
+    background: ${BLUE_60};
+    cursor: grab;
+    z-index: 1;
+    touch-action: none;
+  }
+
+  .handle:active {
+    cursor: grabbing;
+  }
+
+  .handle-inner {
+    position: absolute;
+    inset: 2px;
+    border-radius: 999px;
+    background: #ffffff;
+    transition: background 0.1s ease;
+  }
+
+  .handle.active .handle-inner {
+    background: ${BLUE_60};
+  }
+
+  .handle:focus-visible {
+    outline: 2px solid ${BORDER_FOCUS};
+    outline-offset: 2px;
+  }
+
+  /* ── Labels ──────────────────────────────────────────────────────────────── */
+
+  .labels {
+    display: none;
+    justify-content: space-between;
+    font-size: 12px;
+    line-height: 16px;
+    color: ${TEXT_PRIMARY};
+  }
+
+  :host([labels]) .labels {
+    display: flex;
+  }
+
+  /* ── Tooltip ─────────────────────────────────────────────────────────────── */
+
+  .tooltip {
+    display: none;
+    position: absolute;
+    left: 50%;
+    bottom: 100%;
+    transform: translateX(-50%);
+    margin-bottom: 8px;
+    background: #090F14;
+    color: #ffffff;
+    font-size: 12px;
+    line-height: 16px;
+    padding: 4px 8px;
+    border-radius: 2px;
+    white-space: nowrap;
+    pointer-events: none;
+    z-index: 2;
+  }
+
+  .tooltip::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: -4px;
+    width: 0;
+    height: 0;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    border-top: 4px solid #090F14;
+  }
+
+  .handle.active .tooltip {
+    display: block;
+  }
+
+  /* ── Disabled ────────────────────────────────────────────────────────────── */
+
+  :host([disabled]) {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+
+  :host([disabled]) .handle {
+    cursor: default;
+  }
+
+  /* ── Size: S ────────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) .track-area {
+    height: 12px;
+  }
+
+  :host([size="s"]) .track,
+  :host([size="s"]) .fill {
+    top: 5px;
+  }
+
+  :host([size="s"]) .handle {
+    width: 12px;
+    height: 12px;
+  }
+
+  :host([size="s"]) .labels {
+    margin-top: 2px;
+  }
+
+
+  /* ── Size: M (default) ───────────────────────────────────────────────────── */
+
+  :host .track-area,
+  :host([size="m"]) .track-area {
+    height: 16px;
+  }
+
+  :host .track,
+  :host .fill,
+  :host([size="m"]) .track,
+  :host([size="m"]) .fill {
+    top: 7px;
+  }
+
+  :host .handle,
+  :host([size="m"]) .handle {
+    width: 16px;
+    height: 16px;
+  }
+
+  :host .labels,
+  :host([size="m"]) .labels {
+    margin-top: 4px;
+  }
+
+
+  /* ── Size: L ─────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) .track-area {
+    height: 24px;
+  }
+
+  :host([size="l"]) .track,
+  :host([size="l"]) .fill {
+    top: 11px;
+  }
+
+  :host([size="l"]) .handle {
+    width: 24px;
+    height: 24px;
+  }
+
+  :host([size="l"]) .labels {
+    margin-top: 4px;
+  }
+
+
+  @media (prefers-reduced-motion: reduce) {
+    .handle-inner {
+      transition-duration: 0.01ms !important;
+    }
+  }
+`;

--- a/packages/ui-components/src/components/ui-slider.test.ts
+++ b/packages/ui-components/src/components/ui-slider.test.ts
@@ -1,0 +1,693 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "./ui-slider.js";
+import type { SliderSize } from "./ui-slider.js";
+
+describe("ui-slider", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    el = document.createElement("ui-slider");
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-slider")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("applies adoptedStyleSheets", () => {
+    expect(el.shadowRoot!.adoptedStyleSheets.length).toBe(1);
+  });
+
+  // ── Default rendering ─────────────────────────────────────────────────────
+
+  it("renders a .track-area element", () => {
+    expect(el.shadowRoot!.querySelector(".track-area")).not.toBeNull();
+  });
+
+  it("renders a .track element", () => {
+    expect(el.shadowRoot!.querySelector(".track")).not.toBeNull();
+  });
+
+  it("renders a .fill element", () => {
+    expect(el.shadowRoot!.querySelector(".fill")).not.toBeNull();
+  });
+
+  it("renders a low handle with role=slider", () => {
+    const handles = el.shadowRoot!.querySelectorAll(".handle");
+    expect(handles.length).toBeGreaterThanOrEqual(1);
+    expect(handles[0].getAttribute("role")).toBe("slider");
+  });
+
+  it("renders a high handle element", () => {
+    const handles = el.shadowRoot!.querySelectorAll(".handle");
+    expect(handles.length).toBe(2);
+  });
+
+  it("renders a .labels element", () => {
+    expect(el.shadowRoot!.querySelector(".labels")).not.toBeNull();
+  });
+
+  it("renders tooltip elements inside handles", () => {
+    const tooltips = el.shadowRoot!.querySelectorAll(".tooltip");
+    expect(tooltips.length).toBe(2);
+  });
+
+  // ── Default attribute values ──────────────────────────────────────────────
+
+  it("defaults size to m", () => {
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("defaults min to 0", () => {
+    expect(el.getAttribute("min")).toBe("0");
+  });
+
+  it("defaults max to 100", () => {
+    expect(el.getAttribute("max")).toBe("100");
+  });
+
+  it("defaults value to 0", () => {
+    expect(el.getAttribute("value")).toBe("0");
+  });
+
+  it("defaults step to 1", () => {
+    expect(el.getAttribute("step")).toBe("1");
+  });
+
+  // ── Attribute: size ───────────────────────────────────────────────────────
+
+  it("accepts size=s", () => {
+    el.setAttribute("size", "s");
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("accepts size=m", () => {
+    el.setAttribute("size", "m");
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("accepts size=l", () => {
+    el.setAttribute("size", "l");
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  // ── Attribute: min / max ──────────────────────────────────────────────────
+
+  it("accepts min attribute", () => {
+    el.setAttribute("min", "10");
+    expect(el.getAttribute("min")).toBe("10");
+  });
+
+  it("accepts max attribute", () => {
+    el.setAttribute("max", "200");
+    expect(el.getAttribute("max")).toBe("200");
+  });
+
+  // ── Attribute: value ──────────────────────────────────────────────────────
+
+  it("accepts value attribute", () => {
+    el.setAttribute("value", "50");
+    expect(el.getAttribute("value")).toBe("50");
+  });
+
+  // ── Attribute: value-high ─────────────────────────────────────────────────
+
+  it("accepts value-high attribute", () => {
+    el.setAttribute("range", "");
+    el.setAttribute("value-high", "75");
+    expect(el.getAttribute("value-high")).toBe("75");
+  });
+
+  // ── Attribute: step ───────────────────────────────────────────────────────
+
+  it("accepts step attribute", () => {
+    el.setAttribute("step", "5");
+    expect(el.getAttribute("step")).toBe("5");
+  });
+
+  // ── Attribute: labels ─────────────────────────────────────────────────────
+
+  it("accepts labels attribute", () => {
+    el.setAttribute("labels", "");
+    expect(el.hasAttribute("labels")).toBe(true);
+  });
+
+  // ── Attribute: tooltip ────────────────────────────────────────────────────
+
+  it("accepts tooltip attribute", () => {
+    el.setAttribute("tooltip", "");
+    expect(el.hasAttribute("tooltip")).toBe(true);
+  });
+
+  // ── Attribute: disabled ───────────────────────────────────────────────────
+
+  it("accepts disabled attribute", () => {
+    el.setAttribute("disabled", "");
+    expect(el.hasAttribute("disabled")).toBe(true);
+  });
+
+  // ── Attribute: range ──────────────────────────────────────────────────────
+
+  it("accepts range attribute", () => {
+    el.setAttribute("range", "");
+    expect(el.hasAttribute("range")).toBe(true);
+  });
+
+  // ── Property accessors ────────────────────────────────────────────────────
+
+  it("size getter returns current attribute", () => {
+    el.setAttribute("size", "l");
+    expect((el as unknown as { size: SliderSize }).size).toBe("l");
+  });
+
+  it("size setter updates attribute", () => {
+    (el as unknown as { size: SliderSize }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("min getter returns numeric value", () => {
+    el.setAttribute("min", "10");
+    expect((el as unknown as { min: number }).min).toBe(10);
+  });
+
+  it("min setter updates attribute", () => {
+    (el as unknown as { min: number }).min = 5;
+    expect(el.getAttribute("min")).toBe("5");
+  });
+
+  it("max getter returns numeric value", () => {
+    el.setAttribute("max", "200");
+    expect((el as unknown as { max: number }).max).toBe(200);
+  });
+
+  it("max setter updates attribute", () => {
+    (el as unknown as { max: number }).max = 50;
+    expect(el.getAttribute("max")).toBe("50");
+  });
+
+  it("value getter returns numeric value", () => {
+    el.setAttribute("value", "42");
+    expect((el as unknown as { value: number }).value).toBe(42);
+  });
+
+  it("value setter updates attribute", () => {
+    (el as unknown as { value: number }).value = 30;
+    expect(el.getAttribute("value")).toBe("30");
+  });
+
+  it("valueHigh getter returns numeric value", () => {
+    el.setAttribute("range", "");
+    el.setAttribute("value-high", "80");
+    expect((el as unknown as { valueHigh: number }).valueHigh).toBe(80);
+  });
+
+  it("valueHigh setter updates attribute", () => {
+    (el as unknown as { valueHigh: number }).valueHigh = 90;
+    expect(el.getAttribute("value-high")).toBe("90");
+  });
+
+  it("step getter returns numeric value", () => {
+    el.setAttribute("step", "5");
+    expect((el as unknown as { step: number }).step).toBe(5);
+  });
+
+  it("step setter updates attribute", () => {
+    (el as unknown as { step: number }).step = 10;
+    expect(el.getAttribute("step")).toBe("10");
+  });
+
+  it("isRange getter returns true when range attribute present", () => {
+    el.setAttribute("range", "");
+    expect((el as unknown as { isRange: boolean }).isRange).toBe(true);
+  });
+
+  it("isRange getter returns false when range attribute absent", () => {
+    expect((el as unknown as { isRange: boolean }).isRange).toBe(false);
+  });
+
+  it("disabled getter returns true when disabled attribute present", () => {
+    el.setAttribute("disabled", "");
+    expect((el as unknown as { disabled: boolean }).disabled).toBe(true);
+  });
+
+  it("disabled getter returns false when disabled attribute absent", () => {
+    expect((el as unknown as { disabled: boolean }).disabled).toBe(false);
+  });
+
+  it("disabled setter adds attribute when true", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    expect(el.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("disabled setter removes attribute when false", () => {
+    el.setAttribute("disabled", "");
+    (el as unknown as { disabled: boolean }).disabled = false;
+    expect(el.hasAttribute("disabled")).toBe(false);
+  });
+
+  // ── Single mode ───────────────────────────────────────────────────────────
+
+  it("shows low handle in single mode", () => {
+    el.setAttribute("value", "50");
+    const handles = el.shadowRoot!.querySelectorAll(".handle") as NodeListOf<HTMLElement>;
+    expect(handles[0].style.display).not.toBe("none");
+  });
+
+  it("hides high handle in single mode", () => {
+    el.setAttribute("value", "50");
+    const handles = el.shadowRoot!.querySelectorAll(".handle") as NodeListOf<HTMLElement>;
+    expect(handles[1].style.display).toBe("none");
+  });
+
+  // ── Range mode ────────────────────────────────────────────────────────────
+
+  it("shows both handles in range mode", () => {
+    el.setAttribute("range", "");
+    el.setAttribute("value", "25");
+    el.setAttribute("value-high", "75");
+    const handles = el.shadowRoot!.querySelectorAll(".handle") as NodeListOf<HTMLElement>;
+    expect(handles[0].style.display).not.toBe("none");
+    expect(handles[1].style.display).not.toBe("none");
+  });
+
+  it("positions fill between handles in range mode", () => {
+    el.setAttribute("range", "");
+    el.setAttribute("value", "25");
+    el.setAttribute("value-high", "75");
+    const fill = el.shadowRoot!.querySelector(".fill") as HTMLElement;
+    expect(fill.style.left).toBe("25%");
+    expect(fill.style.right).toBe("25%");
+  });
+
+  it("positions fill from 0 in single mode", () => {
+    el.setAttribute("value", "60");
+    const fill = el.shadowRoot!.querySelector(".fill") as HTMLElement;
+    expect(fill.style.left).toMatch(/^0(px)?$/);
+    expect(fill.style.right).toBe("40%");
+  });
+
+  // ── Value clamping ────────────────────────────────────────────────────────
+
+  it("clamps fill for value below min", () => {
+    el.setAttribute("min", "0");
+    el.setAttribute("max", "100");
+    el.setAttribute("value", "-10");
+    const fill = el.shadowRoot!.querySelector(".fill") as HTMLElement;
+    // Value is clamped to min (0), so fill right = 100%
+    expect(fill.style.right).toBe("100%");
+  });
+
+  it("clamps fill for value above max", () => {
+    el.setAttribute("min", "0");
+    el.setAttribute("max", "100");
+    el.setAttribute("value", "200");
+    const fill = el.shadowRoot!.querySelector(".fill") as HTMLElement;
+    // Value is clamped to max (100), so fill right = 0%
+    expect(fill.style.right).toBe("0%");
+  });
+
+  // ── Step snapping ─────────────────────────────────────────────────────────
+
+  it("step getter defaults to 1 for invalid step", () => {
+    el.setAttribute("step", "0");
+    expect((el as unknown as { step: number }).step).toBe(1);
+  });
+
+  it("step getter returns correct value for valid step", () => {
+    el.setAttribute("step", "10");
+    expect((el as unknown as { step: number }).step).toBe(10);
+  });
+
+  // ── ARIA ──────────────────────────────────────────────────────────────────
+
+  it("sets role=slider on low handle", () => {
+    const handles = el.shadowRoot!.querySelectorAll(".handle");
+    expect(handles[0].getAttribute("role")).toBe("slider");
+  });
+
+  it("sets role=slider on high handle", () => {
+    const handles = el.shadowRoot!.querySelectorAll(".handle");
+    expect(handles[1].getAttribute("role")).toBe("slider");
+  });
+
+  it("sets aria-valuenow on low handle", () => {
+    el.setAttribute("value", "42");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0];
+    expect(handle.getAttribute("aria-valuenow")).toBe("42");
+  });
+
+  it("sets aria-valuemin on low handle", () => {
+    el.setAttribute("min", "10");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0];
+    expect(handle.getAttribute("aria-valuemin")).toBe("10");
+  });
+
+  it("sets aria-valuemax on low handle in single mode", () => {
+    el.setAttribute("max", "200");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0];
+    expect(handle.getAttribute("aria-valuemax")).toBe("200");
+  });
+
+  it("sets aria-valuemax on low handle to valueHigh in range mode", () => {
+    el.setAttribute("range", "");
+    el.setAttribute("value", "20");
+    el.setAttribute("value-high", "80");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0];
+    expect(handle.getAttribute("aria-valuemax")).toBe("80");
+  });
+
+  it("sets aria-valuemin on high handle to value in range mode", () => {
+    el.setAttribute("range", "");
+    el.setAttribute("value", "20");
+    el.setAttribute("value-high", "80");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[1];
+    expect(handle.getAttribute("aria-valuemin")).toBe("20");
+  });
+
+  it("sets aria-valuemax on high handle in range mode", () => {
+    el.setAttribute("range", "");
+    el.setAttribute("max", "200");
+    el.setAttribute("value-high", "150");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[1];
+    expect(handle.getAttribute("aria-valuemax")).toBe("200");
+  });
+
+  it("sets aria-valuenow on high handle in range mode", () => {
+    el.setAttribute("range", "");
+    el.setAttribute("value-high", "60");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[1];
+    expect(handle.getAttribute("aria-valuenow")).toBe("60");
+  });
+
+  it("updates aria-valuenow when value changes", () => {
+    el.setAttribute("value", "10");
+    el.setAttribute("value", "90");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0];
+    expect(handle.getAttribute("aria-valuenow")).toBe("90");
+  });
+
+  // ── Labels ────────────────────────────────────────────────────────────────
+
+  it("shows min value in label", () => {
+    el.setAttribute("min", "10");
+    const labels = el.shadowRoot!.querySelector(".labels");
+    const spans = labels!.querySelectorAll("span");
+    expect(spans[0].textContent).toBe("10");
+  });
+
+  it("shows max value in label", () => {
+    el.setAttribute("max", "200");
+    const labels = el.shadowRoot!.querySelector(".labels");
+    const spans = labels!.querySelectorAll("span");
+    expect(spans[1].textContent).toBe("200");
+  });
+
+  it("updates labels when min/max change", () => {
+    el.setAttribute("min", "5");
+    el.setAttribute("max", "50");
+    const labels = el.shadowRoot!.querySelector(".labels");
+    const spans = labels!.querySelectorAll("span");
+    expect(spans[0].textContent).toBe("5");
+    expect(spans[1].textContent).toBe("50");
+  });
+
+  // ── Tooltips ──────────────────────────────────────────────────────────────
+
+  it("shows current value in low tooltip", () => {
+    el.setAttribute("value", "42");
+    const tooltips = el.shadowRoot!.querySelectorAll(".tooltip");
+    expect(tooltips[0].textContent).toBe("42");
+  });
+
+  it("shows valueHigh in high tooltip in range mode", () => {
+    el.setAttribute("range", "");
+    el.setAttribute("value-high", "80");
+    const tooltips = el.shadowRoot!.querySelectorAll(".tooltip");
+    expect(tooltips[1].textContent).toBe("80");
+  });
+
+  // ── Handle tabindex ───────────────────────────────────────────────────────
+
+  it("sets tabindex=0 on low handle", () => {
+    const handles = el.shadowRoot!.querySelectorAll(".handle");
+    expect(handles[0].getAttribute("tabindex")).toBe("0");
+  });
+
+  it("sets tabindex=0 on high handle", () => {
+    const handles = el.shadowRoot!.querySelectorAll(".handle");
+    expect(handles[1].getAttribute("tabindex")).toBe("0");
+  });
+
+  // ── Events ────────────────────────────────────────────────────────────────
+
+  it("dispatches slider-change on keyboard interaction", () => {
+    el.setAttribute("value", "50");
+    let detail: { value: number; valueHigh?: number } | null = null;
+    el.addEventListener("slider-change", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0] as HTMLElement;
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+
+    expect(detail).not.toBeNull();
+    expect(detail!.value).toBe(51);
+  });
+
+  it("dispatches slider-change with valueHigh in range mode", () => {
+    el.setAttribute("range", "");
+    el.setAttribute("value", "20");
+    el.setAttribute("value-high", "80");
+    let detail: { value: number; valueHigh?: number } | null = null;
+    el.addEventListener("slider-change", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[1] as HTMLElement;
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+
+    expect(detail).not.toBeNull();
+    expect(detail!.valueHigh).toBe(81);
+  });
+
+  it("slider-change event bubbles and is composed", () => {
+    el.setAttribute("value", "50");
+    let bubbles = false;
+    let composed = false;
+    el.addEventListener("slider-change", ((e: CustomEvent) => {
+      bubbles = e.bubbles;
+      composed = e.composed;
+    }) as EventListener);
+
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0] as HTMLElement;
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
+
+    expect(bubbles).toBe(true);
+    expect(composed).toBe(true);
+  });
+
+  it("does not include valueHigh in single mode event", () => {
+    el.setAttribute("value", "50");
+    let detail: { value: number; valueHigh?: number } | null = null;
+    el.addEventListener("slider-change", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0] as HTMLElement;
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+
+    expect(detail!.valueHigh).toBeUndefined();
+  });
+
+  // ── Keyboard ──────────────────────────────────────────────────────────────
+
+  it("ArrowRight increments value by step", () => {
+    el.setAttribute("value", "50");
+    el.setAttribute("step", "1");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0] as HTMLElement;
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    expect(el.getAttribute("value")).toBe("51");
+  });
+
+  it("ArrowUp increments value by step", () => {
+    el.setAttribute("value", "50");
+    el.setAttribute("step", "1");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0] as HTMLElement;
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
+    expect(el.getAttribute("value")).toBe("51");
+  });
+
+  it("ArrowLeft decrements value by step", () => {
+    el.setAttribute("value", "50");
+    el.setAttribute("step", "1");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0] as HTMLElement;
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+    expect(el.getAttribute("value")).toBe("49");
+  });
+
+  it("ArrowDown decrements value by step", () => {
+    el.setAttribute("value", "50");
+    el.setAttribute("step", "1");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0] as HTMLElement;
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    expect(el.getAttribute("value")).toBe("49");
+  });
+
+  it("Home sets value to min", () => {
+    el.setAttribute("value", "50");
+    el.setAttribute("min", "10");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0] as HTMLElement;
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "Home", bubbles: true }));
+    expect(el.getAttribute("value")).toBe("10");
+  });
+
+  it("End sets value to max", () => {
+    el.setAttribute("value", "50");
+    el.setAttribute("max", "100");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0] as HTMLElement;
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "End", bubbles: true }));
+    expect(el.getAttribute("value")).toBe("100");
+  });
+
+  it("keyboard does not go below min", () => {
+    el.setAttribute("value", "0");
+    el.setAttribute("min", "0");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0] as HTMLElement;
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+    expect(el.getAttribute("value")).toBe("0");
+  });
+
+  it("keyboard does not go above max", () => {
+    el.setAttribute("value", "100");
+    el.setAttribute("max", "100");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0] as HTMLElement;
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    expect(el.getAttribute("value")).toBe("100");
+  });
+
+  it("keyboard increments with custom step", () => {
+    el.setAttribute("value", "50");
+    el.setAttribute("step", "10");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0] as HTMLElement;
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    expect(el.getAttribute("value")).toBe("60");
+  });
+
+  it("keyboard on high handle increments valueHigh", () => {
+    el.setAttribute("range", "");
+    el.setAttribute("value", "20");
+    el.setAttribute("value-high", "80");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[1] as HTMLElement;
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    expect(el.getAttribute("value-high")).toBe("81");
+  });
+
+  it("keyboard on high handle decrements valueHigh", () => {
+    el.setAttribute("range", "");
+    el.setAttribute("value", "20");
+    el.setAttribute("value-high", "80");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[1] as HTMLElement;
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+    expect(el.getAttribute("value-high")).toBe("79");
+  });
+
+  it("keyboard does not move low handle past high handle in range mode", () => {
+    el.setAttribute("range", "");
+    el.setAttribute("value", "50");
+    el.setAttribute("value-high", "50");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0] as HTMLElement;
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    expect(el.getAttribute("value")).toBe("50");
+  });
+
+  it("keyboard does not move high handle below low handle in range mode", () => {
+    el.setAttribute("range", "");
+    el.setAttribute("value", "50");
+    el.setAttribute("value-high", "50");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[1] as HTMLElement;
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", bubbles: true }));
+    expect(el.getAttribute("value-high")).toBe("50");
+  });
+
+  it("keyboard is ignored when disabled", () => {
+    el.setAttribute("value", "50");
+    el.setAttribute("disabled", "");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0] as HTMLElement;
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    expect(el.getAttribute("value")).toBe("50");
+  });
+
+  it("unrecognized key does not change value", () => {
+    el.setAttribute("value", "50");
+    const handle = el.shadowRoot!.querySelectorAll(".handle")[0] as HTMLElement;
+    handle.dispatchEvent(new KeyboardEvent("keydown", { key: "a", bubbles: true }));
+    expect(el.getAttribute("value")).toBe("50");
+  });
+
+  // ── observedAttributes ────────────────────────────────────────────────────
+
+  it("observes size attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("size");
+  });
+
+  it("observes min attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("min");
+  });
+
+  it("observes max attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("max");
+  });
+
+  it("observes value attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("value");
+  });
+
+  it("observes value-high attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("value-high");
+  });
+
+  it("observes step attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("step");
+  });
+
+  it("observes labels attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("labels");
+  });
+
+  it("observes tooltip attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("tooltip");
+  });
+
+  it("observes disabled attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("disabled");
+  });
+
+  it("observes range attribute", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed).toContain("range");
+  });
+
+  it("has exactly 10 observed attributes", () => {
+    const observed = (el.constructor as typeof HTMLElement & { observedAttributes: string[] }).observedAttributes;
+    expect(observed.length).toBe(10);
+  });
+});

--- a/packages/ui-components/src/components/ui-slider.ts
+++ b/packages/ui-components/src/components/ui-slider.ts
@@ -1,0 +1,344 @@
+import { STYLES } from "./ui-slider.styles.js";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type SliderSize = "s" | "m" | "l";
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiSlider extends HTMLElement {
+  static readonly observedAttributes = [
+    "size",
+    "min",
+    "max",
+    "value",
+    "value-high",
+    "step",
+    "labels",
+    "tooltip",
+    "disabled",
+    "range",
+  ];
+
+  #trackArea!: HTMLElement;
+  #track!: HTMLElement;
+  #fill!: HTMLElement;
+  #handleLow!: HTMLElement;
+  #handleHigh!: HTMLElement;
+  #tooltipLow!: HTMLElement;
+  #tooltipHigh!: HTMLElement;
+  #labelMin!: HTMLElement;
+  #labelMax!: HTMLElement;
+
+  #dragging: "low" | "high" | null = null;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    const wrapper = document.createElement("div");
+    wrapper.className = "wrapper";
+
+    // Track area
+    this.#trackArea = document.createElement("div");
+    this.#trackArea.className = "track-area";
+
+    this.#track = document.createElement("div");
+    this.#track.className = "track";
+
+    this.#fill = document.createElement("div");
+    this.#fill.className = "fill";
+
+    // Low handle
+    this.#handleLow = document.createElement("div");
+    this.#handleLow.className = "handle";
+    this.#handleLow.setAttribute("tabindex", "0");
+    this.#handleLow.setAttribute("role", "slider");
+    const innerLow = document.createElement("div");
+    innerLow.className = "handle-inner";
+    this.#tooltipLow = document.createElement("div");
+    this.#tooltipLow.className = "tooltip";
+    this.#handleLow.append(innerLow, this.#tooltipLow);
+
+    // High handle (for range mode)
+    this.#handleHigh = document.createElement("div");
+    this.#handleHigh.className = "handle";
+    this.#handleHigh.setAttribute("tabindex", "0");
+    this.#handleHigh.setAttribute("role", "slider");
+    const innerHigh = document.createElement("div");
+    innerHigh.className = "handle-inner";
+    this.#tooltipHigh = document.createElement("div");
+    this.#tooltipHigh.className = "tooltip";
+    this.#handleHigh.append(innerHigh, this.#tooltipHigh);
+
+    this.#trackArea.append(this.#track, this.#fill, this.#handleLow, this.#handleHigh);
+
+    // Labels
+    const labels = document.createElement("div");
+    labels.className = "labels";
+    this.#labelMin = document.createElement("span");
+    this.#labelMax = document.createElement("span");
+    labels.append(this.#labelMin, this.#labelMax);
+
+    wrapper.append(this.#trackArea, labels);
+    shadow.appendChild(wrapper);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("size")) this.setAttribute("size", "m");
+    if (!this.hasAttribute("min")) this.setAttribute("min", "0");
+    if (!this.hasAttribute("max")) this.setAttribute("max", "100");
+    if (!this.hasAttribute("value")) this.setAttribute("value", "0");
+    if (!this.hasAttribute("step")) this.setAttribute("step", "1");
+
+    this._syncAll();
+
+    // Pointer events on track area
+    this.#trackArea.addEventListener("pointerdown", (e) => this._onPointerDown(e));
+
+    // Keyboard on handles
+    this.#handleLow.addEventListener("keydown", (e) => this._onKeyDown(e, "low"));
+    this.#handleHigh.addEventListener("keydown", (e) => this._onKeyDown(e, "high"));
+  }
+
+  attributeChangedCallback(): void {
+    if (this.isConnected) this._syncAll();
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): SliderSize {
+    return (this.getAttribute("size") as SliderSize) ?? "m";
+  }
+  set size(v: SliderSize) {
+    this.setAttribute("size", v);
+  }
+
+  get min(): number {
+    return parseFloat(this.getAttribute("min") ?? "0");
+  }
+  set min(v: number) {
+    this.setAttribute("min", String(v));
+  }
+
+  get max(): number {
+    return parseFloat(this.getAttribute("max") ?? "100");
+  }
+  set max(v: number) {
+    this.setAttribute("max", String(v));
+  }
+
+  get value(): number {
+    return parseFloat(this.getAttribute("value") ?? "0");
+  }
+  set value(v: number) {
+    this.setAttribute("value", String(v));
+  }
+
+  get valueHigh(): number {
+    return parseFloat(this.getAttribute("value-high") ?? String(this.max));
+  }
+  set valueHigh(v: number) {
+    this.setAttribute("value-high", String(v));
+  }
+
+  get step(): number {
+    return parseFloat(this.getAttribute("step") ?? "1") || 1;
+  }
+  set step(v: number) {
+    this.setAttribute("step", String(v));
+  }
+
+  get isRange(): boolean {
+    return this.hasAttribute("range");
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute("disabled");
+  }
+  set disabled(v: boolean) {
+    if (v) this.setAttribute("disabled", "");
+    else this.removeAttribute("disabled");
+  }
+
+  // ── Sync ────────────────────────────────────────────────────────────────
+
+  private _syncAll(): void {
+    const min = this.min;
+    const max = this.max;
+    const range = max - min;
+    if (range <= 0) return;
+
+    const val = Math.max(min, Math.min(max, this.value));
+    const valHigh = this.isRange ? Math.max(min, Math.min(max, this.valueHigh)) : max;
+
+    // Percentages
+    const lowPct = ((val - min) / range) * 100;
+    const highPct = this.isRange ? ((valHigh - min) / range) * 100 : lowPct;
+
+    // Fill position
+    if (this.isRange) {
+      this.#fill.style.left = `${lowPct}%`;
+      this.#fill.style.right = `${100 - highPct}%`;
+      this.#fill.style.top = this.#track.style.top || "";
+    } else {
+      this.#fill.style.left = "0";
+      this.#fill.style.right = `${100 - lowPct}%`;
+      this.#fill.style.top = this.#track.style.top || "";
+    }
+
+    // Handle positions
+    this.#handleLow.style.left = `${lowPct}%`;
+
+    if (this.isRange) {
+      this.#handleHigh.style.display = "";
+      this.#handleHigh.style.left = `${highPct}%`;
+    } else {
+      this.#handleHigh.style.display = "none";
+    }
+
+    // ARIA
+    this.#handleLow.setAttribute("aria-valuemin", String(min));
+    this.#handleLow.setAttribute("aria-valuemax", this.isRange ? String(valHigh) : String(max));
+    this.#handleLow.setAttribute("aria-valuenow", String(val));
+
+    if (this.isRange) {
+      this.#handleHigh.setAttribute("aria-valuemin", String(val));
+      this.#handleHigh.setAttribute("aria-valuemax", String(max));
+      this.#handleHigh.setAttribute("aria-valuenow", String(valHigh));
+    }
+
+    // Tooltips
+    this.#tooltipLow.textContent = String(val);
+    this.#tooltipHigh.textContent = String(valHigh);
+
+    // Labels
+    this.#labelMin.textContent = String(min);
+    this.#labelMax.textContent = String(max);
+  }
+
+  // ── Pointer interaction ─────────────────────────────────────────────────
+
+  private _onPointerDown(e: PointerEvent): void {
+    if (this.disabled) return;
+    e.preventDefault();
+
+    const rect = this.#trackArea.getBoundingClientRect();
+    const pct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+    const rawVal = this.min + pct * (this.max - this.min);
+
+    // Determine which handle to drag
+    if (this.isRange) {
+      const distLow = Math.abs(rawVal - this.value);
+      const distHigh = Math.abs(rawVal - this.valueHigh);
+      this.#dragging = distLow <= distHigh ? "low" : "high";
+    } else {
+      this.#dragging = "low";
+    }
+
+    this._updateFromPointer(e);
+    this._setActive(this.#dragging, true);
+
+    const onMove = (ev: PointerEvent) => this._updateFromPointer(ev);
+    const onUp = () => {
+      this._setActive(this.#dragging!, false);
+      this.#dragging = null;
+      document.removeEventListener("pointermove", onMove);
+      document.removeEventListener("pointerup", onUp);
+    };
+
+    document.addEventListener("pointermove", onMove);
+    document.addEventListener("pointerup", onUp);
+  }
+
+  private _updateFromPointer(e: PointerEvent): void {
+    const rect = this.#trackArea.getBoundingClientRect();
+    const pct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+    const rawVal = this.min + pct * (this.max - this.min);
+    const stepped = this._snap(rawVal);
+
+    if (this.#dragging === "low") {
+      const clamped = this.isRange ? Math.min(stepped, this.valueHigh) : stepped;
+      this.setAttribute("value", String(clamped));
+      this._dispatchChange();
+    } else if (this.#dragging === "high") {
+      const clamped = Math.max(stepped, this.value);
+      this.setAttribute("value-high", String(clamped));
+      this._dispatchChange();
+    }
+  }
+
+  // ── Keyboard ────────────────────────────────────────────────────────────
+
+  private _onKeyDown(e: KeyboardEvent, handle: "low" | "high"): void {
+    if (this.disabled) return;
+    const step = this.step;
+    let delta = 0;
+
+    switch (e.key) {
+      case "ArrowRight":
+      case "ArrowUp":
+        delta = step;
+        break;
+      case "ArrowLeft":
+      case "ArrowDown":
+        delta = -step;
+        break;
+      case "Home":
+        delta = this.min - (handle === "low" ? this.value : this.valueHigh);
+        break;
+      case "End":
+        delta = this.max - (handle === "low" ? this.value : this.valueHigh);
+        break;
+      default:
+        return;
+    }
+
+    e.preventDefault();
+
+    if (handle === "low") {
+      const newVal = Math.max(this.min, Math.min(this.isRange ? this.valueHigh : this.max, this.value + delta));
+      this.setAttribute("value", String(this._snap(newVal)));
+    } else {
+      const newVal = Math.max(this.value, Math.min(this.max, this.valueHigh + delta));
+      this.setAttribute("value-high", String(this._snap(newVal)));
+    }
+
+    this._dispatchChange();
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────────
+
+  private _snap(val: number): number {
+    const step = this.step;
+    const snapped = Math.round((val - this.min) / step) * step + this.min;
+    // Round to avoid floating point issues
+    const decimals = (String(step).split(".")[1] || "").length;
+    return parseFloat(snapped.toFixed(decimals));
+  }
+
+  private _setActive(handle: "low" | "high", active: boolean): void {
+    const el = handle === "low" ? this.#handleLow : this.#handleHigh;
+    if (active) el.classList.add("active");
+    else el.classList.remove("active");
+  }
+
+  private _dispatchChange(): void {
+    this.dispatchEvent(
+      new CustomEvent("slider-change", {
+        detail: {
+          value: this.value,
+          valueHigh: this.isRange ? this.valueHigh : undefined,
+        },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+}
+
+customElements.define("ui-slider", UiSlider);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -241,3 +241,8 @@ export type { SidePanelState } from "./components/ui-side-panel.js";
 
 export { UiSkeleton } from "./components/ui-skeleton.js";
 export type { SkeletonVariant } from "./components/ui-skeleton.js";
+
+// ─── Slider ───────────────────────────────────────────────────────────────────
+
+export { UiSlider } from "./components/ui-slider.js";
+export type { SliderSize } from "./components/ui-slider.js";

--- a/packages/ui-components/src/stories/ui-slider.stories.ts
+++ b/packages/ui-components/src/stories/ui-slider.stories.ts
@@ -1,0 +1,116 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-slider.js";
+
+const meta: Meta = {
+  title: "Components/Slider",
+  component: "ui-slider",
+  argTypes: {
+    size: {
+      control: { type: "select" },
+      options: ["s", "m", "l"],
+    },
+    min: {
+      control: { type: "number" },
+    },
+    max: {
+      control: { type: "number" },
+    },
+    value: {
+      control: { type: "range", min: 0, max: 100, step: 1 },
+    },
+    valueHigh: {
+      control: { type: "range", min: 0, max: 100, step: 1 },
+    },
+    step: {
+      control: { type: "number" },
+    },
+    disabled: {
+      control: { type: "boolean" },
+    },
+  },
+  args: {
+    size: "m",
+    min: 0,
+    max: 100,
+    value: 50,
+    step: 1,
+    disabled: false,
+  },
+  render: (args) => html`
+    <ui-slider
+      size=${args.size}
+      min=${args.min}
+      max=${args.max}
+      value=${args.value}
+      step=${args.step}
+      ?labels=${args.labels}
+      ?tooltip=${args.tooltip}
+      ?disabled=${args.disabled}
+    ></ui-slider>
+  `,
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {};
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 32px; max-width: 400px;">
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Size S</div>
+        <ui-slider size="s" value="50" labels></ui-slider>
+      </div>
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Size M</div>
+        <ui-slider size="m" value="50" labels></ui-slider>
+      </div>
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Size L</div>
+        <ui-slider size="l" value="50" labels></ui-slider>
+      </div>
+    </div>
+  `,
+};
+
+export const Range: Story = {
+  render: () => html`
+    <div style="max-width: 400px;">
+      <ui-slider range value="25" value-high="75" labels tooltip></ui-slider>
+    </div>
+  `,
+};
+
+export const WithLabels: Story = {
+  render: () => html`
+    <div style="max-width: 400px;">
+      <ui-slider value="40" labels></ui-slider>
+    </div>
+  `,
+};
+
+export const Disabled: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 24px; max-width: 400px;">
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Disabled single</div>
+        <ui-slider value="60" disabled labels></ui-slider>
+      </div>
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Disabled range</div>
+        <ui-slider range value="20" value-high="80" disabled labels></ui-slider>
+      </div>
+    </div>
+  `,
+};
+
+export const Steps: Story = {
+  render: () => html`
+    <div style="max-width: 400px;">
+      <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Step = 10</div>
+      <ui-slider value="50" step="10" labels tooltip></ui-slider>
+    </div>
+  `,
+};


### PR DESCRIPTION
## Summary

New `<ui-slider>` Web Component — single value and range slider with drag and keyboard interaction.

## Features

- 3 sizes: `s` (12px handle), `m` (16px handle), `l` (24px handle)
- Single value mode: one draggable handle
- Range mode: two handles with fill between them
- Track: 2px `#9FB1BD`, fill: 2px `#186ADE`
- Handle: blue circle with white inner, active state = solid blue inner
- Optional labels (min/max values below track)
- Optional tooltip on active handle
- Pointer drag interaction + keyboard navigation (Arrow keys, Home/End)
- Step snapping and value clamping
- ARIA: `role="slider"`, `aria-valuenow`, `aria-valuemin`, `aria-valuemax`
- Events: `slider-change` with `detail.value` (+ `detail.valueHigh` for range)
- Disabled state, `prefers-reduced-motion` support

## API

```html
<!-- Single -->
<ui-slider size="m" value="50" labels></ui-slider>

<!-- Range -->
<ui-slider size="l" range value="20" value-high="80" labels tooltip></ui-slider>
```

## Testing

- 3120 unit tests (101 new)
- 6 Storybook stories
- 51 Playwright visual regression tests (1 new)

## Files

- `packages/ui-components/src/components/ui-slider.ts` + `ui-slider.styles.ts`
- `packages/ui-components/src/components/ui-slider.test.ts`
- `packages/ui-components/src/stories/ui-slider.stories.ts`
- `packages/ui-components/src/index.ts` — barrel exports
- `apps/catalog/src/pages/slider.ts` — catalog page