### PR TITLE
feat(ui-components): add ui-tree-item and ui-tree-group components

### DIFF
--- a/apps/catalog/e2e/visual.spec.ts
+++ b/apps/catalog/e2e/visual.spec.ts
@@ -39,6 +39,7 @@ const pages = [
   "side-panel",
   "pagination",
   "steps",
+  "tree",
   "tabs",
   "table",
   "metric",

--- a/apps/catalog/src/main.ts
+++ b/apps/catalog/src/main.ts
@@ -57,6 +57,7 @@ const pageLoaders: Record<string, () => Promise<unknown>> = {
   "side-panel": () => import("./pages/side-panel.js"),
   "pagination": () => import("./pages/pagination.js"),
   "steps": () => import("./pages/steps.js"),
+  "tree": () => import("./pages/tree.js"),
   "tabs": () => import("./pages/tabs.js"),
   "table": () => import("./pages/table.js"),
   "metric": () => import("./pages/metric.js"),

--- a/apps/catalog/src/manifest.ts
+++ b/apps/catalog/src/manifest.ts
@@ -62,6 +62,7 @@ export const manifest: PageMeta[] = [
   { id: "side-panel", title: "Side Panel", section: "Navigation" },
   { id: "pagination", title: "Pagination", section: "Navigation" },
   { id: "steps", title: "Steps", section: "Navigation" },
+  { id: "tree", title: "Tree", section: "Navigation" },
   // Disclosure
   { id: "accordion", title: "Accordion", section: "Disclosure" },
   // Menus & Dropdowns

--- a/apps/catalog/src/pages/tree.ts
+++ b/apps/catalog/src/pages/tree.ts
@@ -1,0 +1,130 @@
+import { registerPage } from "../registry.js";
+
+registerPage("tree", {
+  title: "Tree",
+  section: "Navigation",
+  render: () => `
+    <h3>Variant</h3>
+    <div class="variant-row" style="gap: 60px;">
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">S</span>
+        <ui-tree-group size="s" style="width: 300px;">
+          <ui-tree-item arrow="open" label="Parent"></ui-tree-item>
+          <ui-tree-item arrow="none" level="child-1" label="Child 1"></ui-tree-item>
+          <ui-tree-item arrow="none" level="child-1" label="Child 2"></ui-tree-item>
+        </ui-tree-group>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">M</span>
+        <ui-tree-group size="m" style="width: 300px;">
+          <ui-tree-item arrow="open" label="Parent"></ui-tree-item>
+          <ui-tree-item arrow="none" level="child-1" label="Child 1"></ui-tree-item>
+          <ui-tree-item arrow="none" level="child-1" label="Child 2"></ui-tree-item>
+        </ui-tree-group>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">L</span>
+        <ui-tree-group size="l" style="width: 300px;">
+          <ui-tree-item arrow="open" label="Parent"></ui-tree-item>
+          <ui-tree-item arrow="none" level="child-1" label="Child 1"></ui-tree-item>
+          <ui-tree-item arrow="none" level="child-1" label="Child 2"></ui-tree-item>
+        </ui-tree-group>
+      </div>
+    </div>
+
+    <h3>Level</h3>
+    <div class="variant-row" style="gap: 60px;">
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Parent / Child 1</span>
+        <ui-tree-group style="width: 300px;">
+          <ui-tree-item arrow="open" label="Parent"></ui-tree-item>
+          <ui-tree-item arrow="none" level="child-1" label="Child 1 Item"></ui-tree-item>
+          <ui-tree-item arrow="none" level="child-1" label="Child 1 Item"></ui-tree-item>
+        </ui-tree-group>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Child 2 / Child 3</span>
+        <div style="width: 300px;">
+          <ui-tree-item arrow="none" level="child-2" label="Child 2 Item"></ui-tree-item>
+          <ui-tree-item arrow="none" level="child-3" label="Child 3 Item"></ui-tree-item>
+        </div>
+      </div>
+    </div>
+
+    <h3>Arrow</h3>
+    <div class="variant-row" style="gap: 60px;">
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">None</span>
+        <div style="width: 300px;">
+          <ui-tree-item arrow="none" label="Leaf Item"></ui-tree-item>
+        </div>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Closed</span>
+        <div style="width: 300px;">
+          <ui-tree-item arrow="closed" label="Collapsed"></ui-tree-item>
+        </div>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Open</span>
+        <div style="width: 300px;">
+          <ui-tree-item arrow="open" label="Expanded"></ui-tree-item>
+        </div>
+      </div>
+    </div>
+
+    <h3>State</h3>
+    <div class="variant-row" style="gap: 60px;">
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Enabled</span>
+        <div style="width: 300px;">
+          <ui-tree-item arrow="none" label="Enabled Item"></ui-tree-item>
+        </div>
+      </div>
+      <div class="variant-col" style="align-items: center;">
+        <span class="variant-label">Selected</span>
+        <div style="width: 300px;">
+          <ui-tree-item arrow="none" label="Selected Item" selected></ui-tree-item>
+        </div>
+      </div>
+    </div>
+
+    <h3>Leading Icon</h3>
+    <ui-tree-group style="width: 300px;">
+      <ui-tree-item arrow="open" label="With Icon" leading-icon icon-name="home"></ui-tree-item>
+      <ui-tree-item arrow="none" level="child-1" label="Child" leading-icon icon-name="settings"></ui-tree-item>
+    </ui-tree-group>
+
+    <h3>Checkbox</h3>
+    <ui-tree-group style="width: 300px;">
+      <ui-tree-item arrow="open" label="With Checkbox" checkbox>
+        <ui-checkbox-item slot="checkbox" size="m"></ui-checkbox-item>
+      </ui-tree-item>
+      <ui-tree-item arrow="none" level="child-1" label="Child" checkbox>
+        <ui-checkbox-item slot="checkbox" size="m"></ui-checkbox-item>
+      </ui-tree-item>
+    </ui-tree-group>
+
+    <h3>Secondary Label</h3>
+    <div style="width: 300px;">
+      <ui-tree-item arrow="none" label="Item" secondary-label="Info"></ui-tree-item>
+    </div>
+
+    <h3>Tree Group (Interactive)</h3>
+    <div style="width: 300px;">
+      <ui-tree-group size="m" searchable>
+        <ui-tree-item arrow="closed" label="Documents"></ui-tree-item>
+        <ui-tree-item arrow="none" level="child-1" label="Report.pdf"></ui-tree-item>
+        <ui-tree-item arrow="none" level="child-1" label="Summary.docx"></ui-tree-item>
+        <ui-tree-item arrow="none" level="child-1" label="Notes.txt"></ui-tree-item>
+        <ui-tree-item arrow="open" label="Projects"></ui-tree-item>
+        <ui-tree-item arrow="none" level="child-1" label="Alpha" selected></ui-tree-item>
+        <ui-tree-item arrow="open" level="child-1" label="Beta"></ui-tree-item>
+        <ui-tree-item arrow="open" level="child-2" label="Frontend"></ui-tree-item>
+        <ui-tree-item arrow="closed" level="child-3" label="Components"></ui-tree-item>
+        <ui-tree-item arrow="closed" level="child-2" label="Backend"></ui-tree-item>
+        <ui-tree-item arrow="closed" level="child-1" label="Gamma"></ui-tree-item>
+      </ui-tree-group>
+    </div>
+  `,
+});

--- a/packages/ui-components/src/components/ui-tree-group.test.ts
+++ b/packages/ui-components/src/components/ui-tree-group.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import "./ui-tree-group.js";
+import "./ui-tree-item.js";
+
+describe("ui-tree-group", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-tree-group");
+    document.body.appendChild(el);
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-tree-group")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("applies adoptedStyleSheets", () => {
+    expect(el.shadowRoot!.adoptedStyleSheets.length).toBe(1);
+  });
+
+  // ── Default rendering ─────────────────────────────────────────────────────
+
+  it("renders a .search wrapper", () => {
+    expect(el.shadowRoot!.querySelector(".search")).not.toBeNull();
+  });
+
+  it("renders a .tree wrapper", () => {
+    expect(el.shadowRoot!.querySelector(".tree")).not.toBeNull();
+  });
+
+  it("renders a search slot with name=search", () => {
+    const slot = el.shadowRoot!.querySelector("slot[name='search']");
+    expect(slot).not.toBeNull();
+  });
+
+  it("renders a default slot for tree items", () => {
+    const slot = el.shadowRoot!.querySelector("slot:not([name])");
+    expect(slot).not.toBeNull();
+  });
+
+  // ── Default attributes ────────────────────────────────────────────────────
+
+  it("defaults size to m", () => {
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  // ── Tree role ─────────────────────────────────────────────────────────────
+
+  it("sets role=tree on the .tree container", () => {
+    const tree = el.shadowRoot!.querySelector(".tree");
+    expect(tree!.getAttribute("role")).toBe("tree");
+  });
+
+  // ── Size attribute ────────────────────────────────────────────────────────
+
+  it("accepts size=s", () => {
+    el.setAttribute("size", "s");
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("accepts size=l", () => {
+    el.setAttribute("size", "l");
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  // ── Property accessors ────────────────────────────────────────────────────
+
+  it("size getter returns attribute value", () => {
+    el.setAttribute("size", "l");
+    expect((el as any).size).toBe("l");
+  });
+
+  it("size setter updates attribute", () => {
+    (el as any).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("size getter defaults to m when no attribute", () => {
+    expect((el as any).size).toBe("m");
+  });
+
+  // ── Size propagation ──────────────────────────────────────────────────────
+
+  it("propagates size to slotted ui-tree-item children", async () => {
+    const item = document.createElement("ui-tree-item");
+    el.appendChild(item);
+    // Wait for slotchange
+    await new Promise((r) => setTimeout(r, 0));
+    expect(item.getAttribute("size")).toBe("m");
+  });
+
+  it("updates children size when size attribute changes", async () => {
+    const item = document.createElement("ui-tree-item");
+    el.appendChild(item);
+    await new Promise((r) => setTimeout(r, 0));
+    el.setAttribute("size", "l");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(item.getAttribute("size")).toBe("l");
+  });
+
+  it("does not propagate size to non-tree-item children", async () => {
+    const div = document.createElement("div");
+    el.appendChild(div);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(div.hasAttribute("size")).toBe(false);
+  });
+
+  // ── observedAttributes ────────────────────────────────────────────────────
+
+  it("observes the correct attributes", () => {
+    const observed = (customElements.get("ui-tree-group") as any).observedAttributes;
+    expect(observed).toEqual(["size", "searchable"]);
+  });
+});

--- a/packages/ui-components/src/components/ui-tree-group.ts
+++ b/packages/ui-components/src/components/ui-tree-group.ts
@@ -1,0 +1,349 @@
+import "./ui-tree-item.js";
+import { ICON_SEARCH } from "@maneki/foundation";
+import { semanticVar } from "@maneki/foundation";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const BORDER_MODERATE = semanticVar("border", "moderate");
+const SURFACE_PRIMARY = semanticVar("surface", "primary");
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const TEXT_TERTIARY = semanticVar("text", "tertiary");
+const ICON_SECONDARY = semanticVar("icon", "secondary");
+const BORDER_FOCUS = semanticVar("border", "focus");
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  @font-face {
+    font-family: "Material Symbols Outlined";
+    font-style: normal;
+    src: local("Material Symbols Outlined");
+  }
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    font-family: "Geist", sans-serif;
+  }
+
+  .search {
+    flex-shrink: 0;
+  }
+
+  .search-input-wrapper {
+    display: none;
+    align-items: center;
+    border: 1px solid ${BORDER_MODERATE};
+    background: ${SURFACE_PRIMARY};
+    border-radius: 2px;
+  }
+
+  :host([searchable]) .search-input-wrapper {
+    display: flex;
+  }
+
+  .search-input-wrapper:focus-within {
+    border-color: ${BORDER_FOCUS};
+    outline: 1px solid ${BORDER_FOCUS};
+    outline-offset: -1px;
+  }
+
+  .search-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    color: ${ICON_SECONDARY};
+  }
+
+  .search-icon .material-symbols-outlined {
+    font-family: "Material Symbols Outlined";
+    font-weight: normal;
+    font-style: normal;
+    line-height: 1;
+    display: inline-block;
+    -webkit-font-smoothing: antialiased;
+    font-variation-settings: "FILL" 0;
+  }
+
+  .search-input {
+    flex: 1;
+    min-width: 0;
+    border: none;
+    background: transparent;
+    font-family: "Geist", sans-serif;
+    color: ${TEXT_PRIMARY};
+    outline: none;
+  }
+
+  .search-input::placeholder {
+    color: ${TEXT_TERTIARY};
+  }
+
+  .tree {
+    display: flex;
+    flex-direction: column;
+    padding: 4px 0;
+  }
+
+  ::slotted(ui-tree-item) {
+    width: 100%;
+  }
+
+  ::slotted(ui-tree-item[hidden]) {
+    display: flex !important;
+  }
+
+  /* ── Size: S ─────────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) .search-input-wrapper {
+    height: 24px;
+    padding: 0 8px;
+    gap: 4px;
+  }
+
+  :host([size="s"]) .search-icon {
+    width: 16px;
+    height: 16px;
+  }
+
+  :host([size="s"]) .search-icon .material-symbols-outlined {
+    font-size: 16px;
+  }
+
+  :host([size="s"]) .search-input {
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  :host([size="s"]) {
+    gap: 8px;
+  }
+
+  /* ── Size: M (default) ───────────────────────────────────────────────────── */
+
+  :host,
+  :host([size="m"]) {
+    gap: 12px;
+  }
+
+  :host .search-input-wrapper,
+  :host([size="m"]) .search-input-wrapper {
+    height: 32px;
+    padding: 0 8px;
+    gap: 8px;
+  }
+
+  :host .search-icon,
+  :host([size="m"]) .search-icon {
+    width: 20px;
+    height: 20px;
+  }
+
+  :host .search-icon .material-symbols-outlined,
+  :host([size="m"]) .search-icon .material-symbols-outlined {
+    font-size: 20px;
+  }
+
+  :host .search-input,
+  :host([size="m"]) .search-input {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  /* ── Size: L ─────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) {
+    gap: 16px;
+  }
+
+  :host([size="l"]) .search-input-wrapper {
+    height: 40px;
+    padding: 0 12px;
+    gap: 8px;
+  }
+
+  :host([size="l"]) .search-icon {
+    width: 24px;
+    height: 24px;
+  }
+
+  :host([size="l"]) .search-icon .material-symbols-outlined {
+    font-size: 24px;
+  }
+
+  :host([size="l"]) .search-input {
+    font-size: 16px;
+    line-height: 24px;
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiTreeGroup extends HTMLElement {
+  static readonly observedAttributes = ["size", "searchable"];
+
+  #searchWrapper!: HTMLElement;
+  #searchInput!: HTMLInputElement;
+  #tree!: HTMLElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    // Built-in search input
+    this.#searchWrapper = document.createElement("div");
+    this.#searchWrapper.className = "search-input-wrapper";
+
+    const searchIcon = document.createElement("span");
+    searchIcon.className = "search-icon";
+    const iconEl = document.createElement("span");
+    iconEl.className = "material-symbols-outlined";
+    iconEl.textContent = ICON_SEARCH;
+    searchIcon.appendChild(iconEl);
+
+    this.#searchInput = document.createElement("input");
+    this.#searchInput.className = "search-input";
+    this.#searchInput.type = "text";
+    this.#searchInput.placeholder = "Type to search...";
+
+    this.#searchWrapper.append(searchIcon, this.#searchInput);
+
+    // Search slot (for custom search)
+    const searchSlot = document.createElement("div");
+    searchSlot.className = "search";
+    const searchSlotEl = document.createElement("slot");
+    searchSlotEl.name = "search";
+    searchSlot.appendChild(searchSlotEl);
+
+    // Tree items
+    this.#tree = document.createElement("div");
+    this.#tree.className = "tree";
+    this.#tree.setAttribute("role", "tree");
+    const treeSlot = document.createElement("slot");
+    this.#tree.appendChild(treeSlot);
+
+    shadow.append(this.#searchWrapper, searchSlot, this.#tree);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("size")) this.setAttribute("size", "m");
+
+    const slot = this.shadowRoot!.querySelector("slot:not([name])") as HTMLSlotElement;
+    slot.addEventListener("slotchange", () => {
+      this._propagateSize();
+      this._syncVisibility();
+    });
+    this._propagateSize();
+
+    // Listen for tree-toggle events to manage child visibility
+    this.addEventListener("tree-toggle", () => {
+      this._syncVisibility();
+    });
+
+    // Search filtering
+    this.#searchInput.addEventListener("input", () => {
+      this._filterBySearch();
+    });
+  }
+
+  attributeChangedCallback(name: string): void {
+    if (name === "size" && this.isConnected) this._propagateSize();
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): string {
+    return this.getAttribute("size") ?? "m";
+  }
+  set size(v: string) {
+    this.setAttribute("size", v);
+  }
+
+  get searchable(): boolean {
+    return this.hasAttribute("searchable");
+  }
+  set searchable(v: boolean) {
+    if (v) this.setAttribute("searchable", "");
+    else this.removeAttribute("searchable");
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private _getItems(): HTMLElement[] {
+    const slot = this.shadowRoot!.querySelector("slot:not([name])") as HTMLSlotElement;
+    return slot.assignedElements().filter((el) => el.tagName === "UI-TREE-ITEM") as HTMLElement[];
+  }
+
+  private _propagateSize(): void {
+    const size = this.getAttribute("size");
+    if (!size) return;
+    for (const item of this._getItems()) {
+      item.setAttribute("size", size);
+    }
+  }
+
+  private _syncVisibility(): void {
+    const items = this._getItems();
+    const levelOrder = ["parent", "child-1", "child-2", "child-3"];
+    let hiddenBelowLevel = -1; // -1 means nothing hidden
+
+    for (const item of items) {
+      const level = item.getAttribute("level") ?? "parent";
+      const levelIdx = levelOrder.indexOf(level);
+      const arrow = item.getAttribute("arrow");
+
+      // If we're hiding children and this item is at or deeper than the hidden level
+      if (hiddenBelowLevel >= 0 && levelIdx > hiddenBelowLevel) {
+        item.setAttribute("hidden", "");
+        continue;
+      }
+
+      // This item is at or above the hidden level — show it
+      item.removeAttribute("hidden");
+      hiddenBelowLevel = -1;
+
+      // If this item is collapsed, hide everything below its level
+      if (arrow === "closed") {
+        hiddenBelowLevel = levelIdx;
+      }
+    }
+  }
+
+  private _filterBySearch(): void {
+    const query = this.#searchInput.value.toLowerCase().trim();
+    const items = this._getItems();
+
+    if (!query) {
+      // Reset: show all, then apply collapse visibility
+      for (const item of items) {
+        item.removeAttribute("hidden");
+      }
+      this._syncVisibility();
+      return;
+    }
+
+    // Show items matching query, hide others
+    for (const item of items) {
+      const label = (item.getAttribute("label") ?? "").toLowerCase();
+      if (label.includes(query)) {
+        item.removeAttribute("hidden");
+      } else {
+        item.setAttribute("hidden", "");
+      }
+    }
+  }
+}
+
+customElements.define("ui-tree-group", UiTreeGroup);

--- a/packages/ui-components/src/components/ui-tree-item.styles.ts
+++ b/packages/ui-components/src/components/ui-tree-item.styles.ts
@@ -1,0 +1,316 @@
+import { semanticVar, colorVar } from "@maneki/foundation";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const TEXT_SECONDARY = semanticVar("text", "secondary");
+const ICON_PRIMARY = semanticVar("icon", "primary");
+const BORDER_FOCUS = semanticVar("border", "focus");
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type TreeItemSize = "s" | "m" | "l";
+export type TreeItemLevel = "parent" | "child-1" | "child-2" | "child-3";
+export type TreeItemArrow = "none" | "closed" | "open";
+export type TreeItemState = "enabled" | "hover" | "selected";
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+export const TREE_ITEM_STYLES = /* css */ `
+  @font-face {
+    font-family: "Material Symbols Outlined";
+    font-style: normal;
+    src: local("Material Symbols Outlined");
+  }
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    font-family: "Geist", sans-serif;
+    cursor: pointer;
+    overflow: hidden;
+    max-height: 100px;
+    transition: max-height 0.2s ease, opacity 0.2s ease;
+    opacity: 1;
+  }
+
+  :host([hidden]) {
+    max-height: 0;
+    opacity: 0;
+    padding: 0;
+    pointer-events: none;
+  }
+
+  .base {
+    display: flex;
+    flex: 1 0 0;
+    gap: 4px;
+    align-items: center;
+    min-width: 0;
+    transition: background 0.15s ease;
+  }
+
+  /* ── Chevron ─────────────────────────────────────────────────────────────── */
+
+  .chevron {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    color: ${ICON_PRIMARY};
+    transition: transform 0.2s ease;
+  }
+
+  :host([arrow="open"]) .chevron {
+    transform: rotate(0deg);
+  }
+
+  :host([arrow="closed"]) .chevron {
+    transform: rotate(-90deg);
+  }
+
+  .chevron .material-symbols-outlined {
+    font-family: "Material Symbols Outlined";
+    font-weight: normal;
+    font-style: normal;
+    line-height: 1;
+    letter-spacing: normal;
+    text-transform: none;
+    display: inline-block;
+    white-space: nowrap;
+    -webkit-font-smoothing: antialiased;
+    font-variation-settings: "FILL" 0;
+  }
+
+  :host([arrow="none"]) .chevron {
+    visibility: hidden;
+  }
+
+  /* ── Content ─────────────────────────────────────────────────────────────── */
+
+  .content {
+    display: flex;
+    flex: 1 0 0;
+    gap: 4px;
+    align-items: center;
+    min-width: 0;
+  }
+
+  .leading-icon {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    color: ${ICON_PRIMARY};
+  }
+
+  :host([leading-icon]) .leading-icon {
+    display: flex;
+  }
+
+  .leading-icon .material-symbols-outlined {
+    font-family: "Material Symbols Outlined";
+    font-weight: normal;
+    font-style: normal;
+    line-height: 1;
+    display: inline-block;
+    -webkit-font-smoothing: antialiased;
+    font-variation-settings: "FILL" 0;
+  }
+
+  .checkbox-slot {
+    display: none;
+    flex-shrink: 0;
+  }
+
+  :host([checkbox]) .checkbox-slot {
+    display: flex;
+  }
+
+  .label {
+    flex: 1 0 0;
+    min-width: 0;
+    color: ${TEXT_PRIMARY};
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .secondary-label {
+    display: none;
+    flex: 1 0 0;
+    min-width: 0;
+    color: ${TEXT_SECONDARY};
+    text-align: right;
+    white-space: nowrap;
+  }
+
+  :host([secondary-label]) .secondary-label {
+    display: block;
+  }
+
+  /* ── States ──────────────────────────────────────────────────────────────── */
+
+  :host(:hover) .base {
+    background: rgba(159, 177, 189, 0.1);
+  }
+
+  :host([selected]) .base {
+    background: rgba(24, 106, 222, 0.2);
+  }
+
+  :host(:focus-visible) {
+    outline: 2px solid ${BORDER_FOCUS};
+    outline-offset: -2px;
+  }
+
+  /* ── Size: S ─────────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) .base {
+    padding: 4px 6px;
+  }
+
+  :host([size="s"]) .chevron {
+    width: 16px;
+    height: 16px;
+  }
+
+  :host([size="s"]) .chevron .material-symbols-outlined {
+    font-size: 16px;
+  }
+
+  :host([size="s"]) .leading-icon {
+    width: 16px;
+    height: 16px;
+  }
+
+  :host([size="s"]) .leading-icon .material-symbols-outlined {
+    font-size: 16px;
+  }
+
+  :host([size="s"]) .label {
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  :host([size="s"]) .secondary-label {
+    font-size: 12px;
+    line-height: 16px;
+  }
+
+  /* Level indents for S */
+  :host([size="s"][level="parent"]) .base { padding-left: 6px }
+  :host([size="s"][level="child-1"]) .base { padding-left: 24px }
+  :host([size="s"][level="child-2"]) .base { padding-left: 42px }
+  :host([size="s"][level="child-3"]) .base { padding-left: 60px }
+
+  /* ── Size: M (default) ───────────────────────────────────────────────────── */
+
+  :host .base,
+  :host([size="m"]) .base {
+    padding: 4px 8px;
+  }
+
+  :host .chevron,
+  :host([size="m"]) .chevron {
+    width: 20px;
+    height: 20px;
+  }
+
+  :host .chevron .material-symbols-outlined,
+  :host([size="m"]) .chevron .material-symbols-outlined {
+    font-size: 20px;
+  }
+
+  :host .leading-icon,
+  :host([size="m"]) .leading-icon {
+    width: 18px;
+    height: 18px;
+  }
+
+  :host .leading-icon .material-symbols-outlined,
+  :host([size="m"]) .leading-icon .material-symbols-outlined {
+    font-size: 18px;
+  }
+
+  :host .label,
+  :host([size="m"]) .label {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  :host .secondary-label,
+  :host([size="m"]) .secondary-label {
+    font-size: 12px;
+    line-height: 20px;
+  }
+
+  /* Level indents for M */
+  :host([size="m"][level="parent"]) .base,
+  :host([level="parent"]) .base { padding-left: 8px }
+  :host([size="m"][level="child-1"]) .base,
+  :host([level="child-1"]) .base { padding-left: 32px }
+  :host([size="m"][level="child-2"]) .base,
+  :host([level="child-2"]) .base { padding-left: 56px }
+  :host([size="m"][level="child-3"]) .base,
+  :host([level="child-3"]) .base { padding-left: 80px }
+
+  /* ── Size: L ─────────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) .base {
+    padding: 8px;
+  }
+
+  :host([size="l"]) .chevron {
+    width: 24px;
+    height: 24px;
+  }
+
+  :host([size="l"]) .chevron .material-symbols-outlined {
+    font-size: 24px;
+  }
+
+  :host([size="l"]) .leading-icon {
+    width: 20px;
+    height: 20px;
+  }
+
+  :host([size="l"]) .leading-icon .material-symbols-outlined {
+    font-size: 20px;
+  }
+
+  :host([size="l"]) .content {
+    gap: 6px;
+  }
+
+  :host([size="l"]) .label {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  :host([size="l"]) .secondary-label {
+    font-size: 14px;
+    line-height: 24px;
+  }
+
+  /* Level indents for L */
+  :host([size="l"][level="parent"]) .base { padding-left: 8px }
+  :host([size="l"][level="child-1"]) .base { padding-left: 32px }
+  :host([size="l"][level="child-2"]) .base { padding-left: 56px }
+  :host([size="l"][level="child-3"]) .base { padding-left: 80px }
+
+  @media (prefers-reduced-motion: reduce) {
+    :host,
+    .base,
+    .chevron {
+      transition-duration: 0.01ms !important;
+    }
+  }
+`;

--- a/packages/ui-components/src/components/ui-tree-item.test.ts
+++ b/packages/ui-components/src/components/ui-tree-item.test.ts
@@ -1,0 +1,389 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import "./ui-tree-item.js";
+import type { TreeItemSize, TreeItemLevel, TreeItemArrow } from "./ui-tree-item.styles.js";
+import { TREE_ITEM_STYLES } from "./ui-tree-item.styles.js";
+import { ICON_CHEVRON_RIGHT, ICON_EXPAND_MORE } from "@maneki/foundation";
+
+describe("ui-tree-item", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-tree-item");
+    document.body.appendChild(el);
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-tree-item")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("applies adoptedStyleSheets", () => {
+    expect(el.shadowRoot!.adoptedStyleSheets.length).toBe(1);
+  });
+
+  // ── Default rendering ─────────────────────────────────────────────────────
+
+  it("renders a .base wrapper", () => {
+    expect(el.shadowRoot!.querySelector(".base")).not.toBeNull();
+  });
+
+  it("renders a .chevron element", () => {
+    expect(el.shadowRoot!.querySelector(".chevron")).not.toBeNull();
+  });
+
+  it("renders a .content element", () => {
+    expect(el.shadowRoot!.querySelector(".content")).not.toBeNull();
+  });
+
+  it("renders a .label element", () => {
+    expect(el.shadowRoot!.querySelector(".label")).not.toBeNull();
+  });
+
+  it("renders a .secondary-label element", () => {
+    expect(el.shadowRoot!.querySelector(".secondary-label")).not.toBeNull();
+  });
+
+  it("renders a .leading-icon element", () => {
+    expect(el.shadowRoot!.querySelector(".leading-icon")).not.toBeNull();
+  });
+
+  it("renders a .checkbox-slot element", () => {
+    expect(el.shadowRoot!.querySelector(".checkbox-slot")).not.toBeNull();
+  });
+
+  it("renders a chevron icon inside .chevron", () => {
+    const icon = el.shadowRoot!.querySelector(".chevron .material-symbols-outlined");
+    expect(icon).not.toBeNull();
+  });
+
+  // ── Default attributes ────────────────────────────────────────────────────
+
+  it("defaults size to m", () => {
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("defaults level to parent", () => {
+    expect(el.getAttribute("level")).toBe("parent");
+  });
+
+  it("defaults arrow to none", () => {
+    expect(el.getAttribute("arrow")).toBe("none");
+  });
+
+  it("sets role to treeitem", () => {
+    expect(el.getAttribute("role")).toBe("treeitem");
+  });
+
+  it("sets tabindex to 0", () => {
+    expect(el.getAttribute("tabindex")).toBe("0");
+  });
+
+  // ── Size attribute ────────────────────────────────────────────────────────
+
+  it.each(["s", "m", "l"] satisfies TreeItemSize[])("accepts size=%s", (size) => {
+    el.setAttribute("size", size);
+    expect(el.getAttribute("size")).toBe(size);
+  });
+
+  // ── Level attribute ───────────────────────────────────────────────────────
+
+  it.each(["parent", "child-1", "child-2", "child-3"] satisfies TreeItemLevel[])("accepts level=%s", (level) => {
+    el.setAttribute("level", level);
+    expect(el.getAttribute("level")).toBe(level);
+  });
+
+  // ── Arrow attribute ───────────────────────────────────────────────────────
+
+  it.each(["none", "closed", "open"] satisfies TreeItemArrow[])("accepts arrow=%s", (arrow) => {
+    el.setAttribute("arrow", arrow);
+    expect(el.getAttribute("arrow")).toBe(arrow);
+  });
+
+  // ── Selected attribute ────────────────────────────────────────────────────
+
+  it("does not have selected by default", () => {
+    expect(el.hasAttribute("selected")).toBe(false);
+  });
+
+  it("accepts selected attribute", () => {
+    el.setAttribute("selected", "");
+    expect(el.hasAttribute("selected")).toBe(true);
+  });
+
+  // ── Label attribute ───────────────────────────────────────────────────────
+
+  it("renders label text", () => {
+    el.setAttribute("label", "Documents");
+    const label = el.shadowRoot!.querySelector(".label");
+    expect(label!.textContent).toBe("Documents");
+  });
+
+  it("renders secondary-label text", () => {
+    el.setAttribute("secondary-label", "3 items");
+    const secondary = el.shadowRoot!.querySelector(".secondary-label");
+    expect(secondary!.textContent).toBe("3 items");
+  });
+
+  // ── Leading icon attribute ────────────────────────────────────────────────
+
+  it("renders leading icon when leading-icon is set", () => {
+    el.setAttribute("leading-icon", "");
+    expect(el.shadowRoot!.querySelector(".leading-icon")).not.toBeNull();
+  });
+
+  it("renders icon-name in leading icon element", () => {
+    el.setAttribute("leading-icon", "");
+    el.setAttribute("icon-name", "home");
+    const iconEl = el.shadowRoot!.querySelector(".leading-icon .material-symbols-outlined");
+    expect(iconEl).not.toBeNull();
+  });
+
+  // ── Checkbox attribute ────────────────────────────────────────────────────
+
+  it("renders checkbox slot when checkbox is set", () => {
+    el.setAttribute("checkbox", "");
+    const slot = el.shadowRoot!.querySelector(".checkbox-slot slot[name='checkbox']");
+    expect(slot).not.toBeNull();
+  });
+
+  // ── Property accessors ────────────────────────────────────────────────────
+
+  it("size getter returns attribute value", () => {
+    el.setAttribute("size", "l");
+    expect((el as any).size).toBe("l");
+  });
+
+  it("size setter updates attribute", () => {
+    (el as any).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("level getter returns attribute value", () => {
+    el.setAttribute("level", "child-2");
+    expect((el as any).level).toBe("child-2");
+  });
+
+  it("level setter updates attribute", () => {
+    (el as any).level = "child-1";
+    expect(el.getAttribute("level")).toBe("child-1");
+  });
+
+  it("arrow getter returns attribute value", () => {
+    el.setAttribute("arrow", "open");
+    expect((el as any).arrow).toBe("open");
+  });
+
+  it("arrow setter updates attribute", () => {
+    (el as any).arrow = "closed";
+    expect(el.getAttribute("arrow")).toBe("closed");
+  });
+
+  it("selected getter returns boolean", () => {
+    expect((el as any).selected).toBe(false);
+    el.setAttribute("selected", "");
+    expect((el as any).selected).toBe(true);
+  });
+
+  it("selected setter adds/removes attribute", () => {
+    (el as any).selected = true;
+    expect(el.hasAttribute("selected")).toBe(true);
+    (el as any).selected = false;
+    expect(el.hasAttribute("selected")).toBe(false);
+  });
+
+  it("label getter returns attribute value", () => {
+    el.setAttribute("label", "Foo");
+    expect((el as any).label).toBe("Foo");
+  });
+
+  it("label setter updates attribute", () => {
+    (el as any).label = "Bar";
+    expect(el.getAttribute("label")).toBe("Bar");
+  });
+
+  it("secondaryLabelText getter returns attribute value", () => {
+    el.setAttribute("secondary-label", "sub");
+    expect((el as any).secondaryLabelText).toBe("sub");
+  });
+
+  it("secondaryLabelText setter updates attribute", () => {
+    (el as any).secondaryLabelText = "info";
+    expect(el.getAttribute("secondary-label")).toBe("info");
+  });
+
+  it("iconName getter returns attribute value", () => {
+    el.setAttribute("icon-name", "home");
+    expect((el as any).iconName).toBe("home");
+  });
+
+  it("iconName setter updates attribute", () => {
+    (el as any).iconName = "settings";
+    expect(el.getAttribute("icon-name")).toBe("settings");
+  });
+
+  // ── Arrow chevron icon ────────────────────────────────────────────────────
+
+  it("shows expand-more icon when arrow=closed (rotated via CSS)", () => {
+    el.setAttribute("arrow", "closed");
+    const icon = el.shadowRoot!.querySelector(".chevron .material-symbols-outlined");
+    expect(icon!.textContent).toBe(ICON_EXPAND_MORE);
+  });
+
+  it("shows expand-more icon when arrow=open", () => {
+    el.setAttribute("arrow", "open");
+    const icon = el.shadowRoot!.querySelector(".chevron .material-symbols-outlined");
+    expect(icon!.textContent).toBe(ICON_EXPAND_MORE);
+  });
+
+  it("shows expand-more icon when arrow=none", () => {
+    el.setAttribute("arrow", "none");
+    const icon = el.shadowRoot!.querySelector(".chevron .material-symbols-outlined");
+    expect(icon!.textContent).toBe(ICON_EXPAND_MORE);
+  });
+
+  // ── ARIA ──────────────────────────────────────────────────────────────────
+
+  it("sets aria-expanded=true when arrow=open", () => {
+    el.setAttribute("arrow", "open");
+    expect(el.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  it("sets aria-expanded=false when arrow=closed", () => {
+    el.setAttribute("arrow", "closed");
+    expect(el.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("removes aria-expanded when arrow=none", () => {
+    el.setAttribute("arrow", "open");
+    expect(el.getAttribute("aria-expanded")).toBe("true");
+    el.setAttribute("arrow", "none");
+    expect(el.hasAttribute("aria-expanded")).toBe(false);
+  });
+
+  // ── Click behavior ────────────────────────────────────────────────────────
+
+  it("toggles arrow from closed to open on click", () => {
+    el.setAttribute("arrow", "closed");
+    el.click();
+    expect(el.getAttribute("arrow")).toBe("open");
+  });
+
+  it("toggles arrow from open to closed on click", () => {
+    el.setAttribute("arrow", "open");
+    el.click();
+    expect(el.getAttribute("arrow")).toBe("closed");
+  });
+
+  it("does not change arrow=none on click", () => {
+    el.setAttribute("arrow", "none");
+    el.click();
+    expect(el.getAttribute("arrow")).toBe("none");
+  });
+
+  it("dispatches tree-toggle event on click when arrow is open/closed", () => {
+    el.setAttribute("arrow", "closed");
+    const handler = vi.fn();
+    el.addEventListener("tree-toggle", handler);
+    el.click();
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler.mock.calls[0][0].detail).toEqual({ expanded: true });
+  });
+
+  it("dispatches tree-toggle with expanded=false when closing", () => {
+    el.setAttribute("arrow", "open");
+    const handler = vi.fn();
+    el.addEventListener("tree-toggle", handler);
+    el.click();
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler.mock.calls[0][0].detail).toEqual({ expanded: false });
+  });
+
+  it("does not dispatch tree-toggle when arrow=none", () => {
+    el.setAttribute("arrow", "none");
+    const handler = vi.fn();
+    el.addEventListener("tree-toggle", handler);
+    el.click();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("dispatches tree-select event on click", () => {
+    el.setAttribute("label", "MyItem");
+    const handler = vi.fn();
+    el.addEventListener("tree-select", handler);
+    el.click();
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler.mock.calls[0][0].detail).toEqual({ label: "MyItem" });
+  });
+
+  it("dispatches tree-select even when arrow=none", () => {
+    el.setAttribute("arrow", "none");
+    el.setAttribute("label", "Leaf");
+    const handler = vi.fn();
+    el.addEventListener("tree-select", handler);
+    el.click();
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler.mock.calls[0][0].detail).toEqual({ label: "Leaf" });
+  });
+
+  it("tree-toggle event bubbles and is composed", () => {
+    el.setAttribute("arrow", "closed");
+    const handler = vi.fn();
+    document.body.addEventListener("tree-toggle", handler);
+    el.click();
+    expect(handler).toHaveBeenCalledOnce();
+    document.body.removeEventListener("tree-toggle", handler);
+  });
+
+  it("tree-select event bubbles and is composed", () => {
+    el.setAttribute("label", "Test");
+    const handler = vi.fn();
+    document.body.addEventListener("tree-select", handler);
+    el.click();
+    expect(handler).toHaveBeenCalledOnce();
+    document.body.removeEventListener("tree-select", handler);
+  });
+
+  // ── Keyboard ──────────────────────────────────────────────────────────────
+
+  it("triggers click on Enter key", () => {
+    el.setAttribute("arrow", "closed");
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(el.getAttribute("arrow")).toBe("open");
+  });
+
+  it("triggers click on Space key", () => {
+    el.setAttribute("arrow", "open");
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+    expect(el.getAttribute("arrow")).toBe("closed");
+  });
+
+  // ── observedAttributes ────────────────────────────────────────────────────
+
+  it("observes the correct attributes", () => {
+    const observed = (customElements.get("ui-tree-item") as any).observedAttributes;
+    expect(observed).toEqual([
+      "size",
+      "level",
+      "arrow",
+      "selected",
+      "label",
+      "secondary-label",
+      "leading-icon",
+      "icon-name",
+      "checkbox",
+    ]);
+  });
+
+  // ── Styles export ─────────────────────────────────────────────────────────
+
+  it("exports TREE_ITEM_STYLES string", () => {
+    expect(typeof TREE_ITEM_STYLES).toBe("string");
+    expect(TREE_ITEM_STYLES.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/ui-components/src/components/ui-tree-item.ts
+++ b/packages/ui-components/src/components/ui-tree-item.ts
@@ -1,0 +1,212 @@
+import { TREE_ITEM_STYLES } from "./ui-tree-item.styles.js";
+import { ICON_CHEVRON_RIGHT, ICON_EXPAND_MORE, ICON_CODEPOINTS } from "@maneki/foundation";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type { TreeItemSize, TreeItemLevel, TreeItemArrow, TreeItemState } from "./ui-tree-item.styles.js";
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(TREE_ITEM_STYLES);
+
+export class UiTreeItem extends HTMLElement {
+  static readonly observedAttributes = [
+    "size",
+    "level",
+    "arrow",
+    "selected",
+    "label",
+    "secondary-label",
+    "leading-icon",
+    "icon-name",
+    "checkbox",
+  ];
+
+  #chevron!: HTMLElement;
+  #chevronIcon!: HTMLElement;
+  #leadingIcon!: HTMLElement;
+  #leadingIconEl!: HTMLElement;
+  #checkboxSlot!: HTMLElement;
+  #label!: HTMLElement;
+  #secondaryLabel!: HTMLElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    const base = document.createElement("div");
+    base.className = "base";
+
+    // Chevron
+    this.#chevron = document.createElement("span");
+    this.#chevron.className = "chevron";
+    this.#chevronIcon = document.createElement("span");
+    this.#chevronIcon.className = "material-symbols-outlined";
+    this.#chevronIcon.textContent = ICON_CHEVRON_RIGHT;
+    this.#chevron.appendChild(this.#chevronIcon);
+
+    // Content
+    const content = document.createElement("div");
+    content.className = "content";
+
+    // Leading icon
+    this.#leadingIcon = document.createElement("span");
+    this.#leadingIcon.className = "leading-icon";
+    this.#leadingIconEl = document.createElement("span");
+    this.#leadingIconEl.className = "material-symbols-outlined";
+    this.#leadingIcon.appendChild(this.#leadingIconEl);
+
+    // Checkbox slot
+    this.#checkboxSlot = document.createElement("span");
+    this.#checkboxSlot.className = "checkbox-slot";
+    const cbSlot = document.createElement("slot");
+    cbSlot.name = "checkbox";
+    this.#checkboxSlot.appendChild(cbSlot);
+
+    // Label
+    this.#label = document.createElement("span");
+    this.#label.className = "label";
+
+    // Secondary label
+    this.#secondaryLabel = document.createElement("span");
+    this.#secondaryLabel.className = "secondary-label";
+
+    content.append(this.#leadingIcon, this.#checkboxSlot, this.#label, this.#secondaryLabel);
+    base.append(this.#chevron, content);
+    shadow.appendChild(base);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("size")) this.setAttribute("size", "m");
+    if (!this.hasAttribute("level")) this.setAttribute("level", "parent");
+    if (!this.hasAttribute("arrow")) this.setAttribute("arrow", "none");
+    this.setAttribute("role", "treeitem");
+    this.setAttribute("tabindex", "0");
+    this._syncAll();
+
+    this.addEventListener("click", (e) => {
+      // Don't toggle if click originated from checkbox slot
+      const path = e.composedPath();
+      const fromCheckbox = path.some((el) =>
+        (el as Element).classList?.contains("checkbox-slot") ||
+        (el as Element).tagName === "UI-CHECKBOX-ITEM"
+      );
+      if (fromCheckbox) return;
+
+      const arrow = this.getAttribute("arrow");
+      if (arrow === "open" || arrow === "closed") {
+        const next = arrow === "open" ? "closed" : "open";
+        this.setAttribute("arrow", next);
+        this.dispatchEvent(
+          new CustomEvent("tree-toggle", {
+            detail: { expanded: next === "open" },
+            bubbles: true,
+            composed: true,
+          }),
+        );
+      }
+      this.dispatchEvent(
+        new CustomEvent("tree-select", {
+          detail: { label: this.label },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    });
+
+    this.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        this.click();
+      }
+    });
+  }
+
+  attributeChangedCallback(): void {
+    if (this.isConnected) this._syncAll();
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): string {
+    return this.getAttribute("size") ?? "m";
+  }
+  set size(v: string) {
+    this.setAttribute("size", v);
+  }
+
+  get level(): string {
+    return this.getAttribute("level") ?? "parent";
+  }
+  set level(v: string) {
+    this.setAttribute("level", v);
+  }
+
+  get arrow(): string {
+    return this.getAttribute("arrow") ?? "none";
+  }
+  set arrow(v: string) {
+    this.setAttribute("arrow", v);
+  }
+
+  get selected(): boolean {
+    return this.hasAttribute("selected");
+  }
+  set selected(v: boolean) {
+    if (v) this.setAttribute("selected", "");
+    else this.removeAttribute("selected");
+  }
+
+  get label(): string {
+    return this.getAttribute("label") ?? "";
+  }
+  set label(v: string) {
+    this.setAttribute("label", v);
+  }
+
+  get secondaryLabelText(): string {
+    return this.getAttribute("secondary-label") ?? "";
+  }
+  set secondaryLabelText(v: string) {
+    this.setAttribute("secondary-label", v);
+  }
+
+  get iconName(): string {
+    return this.getAttribute("icon-name") ?? "";
+  }
+  set iconName(v: string) {
+    this.setAttribute("icon-name", v);
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private _syncAll(): void {
+    // Label
+    this.#label.textContent = this.getAttribute("label") ?? "";
+
+    // Secondary label
+    this.#secondaryLabel.textContent = this.getAttribute("secondary-label") ?? "";
+
+    // Chevron icon — always expand_more, CSS rotation handles closed state
+    this.#chevronIcon.textContent = ICON_EXPAND_MORE;
+
+    // Leading icon
+    const iconName = this.getAttribute("icon-name");
+    if (iconName) {
+      this.#leadingIconEl.textContent = ICON_CODEPOINTS[iconName] ?? iconName;
+    }
+
+    // ARIA
+    if (this.getAttribute("arrow") === "open") {
+      this.setAttribute("aria-expanded", "true");
+    } else if (this.getAttribute("arrow") === "closed") {
+      this.setAttribute("aria-expanded", "false");
+    } else {
+      this.removeAttribute("aria-expanded");
+    }
+  }
+}
+
+customElements.define("ui-tree-item", UiTreeItem);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -262,3 +262,9 @@ export { UiStepGroup } from "./components/ui-step-group.js";
 
 export { UiSwitch } from "./components/ui-switch.js";
 export type { SwitchSize, SwitchLabelPosition, SwitchStatus } from "./components/ui-switch.js";
+
+// ─── Tree ─────────────────────────────────────────────────────────────────────
+
+export { UiTreeItem } from "./components/ui-tree-item.js";
+export type { TreeItemSize, TreeItemLevel, TreeItemArrow, TreeItemState } from "./components/ui-tree-item.styles.js";
+export { UiTreeGroup } from "./components/ui-tree-group.js";

--- a/packages/ui-components/src/stories/ui-tree.stories.ts
+++ b/packages/ui-components/src/stories/ui-tree.stories.ts
@@ -1,0 +1,120 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-tree-item.js";
+import "../components/ui-tree-group.js";
+
+const meta: Meta = {
+  title: "Components/Tree",
+  component: "ui-tree-group",
+  argTypes: {
+    size: {
+      control: { type: "select" },
+      options: ["s", "m", "l"],
+    },
+  },
+  args: {
+    size: "m",
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+// ─── Default ────────────────────────────────────────────────────────────────
+
+export const Default: Story = {
+  render: () => html`
+    <ui-tree-group size="m" style="width:320px">
+      <ui-tree-item arrow="open" label="Documents" level="parent"></ui-tree-item>
+      <ui-tree-item arrow="none" label="Resume.pdf" level="child-1"></ui-tree-item>
+      <ui-tree-item arrow="none" label="Cover Letter.docx" level="child-1"></ui-tree-item>
+      <ui-tree-item arrow="closed" label="Projects" level="parent"></ui-tree-item>
+      <ui-tree-item arrow="none" label="Photos" level="parent"></ui-tree-item>
+    </ui-tree-group>
+  `,
+};
+
+// ─── All Sizes ──────────────────────────────────────────────────────────────
+
+export const AllSizes: Story = {
+  render: () => html`
+    <div style="display:flex;gap:48px;align-items:start">
+      <div>
+        <p style="margin:0 0 8px;font-family:sans-serif;font-size:12px;color:#666">Small</p>
+        <ui-tree-group size="s" style="width:240px">
+          <ui-tree-item arrow="open" label="src" level="parent"></ui-tree-item>
+          <ui-tree-item arrow="none" label="index.ts" level="child-1"></ui-tree-item>
+          <ui-tree-item arrow="none" label="utils.ts" level="child-1"></ui-tree-item>
+        </ui-tree-group>
+      </div>
+      <div>
+        <p style="margin:0 0 8px;font-family:sans-serif;font-size:12px;color:#666">Medium</p>
+        <ui-tree-group size="m" style="width:280px">
+          <ui-tree-item arrow="open" label="src" level="parent"></ui-tree-item>
+          <ui-tree-item arrow="none" label="index.ts" level="child-1"></ui-tree-item>
+          <ui-tree-item arrow="none" label="utils.ts" level="child-1"></ui-tree-item>
+        </ui-tree-group>
+      </div>
+      <div>
+        <p style="margin:0 0 8px;font-family:sans-serif;font-size:12px;color:#666">Large</p>
+        <ui-tree-group size="l" style="width:320px">
+          <ui-tree-item arrow="open" label="src" level="parent"></ui-tree-item>
+          <ui-tree-item arrow="none" label="index.ts" level="child-1"></ui-tree-item>
+          <ui-tree-item arrow="none" label="utils.ts" level="child-1"></ui-tree-item>
+        </ui-tree-group>
+      </div>
+    </div>
+  `,
+};
+
+// ─── With Leading Icon ──────────────────────────────────────────────────────
+
+export const WithLeadingIcon: Story = {
+  render: () => html`
+    <ui-tree-group size="m" style="width:320px">
+      <ui-tree-item arrow="open" label="Home" level="parent" leading-icon icon-name="home"></ui-tree-item>
+      <ui-tree-item arrow="none" label="Dashboard" level="child-1" leading-icon icon-name="bar_chart"></ui-tree-item>
+      <ui-tree-item arrow="none" label="Settings" level="child-1" leading-icon icon-name="settings"></ui-tree-item>
+      <ui-tree-item arrow="closed" label="Users" level="parent" leading-icon icon-name="group"></ui-tree-item>
+      <ui-tree-item arrow="none" label="Profile" level="parent" leading-icon icon-name="person"></ui-tree-item>
+    </ui-tree-group>
+  `,
+};
+
+// ─── With Checkbox ──────────────────────────────────────────────────────────
+
+export const WithCheckbox: Story = {
+  render: () => html`
+    <ui-tree-group size="m" style="width:320px">
+      <ui-tree-item arrow="open" label="Notifications" level="parent" checkbox>
+        <ui-checkbox-item slot="checkbox" size="m" checked></ui-checkbox-item>
+      </ui-tree-item>
+      <ui-tree-item arrow="none" label="Email alerts" level="child-1" checkbox>
+        <ui-checkbox-item slot="checkbox" size="m" checked></ui-checkbox-item>
+      </ui-tree-item>
+      <ui-tree-item arrow="none" label="Push notifications" level="child-1" checkbox>
+        <ui-checkbox-item slot="checkbox" size="m"></ui-checkbox-item>
+      </ui-tree-item>
+      <ui-tree-item arrow="closed" label="Privacy" level="parent" checkbox>
+        <ui-checkbox-item slot="checkbox" size="m" indeterminate></ui-checkbox-item>
+      </ui-tree-item>
+    </ui-tree-group>
+  `,
+};
+
+// ─── Tree Group With Search ─────────────────────────────────────────────────
+
+export const TreeGroupWithSearch: Story = {
+  render: () => html`
+    <ui-tree-group size="m" style="width:320px">
+      <ui-input slot="search" size="m" placeholder="Search tree…" type="clearable" style="margin-bottom:8px"></ui-input>
+      <ui-tree-item arrow="open" label="Application" level="parent"></ui-tree-item>
+      <ui-tree-item arrow="open" label="Components" level="child-1"></ui-tree-item>
+      <ui-tree-item arrow="none" label="Header.tsx" level="child-2"></ui-tree-item>
+      <ui-tree-item arrow="none" label="Footer.tsx" level="child-2"></ui-tree-item>
+      <ui-tree-item arrow="closed" label="Pages" level="child-1"></ui-tree-item>
+      <ui-tree-item arrow="none" label="Assets" level="parent"></ui-tree-item>
+      <ui-tree-item arrow="closed" label="Config" level="parent"></ui-tree-item>
+    </ui-tree-group>
+  `,
+};


### PR DESCRIPTION
## Summary

New `<ui-tree-item>` and `<ui-tree-group>` Web Components for hierarchical tree navigation.

## `<ui-tree-item>`

- 3 sizes: `s` (12px, 16px chevron), `m` (14px, 20px chevron), `l` (16px, 24px chevron)
- 4 nesting levels: `parent`, `child-1`, `child-2`, `child-3` (increasing left indent)
- Arrow: `none` (leaf), `closed` (chevron-right), `open` (chevron-down)
- States: enabled (default), hover (gray 10% bg), selected (blue 20% bg)
- Optional: leading icon (`icon-name`), checkbox slot, secondary label
- ARIA: `role="treeitem"`, `aria-expanded`, `tabindex="0"`
- Events: `tree-toggle` (expand/collapse), `tree-select` (item click)

## `<ui-tree-group>`

- Container with `role="tree"`, search slot, size propagation
- Wraps `<ui-tree-item>` elements

## API

```html
<ui-tree-group size="m">
  <ui-tree-item arrow="open" label="Documents"></ui-tree-item>
  <ui-tree-item arrow="none" level="child-1" label="Report.pdf"></ui-tree-item>
  <ui-tree-item arrow="none" level="child-1" label="Summary.docx" selected></ui-tree-item>
  <ui-tree-item arrow="closed" level="child-1" label="Archive"></ui-tree-item>
</ui-tree-group>
```

## Testing

- 3417 unit tests (85 new: 67 tree-item + 18 tree-group)
- 5 Storybook stories
- 55 Playwright visual regression tests (1 new)

## Files

- `packages/ui-components/src/components/ui-tree-item.ts` + `ui-tree-item.styles.ts`
- `packages/ui-components/src/components/ui-tree-group.ts`
- `packages/ui-components/src/components/ui-tree-item.test.ts` + `ui-tree-group.test.ts`
- `packages/ui-components/src/stories/ui-tree.stories.ts`
- `packages/ui-components/src/index.ts` — barrel exports
- `apps/catalog/src/pages/tree.ts` — catalog page