### PR TITLE
feat(ui-components): add ui-switch component

### DIFF
--- a/apps/catalog/e2e/visual.spec.ts
+++ b/apps/catalog/e2e/visual.spec.ts
@@ -28,6 +28,7 @@ const pages = [
   "queryfield",
   "search",
   "slider",
+  "switch",
   "card",
   "breadcrumb",
   "accordion",

--- a/apps/catalog/src/main.ts
+++ b/apps/catalog/src/main.ts
@@ -46,6 +46,7 @@ const pageLoaders: Record<string, () => Promise<unknown>> = {
   "queryfield": () => import("./pages/queryfield.js"),
   "search": () => import("./pages/search.js"),
   "slider": () => import("./pages/slider.js"),
+  "switch": () => import("./pages/switch.js"),
   "card": () => import("./pages/card.js"),
   "breadcrumb": () => import("./pages/breadcrumb.js"),
   "accordion": () => import("./pages/accordion.js"),

--- a/apps/catalog/src/manifest.ts
+++ b/apps/catalog/src/manifest.ts
@@ -52,6 +52,7 @@ export const manifest: PageMeta[] = [
   { id: "queryfield", title: "Queryfield", section: "Form Controls" },
   { id: "search", title: "Search", section: "Form Controls" },
   { id: "slider", title: "Slider", section: "Form Controls" },
+  { id: "switch", title: "Switch", section: "Form Controls" },
   // Containers
   { id: "card", title: "Card", section: "Containers" },
   { id: "carousel", title: "Carousel", section: "Containers" },

--- a/apps/catalog/src/pages/switch.ts
+++ b/apps/catalog/src/pages/switch.ts
@@ -1,0 +1,78 @@
+import { registerPage } from "../registry.js";
+
+registerPage("switch", {
+  title: "Switch",
+  section: "Form Controls",
+  render: () => `
+    <h3>Variant</h3>
+    <div class="variant-row" style="gap: 40px;">
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">S</span>
+        <ui-switch size="s" checked></ui-switch>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">M</span>
+        <ui-switch size="m" checked></ui-switch>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">L</span>
+        <ui-switch size="l" checked></ui-switch>
+      </div>
+    </div>
+
+    <h3>State</h3>
+    <div class="variant-row" style="gap: 60px;">
+      <div class="stack-l" style="gap: 16px; align-items: center;">
+        <span class="variant-label">Enabled</span>
+        <ui-switch size="m" checked></ui-switch>
+        <ui-switch size="m"></ui-switch>
+      </div>
+      <div class="stack-l" style="gap: 16px; align-items: center;">
+        <span class="variant-label">Disabled</span>
+        <ui-switch size="m" checked disabled></ui-switch>
+        <ui-switch size="m" disabled></ui-switch>
+      </div>
+    </div>
+
+    <h3>Status</h3>
+    <div class="variant-row" style="gap: 60px;">
+      <div class="stack-l" style="gap: 16px; align-items: center;">
+        <span class="variant-label">None</span>
+        <ui-switch size="m" checked></ui-switch>
+        <ui-switch size="m"></ui-switch>
+      </div>
+      <div class="stack-l" style="gap: 16px; align-items: center;">
+        <span class="variant-label">Error</span>
+        <ui-switch size="m" checked status="error"></ui-switch>
+        <ui-switch size="m" status="error"></ui-switch>
+      </div>
+    </div>
+
+    <h3>Label</h3>
+    <div class="variant-row" style="gap: 60px;">
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">None</span>
+        <ui-switch size="m" checked></ui-switch>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Left</span>
+        <ui-switch size="m" label="Label" label-position="left" checked></ui-switch>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Right</span>
+        <ui-switch size="m" label="Label" label-position="right" checked></ui-switch>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Top</span>
+        <ui-switch size="m" label="Label" label-position="top" checked></ui-switch>
+      </div>
+    </div>
+
+    <h3>Interactive (click to toggle)</h3>
+    <div class="stack-l" style="gap: 16px;">
+      <ui-switch size="l" label="Enable feature" label-position="right"></ui-switch>
+      <ui-switch size="m" label="Auto-save" label-position="right" checked></ui-switch>
+      <ui-switch size="s" label="Compact mode" label-position="right"></ui-switch>
+    </div>
+  `,
+});

--- a/packages/ui-components/src/components/ui-switch.test.ts
+++ b/packages/ui-components/src/components/ui-switch.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "./ui-switch.js";
+import type { SwitchSize, SwitchLabelPosition } from "./ui-switch.js";
+
+describe("ui-switch", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    el = document.createElement("ui-switch");
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-switch")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("applies adoptedStyleSheets", () => {
+    expect(el.shadowRoot!.adoptedStyleSheets.length).toBe(1);
+  });
+
+  // ── Default rendering ─────────────────────────────────────────────────────
+
+  it("renders a .switch element", () => {
+    expect(el.shadowRoot!.querySelector(".switch")).not.toBeNull();
+  });
+
+  it("renders a .handle element inside .switch", () => {
+    const track = el.shadowRoot!.querySelector(".switch");
+    expect(track!.querySelector(".handle")).not.toBeNull();
+  });
+
+  it("renders a .label element", () => {
+    expect(el.shadowRoot!.querySelector(".label")).not.toBeNull();
+  });
+
+  // ── Default attributes ────────────────────────────────────────────────────
+
+  it("defaults size to m", () => {
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("defaults label-position to none", () => {
+    expect(el.getAttribute("label-position")).toBe("none");
+  });
+
+  it("is not checked by default", () => {
+    expect(el.hasAttribute("checked")).toBe(false);
+  });
+
+  it("is not disabled by default", () => {
+    expect(el.hasAttribute("disabled")).toBe(false);
+  });
+
+  // ── Size attribute ────────────────────────────────────────────────────────
+
+  it.each(["s", "m", "l"] as SwitchSize[])("accepts size=%s", (size) => {
+    el.setAttribute("size", size);
+    expect(el.getAttribute("size")).toBe(size);
+  });
+
+  // ── Checked attribute ─────────────────────────────────────────────────────
+
+  it("reflects checked attribute when set", () => {
+    el.setAttribute("checked", "");
+    expect(el.hasAttribute("checked")).toBe(true);
+  });
+
+  it("removes checked attribute when removed", () => {
+    el.setAttribute("checked", "");
+    el.removeAttribute("checked");
+    expect(el.hasAttribute("checked")).toBe(false);
+  });
+
+  // ── Disabled attribute ────────────────────────────────────────────────────
+
+  it("reflects disabled attribute when set", () => {
+    el.setAttribute("disabled", "");
+    expect(el.hasAttribute("disabled")).toBe(true);
+  });
+
+  // ── Label attribute ───────────────────────────────────────────────────────
+
+  it("renders label text from attribute", () => {
+    el.setAttribute("label", "Dark mode");
+    const label = el.shadowRoot!.querySelector(".label");
+    expect(label!.textContent).toBe("Dark mode");
+  });
+
+  it("updates label text when attribute changes", () => {
+    el.setAttribute("label", "First");
+    el.setAttribute("label", "Second");
+    const label = el.shadowRoot!.querySelector(".label");
+    expect(label!.textContent).toBe("Second");
+  });
+
+  // ── Label position attribute ──────────────────────────────────────────────
+
+  it.each(["none", "left", "right"] as SwitchLabelPosition[])(
+    "accepts label-position=%s",
+    (pos) => {
+      el.setAttribute("label-position", pos);
+      expect(el.getAttribute("label-position")).toBe(pos);
+    },
+  );
+
+  it("places label before track when label-position=left", () => {
+    el.setAttribute("label", "Toggle");
+    el.setAttribute("label-position", "left");
+    const children = Array.from(el.shadowRoot!.children);
+    const labelIdx = children.indexOf(
+      el.shadowRoot!.querySelector(".label") as Element,
+    );
+    const trackIdx = children.indexOf(
+      el.shadowRoot!.querySelector(".switch") as Element,
+    );
+    expect(labelIdx).toBeLessThan(trackIdx);
+  });
+
+  it("places label after track when label-position=right", () => {
+    el.setAttribute("label", "Toggle");
+    el.setAttribute("label-position", "right");
+    const children = Array.from(el.shadowRoot!.children);
+    const labelIdx = children.indexOf(
+      el.shadowRoot!.querySelector(".label") as Element,
+    );
+    const trackIdx = children.indexOf(
+      el.shadowRoot!.querySelector(".switch") as Element,
+    );
+    expect(labelIdx).toBeGreaterThan(trackIdx);
+  });
+
+  // ── Property accessors ────────────────────────────────────────────────────
+
+  it("size getter returns current size", () => {
+    el.setAttribute("size", "l");
+    expect((el as any).size).toBe("l");
+  });
+
+  it("size setter updates attribute", () => {
+    (el as any).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("checked getter returns false by default", () => {
+    expect((el as any).checked).toBe(false);
+  });
+
+  it("checked setter adds attribute when true", () => {
+    (el as any).checked = true;
+    expect(el.hasAttribute("checked")).toBe(true);
+  });
+
+  it("checked setter removes attribute when false", () => {
+    (el as any).checked = true;
+    (el as any).checked = false;
+    expect(el.hasAttribute("checked")).toBe(false);
+  });
+
+  it("disabled getter returns false by default", () => {
+    expect((el as any).disabled).toBe(false);
+  });
+
+  it("disabled setter adds attribute when true", () => {
+    (el as any).disabled = true;
+    expect(el.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("disabled setter removes attribute when false", () => {
+    (el as any).disabled = true;
+    (el as any).disabled = false;
+    expect(el.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("label getter returns empty string by default", () => {
+    expect((el as any).label).toBe("");
+  });
+
+  it("label setter updates attribute", () => {
+    (el as any).label = "Notifications";
+    expect(el.getAttribute("label")).toBe("Notifications");
+  });
+
+  it("labelPosition getter returns none by default", () => {
+    expect((el as any).labelPosition).toBe("none");
+  });
+
+  it("labelPosition setter updates attribute", () => {
+    (el as any).labelPosition = "right";
+    expect(el.getAttribute("label-position")).toBe("right");
+  });
+
+  // ── Toggle (click) ───────────────────────────────────────────────────────
+
+  it("click toggles checked from false to true", () => {
+    el.click();
+    expect(el.hasAttribute("checked")).toBe(true);
+  });
+
+  it("click toggles checked from true to false", () => {
+    el.setAttribute("checked", "");
+    el.click();
+    expect(el.hasAttribute("checked")).toBe(false);
+  });
+
+  it("click dispatches switch-change event", () => {
+    let detail: { checked: boolean } | null = null;
+    el.addEventListener("switch-change", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+    el.click();
+    expect(detail).not.toBeNull();
+    expect(detail!.checked).toBe(true);
+  });
+
+  it("switch-change event bubbles", () => {
+    let bubbled = false;
+    document.body.addEventListener("switch-change", () => {
+      bubbled = true;
+    });
+    el.click();
+    expect(bubbled).toBe(true);
+  });
+
+  it("switch-change event is composed", () => {
+    let composed = false;
+    el.addEventListener("switch-change", ((e: CustomEvent) => {
+      composed = e.composed;
+    }) as EventListener);
+    el.click();
+    expect(composed).toBe(true);
+  });
+
+  // ── Keyboard ──────────────────────────────────────────────────────────────
+
+  it("Space key toggles checked", () => {
+    const track = el.shadowRoot!.querySelector(".switch") as HTMLElement;
+    track.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+    expect(el.hasAttribute("checked")).toBe(true);
+  });
+
+  it("Enter key toggles checked", () => {
+    const track = el.shadowRoot!.querySelector(".switch") as HTMLElement;
+    track.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+    expect(el.hasAttribute("checked")).toBe(true);
+  });
+
+  it("other keys do not toggle", () => {
+    const track = el.shadowRoot!.querySelector(".switch") as HTMLElement;
+    track.dispatchEvent(new KeyboardEvent("keydown", { key: "a", bubbles: true }));
+    expect(el.hasAttribute("checked")).toBe(false);
+  });
+
+  it("Space dispatches switch-change event", () => {
+    let fired = false;
+    el.addEventListener("switch-change", () => {
+      fired = true;
+    });
+    const track = el.shadowRoot!.querySelector(".switch") as HTMLElement;
+    track.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+    expect(fired).toBe(true);
+  });
+
+  // ── Disabled ──────────────────────────────────────────────────────────────
+
+  it("click does not toggle when disabled", () => {
+    el.setAttribute("disabled", "");
+    el.click();
+    expect(el.hasAttribute("checked")).toBe(false);
+  });
+
+  it("Space does not toggle when disabled", () => {
+    el.setAttribute("disabled", "");
+    const track = el.shadowRoot!.querySelector(".switch") as HTMLElement;
+    track.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+    expect(el.hasAttribute("checked")).toBe(false);
+  });
+
+  it("does not dispatch switch-change when disabled", () => {
+    el.setAttribute("disabled", "");
+    let fired = false;
+    el.addEventListener("switch-change", () => {
+      fired = true;
+    });
+    el.click();
+    expect(fired).toBe(false);
+  });
+
+  // ── ARIA ──────────────────────────────────────────────────────────────────
+
+  it("track has role=switch", () => {
+    const track = el.shadowRoot!.querySelector(".switch");
+    expect(track!.getAttribute("role")).toBe("switch");
+  });
+
+  it("track has tabindex=0", () => {
+    const track = el.shadowRoot!.querySelector(".switch");
+    expect(track!.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("aria-checked is false by default", () => {
+    const track = el.shadowRoot!.querySelector(".switch");
+    expect(track!.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("aria-checked updates to true when checked", () => {
+    el.setAttribute("checked", "");
+    const track = el.shadowRoot!.querySelector(".switch");
+    expect(track!.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("aria-checked updates back to false when unchecked", () => {
+    el.setAttribute("checked", "");
+    el.removeAttribute("checked");
+    const track = el.shadowRoot!.querySelector(".switch");
+    expect(track!.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("sets aria-label from label attribute", () => {
+    el.setAttribute("label", "Dark mode");
+    const track = el.shadowRoot!.querySelector(".switch");
+    expect(track!.getAttribute("aria-label")).toBe("Dark mode");
+  });
+
+  // ── observedAttributes ────────────────────────────────────────────────────
+
+  it("observedAttributes includes size", () => {
+    const observed = (customElements.get("ui-switch") as any).observedAttributes;
+    expect(observed).toContain("size");
+  });
+
+  it("observedAttributes includes checked", () => {
+    const observed = (customElements.get("ui-switch") as any).observedAttributes;
+    expect(observed).toContain("checked");
+  });
+
+  it("observedAttributes includes disabled", () => {
+    const observed = (customElements.get("ui-switch") as any).observedAttributes;
+    expect(observed).toContain("disabled");
+  });
+
+  it("observedAttributes includes label", () => {
+    const observed = (customElements.get("ui-switch") as any).observedAttributes;
+    expect(observed).toContain("label");
+  });
+
+  it("observedAttributes includes label-position", () => {
+    const observed = (customElements.get("ui-switch") as any).observedAttributes;
+    expect(observed).toContain("label-position");
+  });
+});

--- a/packages/ui-components/src/components/ui-switch.ts
+++ b/packages/ui-components/src/components/ui-switch.ts
@@ -1,0 +1,378 @@
+import { semanticVar, colorVar } from "@maneki/foundation";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const TEXT_SECONDARY = semanticVar("text", "secondary");
+const BLUE_30 = colorVar("blue", 30);
+const BLUE_60 = colorVar("blue", 60);
+const BORDER_FOCUS = semanticVar("border", "focus");
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type SwitchSize = "s" | "m" | "l";
+export type SwitchLabelPosition = "none" | "left" | "right" | "top";
+export type SwitchStatus = "none" | "error";
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: inline-flex;
+    align-items: center;
+    font-family: "Geist", sans-serif;
+    cursor: pointer;
+    user-select: none;
+    -webkit-user-select: none;
+  }
+
+  /* ── Switch container (track + handle) ───────────────────────────────────── */
+
+  .switch {
+    position: relative;
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+  }
+
+  .switch:focus-visible {
+    outline: 2px solid ${BORDER_FOCUS};
+    outline-offset: 2px;
+    border-radius: 999px;
+  }
+
+  /* ── Track (thin bar behind handle) ──────────────────────────────────────── */
+
+  .track {
+    position: absolute;
+    left: 0;
+    right: 0;
+    border-radius: 999px;
+    background: #C1CCD6;
+    transition: background 0.2s ease;
+  }
+
+  :host([checked]) .track {
+    background: ${BLUE_30};
+  }
+
+  :host([status="error"]) .track {
+    background: #FADCD9;
+  }
+
+  /* ── Handle (circle that slides) ─────────────────────────────────────────── */
+
+  .handle {
+    position: absolute;
+    left: 0;
+    border-radius: 999px;
+    background: #9FB1BD;
+    transition: left 0.2s ease, background 0.2s ease;
+  }
+
+  :host([checked]) .handle {
+    background: ${BLUE_60};
+  }
+
+  :host([status="error"]) .handle {
+    background: #D91F11;
+  }
+
+  /* ── Label ───────────────────────────────────────────────────────────────── */
+
+  .label {
+    display: none;
+    color: ${TEXT_PRIMARY};
+    white-space: nowrap;
+  }
+
+  :host([label-position="left"]) .label,
+  :host([label-position="right"]) .label,
+  :host([label-position="top"]) .label {
+    display: inline;
+  }
+
+  :host([label-position="top"]) {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  :host([label-position="top"]) .label {
+    font-weight: 500;
+    color: ${TEXT_SECONDARY};
+  }
+
+  /* ── Disabled ────────────────────────────────────────────────────────────── */
+
+  :host([disabled]) {
+    cursor: default;
+    pointer-events: none;
+    opacity: 0.5;
+  }
+
+  /* ── Size: S ─────────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) {
+    gap: 8px;
+  }
+
+  :host([size="s"]) .switch {
+    width: 20px;
+    height: 12px;
+  }
+
+  :host([size="s"]) .track {
+    height: 2px;
+    top: 5px;
+  }
+
+  :host([size="s"]) .handle {
+    width: 12px;
+    height: 12px;
+    top: 0;
+  }
+
+  :host([size="s"][checked]) .handle {
+    left: 8px;
+  }
+
+  :host([size="s"]) .label {
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  /* ── Size: M (default) ───────────────────────────────────────────────────── */
+
+  :host,
+  :host([size="m"]) {
+    gap: 8px;
+  }
+
+  :host .switch,
+  :host([size="m"]) .switch {
+    width: 28px;
+    height: 16px;
+  }
+
+  :host .track,
+  :host([size="m"]) .track {
+    height: 4px;
+    top: 6px;
+  }
+
+  :host .handle,
+  :host([size="m"]) .handle {
+    width: 16px;
+    height: 16px;
+    top: 0;
+  }
+
+  :host([checked]) .handle,
+  :host([size="m"][checked]) .handle {
+    left: 12px;
+  }
+
+  :host .label,
+  :host([size="m"]) .label {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  /* ── Size: L ─────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) {
+    gap: 8px;
+  }
+
+  :host([size="l"]) .switch {
+    width: 36px;
+    height: 20px;
+  }
+
+  :host([size="l"]) .track {
+    height: 6px;
+    top: 7px;
+  }
+
+  :host([size="l"]) .handle {
+    width: 20px;
+    height: 20px;
+    top: 0;
+  }
+
+  :host([size="l"][checked]) .handle {
+    left: 16px;
+  }
+
+  :host([size="l"]) .label {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .track,
+    .handle {
+      transition-duration: 0.01ms !important;
+    }
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiSwitch extends HTMLElement {
+  static readonly observedAttributes = [
+    "size",
+    "checked",
+    "disabled",
+    "label",
+    "label-position",
+    "status",
+  ];
+
+  #switchEl!: HTMLElement;
+  #track!: HTMLElement;
+  #handle!: HTMLElement;
+  #labelEl!: HTMLElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    // Label
+    this.#labelEl = document.createElement("span");
+    this.#labelEl.className = "label";
+
+    // Switch container
+    this.#switchEl = document.createElement("div");
+    this.#switchEl.className = "switch";
+    this.#switchEl.setAttribute("role", "switch");
+    this.#switchEl.setAttribute("tabindex", "0");
+
+    // Track
+    this.#track = document.createElement("div");
+    this.#track.className = "track";
+
+    // Handle
+    this.#handle = document.createElement("div");
+    this.#handle.className = "handle";
+
+    this.#switchEl.append(this.#track, this.#handle);
+    shadow.append(this.#labelEl, this.#switchEl);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("size")) this.setAttribute("size", "m");
+    if (!this.hasAttribute("label-position")) this.setAttribute("label-position", "none");
+    if (!this.hasAttribute("status")) this.setAttribute("status", "none");
+    this._syncAll();
+
+    this.addEventListener("click", () => {
+      if (this.disabled) return;
+      this.toggle();
+    });
+
+    this.#switchEl.addEventListener("keydown", (e) => {
+      if (this.disabled) return;
+      if (e.key === " " || e.key === "Enter") {
+        e.preventDefault();
+        this.toggle();
+      }
+    });
+  }
+
+  attributeChangedCallback(): void {
+    if (this.isConnected) this._syncAll();
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): SwitchSize {
+    return (this.getAttribute("size") as SwitchSize) ?? "m";
+  }
+  set size(v: SwitchSize) {
+    this.setAttribute("size", v);
+  }
+
+  get checked(): boolean {
+    return this.hasAttribute("checked");
+  }
+  set checked(v: boolean) {
+    if (v) this.setAttribute("checked", "");
+    else this.removeAttribute("checked");
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute("disabled");
+  }
+  set disabled(v: boolean) {
+    if (v) this.setAttribute("disabled", "");
+    else this.removeAttribute("disabled");
+  }
+
+  get label(): string {
+    return this.getAttribute("label") ?? "";
+  }
+  set label(v: string) {
+    this.setAttribute("label", v);
+  }
+
+  get labelPosition(): SwitchLabelPosition {
+    return (this.getAttribute("label-position") as SwitchLabelPosition) ?? "none";
+  }
+  set labelPosition(v: SwitchLabelPosition) {
+    this.setAttribute("label-position", v);
+  }
+
+  get status(): SwitchStatus {
+    return (this.getAttribute("status") as SwitchStatus) ?? "none";
+  }
+  set status(v: SwitchStatus) {
+    this.setAttribute("status", v);
+  }
+
+  // ── Public API ──────────────────────────────────────────────────────────
+
+  toggle(): void {
+    this.checked = !this.checked;
+    this.dispatchEvent(
+      new CustomEvent("switch-change", {
+        detail: { checked: this.checked },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private _syncAll(): void {
+    // Label
+    this.#labelEl.textContent = this.getAttribute("label") ?? "";
+
+    // Label position: reorder DOM
+    const pos = this.getAttribute("label-position");
+    if (pos === "left" || pos === "top") {
+      this.#labelEl.remove();
+      this.shadowRoot!.insertBefore(this.#labelEl, this.#switchEl);
+    } else if (pos === "right") {
+      this.#labelEl.remove();
+      this.shadowRoot!.appendChild(this.#labelEl);
+    }
+
+    // ARIA
+    this.#switchEl.setAttribute("aria-checked", String(this.checked));
+    if (this.label) this.#switchEl.setAttribute("aria-label", this.label);
+  }
+}
+
+customElements.define("ui-switch", UiSwitch);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -257,3 +257,8 @@ export type { TooltipSize, TooltipPlacement } from "./components/ui-tooltip.js";
 export { UiStepItem } from "./components/ui-step-item.js";
 export type { StepSize, StepStatus, StepOrientation } from "./components/ui-step-item.styles.js";
 export { UiStepGroup } from "./components/ui-step-group.js";
+
+// ─── Switch ───────────────────────────────────────────────────────────────────
+
+export { UiSwitch } from "./components/ui-switch.js";
+export type { SwitchSize, SwitchLabelPosition, SwitchStatus } from "./components/ui-switch.js";

--- a/packages/ui-components/src/stories/ui-switch.stories.ts
+++ b/packages/ui-components/src/stories/ui-switch.stories.ts
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-switch.js";
+
+const meta: Meta = {
+  title: "Components/Switch",
+  component: "ui-switch",
+  argTypes: {
+    size: {
+      control: { type: "select" },
+      options: ["s", "m", "l"],
+    },
+    checked: {
+      control: { type: "boolean" },
+    },
+    disabled: {
+      control: { type: "boolean" },
+    },
+    label: {
+      control: { type: "text" },
+    },
+    labelPosition: {
+      control: { type: "select" },
+      options: ["none", "left", "right"],
+    },
+  },
+  args: {
+    size: "m",
+    checked: false,
+    disabled: false,
+    label: "",
+    labelPosition: "none",
+  },
+  render: (args) => html`
+    <ui-switch
+      size=${args.size}
+      ?checked=${args.checked}
+      ?disabled=${args.disabled}
+      label=${args.label}
+      label-position=${args.labelPosition}
+    ></ui-switch>
+  `,
+};
+
+export default meta;
+type Story = StoryObj;
+
+export const Default: Story = {};
+
+export const Checked: Story = {
+  args: {
+    checked: true,
+  },
+};
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 24px;">
+      <div style="display: flex; align-items: center; gap: 24px;">
+        <div style="font-size: 12px; color: #666; width: 50px;">Size S</div>
+        <ui-switch size="s"></ui-switch>
+        <ui-switch size="s" checked></ui-switch>
+      </div>
+      <div style="display: flex; align-items: center; gap: 24px;">
+        <div style="font-size: 12px; color: #666; width: 50px;">Size M</div>
+        <ui-switch size="m"></ui-switch>
+        <ui-switch size="m" checked></ui-switch>
+      </div>
+      <div style="display: flex; align-items: center; gap: 24px;">
+        <div style="font-size: 12px; color: #666; width: 50px;">Size L</div>
+        <ui-switch size="l"></ui-switch>
+        <ui-switch size="l" checked></ui-switch>
+      </div>
+    </div>
+  `,
+};
+
+export const WithLabel: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 24px;">
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Label left</div>
+        <ui-switch label="Dark mode" label-position="left"></ui-switch>
+      </div>
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Label right</div>
+        <ui-switch label="Notifications" label-position="right"></ui-switch>
+      </div>
+      <div>
+        <div style="margin-bottom: 8px; font-size: 12px; color: #666;">Label left, checked</div>
+        <ui-switch label="Auto-save" label-position="left" checked></ui-switch>
+      </div>
+    </div>
+  `,
+};
+
+export const Disabled: Story = {
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 24px;">
+      <div style="display: flex; align-items: center; gap: 24px;">
+        <div style="font-size: 12px; color: #666; width: 120px;">Disabled unchecked</div>
+        <ui-switch disabled></ui-switch>
+      </div>
+      <div style="display: flex; align-items: center; gap: 24px;">
+        <div style="font-size: 12px; color: #666; width: 120px;">Disabled checked</div>
+        <ui-switch disabled checked></ui-switch>
+      </div>
+    </div>
+  `,
+};


### PR DESCRIPTION
## Summary

New `<ui-switch>` Web Component — toggle switch with label support.

## Features

- 3 sizes: `s` (24×14), `m` (32×18), `l` (44×24)
- States: on/off (`checked` attribute), disabled, focus
- Optional label with position (`none`, `left`, `right`)
- Track: gray off (`#9FB1BD`), blue on (`#186ADE`)
- Thumb: white circle with shadow, slides with 200ms transition
- Click + keyboard (Space/Enter) toggle
- ARIA: `role="switch"`, `aria-checked`, `tabindex="0"`
- Events: `switch-change` with `detail.checked`
- `prefers-reduced-motion` support

## API

```html
<ui-switch size="m" label="Dark mode" label-position="left"></ui-switch>
<ui-switch size="l" checked label="Notifications" label-position="right"></ui-switch>
<ui-switch size="m" disabled></ui-switch>
```

## Testing

- 3332 unit tests (58 new)
- 5 Storybook stories
- 54 Playwright visual regression tests (1 new)

## Files

- `packages/ui-components/src/components/ui-switch.ts`
- `packages/ui-components/src/components/ui-switch.test.ts`
- `packages/ui-components/src/stories/ui-switch.stories.ts`
- `packages/ui-components/src/index.ts` — barrel exports
- `apps/catalog/src/pages/switch.ts` — catalog page