### PR TITLE
feat(ui-components): add ui-tooltip component

### DIFF
--- a/apps/catalog/e2e/visual.spec.ts
+++ b/apps/catalog/e2e/visual.spec.ts
@@ -46,6 +46,7 @@ const pages = [
   "scrollbar",
   "skeleton",
   "popover",
+  "tooltip",
   "carousel",
   "calendar",
   "datetime-picker",

--- a/apps/catalog/src/main.ts
+++ b/apps/catalog/src/main.ts
@@ -64,6 +64,7 @@ const pageLoaders: Record<string, () => Promise<unknown>> = {
   "scrollbar": () => import("./pages/scrollbar.js"),
   "skeleton": () => import("./pages/skeleton.js"),
   "popover": () => import("./pages/popover.js"),
+  "tooltip": () => import("./pages/tooltip.js"),
   "carousel": () => import("./pages/carousel.js"),
   "calendar": () => import("./pages/calendar.js"),
   "datetime-picker": () => import("./pages/datetime-picker.js"),

--- a/apps/catalog/src/manifest.ts
+++ b/apps/catalog/src/manifest.ts
@@ -68,6 +68,7 @@ export const manifest: PageMeta[] = [
   // Overlays
   { id: "modal", title: "Modal", section: "Overlays" },
   { id: "popover", title: "Popover", section: "Overlays" },
+  { id: "tooltip", title: "Tooltip", section: "Overlays" },
   // Tabs
   { id: "tabs", title: "Tabs", section: "Tabs" },
   // Data Display

--- a/apps/catalog/src/pages/tooltip.ts
+++ b/apps/catalog/src/pages/tooltip.ts
@@ -1,0 +1,119 @@
+import { registerPage } from "../registry.js";
+
+registerPage("tooltip", {
+  title: "Tooltip",
+  section: "Overlays",
+  render: () => `
+    <h3>Sizes</h3>
+    <div class="variant-row" style="gap: 80px; padding: 40px 0;">
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">XS</span>
+        <ui-tooltip size="xs" placement="top" text="Tooltip" open>
+          <ui-button size="s">Hover me</ui-button>
+        </ui-tooltip>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">S</span>
+        <ui-tooltip size="s" placement="top" text="Tooltip" open>
+          <ui-button size="s">Hover me</ui-button>
+        </ui-tooltip>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">M</span>
+        <ui-tooltip size="m" placement="top" text="Tooltip" open>
+          <ui-button size="m">Hover me</ui-button>
+        </ui-tooltip>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">L</span>
+        <ui-tooltip size="l" placement="top" text="Tooltip" open>
+          <ui-button size="m">Hover me</ui-button>
+        </ui-tooltip>
+      </div>
+    </div>
+
+    <h3>Placements</h3>
+    <div class="variant-row" style="gap: 120px; justify-content: center; padding: 60px 0;">
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Top</span>
+        <ui-tooltip placement="top" text="Tooltip" open>
+          <ui-button size="s">Trigger</ui-button>
+        </ui-tooltip>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Bottom</span>
+        <ui-tooltip placement="bottom" text="Tooltip" open>
+          <ui-button size="s">Trigger</ui-button>
+        </ui-tooltip>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Left</span>
+        <ui-tooltip placement="left" text="Tooltip" open>
+          <ui-button size="s">Trigger</ui-button>
+        </ui-tooltip>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Right</span>
+        <ui-tooltip placement="right" text="Tooltip" open>
+          <ui-button size="s">Trigger</ui-button>
+        </ui-tooltip>
+      </div>
+    </div>
+
+    <div class="variant-row" style="gap: 120px; justify-content: center; padding: 60px 0;">
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Top Left</span>
+        <ui-tooltip placement="top-left" text="Tooltip" open>
+          <ui-button size="s">Trigger</ui-button>
+        </ui-tooltip>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Top Right</span>
+        <ui-tooltip placement="top-right" text="Tooltip" open>
+          <ui-button size="s">Trigger</ui-button>
+        </ui-tooltip>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Bottom Left</span>
+        <ui-tooltip placement="bottom-left" text="Tooltip" open>
+          <ui-button size="s">Trigger</ui-button>
+        </ui-tooltip>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Bottom Right</span>
+        <ui-tooltip placement="bottom-right" text="Tooltip" open>
+          <ui-button size="s">Trigger</ui-button>
+        </ui-tooltip>
+      </div>
+    </div>
+
+    <h3>Dismissible</h3>
+    <div class="variant-row" style="gap: 120px; padding: 60px 0;">
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Off</span>
+        <ui-tooltip placement="top" text="Tooltip" open>
+          <ui-button size="m">Trigger</ui-button>
+        </ui-tooltip>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">On</span>
+        <ui-tooltip placement="top" text="Tooltip" dismissible open>
+          <ui-button size="m">Trigger</ui-button>
+        </ui-tooltip>
+      </div>
+    </div>
+
+    <h3>Interactive (hover to show)</h3>
+    <div class="variant-row" style="gap: 40px; padding: 60px 0;">
+      <ui-tooltip placement="top" text="I appear on hover">
+        <ui-button size="m">Hover me</ui-button>
+      </ui-tooltip>
+      <ui-tooltip placement="bottom" text="Bottom tooltip">
+        <ui-button size="m">Hover me</ui-button>
+      </ui-tooltip>
+      <ui-tooltip placement="right" text="Right tooltip" dismissible>
+        <ui-button size="m">Hover me</ui-button>
+      </ui-tooltip>
+    </div>
+  `,
+});

--- a/packages/ui-components/src/components/ui-tooltip.test.ts
+++ b/packages/ui-components/src/components/ui-tooltip.test.ts
@@ -1,0 +1,386 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "./ui-tooltip.js";
+import type { TooltipSize, TooltipPlacement } from "./ui-tooltip.js";
+import { UiTooltip } from "./ui-tooltip.js";
+
+describe("ui-tooltip", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-tooltip");
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-tooltip")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("applies adoptedStyleSheets", () => {
+    expect(el.shadowRoot!.adoptedStyleSheets.length).toBe(1);
+  });
+
+  // ── Default rendering ─────────────────────────────────────────────────────
+
+  it("renders a .panel element", () => {
+    expect(el.shadowRoot!.querySelector(".panel")).not.toBeNull();
+  });
+
+  it("panel is hidden by default", () => {
+    const panel = el.shadowRoot!.querySelector(".panel") as HTMLElement;
+    expect(panel.style.display !== "flex").toBe(true);
+  });
+
+  it("renders a .text element", () => {
+    expect(el.shadowRoot!.querySelector(".text")).not.toBeNull();
+  });
+
+  it("renders a .close button", () => {
+    expect(el.shadowRoot!.querySelector(".close")).not.toBeNull();
+  });
+
+  it("close button is hidden by default", () => {
+    const close = el.shadowRoot!.querySelector(".close") as HTMLElement;
+    const style = getComputedStyle(close);
+    // Without dismissible attribute, close button has display:none via CSS
+    expect(el.hasAttribute("dismissible")).toBe(false);
+  });
+
+  it("renders an .arrow element", () => {
+    expect(el.shadowRoot!.querySelector(".arrow")).not.toBeNull();
+  });
+
+  it("renders a trigger slot", () => {
+    const slot = el.shadowRoot!.querySelector("slot");
+    expect(slot).not.toBeNull();
+  });
+
+  // ── Default attributes ─────────────────────────────────────────────────────
+
+  it("defaults size to m", () => {
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("defaults placement to top", () => {
+    expect(el.getAttribute("placement")).toBe("top");
+  });
+
+  it("defaults trigger to hover", () => {
+    expect(el.getAttribute("trigger")).toBe("hover");
+  });
+
+  it("is not open by default", () => {
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  it("is not dismissible by default", () => {
+    expect(el.hasAttribute("dismissible")).toBe(false);
+  });
+
+  // ── observedAttributes ─────────────────────────────────────────────────────
+
+  it("observes the correct attributes", () => {
+    expect(UiTooltip.observedAttributes).toEqual([
+      "size",
+      "placement",
+      "text",
+      "dismissible",
+      "open",
+      "trigger",
+    ]);
+  });
+
+  // ── Size attribute ─────────────────────────────────────────────────────────
+
+  it.each(["xs", "s", "m", "l"] as TooltipSize[])("accepts size=%s", (size) => {
+    el.setAttribute("size", size);
+    expect(el.getAttribute("size")).toBe(size);
+  });
+
+  // ── Placement attribute ────────────────────────────────────────────────────
+
+  it.each([
+    "top",
+    "bottom",
+    "left",
+    "right",
+    "top-left",
+    "top-right",
+    "bottom-left",
+    "bottom-right",
+  ] as TooltipPlacement[])("accepts placement=%s", (placement) => {
+    el.setAttribute("placement", placement);
+    expect(el.getAttribute("placement")).toBe(placement);
+  });
+
+  // ── Text attribute ─────────────────────────────────────────────────────────
+
+  it("sets text content via attribute", () => {
+    el.setAttribute("text", "Hello tooltip");
+    const textEl = el.shadowRoot!.querySelector(".text") as HTMLElement;
+    expect(textEl.textContent).toBe("Hello tooltip");
+  });
+
+  it("updates text content when attribute changes", () => {
+    el.setAttribute("text", "First");
+    el.setAttribute("text", "Second");
+    const textEl = el.shadowRoot!.querySelector(".text") as HTMLElement;
+    expect(textEl.textContent).toBe("Second");
+  });
+
+  it("clears text content when attribute removed", () => {
+    el.setAttribute("text", "Hello");
+    el.removeAttribute("text");
+    const textEl = el.shadowRoot!.querySelector(".text") as HTMLElement;
+    expect(textEl.textContent).toBe("");
+  });
+
+  // ── Dismissible attribute ──────────────────────────────────────────────────
+
+  it("sets dismissible attribute", () => {
+    el.setAttribute("dismissible", "");
+    expect(el.hasAttribute("dismissible")).toBe(true);
+  });
+
+  it("removes dismissible attribute", () => {
+    el.setAttribute("dismissible", "");
+    el.removeAttribute("dismissible");
+    expect(el.hasAttribute("dismissible")).toBe(false);
+  });
+
+  // ── Open attribute ─────────────────────────────────────────────────────────
+
+  it("sets open attribute", () => {
+    el.setAttribute("open", "");
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  it("removes open attribute", () => {
+    el.setAttribute("open", "");
+    el.removeAttribute("open");
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  // ── Trigger attribute ──────────────────────────────────────────────────────
+
+  it("sets trigger attribute", () => {
+    el.setAttribute("trigger", "click");
+    expect(el.getAttribute("trigger")).toBe("click");
+  });
+
+  // ── Property accessors: size ───────────────────────────────────────────────
+
+  it("gets size property", () => {
+    expect((el as unknown as UiTooltip).size).toBe("m");
+  });
+
+  it("sets size property", () => {
+    (el as unknown as UiTooltip).size = "l";
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  it("size property reflects attribute", () => {
+    el.setAttribute("size", "xs");
+    expect((el as unknown as UiTooltip).size).toBe("xs");
+  });
+
+  // ── Property accessors: placement ──────────────────────────────────────────
+
+  it("gets placement property", () => {
+    expect((el as unknown as UiTooltip).placement).toBe("top");
+  });
+
+  it("sets placement property", () => {
+    (el as unknown as UiTooltip).placement = "bottom-right";
+    expect(el.getAttribute("placement")).toBe("bottom-right");
+  });
+
+  it("placement property reflects attribute", () => {
+    el.setAttribute("placement", "left");
+    expect((el as unknown as UiTooltip).placement).toBe("left");
+  });
+
+  // ── Property accessors: text ───────────────────────────────────────────────
+
+  it("gets text property", () => {
+    el.setAttribute("text", "Hello");
+    expect((el as unknown as UiTooltip).text).toBe("Hello");
+  });
+
+  it("sets text property", () => {
+    (el as unknown as UiTooltip).text = "World";
+    expect(el.getAttribute("text")).toBe("World");
+  });
+
+  it("text property defaults to empty string", () => {
+    expect((el as unknown as UiTooltip).text).toBe("");
+  });
+
+  // ── Property accessors: dismissible ────────────────────────────────────────
+
+  it("gets dismissible property", () => {
+    expect((el as unknown as UiTooltip).dismissible).toBe(false);
+  });
+
+  it("sets dismissible property to true", () => {
+    (el as unknown as UiTooltip).dismissible = true;
+    expect(el.hasAttribute("dismissible")).toBe(true);
+  });
+
+  it("sets dismissible property to false", () => {
+    (el as unknown as UiTooltip).dismissible = true;
+    (el as unknown as UiTooltip).dismissible = false;
+    expect(el.hasAttribute("dismissible")).toBe(false);
+  });
+
+  // ── Property accessors: open ───────────────────────────────────────────────
+
+  it("gets open property", () => {
+    expect((el as unknown as UiTooltip).open).toBe(false);
+  });
+
+  it("sets open property to true", () => {
+    (el as unknown as UiTooltip).open = true;
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  it("sets open property to false", () => {
+    (el as unknown as UiTooltip).open = true;
+    (el as unknown as UiTooltip).open = false;
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  // ── Property accessors: trigger ────────────────────────────────────────────
+
+  it("gets trigger property", () => {
+    expect((el as unknown as UiTooltip).trigger).toBe("hover");
+  });
+
+  it("sets trigger property", () => {
+    (el as unknown as UiTooltip).trigger = "click";
+    expect(el.getAttribute("trigger")).toBe("click");
+  });
+
+  // ── Open / close behavior ──────────────────────────────────────────────────
+
+  it("setting open attribute shows panel", () => {
+    el.setAttribute("open", "");
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  it("removing open attribute hides panel", () => {
+    el.setAttribute("open", "");
+    el.removeAttribute("open");
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  it("open property setter calls _open", () => {
+    (el as unknown as UiTooltip).open = true;
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  it("open property setter calls _close", () => {
+    (el as unknown as UiTooltip).open = true;
+    (el as unknown as UiTooltip).open = false;
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  // ── Hover trigger ──────────────────────────────────────────────────────────
+
+  it("mouseenter opens tooltip when trigger is hover", () => {
+    el.dispatchEvent(new MouseEvent("mouseenter"));
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  it("mouseleave closes tooltip when trigger is hover", () => {
+    el.dispatchEvent(new MouseEvent("mouseenter"));
+    el.dispatchEvent(new MouseEvent("mouseleave"));
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  it("mouseenter does not open when trigger is not hover", () => {
+    el.setAttribute("trigger", "click");
+    el.dispatchEvent(new MouseEvent("mouseenter"));
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  it("mouseleave does not close dismissible tooltip", () => {
+    el.setAttribute("dismissible", "");
+    el.dispatchEvent(new MouseEvent("mouseenter"));
+    el.dispatchEvent(new MouseEvent("mouseleave"));
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  // ── Focus trigger ──────────────────────────────────────────────────────────
+
+  it("focusin opens tooltip when trigger is hover", () => {
+    el.dispatchEvent(new FocusEvent("focusin"));
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  it("focusout closes tooltip when trigger is hover", () => {
+    el.dispatchEvent(new FocusEvent("focusin"));
+    el.dispatchEvent(new FocusEvent("focusout"));
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  it("focusout does not close dismissible tooltip", () => {
+    el.setAttribute("dismissible", "");
+    el.dispatchEvent(new FocusEvent("focusin"));
+    el.dispatchEvent(new FocusEvent("focusout"));
+    expect(el.hasAttribute("open")).toBe(true);
+  });
+
+  // ── Dismissible close button ───────────────────────────────────────────────
+
+  it("close button click closes tooltip", () => {
+    el.setAttribute("dismissible", "");
+    el.setAttribute("open", "");
+    const closeBtn = el.shadowRoot!.querySelector(".close") as HTMLButtonElement;
+    closeBtn.click();
+    expect(el.hasAttribute("open")).toBe(false);
+  });
+
+  it("close button has aria-label", () => {
+    const closeBtn = el.shadowRoot!.querySelector(".close") as HTMLButtonElement;
+    expect(closeBtn.getAttribute("aria-label")).toBe("Close");
+  });
+
+  it("close button has type=button", () => {
+    const closeBtn = el.shadowRoot!.querySelector(".close") as HTMLButtonElement;
+    expect(closeBtn.type).toBe("button");
+  });
+
+  // ── ARIA ───────────────────────────────────────────────────────────────────
+
+  it("panel has role=tooltip", () => {
+    const panel = el.shadowRoot!.querySelector(".panel") as HTMLElement;
+    expect(panel.getAttribute("role")).toBe("tooltip");
+  });
+
+  // ── Close button icon ──────────────────────────────────────────────────────
+
+  it("close button contains a material icon span", () => {
+    const icon = el.shadowRoot!.querySelector(
+      ".close .material-symbols-outlined",
+    ) as HTMLElement;
+    expect(icon).not.toBeNull();
+  });
+
+  it("close icon has content", () => {
+    const icon = el.shadowRoot!.querySelector(
+      ".close .material-symbols-outlined",
+    ) as HTMLElement;
+    expect(icon.textContent).toBeTruthy();
+  });
+});

--- a/packages/ui-components/src/components/ui-tooltip.ts
+++ b/packages/ui-components/src/components/ui-tooltip.ts
@@ -1,0 +1,485 @@
+import { ICON_CLOSE } from "@maneki/foundation";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type TooltipSize = "xs" | "s" | "m" | "l";
+export type TooltipPlacement =
+  | "top"
+  | "bottom"
+  | "left"
+  | "right"
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right";
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  @font-face {
+    font-family: "Material Symbols Outlined";
+    font-style: normal;
+    src: local("Material Symbols Outlined");
+  }
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: inline-flex;
+    position: relative;
+    width: fit-content;
+    font-family: "Geist", sans-serif;
+  }
+
+  /* ── Tooltip panel ───────────────────────────────────────────────────────── */
+
+  .panel {
+    position: absolute;
+    z-index: 1000;
+    display: none;
+    background: #090F14;
+    color: #ffffff;
+    border-radius: 2px;
+    white-space: nowrap;
+    pointer-events: none;
+  }
+
+  :host([open]) .panel {
+    display: flex;
+    align-items: center;
+    pointer-events: auto;
+  }
+
+  .text {
+    text-align: center;
+  }
+
+  /* ── Close button ────────────────────────────────────────────────────────── */
+
+  .close {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    color: #ffffff;
+    cursor: pointer;
+    padding: 0;
+    flex-shrink: 0;
+  }
+
+  :host([dismissible]) .close {
+    display: inline-flex;
+  }
+
+  .close .material-symbols-outlined {
+    font-family: "Material Symbols Outlined";
+    font-weight: normal;
+    font-style: normal;
+    line-height: 1;
+    display: inline-block;
+    -webkit-font-smoothing: antialiased;
+    font-variation-settings: "FILL" 0;
+  }
+
+  /* ── Arrow ───────────────────────────────────────────────────────────────── */
+
+  .arrow {
+    position: absolute;
+    width: 8px;
+    height: 4px;
+    overflow: hidden;
+  }
+
+  .arrow::after {
+    content: "";
+    position: absolute;
+    width: 6px;
+    height: 6px;
+    background: #090F14;
+    transform: rotate(45deg);
+  }
+
+  /* Arrow for top placements (arrow at bottom of panel, pointing down) */
+  :host([placement="top"]) .arrow,
+  :host([placement="top-left"]) .arrow,
+  :host([placement="top-right"]) .arrow {
+    bottom: -4px;
+  }
+
+  :host([placement="top"]) .arrow::after,
+  :host([placement="top-left"]) .arrow::after,
+  :host([placement="top-right"]) .arrow::after {
+    top: -3px;
+    left: 1px;
+  }
+
+  :host([placement="top"]) .arrow {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  :host([placement="top-left"]) .arrow {
+    left: 12px;
+  }
+
+  :host([placement="top-right"]) .arrow {
+    right: 12px;
+  }
+
+  /* Arrow for bottom placements (arrow at top of panel, pointing up) */
+  :host([placement="bottom"]) .arrow,
+  :host([placement="bottom-left"]) .arrow,
+  :host([placement="bottom-right"]) .arrow {
+    top: -4px;
+  }
+
+  :host([placement="bottom"]) .arrow::after,
+  :host([placement="bottom-left"]) .arrow::after,
+  :host([placement="bottom-right"]) .arrow::after {
+    bottom: -3px;
+    left: 1px;
+  }
+
+  :host([placement="bottom"]) .arrow {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  :host([placement="bottom-left"]) .arrow {
+    left: 12px;
+  }
+
+  :host([placement="bottom-right"]) .arrow {
+    right: 12px;
+  }
+
+  /* Arrow for left placement (arrow at right of panel, pointing right) */
+  :host([placement="left"]) .arrow {
+    right: -4px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 4px;
+    height: 8px;
+  }
+
+  :host([placement="left"]) .arrow::after {
+    top: 1px;
+    left: -3px;
+  }
+
+  /* Arrow for right placement (arrow at left of panel, pointing left) */
+  :host([placement="right"]) .arrow {
+    left: -4px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 4px;
+    height: 8px;
+  }
+
+  :host([placement="right"]) .arrow::after {
+    top: 1px;
+    right: -3px;
+    left: auto;
+  }
+
+  /* ── Panel positioning ───────────────────────────────────────────────────── */
+
+  :host([placement="top"]) .panel,
+  :host([placement="top-left"]) .panel,
+  :host([placement="top-right"]) .panel {
+    bottom: 100%;
+    margin-bottom: 6px;
+  }
+
+  :host([placement="top"]) .panel {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  :host([placement="top-left"]) .panel {
+    left: 0;
+  }
+
+  :host([placement="top-right"]) .panel {
+    right: 0;
+  }
+
+  :host([placement="bottom"]) .panel,
+  :host([placement="bottom-left"]) .panel,
+  :host([placement="bottom-right"]) .panel {
+    top: 100%;
+    margin-top: 6px;
+  }
+
+  :host([placement="bottom"]) .panel {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  :host([placement="bottom-left"]) .panel {
+    left: 0;
+  }
+
+  :host([placement="bottom-right"]) .panel {
+    right: 0;
+  }
+
+  :host([placement="left"]) .panel {
+    right: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+    margin-right: 6px;
+  }
+
+  :host([placement="right"]) .panel {
+    left: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+    margin-left: 6px;
+  }
+
+  /* ── Size: XS ────────────────────────────────────────────────────────────── */
+
+  :host([size="xs"]) .panel {
+    padding: 2px 4px;
+    gap: 4px;
+  }
+
+  :host([size="xs"]) .text {
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  :host([size="xs"]) .close {
+    width: 12px;
+    height: 12px;
+  }
+
+  :host([size="xs"]) .close .material-symbols-outlined {
+    font-size: 12px;
+  }
+
+  /* ── Size: S ─────────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) .panel {
+    padding: 4px 8px;
+    gap: 4px;
+  }
+
+  :host([size="s"]) .text {
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  :host([size="s"]) .close {
+    width: 14px;
+    height: 14px;
+  }
+
+  :host([size="s"]) .close .material-symbols-outlined {
+    font-size: 14px;
+  }
+
+  /* ── Size: M (default) ───────────────────────────────────────────────────── */
+
+  :host .panel,
+  :host([size="m"]) .panel {
+    padding: 6px 12px;
+    gap: 8px;
+  }
+
+  :host .text,
+  :host([size="m"]) .text {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  :host .close,
+  :host([size="m"]) .close {
+    width: 14px;
+    height: 14px;
+  }
+
+  :host .close .material-symbols-outlined,
+  :host([size="m"]) .close .material-symbols-outlined {
+    font-size: 14px;
+  }
+
+  /* ── Size: L ─────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) .panel {
+    padding: 10px 16px;
+    gap: 8px;
+  }
+
+  :host([size="l"]) .text {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  :host([size="l"]) .close {
+    width: 20px;
+    height: 20px;
+  }
+
+  :host([size="l"]) .close .material-symbols-outlined {
+    font-size: 20px;
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiTooltip extends HTMLElement {
+  static readonly observedAttributes = [
+    "size",
+    "placement",
+    "text",
+    "dismissible",
+    "open",
+    "trigger",
+  ];
+
+  #panel!: HTMLElement;
+  #textEl!: HTMLElement;
+  #closeBtn!: HTMLButtonElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    // Trigger slot
+    const triggerSlot = document.createElement("slot");
+
+    // Panel
+    this.#panel = document.createElement("div");
+    this.#panel.className = "panel";
+    this.#panel.setAttribute("role", "tooltip");
+
+    // Arrow
+    const arrow = document.createElement("div");
+    arrow.className = "arrow";
+
+    // Text
+    this.#textEl = document.createElement("span");
+    this.#textEl.className = "text";
+
+    // Close button
+    this.#closeBtn = document.createElement("button");
+    this.#closeBtn.className = "close";
+    this.#closeBtn.type = "button";
+    this.#closeBtn.setAttribute("aria-label", "Close");
+    const closeIcon = document.createElement("span");
+    closeIcon.className = "material-symbols-outlined";
+    closeIcon.textContent = ICON_CLOSE;
+    this.#closeBtn.appendChild(closeIcon);
+
+    this.#panel.append(this.#textEl, this.#closeBtn, arrow);
+    shadow.append(triggerSlot, this.#panel);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("size")) this.setAttribute("size", "m");
+    if (!this.hasAttribute("placement")) this.setAttribute("placement", "top");
+    if (!this.hasAttribute("trigger")) this.setAttribute("trigger", "hover");
+
+    this.#closeBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this._close();
+    });
+
+    // Hover trigger
+    this.addEventListener("mouseenter", () => {
+      if (this.trigger === "hover") this._open();
+    });
+    this.addEventListener("mouseleave", () => {
+      if (this.trigger === "hover" && !this.hasAttribute("dismissible")) this._close();
+    });
+
+    // Focus trigger
+    this.addEventListener("focusin", () => {
+      if (this.trigger === "hover") this._open();
+    });
+    this.addEventListener("focusout", () => {
+      if (this.trigger === "hover" && !this.hasAttribute("dismissible")) this._close();
+    });
+  }
+
+  attributeChangedCallback(
+    name: string,
+    _oldValue: string | null,
+    newValue: string | null,
+  ): void {
+    switch (name) {
+      case "text":
+        this.#textEl.textContent = newValue ?? "";
+        break;
+    }
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): TooltipSize {
+    return (this.getAttribute("size") as TooltipSize) ?? "m";
+  }
+  set size(v: TooltipSize) {
+    this.setAttribute("size", v);
+  }
+
+  get placement(): TooltipPlacement {
+    return (this.getAttribute("placement") as TooltipPlacement) ?? "top";
+  }
+  set placement(v: TooltipPlacement) {
+    this.setAttribute("placement", v);
+  }
+
+  get text(): string {
+    return this.getAttribute("text") ?? "";
+  }
+  set text(v: string) {
+    this.setAttribute("text", v);
+  }
+
+  get dismissible(): boolean {
+    return this.hasAttribute("dismissible");
+  }
+  set dismissible(v: boolean) {
+    if (v) this.setAttribute("dismissible", "");
+    else this.removeAttribute("dismissible");
+  }
+
+  get open(): boolean {
+    return this.hasAttribute("open");
+  }
+  set open(v: boolean) {
+    if (v) this._open();
+    else this._close();
+  }
+
+  get trigger(): string {
+    return this.getAttribute("trigger") ?? "hover";
+  }
+  set trigger(v: string) {
+    this.setAttribute("trigger", v);
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private _open(): void {
+    this.setAttribute("open", "");
+  }
+
+  private _close(): void {
+    this.removeAttribute("open");
+  }
+}
+
+customElements.define("ui-tooltip", UiTooltip);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -246,3 +246,8 @@ export type { SkeletonVariant } from "./components/ui-skeleton.js";
 
 export { UiSlider } from "./components/ui-slider.js";
 export type { SliderSize } from "./components/ui-slider.js";
+
+// ─── Tooltip ──────────────────────────────────────────────────────────────────
+
+export { UiTooltip } from "./components/ui-tooltip.js";
+export type { TooltipSize, TooltipPlacement } from "./components/ui-tooltip.js";

--- a/packages/ui-components/src/stories/ui-tooltip.stories.ts
+++ b/packages/ui-components/src/stories/ui-tooltip.stories.ts
@@ -1,0 +1,118 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-tooltip.js";
+
+const meta: Meta = {
+  title: "Components/Tooltip",
+  component: "ui-tooltip",
+  argTypes: {
+    size: {
+      control: { type: "select" },
+      options: ["xs", "s", "m", "l"],
+    },
+    placement: {
+      control: { type: "select" },
+      options: [
+        "top",
+        "bottom",
+        "left",
+        "right",
+        "top-left",
+        "top-right",
+        "bottom-left",
+        "bottom-right",
+      ],
+    },
+    text: {
+      control: { type: "text" },
+    },
+    dismissible: {
+      control: { type: "boolean" },
+    },
+    open: {
+      control: { type: "boolean" },
+    },
+    trigger: {
+      control: { type: "select" },
+      options: ["hover", "click"],
+    },
+  },
+  args: {
+    size: "m",
+    placement: "top",
+    text: "Tooltip",
+    dismissible: false,
+    open: true,
+    trigger: "hover",
+  },
+  render: (args) => html`
+    <div style="padding: 80px 200px; display: inline-block;">
+      <ui-tooltip
+        size=${args.size}
+        placement=${args.placement}
+        text=${args.text}
+        ?dismissible=${args.dismissible}
+        ?open=${args.open}
+        trigger=${args.trigger}
+      >
+        <button>Hover me</button>
+      </ui-tooltip>
+    </div>
+  `,
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {};
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 80px; padding: 60px 40px; align-items: center;">
+      ${(["xs", "s", "m", "l"] as const).map(
+        (size) => html`
+          <ui-tooltip size=${size} text="Size ${size}" open placement="top">
+            <button>Size ${size}</button>
+          </ui-tooltip>
+        `,
+      )}
+    </div>
+  `,
+};
+
+export const AllPlacements: Story = {
+  render: () => html`
+    <div
+      style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 40px; padding: 100px 80px;"
+    >
+      ${(
+        [
+          "top",
+          "top-left",
+          "top-right",
+          "bottom",
+          "bottom-left",
+          "bottom-right",
+          "left",
+          "right",
+        ] as const
+      ).map(
+        (placement) => html`
+          <div style="display: flex; justify-content: center;">
+            <ui-tooltip placement=${placement} text=${placement} open>
+              <button>${placement}</button>
+            </ui-tooltip>
+          </div>
+        `,
+      )}
+    </div>
+  `,
+};
+
+export const Dismissible: Story = {
+  args: {
+    dismissible: true,
+    open: true,
+    text: "Dismissible tooltip",
+  },
+};


### PR DESCRIPTION
## Summary

New `<ui-tooltip>` Web Component — lightweight tooltip with arrow, hover/focus trigger, and 8 placements.

## Features

- 4 sizes: `xs` (4px/2px padding), `s` (8px/4px), `m` (12px/6px), `l` (16px/10px)
- 8 placements: `top`, `bottom`, `left`, `right`, `top-left`, `top-right`, `bottom-left`, `bottom-right`
- Optional `dismissible` with close icon
- Dark background (#090F14), white text, 2px radius, CSS arrow tip
- Hover + focus trigger by default, programmatic `open` attribute
- ARIA: `role="tooltip"` on panel

## API

```html
<!-- Hover trigger (default) -->
<ui-tooltip size="m" placement="top" text="Tooltip text">
  <button>Hover me</button>
</ui-tooltip>

<!-- Dismissible -->
<ui-tooltip placement="bottom" text="Click X to close" dismissible open>
  <button>Trigger</button>
</ui-tooltip>
```

## Note on Slider Refactor

The `<ui-slider>` inline tooltip was not refactored to use `<ui-tooltip>` — the slider tooltip is drag-state-driven (shows on active handle, updates value dynamically during pointer move) which is fundamentally different from a hover tooltip. Keeping the inline implementation.

## Testing

- 3190 unit tests (70 new)
- 4 Storybook stories
- 52 Playwright visual regression tests (1 new)

## Files

- `packages/ui-components/src/components/ui-tooltip.ts`
- `packages/ui-components/src/components/ui-tooltip.test.ts`
- `packages/ui-components/src/stories/ui-tooltip.stories.ts`
- `packages/ui-components/src/index.ts` — barrel exports
- `apps/catalog/src/pages/tooltip.ts` — catalog page