### PR TITLE
fix(ui-link): remove dead ICON_ACTION constant

### DIFF
--- a/packages/ui-components/src/components/ui-link.ts
+++ b/packages/ui-components/src/components/ui-link.ts
@@ -11,7 +11,6 @@ const TEXT_LINK = semanticVar("text", "link");
 const TEXT_LINK_HOVER = semanticVar("text", "linkHover");
 const TEXT_LINK_ACTIVE = semanticVar("text", "linkActive");
 const TEXT_VISITED = semanticVar("text", "visited");
-const ICON_ACTION = semanticVar("icon", "action");
 const SP_025 = spaceVar("0.25");
 const SP_05 = spaceVar("0.5");
 


### PR DESCRIPTION
## Summary

Audit of `<ui-link>` component — very clean, 1 dead code removal.

## Change

Removed dead `ICON_ACTION` constant (`semanticVar("icon", "action")`) — was declared but never referenced in the CSS. The link icon inherits color from the parent text color via `currentColor`.

## Audit Results (no action needed)

- 4 `semanticVar()` tokens correctly wired (text-link, text-linkHover, text-linkActive, text-visited) ✅
- 2 `spaceVar()` tokens correctly wired (gap s/m) ✅
- Zero hardcoded hex colors ✅
- Zero `rgba()` values ✅
- Zero duplicate CSS ✅
- No border-radius or border-width needed ✅
- Font-size/line-height — deferred to repo-wide `typeVar()` refactor

## Testing

- 3590 unit tests pass
- 56 Playwright visual regression tests pass