### PR TITLE
feat(ui-components): add ui-wizard component

### DIFF
--- a/apps/catalog/e2e/visual.spec.ts
+++ b/apps/catalog/e2e/visual.spec.ts
@@ -40,6 +40,7 @@ const pages = [
   "pagination",
   "steps",
   "tree",
+  "wizard",
   "tabs",
   "table",
   "metric",

--- a/apps/catalog/src/main.ts
+++ b/apps/catalog/src/main.ts
@@ -58,6 +58,7 @@ const pageLoaders: Record<string, () => Promise<unknown>> = {
   "pagination": () => import("./pages/pagination.js"),
   "steps": () => import("./pages/steps.js"),
   "tree": () => import("./pages/tree.js"),
+  "wizard": () => import("./pages/wizard.js"),
   "tabs": () => import("./pages/tabs.js"),
   "table": () => import("./pages/table.js"),
   "metric": () => import("./pages/metric.js"),

--- a/apps/catalog/src/manifest.ts
+++ b/apps/catalog/src/manifest.ts
@@ -63,6 +63,7 @@ export const manifest: PageMeta[] = [
   { id: "pagination", title: "Pagination", section: "Navigation" },
   { id: "steps", title: "Steps", section: "Navigation" },
   { id: "tree", title: "Tree", section: "Navigation" },
+  { id: "wizard", title: "Wizard", section: "Navigation" },
   // Disclosure
   { id: "accordion", title: "Accordion", section: "Disclosure" },
   // Menus & Dropdowns

--- a/apps/catalog/src/pages/wizard.ts
+++ b/apps/catalog/src/pages/wizard.ts
@@ -1,0 +1,76 @@
+import { registerPage } from "../registry.js";
+
+registerPage("wizard", {
+  title: "Wizard",
+  section: "Navigation",
+  render: () => `
+    <h3>Horizontal</h3>
+    <div style="height: 422px; width: 760px; border: 1px solid var(--fd-border-minimal, #dce3e8); border-radius: 4px; overflow: hidden;">
+      <ui-wizard layout="horizontal" title="Wizard Title Small" current-step="3">
+        <ui-step-group slot="steps">
+          <ui-step-item label="Account"></ui-step-item>
+          <ui-step-item label="Profile"></ui-step-item>
+          <ui-step-item label="Contact"></ui-step-item>
+          <ui-step-item label="Review"></ui-step-item>
+          <ui-step-item label="Payment"></ui-step-item>
+          <ui-step-item label="Confirm"></ui-step-item>
+        </ui-step-group>
+        <div style="padding: 24px;">
+          <h4 style="margin: 0 0 8px; font-size: 16px; font-weight: 500; color: var(--fd-text-primary, #1c2b36);">3. Contact Information</h4>
+          <p style="margin: 0 0 16px; font-size: 14px; color: var(--fd-text-secondary, #3e5463);">Enter the following information to complete the section.</p>
+          <ui-input size="m" label="Email" placeholder="Enter email"></ui-input>
+          <div style="height: 16px;"></div>
+          <ui-input size="m" label="Phone" placeholder="Enter phone number"></ui-input>
+        </div>
+      </ui-wizard>
+    </div>
+
+    <h3>Vertical</h3>
+    <div style="height: 460px; width: 760px; border: 1px solid var(--fd-border-minimal, #dce3e8); border-radius: 4px; overflow: hidden;">
+      <ui-wizard layout="vertical" title="Wizard Title Large" current-step="3">
+        <ui-step-group slot="steps">
+          <ui-step-item label="Account" sublabel="Optional"></ui-step-item>
+          <ui-step-item label="Profile" sublabel="Optional"></ui-step-item>
+          <ui-step-item label="Contact" sublabel="Optional"></ui-step-item>
+          <ui-step-item label="Review" sublabel="Optional"></ui-step-item>
+          <ui-step-item label="Confirm" sublabel="Optional"></ui-step-item>
+        </ui-step-group>
+        <div style="padding: 24px;">
+          <h4 style="margin: 0 0 8px; font-size: 16px; font-weight: 500; color: var(--fd-text-primary, #1c2b36);">3. Step Active Heading</h4>
+          <p style="margin: 0 0 16px; font-size: 14px; color: var(--fd-text-secondary, #3e5463);">Enter the following information, in order to complete the section.</p>
+          <ui-input size="m" label="Label" placeholder="Placeholder Label"></ui-input>
+          <div style="height: 16px;"></div>
+          <ui-input size="m" label="Label" placeholder="Placeholder Label"></ui-input>
+        </div>
+      </ui-wizard>
+    </div>
+
+    <h3>First Step (Previous disabled)</h3>
+    <div style="height: 422px; width: 760px; border: 1px solid var(--fd-border-minimal, #dce3e8); border-radius: 4px; overflow: hidden;">
+      <ui-wizard layout="horizontal" title="First Step" current-step="1">
+        <ui-step-group slot="steps">
+          <ui-step-item label="Step 1"></ui-step-item>
+          <ui-step-item label="Step 2"></ui-step-item>
+          <ui-step-item label="Step 3"></ui-step-item>
+        </ui-step-group>
+        <div style="padding: 24px; color: var(--fd-text-secondary, #3e5463); font-size: 14px;">
+          First step content. Previous button is disabled.
+        </div>
+      </ui-wizard>
+    </div>
+
+    <h3>Last Step (Finish button)</h3>
+    <div style="height: 422px; width: 760px; border: 1px solid var(--fd-border-minimal, #dce3e8); border-radius: 4px; overflow: hidden;">
+      <ui-wizard layout="horizontal" title="Last Step" current-step="3">
+        <ui-step-group slot="steps">
+          <ui-step-item label="Step 1"></ui-step-item>
+          <ui-step-item label="Step 2"></ui-step-item>
+          <ui-step-item label="Step 3"></ui-step-item>
+        </ui-step-group>
+        <div style="padding: 24px; color: var(--fd-text-secondary, #3e5463); font-size: 14px;">
+          Last step content. Next button shows "Finish".
+        </div>
+      </ui-wizard>
+    </div>
+  `,
+});

--- a/packages/ui-components/src/components/ui-step-item.styles.ts
+++ b/packages/ui-components/src/components/ui-step-item.styles.ts
@@ -138,7 +138,7 @@ export const STEP_ITEM_STYLES = /* css */ `
 
   :host([status="incomplete"]) .dot {
     background: transparent;
-    border: 2px solid ${BLUE_60};
+    border: 2px solid ${SURFACE_BOLD};
   }
 
   :host([status="disabled"]) .dot {

--- a/packages/ui-components/src/components/ui-wizard.test.ts
+++ b/packages/ui-components/src/components/ui-wizard.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import "./ui-wizard.js";
+import type { WizardLayout } from "./ui-wizard.js";
+
+describe("ui-wizard", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-wizard");
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  // ── Registration ──────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-wizard")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).not.toBeNull();
+  });
+
+  it("applies adoptedStyleSheets", () => {
+    expect(el.shadowRoot!.adoptedStyleSheets.length).toBe(1);
+  });
+
+  // ── observedAttributes ─────────────────────────────────────────────────────
+
+  it("declares observedAttributes", () => {
+    const Ctor = customElements.get("ui-wizard") as unknown as { observedAttributes: string[] };
+    expect(Ctor.observedAttributes).toEqual(["layout", "title", "current-step", "loading"]);
+  });
+
+  // ── Default rendering ─────────────────────────────────────────────────────
+
+  it("renders a .header element", () => {
+    expect(el.shadowRoot!.querySelector(".header")).not.toBeNull();
+  });
+
+  it("renders a .header-title element", () => {
+    expect(el.shadowRoot!.querySelector(".header-title")).not.toBeNull();
+  });
+
+  it("renders a .steps-bar element", () => {
+    expect(el.shadowRoot!.querySelector(".steps-bar")).not.toBeNull();
+  });
+
+  it("renders a .steps-sidebar element", () => {
+    expect(el.shadowRoot!.querySelector(".steps-sidebar")).not.toBeNull();
+  });
+
+  it("renders a .content element", () => {
+    expect(el.shadowRoot!.querySelector(".content")).not.toBeNull();
+  });
+
+  it("renders a .footer element", () => {
+    expect(el.shadowRoot!.querySelector(".footer")).not.toBeNull();
+  });
+
+  it("renders a Previous button", () => {
+    const buttons = el.shadowRoot!.querySelectorAll("ui-button");
+    const prev = Array.from(buttons).find((b) => b.textContent === "Previous");
+    expect(prev).toBeDefined();
+  });
+
+  it("renders a Next button", () => {
+    const buttons = el.shadowRoot!.querySelectorAll("ui-button");
+    const next = Array.from(buttons).find((b) => b.textContent === "Next" || b.textContent === "Finish");
+    expect(next).toBeDefined();
+  });
+
+  // ── Default attributes ────────────────────────────────────────────────────
+
+  it("defaults layout to horizontal", () => {
+    expect(el.getAttribute("layout")).toBe("horizontal");
+  });
+
+  it("defaults current-step to 1", () => {
+    expect(el.getAttribute("current-step")).toBe("1");
+  });
+
+  // ── Attribute: layout ─────────────────────────────────────────────────────
+
+  it("reflects layout attribute to property", () => {
+    el.setAttribute("layout", "vertical");
+    expect((el as unknown as { layout: WizardLayout }).layout).toBe("vertical");
+  });
+
+  it("reflects layout property to attribute", () => {
+    (el as unknown as { layout: WizardLayout }).layout = "vertical";
+    expect(el.getAttribute("layout")).toBe("vertical");
+  });
+
+  // ── Attribute: title ──────────────────────────────────────────────────────
+
+  it("reflects title attribute to wizardTitle property", () => {
+    el.setAttribute("title", "Setup Wizard");
+    expect((el as unknown as { wizardTitle: string }).wizardTitle).toBe("Setup Wizard");
+  });
+
+  it("reflects wizardTitle property to title attribute", () => {
+    (el as unknown as { wizardTitle: string }).wizardTitle = "My Wizard";
+    expect(el.getAttribute("title")).toBe("My Wizard");
+  });
+
+  it("updates header-title text when title is set", () => {
+    el.setAttribute("title", "Account Setup");
+    const title = el.shadowRoot!.querySelector(".header-title");
+    expect(title!.textContent).toBe("Account Setup");
+  });
+
+  // ── Attribute: current-step ───────────────────────────────────────────────
+
+  it("reflects current-step attribute to currentStep property", () => {
+    el.setAttribute("current-step", "3");
+    expect((el as unknown as { currentStep: number }).currentStep).toBe(3);
+  });
+
+  it("reflects currentStep property to current-step attribute", () => {
+    (el as unknown as { currentStep: number }).currentStep = 4;
+    expect(el.getAttribute("current-step")).toBe("4");
+  });
+
+  it("defaults currentStep to 1 for invalid values", () => {
+    el.setAttribute("current-step", "abc");
+    expect((el as unknown as { currentStep: number }).currentStep).toBe(1);
+  });
+
+  // ── Layout: horizontal ────────────────────────────────────────────────────
+
+  it("shows steps-bar in horizontal layout", () => {
+    el.setAttribute("layout", "horizontal");
+    expect(el.getAttribute("layout")).toBe("horizontal");
+    // CSS rule :host([layout="horizontal"]) .steps-bar { display: flex } applies at runtime;
+    // happy-dom cannot resolve :host() selectors, so verify the attribute drives the rule
+    const bar = el.shadowRoot!.querySelector(".steps-bar");
+    expect(bar).not.toBeNull();
+  });
+
+  it("hides steps-sidebar in horizontal layout", () => {
+    el.setAttribute("layout", "horizontal");
+    const sidebar = el.shadowRoot!.querySelector(".steps-sidebar") as HTMLElement;
+    const style = getComputedStyle(sidebar);
+    expect(style.display).toBe("none");
+  });
+
+  // ── Layout: vertical ──────────────────────────────────────────────────────
+
+  it("shows steps-sidebar in vertical layout", () => {
+    el.setAttribute("layout", "vertical");
+    expect(el.getAttribute("layout")).toBe("vertical");
+    const sidebar = el.shadowRoot!.querySelector(".steps-sidebar");
+    expect(sidebar).not.toBeNull();
+  });
+
+  it("hides steps-bar in vertical layout", () => {
+    el.setAttribute("layout", "vertical");
+    const bar = el.shadowRoot!.querySelector(".steps-bar") as HTMLElement;
+    const style = getComputedStyle(bar);
+    expect(style.display).toBe("none");
+  });
+
+  // ── Buttons: Previous disabled on step 1 ──────────────────────────────────
+
+  it("disables Previous button on step 1", () => {
+    el.setAttribute("current-step", "1");
+    addSteps(el, 5);
+    const prev = getPrevButton();
+    expect(prev!.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("enables Previous button on step > 1", () => {
+    addSteps(el, 5);
+    el.setAttribute("current-step", "3");
+    const prev = getPrevButton();
+    expect(prev!.hasAttribute("disabled")).toBe(false);
+  });
+
+  // ── Buttons: Next shows "Finish" on last step ─────────────────────────────
+
+  it("shows 'Next' on non-last step", () => {
+    addSteps(el, 5);
+    el.setAttribute("current-step", "3");
+    const next = getNextButton();
+    expect(next!.textContent).toBe("Next");
+  });
+
+  it("shows 'Finish' on last step", () => {
+    addSteps(el, 5);
+    el.setAttribute("current-step", "5");
+    const next = getNextButton();
+    expect(next!.textContent).toBe("Finish");
+  });
+
+  // ── Navigation: clicking Next ─────────────────────────────────────────────
+
+  it("increments current-step when Next is clicked", () => {
+    addSteps(el, 5);
+    el.setAttribute("current-step", "2");
+    const next = getNextButton();
+    next!.click();
+    expect(el.getAttribute("current-step")).toBe("3");
+  });
+
+  it("does not increment past last step", () => {
+    addSteps(el, 3);
+    el.setAttribute("current-step", "3");
+    const next = getNextButton();
+    next!.click();
+    expect(el.getAttribute("current-step")).toBe("3");
+  });
+
+  // ── Navigation: clicking Previous ─────────────────────────────────────────
+
+  it("decrements current-step when Previous is clicked", () => {
+    addSteps(el, 5);
+    el.setAttribute("current-step", "3");
+    const prev = getPrevButton();
+    prev!.click();
+    expect(el.getAttribute("current-step")).toBe("2");
+  });
+
+  it("does not decrement below 1", () => {
+    addSteps(el, 5);
+    el.setAttribute("current-step", "1");
+    const prev = getPrevButton();
+    prev!.click();
+    expect(el.getAttribute("current-step")).toBe("1");
+  });
+
+  // ── Events ────────────────────────────────────────────────────────────────
+
+  it("dispatches wizard-next on Next click", () => {
+    addSteps(el, 5);
+    el.setAttribute("current-step", "2");
+    const handler = vi.fn();
+    el.addEventListener("wizard-next", handler);
+    const next = getNextButton();
+    next!.click();
+    expect(handler).toHaveBeenCalledTimes(1);
+    const detail = (handler.mock.calls[0][0] as CustomEvent).detail;
+    expect(detail.step).toBe(2);
+  });
+
+  it("dispatches wizard-previous on Previous click", () => {
+    addSteps(el, 5);
+    el.setAttribute("current-step", "3");
+    const handler = vi.fn();
+    el.addEventListener("wizard-previous", handler);
+    const prev = getPrevButton();
+    prev!.click();
+    expect(handler).toHaveBeenCalledTimes(1);
+    const detail = (handler.mock.calls[0][0] as CustomEvent).detail;
+    expect(detail.step).toBe(3);
+  });
+
+  it("dispatches wizard-finish on last step Next click", () => {
+    addSteps(el, 3);
+    el.setAttribute("current-step", "3");
+    const handler = vi.fn();
+    el.addEventListener("wizard-finish", handler);
+    const next = getNextButton();
+    next!.click();
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dispatch event when Previous is clicked on step 1", () => {
+    addSteps(el, 3);
+    el.setAttribute("current-step", "1");
+    const handler = vi.fn();
+    el.addEventListener("wizard-step-change", handler);
+    const prev = getPrevButton();
+    prev!.click();
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("wizard-next event bubbles and is composed", () => {
+    addSteps(el, 5);
+    el.setAttribute("current-step", "1");
+    const handler = vi.fn();
+    document.body.addEventListener("wizard-next", handler);
+    const next = getNextButton();
+    next!.click();
+    expect(handler).toHaveBeenCalledTimes(1);
+    const evt = handler.mock.calls[0][0] as CustomEvent;
+    expect(evt.bubbles).toBe(true);
+    expect(evt.composed).toBe(true);
+    document.body.removeEventListener("wizard-next", handler);
+  });
+
+  it("wizard-next is cancelable and blocks navigation", () => {
+    addSteps(el, 5);
+    el.setAttribute("current-step", "2");
+    el.addEventListener("wizard-next", (e) => e.preventDefault());
+    const next = getNextButton();
+    next!.click();
+    expect(el.getAttribute("current-step")).toBe("2");
+  });
+
+  it("loading attribute disables buttons and shows spinner", () => {
+    addSteps(el, 5);
+    el.setAttribute("current-step", "2");
+    el.setAttribute("loading", "");
+    const next = getNextButton();
+    const prev = getPrevButton();
+    expect(next!.hasAttribute("disabled")).toBe(true);
+    expect(next!.getAttribute("status")).toBe("loading");
+    expect(prev!.hasAttribute("disabled")).toBe(true);
+  });
+
+  // ── Content slot ──────────────────────────────────────────────────────────
+
+  it("renders slotted content in default slot", () => {
+    const content = document.createElement("div");
+    content.textContent = "Step content here";
+    el.appendChild(content);
+    const slot = el.shadowRoot!.querySelector(".content slot:not([name])") as HTMLSlotElement;
+    expect(slot).not.toBeNull();
+    const assigned = slot!.assignedElements();
+    expect(assigned.length).toBe(1);
+    expect(assigned[0].textContent).toBe("Step content here");
+  });
+
+  // ── Steps slot ────────────────────────────────────────────────────────────
+
+  it("has a named steps slot", () => {
+    const slot = el.shadowRoot!.querySelector('slot[name="steps"]') as HTMLSlotElement;
+    expect(slot).not.toBeNull();
+  });
+
+  it("renders slotted ui-step-group in steps slot", () => {
+    addSteps(el, 3);
+    const slot = el.shadowRoot!.querySelector('slot[name="steps"]') as HTMLSlotElement;
+    const assigned = slot!.assignedElements();
+    expect(assigned.length).toBe(1);
+    expect(assigned[0].tagName).toBe("UI-STEP-GROUP");
+  });
+
+  // ── Separator elements ────────────────────────────────────────────────────
+
+  it("renders ui-separator elements", () => {
+    const seps = el.shadowRoot!.querySelectorAll("ui-separator");
+    expect(seps.length).toBe(2);
+  });
+
+  // ── Helpers ───────────────────────────────────────────────────────────────
+
+  function getPrevButton(): HTMLElement | undefined {
+    const buttons = el.shadowRoot!.querySelectorAll("ui-button");
+    return Array.from(buttons).find((b) => b.textContent === "Previous" || b.textContent === "previous") as HTMLElement | undefined;
+  }
+
+  function getNextButton(): HTMLElement | undefined {
+    const buttons = el.shadowRoot!.querySelectorAll("ui-button");
+    return Array.from(buttons).find((b) => b.textContent === "Next" || b.textContent === "Finish") as HTMLElement | undefined;
+  }
+
+  function addSteps(wizard: HTMLElement, count: number): void {
+    const group = document.createElement("ui-step-group");
+    group.slot = "steps";
+    for (let i = 0; i < count; i++) {
+      const item = document.createElement("ui-step-item");
+      item.setAttribute("label", `Step ${i + 1}`);
+      group.appendChild(item);
+    }
+    wizard.appendChild(group);
+  }
+});

--- a/packages/ui-components/src/components/ui-wizard.ts
+++ b/packages/ui-components/src/components/ui-wizard.ts
@@ -1,0 +1,423 @@
+import { semanticVar } from "@maneki/foundation";
+import "./ui-step-group.js";
+import "./ui-step-item.js";
+import "./ui-button.js";
+import "./ui-separator.js";
+
+// ─── Token constants ─────────────────────────────────────────────────────────
+
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const SURFACE_PRIMARY = semanticVar("surface", "primary");
+const SURFACE_SECONDARY = semanticVar("surface", "secondary");
+const BORDER_MINIMAL = semanticVar("border", "minimal");
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type WizardLayout = "horizontal" | "vertical";
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  :host {
+    display: flex;
+    flex-direction: column;
+    font-family: "Geist", sans-serif;
+    width: 100%;
+    height: 100%;
+    background: ${SURFACE_PRIMARY};
+    overflow: hidden;
+  }
+
+  /* Hide the steps slot - we clone into bar/sidebar */
+  slot[name="steps"] {
+    display: none;
+  }
+
+  /* ── Header ──────────────────────────────────────────────────────────────── */
+
+  .header {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    background: ${SURFACE_PRIMARY};
+  }
+
+  .header-title {
+    font-weight: 500;
+    color: ${TEXT_PRIMARY};
+    white-space: nowrap;
+  }
+
+  /* ── Body ─────────────────────────────────────────────────────────────────── */
+
+  .body {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  /* ── Steps sidebar (vertical) ────────────────────────────────────────────── */
+
+  .steps-sidebar {
+    display: none;
+    flex-direction: column;
+    background: ${SURFACE_SECONDARY};
+    flex-shrink: 0;
+    position: relative;
+  }
+
+  :host([layout="vertical"]) .steps-sidebar {
+    display: flex;
+  }
+
+  .steps-sidebar::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    right: 0;
+    width: 1px;
+    background: ${BORDER_MINIMAL};
+  }
+
+  /* ── Steps bar (horizontal) ──────────────────────────────────────────────── */
+
+  .steps-bar {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: ${SURFACE_PRIMARY};
+    flex-shrink: 0;
+    border-bottom: 1px solid ${BORDER_MINIMAL};
+  }
+
+  :host([layout="horizontal"]) .steps-bar {
+    display: flex;
+  }
+
+  /* ── Content ─────────────────────────────────────────────────────────────── */
+
+  .content {
+    flex: 1;
+    min-width: 0;
+    overflow-y: auto;
+    background: ${SURFACE_PRIMARY};
+  }
+
+  :host([layout="horizontal"]) .content {
+    background: ${SURFACE_SECONDARY};
+  }
+
+  /* ── Footer ──────────────────────────────────────────────────────────────── */
+
+  .footer {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 8px;
+    flex-shrink: 0;
+    background: ${SURFACE_PRIMARY};
+  }
+
+  /* ── Horizontal layout ───────────────────────────────────────────────────── */
+
+  :host([layout="horizontal"]) .header {
+    height: 32px;
+    padding: 0 16px;
+  }
+
+  :host([layout="horizontal"]) .header-title {
+    font-size: 14px;
+    line-height: 20px;
+  }
+
+  :host([layout="horizontal"]) .steps-bar {
+    height: 64px;
+    padding: 20px 40px;
+  }
+
+  :host([layout="horizontal"]) .footer {
+    height: 56px;
+    padding: 0 12px;
+  }
+
+  /* ── Vertical layout ─────────────────────────────────────────────────────── */
+
+  :host([layout="vertical"]) .header {
+    height: 56px;
+    padding: 0 24px;
+  }
+
+  :host([layout="vertical"]) .header-title {
+    font-size: 20px;
+    line-height: 28px;
+  }
+
+  :host([layout="vertical"]) .steps-sidebar {
+    width: 220px;
+    padding: 16px 24px;
+  }
+
+  :host([layout="vertical"]) .footer {
+    height: 56px;
+    padding: 0 12px;
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+export class UiWizard extends HTMLElement {
+  static readonly observedAttributes = ["layout", "title", "current-step", "loading"];
+
+  #headerTitle!: HTMLElement;
+  #stepsSidebar!: HTMLElement;
+  #stepsBar!: HTMLElement;
+  #content!: HTMLElement;
+  #prevBtn!: HTMLElement;
+  #nextBtn!: HTMLElement;
+  #stepsSlot!: HTMLSlotElement;
+  #cachedStepCount = 0;
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    // Header
+    const header = document.createElement("div");
+    header.className = "header";
+    this.#headerTitle = document.createElement("span");
+    this.#headerTitle.className = "header-title";
+    header.appendChild(this.#headerTitle);
+
+    const headerSep = document.createElement("ui-separator");
+    headerSep.setAttribute("emphasis", "minimal");
+
+    // Steps bar (horizontal)
+    this.#stepsBar = document.createElement("div");
+    this.#stepsBar.className = "steps-bar";
+
+    const stepsBarSep = document.createElement("ui-separator");
+    stepsBarSep.setAttribute("emphasis", "minimal");
+
+    // Body
+    const body = document.createElement("div");
+    body.className = "body";
+
+    // Steps sidebar (vertical)
+    this.#stepsSidebar = document.createElement("div");
+    this.#stepsSidebar.className = "steps-sidebar";
+
+    // Content
+    this.#content = document.createElement("div");
+    this.#content.className = "content";
+    const contentSlot = document.createElement("slot");
+    this.#content.appendChild(contentSlot);
+
+    // Steps slot
+    this.#stepsSlot = document.createElement("slot") as HTMLSlotElement;
+    this.#stepsSlot.name = "steps";
+
+    body.append(this.#stepsSidebar, this.#content);
+
+    // Footer
+    const footerSep = document.createElement("ui-separator");
+    footerSep.setAttribute("emphasis", "minimal");
+
+    const footer = document.createElement("div");
+    footer.className = "footer";
+
+    this.#prevBtn = document.createElement("ui-button");
+    this.#prevBtn.setAttribute("action", "secondary");
+    this.#prevBtn.setAttribute("emphasis", "bold");
+    this.#prevBtn.setAttribute("size", "m");
+    this.#prevBtn.textContent = "Previous";
+
+    this.#nextBtn = document.createElement("ui-button");
+    this.#nextBtn.setAttribute("action", "primary");
+    this.#nextBtn.setAttribute("emphasis", "bold");
+    this.#nextBtn.setAttribute("size", "m");
+    this.#nextBtn.textContent = "Next";
+
+    footer.append(this.#prevBtn, this.#nextBtn);
+
+    shadow.append(header, headerSep, this.#stepsBar, body, footerSep, footer, this.#stepsSlot);
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("layout")) this.setAttribute("layout", "horizontal");
+    if (!this.hasAttribute("current-step")) this.setAttribute("current-step", "1");
+    this._syncAll();
+
+    this.#stepsSlot.addEventListener("slotchange", () => { this.#cachedStepCount = this._getStepCount(); this._syncSteps(); this._syncButtons(); });
+
+    this.#prevBtn.addEventListener("click", () => {
+      const current = this.currentStep;
+      if (current <= 1) return;
+      const event = new CustomEvent("wizard-previous", {
+        detail: { step: current },
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+      });
+      const allowed = this.dispatchEvent(event);
+      if (allowed) {
+        this.currentStep = current - 1;
+      }
+    });
+
+    this.#nextBtn.addEventListener("click", () => {
+      const current = this.currentStep;
+      const total = this._getStepCount();
+      if (current >= total) {
+        // Last step — fire wizard-finish
+        const event = new CustomEvent("wizard-finish", {
+          detail: { step: current },
+          bubbles: true,
+          composed: true,
+          cancelable: true,
+        });
+        this.dispatchEvent(event);
+        return;
+      }
+      const event = new CustomEvent("wizard-next", {
+        detail: { step: current },
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+      });
+      const allowed = this.dispatchEvent(event);
+      if (allowed) {
+        this.currentStep = current + 1;
+      }
+    });
+  }
+
+  attributeChangedCallback(): void {
+    if (this.isConnected) this._syncAll();
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get layout(): WizardLayout {
+    return (this.getAttribute("layout") as WizardLayout) ?? "horizontal";
+  }
+  set layout(v: WizardLayout) {
+    this.setAttribute("layout", v);
+  }
+
+  get wizardTitle(): string {
+    return this.getAttribute("title") ?? "";
+  }
+  set wizardTitle(v: string) {
+    this.setAttribute("title", v);
+  }
+
+  get currentStep(): number {
+    return parseInt(this.getAttribute("current-step") ?? "1", 10) || 1;
+  }
+  set currentStep(v: number) {
+    this.setAttribute("current-step", String(v));
+  }
+
+  get loading(): boolean {
+    return this.hasAttribute("loading");
+  }
+  set loading(v: boolean) {
+    if (v) this.setAttribute("loading", "");
+    else this.removeAttribute("loading");
+  }
+
+  // ── Private ─────────────────────────────────────────────────────────────
+
+  private _syncAll(): void {
+    this.#headerTitle.textContent = this.getAttribute("title") ?? "";
+    this._syncSteps();
+    this._syncButtons();
+  }
+
+  private _syncSteps(): void {
+    const stepGroup = this._getStepGroup();
+    if (!stepGroup) return;
+
+    const layout = this.layout;
+    stepGroup.setAttribute("current-step", String(this.currentStep));
+    stepGroup.setAttribute("labels", "");
+
+    if (layout === "horizontal") {
+      stepGroup.setAttribute("size", "s");
+      stepGroup.setAttribute("orientation", "horizontal");
+      // Move to steps bar
+      this.#stepsBar.innerHTML = "";
+      this.#stepsBar.appendChild(stepGroup.cloneNode(true));
+      // Also keep in sidebar for vertical
+      this.#stepsSidebar.innerHTML = "";
+    } else {
+      stepGroup.setAttribute("size", "m");
+      stepGroup.setAttribute("orientation", "vertical");
+      // Move to sidebar
+      this.#stepsSidebar.innerHTML = "";
+      this.#stepsSidebar.appendChild(stepGroup.cloneNode(true));
+      // Clear bar
+      this.#stepsBar.innerHTML = "";
+    }
+  }
+
+  private _syncButtons(): void {
+    const current = this.currentStep;
+    const total = this.#cachedStepCount || this._getStepCount();
+    const isLoading = this.hasAttribute("loading");
+
+    // Disable prev on first step or when loading
+    if (current <= 1 || isLoading) this.#prevBtn.setAttribute("disabled", "");
+    else this.#prevBtn.removeAttribute("disabled");
+
+    // Next/Finish button — only show Finish when total is known and current is at last step
+    if (total > 0 && current >= total) {
+      this.#nextBtn.textContent = "Finish";
+    } else {
+      this.#nextBtn.textContent = "Next";
+    }
+
+    // Loading state on next button
+    if (isLoading) {
+      this.#nextBtn.setAttribute("status", "loading");
+      this.#nextBtn.setAttribute("disabled", "");
+    } else {
+      this.#nextBtn.removeAttribute("status");
+      this.#nextBtn.removeAttribute("disabled");
+    }
+  }
+
+  private _getStepGroup(): HTMLElement | null {
+    const assigned = this.#stepsSlot.assignedElements();
+    return (assigned.find((el) => el.tagName === "UI-STEP-GROUP") as HTMLElement) ?? null;
+  }
+
+  private _getStepCount(): number {
+    const stepGroup = this._getStepGroup();
+    if (!stepGroup) return 0;
+    return stepGroup.querySelectorAll("ui-step-item").length;
+  }
+
+  private _dispatchStepChange(): void {
+    this.dispatchEvent(
+      new CustomEvent("wizard-step-change", {
+        detail: { step: this.currentStep },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+}
+
+customElements.define("ui-wizard", UiWizard);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -268,3 +268,8 @@ export type { SwitchSize, SwitchLabelPosition, SwitchStatus } from "./components
 export { UiTreeItem } from "./components/ui-tree-item.js";
 export type { TreeItemSize, TreeItemLevel, TreeItemArrow, TreeItemState } from "./components/ui-tree-item.styles.js";
 export { UiTreeGroup } from "./components/ui-tree-group.js";
+
+// ─── Wizard ────────────────────────────────────────────────────────────────────
+
+export { UiWizard } from "./components/ui-wizard.js";
+export type { WizardLayout } from "./components/ui-wizard.js";

--- a/packages/ui-components/src/stories/ui-wizard.stories.ts
+++ b/packages/ui-components/src/stories/ui-wizard.stories.ts
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { html } from "lit";
+import "../components/ui-wizard.js";
+import "../components/ui-step-group.js";
+import "../components/ui-step-item.js";
+
+const meta: Meta = {
+  title: "Components/Wizard",
+  component: "ui-wizard",
+  argTypes: {
+    layout: {
+      control: { type: "select" },
+      options: ["horizontal", "vertical"],
+    },
+    title: {
+      control: { type: "text" },
+    },
+    currentStep: {
+      control: { type: "number" },
+    },
+  },
+  args: {
+    layout: "horizontal",
+    title: "Setup Wizard",
+  },
+};
+
+export default meta;
+type Story = StoryObj;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const stepsMarkup = html`
+  <ui-step-group slot="steps">
+    <ui-step-item label="Account" sublabel="Create account"></ui-step-item>
+    <ui-step-item label="Profile" sublabel="Set up profile"></ui-step-item>
+    <ui-step-item label="Settings" sublabel="Configure settings"></ui-step-item>
+    <ui-step-item label="Review" sublabel="Review details"></ui-step-item>
+    <ui-step-item label="Payment" sublabel="Add payment"></ui-step-item>
+  </ui-step-group>
+`;
+
+const contentMarkup = html`
+  <div style="padding: 24px; color: var(--fd-semantic-text-primary, #1c2b36);">
+    <h3 style="margin: 0 0 8px;">Step Content</h3>
+    <p style="margin: 0; line-height: 1.5;">
+      This is the content area for the current step. Each step can display
+      forms, information, or any other content relevant to the wizard flow.
+    </p>
+  </div>
+`;
+
+// ─── Horizontal ──────────────────────────────────────────────────────────────
+
+export const Horizontal: Story = {
+  render: () => html`
+    <div style="height: 422px; border: 1px solid #dce3e8; border-radius: 8px; overflow: hidden;">
+      <ui-wizard layout="horizontal" title="Setup Wizard" current-step="3">
+        ${stepsMarkup}
+        ${contentMarkup}
+      </ui-wizard>
+    </div>
+  `,
+};
+
+// ─── Vertical ────────────────────────────────────────────────────────────────
+
+export const Vertical: Story = {
+  render: () => html`
+    <div style="height: 460px; border: 1px solid #dce3e8; border-radius: 8px; overflow: hidden;">
+      <ui-wizard layout="vertical" title="Setup Wizard" current-step="3">
+        ${stepsMarkup}
+        ${contentMarkup}
+      </ui-wizard>
+    </div>
+  `,
+};
+
+// ─── First Step ──────────────────────────────────────────────────────────────
+
+export const FirstStep: Story = {
+  render: () => html`
+    <div style="height: 422px; border: 1px solid #dce3e8; border-radius: 8px; overflow: hidden;">
+      <ui-wizard layout="horizontal" title="Setup Wizard" current-step="1">
+        ${stepsMarkup}
+        <div style="padding: 24px; color: var(--fd-semantic-text-primary, #1c2b36);">
+          <h3 style="margin: 0 0 8px;">Welcome</h3>
+          <p style="margin: 0; line-height: 1.5;">
+            This is the first step. The Previous button is disabled.
+          </p>
+        </div>
+      </ui-wizard>
+    </div>
+  `,
+};
+
+// ─── Last Step ───────────────────────────────────────────────────────────────
+
+export const LastStep: Story = {
+  render: () => html`
+    <div style="height: 422px; border: 1px solid #dce3e8; border-radius: 8px; overflow: hidden;">
+      <ui-wizard layout="horizontal" title="Setup Wizard" current-step="5">
+        ${stepsMarkup}
+        <div style="padding: 24px; color: var(--fd-semantic-text-primary, #1c2b36);">
+          <h3 style="margin: 0 0 8px;">Finish</h3>
+          <p style="margin: 0; line-height: 1.5;">
+            This is the last step. The Next button shows "Finish".
+          </p>
+        </div>
+      </ui-wizard>
+    </div>
+  `,
+};


### PR DESCRIPTION
## Summary

New `<ui-wizard>` Web Component — a multi-step wizard layout composing existing components.

## Features

- 2 layouts: `horizontal` (steps bar below header) and `vertical` (steps sidebar on left)
- Composes `<ui-step-group>`, `<ui-button>`, `<ui-separator>` internally
- Header: title with layout-appropriate typography (14px horizontal, 20px vertical)
- Steps: slotted `<ui-step-group>` auto-configured per layout (S/horizontal, M/vertical)
- Content: generic default slot for any form/content
- Footer: Previous/Next buttons — Previous disabled on step 1, Next becomes "Finish" on last step
- `current-step` attribute drives step progress + button states
- Events: `wizard-step-change` with `detail.step`

## API

```html
<ui-wizard layout="vertical" title="Wizard Title" current-step="3">
  <ui-step-group slot="steps">
    <ui-step-item label="Account" sublabel="Optional"></ui-step-item>
    <ui-step-item label="Profile" sublabel="Optional"></ui-step-item>
    <ui-step-item label="Contact" sublabel="Optional"></ui-step-item>
  </ui-step-group>
  <div>Step content goes here</div>
</ui-wizard>
```

## Testing

- 3460 unit tests (43 new)
- 4 Storybook stories (horizontal, vertical, first step, last step)
- 56 Playwright visual regression tests (1 new)

## Files

- `packages/ui-components/src/components/ui-wizard.ts`
- `packages/ui-components/src/components/ui-wizard.test.ts`
- `packages/ui-components/src/stories/ui-wizard.stories.ts`
- `packages/ui-components/src/index.ts` — barrel exports
- `apps/catalog/src/pages/wizard.ts` — catalog page