### PR TITLE
fix(ui-icon): remove dead ICON_PRIMARY constant

### DIFF
--- a/packages/ui-components/src/components/ui-icon.ts
+++ b/packages/ui-components/src/components/ui-icon.ts
@@ -17,7 +17,6 @@ export type IconState =
 
 // ─── Token constants ─────────────────────────────────────────────────────────
 
-const ICON_PRIMARY = semanticVar("icon", "primary");
 const ICON_REVERSED = semanticVar("icon", "reversed");
 const ICON_ACTION = semanticVar("icon", "action");
 const DISABLED_MINIMAL = semanticVar("stateDisabled", "minimal");


### PR DESCRIPTION
## Summary

Audit of `<ui-icon>` component — very clean, only 1 issue found.

## Change

Removed dead `ICON_PRIMARY` constant (`semanticVar("icon", "primary")`) — was declared but never referenced in the CSS. The enabled state correctly uses `currentColor` which inherits from the parent element, enabling proper composition (icons inside buttons, links, etc. inherit their parent's color).

## Audit Results (no action needed)

- 3 `semanticVar()` tokens correctly wired (ICON_REVERSED, ICON_ACTION, DISABLED_MINIMAL) ✅
- Zero hardcoded hex colors ✅
- 3 `rgba()` values for inverse overlay states — acceptable exceptions ✅
- 15 raw px fallbacks in `var(--ui-icon-size, Npx)` — correct override pattern ✅
- No `spaceVar`/`radiusVar`/`borderWidthVar` needed (no padding, borders, or radius) ✅
- Zero duplicate CSS ✅

## Testing

- 3590 unit tests pass (incl. 104 CSS lint + 24 minifier tests)
- 56 Playwright visual regression tests pass