### PR TITLE
fix(ui-label): tokenize spacing value

### DIFF
--- a/packages/ui-components/src/components/ui-label.ts
+++ b/packages/ui-components/src/components/ui-label.ts
@@ -1,4 +1,4 @@
-import { semanticVar } from "@maneki/foundation";
+import { semanticVar, spaceVar } from "@maneki/foundation";
 
 // ─── Type-safe property unions ───────────────────────────────────────────────
 
@@ -37,7 +37,7 @@ export const STYLES = /* css */ `
     color: ${STATUS_ERROR};
     font-size: var(--_font-size);
     line-height: var(--_line-height);
-    margin-left: 2px;
+    margin-left: ${spaceVar("0.25")};
   }
 
   :host(:not([required])) .required {


### PR DESCRIPTION
## Summary

Audit of `<ui-label>` component — very clean, 1 spacing fix.

## Change

- `margin-left: 2px` → `spaceVar("0.25")` (required asterisk spacing)
- Added `spaceVar` import

## Audit Results (no action needed)

- 3 `semanticVar()` tokens correctly wired (text-secondary, disabled-text, status-error) ✅
- Zero hardcoded hex colors ✅
- Zero `rgba()` values ✅
- Zero duplicate CSS ✅
- No border-radius or border-width needed ✅
- Font-size/line-height — deferred to repo-wide `typeVar()` refactor

## Testing

- 3590 unit tests pass
- 56 Playwright visual regression tests pass