### PR TITLE
fix(metric): audit — tokenize spacing, shape, fix semantic mismatch across 2 files

### DIFF
--- a/packages/ui-components/src/components/ui-metric-group.ts
+++ b/packages/ui-components/src/components/ui-metric-group.ts
@@ -1,4 +1,4 @@
-import { semanticVar } from "@maneki/foundation";
+import { semanticVar, spaceVar, borderWidthVar } from "@maneki/foundation";
 import type { MetricSize } from "./ui-metric.js";
 
 // ─── Token constants ─────────────────────────────────────────────────────────
@@ -22,7 +22,7 @@ const STYLES = /* css */ `
 
   .wrapper {
     display: flex;
-    gap: 8px;
+    gap: ${spaceVar("1")};
     align-items: stretch;
     height: 100%;
   }
@@ -30,7 +30,7 @@ const STYLES = /* css */ `
   /* ── Separator ───────────────────────────────────────────────────────────── */
 
   .separator {
-    width: 1px;
+    width: ${borderWidthVar("sm")};
     align-self: stretch;
     background: ${BORDER_MODERATE};
     flex-shrink: 0;
@@ -41,9 +41,9 @@ const STYLES = /* css */ `
   .group {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: ${spaceVar("0.5")};
     align-items: flex-start;
-    padding-top: 8px;
+    padding-top: ${spaceVar("1")};
   }
 
   /* ── Title ───────────────────────────────────────────────────────────────── */
@@ -74,36 +74,36 @@ const STYLES = /* css */ `
 
   :host .metrics,
   :host([size="s"]) .metrics {
-    gap: 20px;
+    gap: ${spaceVar("2.5")};
   }
 
   :host .title,
   :host([size="s"]) .title {
-    padding-left: 8px;
+    padding-left: ${spaceVar("1")};
   }
 
   :host([size="xs"]) .metrics {
-    gap: 16px;
+    gap: ${spaceVar("2")};
   }
 
   :host([size="xs"]) .title {
-    padding-left: 8px;
+    padding-left: ${spaceVar("1")};
   }
 
   :host([size="m"]) .metrics {
-    gap: 24px;
+    gap: ${spaceVar("3")};
   }
 
   :host([size="m"]) .title {
-    padding-left: 12px;
+    padding-left: ${spaceVar("1.5")};
   }
 
   :host([size="l"]) .metrics {
-    gap: 32px;
+    gap: ${spaceVar("4")};
   }
 
   :host([size="l"]) .title {
-    padding-left: 16px;
+    padding-left: ${spaceVar("2")};
   }
 `;
 

--- a/packages/ui-components/src/components/ui-metric.styles.ts
+++ b/packages/ui-components/src/components/ui-metric.styles.ts
@@ -1,4 +1,4 @@
-import { semanticVar, colorVar, spaceVar } from "@maneki/foundation";
+import { semanticVar, colorVar, spaceVar, radiusVar } from "@maneki/foundation";
 
 // ─── Token constants ─────────────────────────────────────────────────────────
 
@@ -6,9 +6,16 @@ const TEXT_PRIMARY = semanticVar("text", "primary");
 const TEXT_SECONDARY = semanticVar("text", "secondary");
 const GREEN_60 = colorVar("green", 60);
 const RED_60 = colorVar("red", 60);
-const DISABLED_MINIMAL = semanticVar("stateDisabled", "minimal");
+const ACTIVE_SURFACE = semanticVar("stateActive", "surfaceSubtle");
 const HOVER_SURFACE = semanticVar("stateHover", "surfaceMinimal");
 
+const SP_025 = spaceVar("0.25");   // 2px
+const SP_05 = spaceVar("0.5");     // 4px
+const SP_075 = spaceVar("0.75");   // 6px
+const SP_1 = spaceVar("1");         // 8px
+const SP_15 = spaceVar("1.5");     // 12px
+const SP_2 = spaceVar("2");         // 16px
+const RADIUS_SM = radiusVar("sm");
 // ─── Styles ──────────────────────────────────────────────────────────────────
 
 export const STYLES = /* css */ `
@@ -27,7 +34,7 @@ export const STYLES = /* css */ `
   .base {
     display: flex;
     align-items: flex-start;
-    border-radius: 2px;
+    border-radius: ${RADIUS_SM};
     font-family: "Geist", sans-serif;
   }
 
@@ -40,14 +47,14 @@ export const STYLES = /* css */ `
   :host([orientation="horizontal"]) .base {
     flex-direction: row;
     align-items: center;
-    gap: 8px;
+    gap: ${SP_1};
     white-space: nowrap;
   }
 
   :host([orientation="horizontal"]) .content {
     flex-direction: row;
     align-items: center;
-    gap: 8px;
+    gap: ${SP_1};
   }
 
   :host([orientation="horizontal"]) .value-container {
@@ -69,7 +76,7 @@ export const STYLES = /* css */ `
   }
 
   :host([legend-color]) .base {
-    gap: 8px;
+    gap: ${SP_1};
   }
 
   /* ── Content ─────────────────────────────────────────────────────────────── */
@@ -78,7 +85,7 @@ export const STYLES = /* css */ `
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 2px;
+    gap: ${SP_025};
   }
 
   .label {
@@ -140,7 +147,7 @@ export const STYLES = /* css */ `
   .delta-content {
     display: flex;
     align-items: center;
-    gap: 4px;
+    gap: ${SP_05};
     font-size: 12px;
     line-height: 16px;
     font-weight: 400;
@@ -191,17 +198,17 @@ export const STYLES = /* css */ `
   }
 
   :host([clickable]) .base:active {
-    background: ${DISABLED_MINIMAL};
+    background: ${ACTIVE_SURFACE};
   }
 
   /* ── Size: xs ────────────────────────────────────────────────────────────── */
 
   :host([size="xs"]) .base {
-    padding: 4px 8px;
+    padding: ${SP_05} ${SP_1};
   }
 
   :host([size="xs"][legend-color]) .base {
-    padding: 4px 8px 4px 6px;
+    padding: ${SP_05} ${SP_1} ${SP_05} ${SP_075};
   }
 
   :host([size="xs"]) .content {
@@ -225,24 +232,24 @@ export const STYLES = /* css */ `
   }
 
   :host([size="xs"]) .value-container {
-    gap: 4px;
+    gap: ${SP_05};
   }
 
   /* ── Size: s (default) ───────────────────────────────────────────────────── */
 
   :host .base,
   :host([size="s"]) .base {
-    padding: 4px 8px;
+    padding: ${SP_05} ${SP_1};
   }
 
   :host([legend-color]) .base,
   :host([size="s"][legend-color]) .base {
-    padding: 4px 8px 4px 6px;
+    padding: ${SP_05} ${SP_1} ${SP_05} ${SP_075};
   }
 
   :host .content,
   :host([size="s"]) .content {
-    gap: 2px;
+    gap: ${SP_025};
   }
 
   :host .value,
@@ -266,21 +273,21 @@ export const STYLES = /* css */ `
 
   :host .value-container,
   :host([size="s"]) .value-container {
-    gap: 4px;
+    gap: ${SP_05};
   }
 
   /* ── Size: m ─────────────────────────────────────────────────────────────── */
 
   :host([size="m"]) .base {
-    padding: 6px 12px;
+    padding: ${SP_075} ${SP_15};
   }
 
   :host([size="m"][legend-color]) .base {
-    padding: 6px 12px 6px 8px;
+    padding: ${SP_075} ${SP_15} ${SP_075} ${SP_1};
   }
 
   :host([size="m"]) .content {
-    gap: 2px;
+    gap: ${SP_025};
   }
 
   :host([size="m"]) .value {
@@ -300,7 +307,7 @@ export const STYLES = /* css */ `
   }
 
   :host([size="m"]) .value-container {
-    gap: 4px;
+    gap: ${SP_05};
   }
 
   :host([size="m"][orientation="horizontal"]) .base {
@@ -315,15 +322,15 @@ export const STYLES = /* css */ `
   /* ── Size: l ─────────────────────────────────────────────────────────────── */
 
   :host([size="l"]) .base {
-    padding: 8px 16px;
+    padding: ${SP_1} ${SP_2};
   }
 
   :host([size="l"][legend-color]) .base {
-    padding: 8px 16px 8px 8px;
+    padding: ${SP_1} ${SP_2} ${SP_1} ${SP_1};
   }
 
   :host([size="l"]) .content {
-    gap: 2px;
+    gap: ${SP_025};
   }
 
   :host([size="l"]) .value {
@@ -343,13 +350,13 @@ export const STYLES = /* css */ `
   }
 
   :host([size="l"]) .value-container {
-    gap: 4px;
+    gap: ${SP_05};
   }
 
   /* ── Clickable hover bg for m size ───────────────────────────────────────── */
 
   :host([size="m"][clickable]) .base {
-    background: ${DISABLED_MINIMAL};
+    background: ${ACTIVE_SURFACE};
   }
 
   :host([size="m"][clickable]) .base:hover {


### PR DESCRIPTION
## Summary

Audit and fix hardcoded values across the metric component family (3 files audited, 2 changed).

## Semantic Fix

- **`DISABLED_MINIMAL` used for active/pressed state** → replaced with `stateActive.surfaceSubtle` — using a "disabled" token for a press interaction was semantically wrong

## Spacing Tokenized

### `ui-metric.styles.ts` (26 values)
- `gap: 2px/4px/8px/12px` → `spaceVar("0.25")`/`("0.5")`/`("1")`/`("1.5")`
- `padding: 4px 8px` / `6px 12px` / `8px 16px` → `spaceVar()` combinations
- Legend padding variants → `spaceVar()` combinations
- `padding-top: 8px` → `spaceVar("1")`
- `spaceVar` was imported but never used — now actually used

### `ui-metric-group.ts` (12 values)
- `gap: 16px/20px/24px/32px` → `spaceVar("2")`/`("2.5")`/`("3")`/`("4")`
- `padding-left: 8px/12px/16px` → `spaceVar("1")`/`("1.5")`/`("2")`
- `padding-top: 8px` → `spaceVar("1")`
- `gap: 4px/8px` → `spaceVar("0.5")`/`("1")`

## Shape Tokenized

- `border-radius: 2px` → `radiusVar("sm")` (metric styles)
- `width: 1px` (separator) → `borderWidthVar("sm")` (metric group)

## Not Changed (acceptable exceptions)

- Arrow geometry (CSS triangle border trick) — no token equivalent
- Font-size/line-height — deferred to `typeVar()` refactor
- `10px` padding-top — no exact token

## Testing

- 3590 unit tests pass
- 56 Playwright visual regression tests pass