### PR TITLE
chore: add CSS duplicate property lint test + document anti-pattern

### DIFF
--- a/packages/ui-components/AGENTS.md
+++ b/packages/ui-components/AGENTS.md
@@ -254,6 +254,7 @@ Currently extracted: ui-input, ui-select, ui-dropdown-item, ui-dropdown-split, u
 - **No `as any`, `@ts-ignore`, `@ts-expect-error`** — never suppress types
 - **No light DOM components** — always Shadow DOM with `attachShadow({ mode: "open" })`
 - **No CSS var name mismatches** — component override vars must match exactly between parent and child (e.g., `--ui-btn-radius`, not `--ui-button-radius`)
+- **No duplicate consecutive CSS properties** — when replacing hardcoded values with tokens, always use range replace (`pos` + `end`) to cover multi-line blocks (e.g., width + height). Single-line replace leaves the original line intact, creating a duplicate that silently overrides the token. Enforced by `css-lint.test.ts`.
 - **No inline SVG icons in new components** — use Material Symbols font instead (see ICONS section)
 - **Read Figma semantic tokens carefully.** Figma uses domain-specific token names (e.g., `Form/input-border`, `State/Selected/Surface/selected-bold`) that map to foundation tokens. Always check the Figma design context for the exact token names and map them to the closest foundation equivalent:
   - `Form/input-border` → `semanticVar("form", "inputBorder")` (`#9FB1BD`) — form control border

--- a/packages/ui-components/src/components/css-lint.test.ts
+++ b/packages/ui-components/src/components/css-lint.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Lint test: detect duplicate CSS properties in component style template literals.
+ *
+ * Catches a common AI editing bug where a tokenized line is inserted but the
+ * original hardcoded line below it is left intact, e.g.:
+ *
+ *   height: ${SP_4};
+ *   height: 32px;        ← duplicate, overrides the token
+ *
+ * This test scans all `STYLES` / `*_STYLES` template literals in component
+ * files and flags consecutive lines with the same CSS property name.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const COMPONENTS_DIR = join(dirname(fileURLToPath(import.meta.url)), ".");
+
+function findDuplicateCssProperties(css: string): { line: number; property: string; first: string; second: string }[] {
+  const lines = css.split("\n");
+  const duplicates: { line: number; property: string; first: string; second: string }[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const prev = lines[i - 1].trim();
+    const curr = lines[i].trim();
+
+    // Skip empty lines, comments, selectors, braces
+    if (!prev || !curr) continue;
+    if (prev.startsWith("/*") || prev.startsWith("*") || prev.startsWith("//")) continue;
+    if (curr.startsWith("/*") || curr.startsWith("*") || curr.startsWith("//")) continue;
+    if (prev.includes("{") || prev.includes("}")) continue;
+    if (curr.includes("{") || curr.includes("}")) continue;
+
+    // Extract CSS property name (everything before the colon)
+    const prevProp = prev.split(":")[0]?.trim();
+    const currProp = curr.split(":")[0]?.trim();
+
+    if (!prevProp || !currProp) continue;
+
+    // Skip CSS custom properties (--var declarations) — they can legitimately repeat
+    if (prevProp.startsWith("--") || currProp.startsWith("--")) continue;
+
+    // Skip if either line doesn't end with semicolon (not a property declaration)
+    if (!prev.endsWith(";") || !curr.endsWith(";")) continue;
+
+    if (prevProp === currProp) {
+      duplicates.push({
+        line: i + 1,
+        property: currProp,
+        first: prev,
+        second: curr,
+      });
+    }
+  }
+
+  return duplicates;
+}
+
+describe("CSS duplicate property lint", () => {
+  const files = readdirSync(COMPONENTS_DIR)
+    .filter((f: string) => f.endsWith(".ts") && !f.endsWith(".test.ts") && !f.endsWith(".stories.ts"));
+
+  for (const file of files) {
+    it(`${file} has no duplicate consecutive CSS properties`, () => {
+      const content = readFileSync(join(COMPONENTS_DIR, file), "utf-8");
+
+      // Extract template literal content from STYLES / *_STYLES constants
+      const styleMatches = content.matchAll(/(?:const\s+\w*STYLES?\w*\s*=\s*\/\*\s*css\s*\*\/\s*`|const\s+STYLES\s*=\s*`)([\s\S]*?)`/g);
+
+      for (const match of styleMatches) {
+        const css = match[1];
+        const duplicates = findDuplicateCssProperties(css);
+
+        if (duplicates.length > 0) {
+          const messages = duplicates.map(
+            (d) => `  Line ~${d.line}: "${d.property}" declared twice:\n    ${d.first}\n    ${d.second}`,
+          );
+          expect.fail(
+            `${file} has ${duplicates.length} duplicate CSS property(ies):\n${messages.join("\n")}`,
+          );
+        }
+      }
+    });
+  }
+});

--- a/packages/ui-components/tsconfig.json
+++ b/packages/ui-components/tsconfig.json
@@ -16,5 +16,5 @@
     "isolatedModules": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

Adds automated enforcement against duplicate consecutive CSS properties in component style template literals, plus documents the anti-pattern in AGENTS.md.

## Problem

When replacing hardcoded CSS values with tokens, a common editing bug is using single-line replace instead of range replace — the tokenized line gets inserted but the original hardcoded line below it stays, silently overriding the token:

```css
height: ${SP_4};     /* ← new tokenized line */
height: 32px;        /* ← original, overrides the token */
```

## Solution

1. **`css-lint.test.ts`** — scans all 104 component files' `STYLES` template literals for consecutive lines with the same CSS property name. Catches the bug at CI time.

2. **AGENTS.md anti-pattern** — documents the root cause and fix: "always use range replace (`pos` + `end`) to cover multi-line blocks"

## Test Details

- Extracts CSS from `/* css */` tagged template literals
- Skips comments, selectors, braces, CSS custom properties (`--var`)
- Only flags consecutive same-property declarations (not same property in different rule blocks)
- 104 component files scanned, all pass

## Testing

- 3566 unit tests pass (104 new lint tests)
- 56 Playwright visual regression tests pass