### PR TITLE
fix(dropdown): audit — tokenize shape values and semantic state tokens across 4 files

### DIFF
--- a/packages/ui-components/src/components/ui-dropdown-item.styles.ts
+++ b/packages/ui-components/src/components/ui-dropdown-item.styles.ts
@@ -9,6 +9,8 @@ const SURFACE_SECONDARY = semanticVar("surface", "secondary");
 const FORM_INPUT_BORDER = semanticVar("form", "inputBorder");
 const SELECTED_BOLD = semanticVar("stateSelected", "surfaceBold");
 const BORDER_CONTRAST = semanticVar("border", "contrast");
+const HOVER_SURFACE = semanticVar("stateHover", "surfaceMinimal");
+const DISABLED_TEXT = semanticVar("stateDisabled", "text");
 const SP_05 = spaceVar("0.5");   // 4px — description gap
 const SP_075 = spaceVar("0.75"); // 6px
 const SP_1 = spaceVar("1");      // 8px
@@ -62,7 +64,7 @@ export const STYLES = /* css */ `
   }
 
   .item:hover {
-    background-color: var(--ui-dd-item-hover-bg, rgba(159, 177, 189, 0.1));
+    background-color: var(--ui-dd-item-hover-bg, ${HOVER_SURFACE});
   }
 
   .item:active {
@@ -172,7 +174,7 @@ export const STYLES = /* css */ `
   /* ── Disabled ───────────────────────────────────────────────────────────── */
 
   :host([disabled]) .item {
-    color: var(--ui-dd-item-disabled-color, rgba(91, 114, 130, 0.5));
+    color: var(--ui-dd-item-disabled-color, ${DISABLED_TEXT});
     cursor: not-allowed;
     pointer-events: none;
   }

--- a/packages/ui-components/src/components/ui-dropdown-split.styles.ts
+++ b/packages/ui-components/src/components/ui-dropdown-split.styles.ts
@@ -1,4 +1,4 @@
-import { semanticVar, spaceVar, elevationVar } from "@maneki/foundation";
+import { semanticVar, spaceVar, elevationVar, radiusVar, borderWidthVar } from "@maneki/foundation";
 
 // ─── Token constants ─────────────────────────────────────────────────────────
 
@@ -19,6 +19,14 @@ const SP_25 = spaceVar("2.5");
 const SP_3 = spaceVar("3");
 const SP_4 = spaceVar("4");
 
+const RADIUS_SM = radiusVar("sm");
+const RADIUS_PILL = radiusVar("pill");
+const RADIUS_NONE = radiusVar("none");
+const BORDER_SM = borderWidthVar("sm");
+const HOVER_BOLD = semanticVar("stateHover", "surfaceBold");
+const HOVER_SUBTLE = semanticVar("stateHover", "surfaceSubtle");
+const ACTIVE_BOLD = semanticVar("stateActive", "surfaceBold");
+const ACTIVE_SUBTLE = semanticVar("stateActive", "surfaceSubtle");
 // ─── Styles ──────────────────────────────────────────────────────────────────
 
 export const STYLES = /* css */ `
@@ -39,7 +47,9 @@ export const STYLES = /* css */ `
     display: inline-flex;
     flex-direction: row;
     align-items: stretch;
-    border: 1px solid transparent;
+    border-width: ${BORDER_SM};
+    border-style: solid;
+    border-color: transparent;
     cursor: pointer;
     user-select: none;
     -webkit-user-select: none;
@@ -48,11 +58,11 @@ export const STYLES = /* css */ `
   /* ── Shape ─────────────────────────────────────────────────────────────── */
 
   :host .base {
-    border-radius: var(--ui-dds-radius, 2px);
+    border-radius: var(--ui-dds-radius, ${RADIUS_SM});
   }
 
   :host([shape="rounded"]) .base {
-    border-radius: var(--ui-dds-radius, 999px);
+    border-radius: var(--ui-dds-radius, ${RADIUS_PILL});
   }
 
   /* ── Shared button reset ────────────────────────────────────────────────── */
@@ -83,19 +93,19 @@ export const STYLES = /* css */ `
   /* ── Border-radius on outer corners only ────────────────────────────────── */
 
   :host .left {
-    border-radius: 2px 0 0 2px;
+    border-radius: ${RADIUS_SM} ${RADIUS_NONE} ${RADIUS_NONE} ${RADIUS_SM};
   }
 
   :host .right {
-    border-radius: 0 2px 2px 0;
+    border-radius: ${RADIUS_NONE} ${RADIUS_SM} ${RADIUS_SM} ${RADIUS_NONE};
   }
 
   :host([shape="rounded"]) .left {
-    border-radius: 999px 0 0 999px;
+    border-radius: ${RADIUS_PILL} ${RADIUS_NONE} ${RADIUS_NONE} ${RADIUS_PILL};
   }
 
   :host([shape="rounded"]) .right {
-    border-radius: 0 999px 999px 0;
+    border-radius: ${RADIUS_NONE} ${RADIUS_PILL} ${RADIUS_PILL} ${RADIUS_NONE};
   }
 
   /* ── Size: m (default) ──────────────────────────────────────────────────── */
@@ -332,26 +342,26 @@ export const STYLES = /* css */ `
   /* ── Hover state (independent per button) ─────────────────────────────── */
   .left:hover,
   .right:hover {
-    background-image: linear-gradient(rgba(14, 23, 31, 0.1), rgba(14, 23, 31, 0.1));
+    background-image: linear-gradient(${HOVER_BOLD}, ${HOVER_BOLD});
   }
   :host([emphasis="subtle"]) .left:hover,
   :host([emphasis="subtle"]) .right:hover,
   :host([emphasis="minimal"]) .left:hover,
   :host([emphasis="minimal"]) .right:hover {
     background-image: none;
-    background-color: rgba(14, 23, 31, 0.06);
+    background-color: ${HOVER_SUBTLE};
   }
   /* ── Active state ────────────────────────────────────────────────────── */
   .left:active,
   .right:active {
-    background-image: linear-gradient(rgba(14, 23, 31, 0.2), rgba(14, 23, 31, 0.2));
+    background-image: linear-gradient(${ACTIVE_BOLD}, ${ACTIVE_BOLD});
   }
   :host([emphasis="subtle"]) .left:active,
   :host([emphasis="subtle"]) .right:active,
   :host([emphasis="minimal"]) .left:active,
   :host([emphasis="minimal"]) .right:active {
     background-image: none;
-    background-color: rgba(14, 23, 31, 0.12);
+    background-color: ${ACTIVE_SUBTLE};
   }
   /* ── Focus-visible (double ring) ─────────────────────────────────────── */
   .left:focus-visible,
@@ -471,7 +481,7 @@ export const STYLES = /* css */ `
     padding: ${SP_05} 0;
     background-color: var(--ui-dds-menu-bg, ${SURFACE_PRIMARY});
     box-shadow: var(--ui-dds-menu-shadow, ${ELEVATION_05});
-    border-radius: 2px;
+    border-radius: ${RADIUS_SM};
     overflow: visible;
     opacity: 0;
     visibility: hidden;

--- a/packages/ui-components/src/components/ui-dropdown.ts
+++ b/packages/ui-components/src/components/ui-dropdown.ts
@@ -1,4 +1,4 @@
-import { colorVar, semanticVar, spaceVar, elevationVar } from "@maneki/foundation";
+import { semanticVar, spaceVar, elevationVar, radiusVar } from "@maneki/foundation";
 import "./ui-button.js";
 import "./ui-icon.js";
 
@@ -77,7 +77,7 @@ export const STYLES = /* css */ `
     padding: ${SP_05} 0;
     background-color: var(--ui-dd-menu-bg, ${SURFACE_PRIMARY});
     box-shadow: var(--ui-dd-menu-shadow, ${ELEVATION_05});
-    border-radius: 2px;
+    border-radius: ${radiusVar("sm")};
     overflow: visible;
     opacity: 0;
     visibility: hidden;

--- a/packages/ui-components/src/components/ui-menu.ts
+++ b/packages/ui-components/src/components/ui-menu.ts
@@ -1,4 +1,4 @@
-import { semanticVar, spaceVar, elevationVar } from "@maneki/foundation";
+import { semanticVar, spaceVar, elevationVar, radiusVar } from "@maneki/foundation";
 
 // ─── Type-safe property unions ───────────────────────────────────────────────
 
@@ -27,7 +27,7 @@ export const STYLES = /* css */ `
     padding: ${SP_05} 0;
     background-color: var(--ui-menu-bg, ${SURFACE_PRIMARY});
     box-shadow: var(--ui-menu-shadow, ${ELEVATION_05});
-    border-radius: var(--ui-menu-radius, 2px);
+    border-radius: var(--ui-menu-radius, ${radiusVar("sm")});
     opacity: 0;
     visibility: hidden;
     transform: translateY(-4px);


### PR DESCRIPTION
## Summary

Audit and fix hardcoded values across the dropdown component family (8 files audited, 4 files changed).

## Shape Tokens

- **ui-dropdown-split.styles.ts**: 9 `border-radius` → `radiusVar("sm")`/`("pill")`/`("none")` + compound variants, `border: 1px` → `borderWidthVar("sm")` longhand
- **ui-dropdown.ts**: `border-radius: 2px` → `radiusVar("sm")`, removed unused `colorVar` import
- **ui-menu.ts**: `border-radius` fallback `2px` → `radiusVar("sm")`

## Semantic State Tokens

- **ui-dropdown-split.styles.ts**: 4 `rgba(14,23,31,...)` overlays → `stateHover.surfaceBold`/`surfaceSubtle` + `stateActive.surfaceBold`/`surfaceSubtle` (matches button pattern)
- **ui-dropdown-item.styles.ts**: hover `rgba(159,177,189,0.1)` → `stateHover.surfaceMinimal`, disabled `rgba(91,114,130,0.5)` → `stateDisabled.text`

## Not Changed (acceptable exceptions)

- `#ffffff` × 6 in split styles — white on colored backgrounds (allowed per AGENTS.md)
- `rgba()` divider opacities — unique values, no token match
- `10px` padding — no exact spacing token
- `min-width: 240px` — no token
- Font-size/line-height — needs `typeVar()` refactor (repo-wide)

## Testing

- 3590 unit tests pass (incl. 104 CSS lint + 24 minifier tests)
- 56 Playwright visual regression tests pass