### PR TITLE
fix(input): audit — fix textarea warning bug, tokenize shape values across 3 files

### DIFF
--- a/packages/ui-components/src/components/ui-input-group.ts
+++ b/packages/ui-components/src/components/ui-input-group.ts
@@ -1,4 +1,4 @@
-import { semanticVar, spaceVar } from "@maneki/foundation";
+import { semanticVar, spaceVar, radiusVar, borderWidthVar } from "@maneki/foundation";
 
 // ─── Type-safe property unions ───────────────────────────────────────────────
 
@@ -33,8 +33,10 @@ const STYLES = /* css */ `
   .wrapper {
     display: flex;
     align-items: stretch;
-    border: 1px solid var(--ui-ig-border, ${FORM_INPUT_BORDER});
-    border-radius: 2px;
+    border-width: ${borderWidthVar("sm")};
+    border-style: solid;
+    border-color: var(--ui-ig-border, ${FORM_INPUT_BORDER});
+    border-radius: ${radiusVar("sm")};
     overflow: hidden;
     width: 100%;
     transition: border-color 0.15s ease;
@@ -80,7 +82,7 @@ const STYLES = /* css */ `
 
   .separator {
     display: none;
-    width: 1px;
+    width: ${borderWidthVar("sm")};
     align-self: stretch;
     background-color: var(--ui-ig-separator, ${FORM_INPUT_BORDER});
     flex-shrink: 0;
@@ -105,7 +107,7 @@ const STYLES = /* css */ `
     display: flex;
     flex: 1;
     min-width: 0;
-    background-color: #ffffff;
+    background-color: var(--ui-ig-input-bg, #ffffff);
   }
 
   ::slotted(ui-input) {

--- a/packages/ui-components/src/components/ui-input.styles.ts
+++ b/packages/ui-components/src/components/ui-input.styles.ts
@@ -1,4 +1,4 @@
-import { semanticVar, spaceVar } from "@maneki/foundation";
+import { semanticVar, spaceVar, radiusVar, borderWidthVar } from "@maneki/foundation";
 
 // ─── Token constants ─────────────────────────────────────────────────────────
 
@@ -66,8 +66,10 @@ export const STYLES = /* css */ `
   .input-container {
     display: flex;
     align-items: center;
-    border: 1px solid var(--ui-input-border, ${FORM_INPUT_BORDER});
-    border-radius: 2px;
+    border-width: ${borderWidthVar("sm")};
+    border-style: solid;
+    border-color: var(--ui-input-border, ${FORM_INPUT_BORDER});
+    border-radius: ${radiusVar("sm")};
     background-color: var(--ui-input-bg, #ffffff);
     transition:
       border-color 0.15s ease,

--- a/packages/ui-components/src/components/ui-textarea.styles.ts
+++ b/packages/ui-components/src/components/ui-textarea.styles.ts
@@ -1,4 +1,4 @@
-import { semanticVar, spaceVar } from "@maneki/foundation";
+import { semanticVar, spaceVar, radiusVar, borderWidthVar } from "@maneki/foundation";
 
 // ─── Token constants ─────────────────────────────────────────────────────────
 
@@ -79,8 +79,10 @@ export const STYLES = /* css */ `
   .textarea-container {
     display: flex;
     position: relative;
-    border: 1px solid var(--ui-textarea-border, ${FORM_INPUT_BORDER});
-    border-radius: 2px;
+    border-width: ${borderWidthVar("sm")};
+    border-style: solid;
+    border-color: var(--ui-textarea-border, ${FORM_INPUT_BORDER});
+    border-radius: ${radiusVar("sm")};
     background-color: var(--ui-textarea-bg, #ffffff);
     transition:
       border-color 0.15s ease,
@@ -229,12 +231,12 @@ export const STYLES = /* css */ `
   /* ── Warning state ─────────────────────────────────────────────────────── */
 
   :host([status="warning"]) .textarea-container {
-    border-color: ${BORDER_FOCUS};
+    border-color: ${STATUS_WARNING};
   }
 
   :host([status="warning"]:focus-within) .textarea-container {
-    border-color: ${BORDER_FOCUS};
-    box-shadow: 0 0 0 1px ${BORDER_FOCUS};
+    border-color: ${STATUS_WARNING};
+    box-shadow: 0 0 0 1px ${STATUS_WARNING};
   }
 
   /* ── Success state ─────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Audit and fix hardcoded values across the input component family (5 files audited, 3 changed).

## Critical Bug Fix

- **ui-textarea.styles.ts**: Warning state used `BORDER_FOCUS` (blue `#186ADE`) instead of `STATUS_WARNING` — textarea warning borders were rendering blue instead of warning color. Copy-paste bug from input styles.

## Shape Tokens (3 files)

| File | border | border-radius | separator |
|------|--------|---------------|-----------|
| `ui-input.styles.ts` | `1px` → `borderWidthVar("sm")` longhand | `2px` → `radiusVar("sm")` | — |
| `ui-textarea.styles.ts` | `1px` → `borderWidthVar("sm")` longhand | `2px` → `radiusVar("sm")` | — |
| `ui-input-group.ts` | `1px` → `borderWidthVar("sm")` longhand | `2px` → `radiusVar("sm")` | `width: 1px` → `borderWidthVar("sm")` |

## Consistency Fix

- **ui-input-group.ts**: Bare `#ffffff` → `var(--ui-ig-input-bg, #ffffff)` — wrapped in CSS custom property override pattern for consistency with other files

## Not Changed (acceptable exceptions)

- `#ffffff` in `var()` fallbacks — allowed per AGENTS.md
- Size-variant px values (heights, font-sizes) — component-specific dimensions
- `7px` textarea padding — Figma-specific, no exact token

## Testing

- 3590 unit tests pass (incl. 104 CSS lint + 24 minifier tests)
- 56 Playwright visual regression tests pass