### PR TITLE
refactor: replace hardcoded typography with typeBlock() tokens

### DIFF
--- a/packages/foundation/src/index.ts
+++ b/packages/foundation/src/index.ts
@@ -10,6 +10,7 @@ export {
   elevationVar,
   typographyToCssProperties,
   typeVar,
+  typeBlock,
   spacingToCssProperties,
   spaceVar,
   radiusToCssProperties,

--- a/packages/foundation/src/token-constants.ts
+++ b/packages/foundation/src/token-constants.ts
@@ -20,6 +20,7 @@ import {
   radiusVar,
   borderWidthVar,
   elevationVar,
+  typeBlock,
 } from "./tokens.js";
 
 // ─── Text ───────────────────────────────────────────────────────────────────
@@ -297,3 +298,43 @@ export const ELEVATION_03 = elevationVar("03");
 export const ELEVATION_04 = elevationVar("04");
 export const ELEVATION_05 = elevationVar("05");
 export const ELEVATION_06 = elevationVar("06");
+
+// ─── Font Family ────────────────────────────────────────────────────────────
+
+export const FONT_PRIMARY = "'Geist', sans-serif";
+export const FONT_CODE = "'Roboto Mono', monospace";
+// ─── Typography Blocks ──────────────────────────────────────────────────────
+// Each constant is a CSS block: font-size + line-height + font-weight as var() refs.
+
+// Display: light weight, large sizes
+export const TYPE_DISPLAY_01 = typeBlock("display", "01");  // 78px/104px/300
+export const TYPE_DISPLAY_02 = typeBlock("display", "02");  // 60px/80px/300
+export const TYPE_DISPLAY_03 = typeBlock("display", "03");  // 48px/64px/300
+
+// Heading: medium weight
+export const TYPE_HEADING_01 = typeBlock("heading", "01");  // 40px/52px/500
+export const TYPE_HEADING_02 = typeBlock("heading", "02");  // 32px/40px/500
+export const TYPE_HEADING_03 = typeBlock("heading", "03");  // 24px/32px/500
+export const TYPE_HEADING_04 = typeBlock("heading", "04");  // 20px/28px/500
+export const TYPE_HEADING_05 = typeBlock("heading", "05");  // 16px/24px/500
+export const TYPE_HEADING_06 = typeBlock("heading", "06");  // 14px/20px/500
+export const TYPE_HEADING_07 = typeBlock("heading", "07");  // 12px/16px/500
+
+// Body: regular weight
+export const TYPE_BODY_01 = typeBlock("body", "01");        // 16px/24px/400
+export const TYPE_BODY_02 = typeBlock("body", "02");        // 14px/20px/400
+export const TYPE_BODY_03 = typeBlock("body", "03");        // 12px/16px/400
+
+// UI
+export const TYPE_UI_01 = typeBlock("ui", "01");            // 24px/32px/400
+export const TYPE_UI_02 = typeBlock("ui", "02");            // 11px/16px/500
+
+// Caption
+export const TYPE_CAPTION_01 = typeBlock("caption", "01");  // 11px/16px/400
+
+// Badge
+export const TYPE_BADGE_01 = typeBlock("badge", "01");      // 14px/20px/400
+
+// Code
+export const TYPE_CODE_01 = typeBlock("code", "01");        // 14px/20px/400
+export const TYPE_CODE_02 = typeBlock("code", "02");        // 12px/16px/400

--- a/packages/foundation/src/tokens.ts
+++ b/packages/foundation/src/tokens.ts
@@ -190,6 +190,31 @@ export function typeVar<G extends TypographyGroup>(
   return `var(--fd-type-${toKebab(group)}-${key}-${prop})`;
 }
 
+/**
+ * Returns a CSS block with font-family, font-size, line-height, and font-weight
+ * properties as `var()` references for a typography token.
+ *
+ * Usage in template literals:
+ * ```ts
+ * ${typeBlock("body", "02")}
+ * // → font-family: var(--fd-type-body-02-font-family);
+ * //   font-size: var(--fd-type-body-02-font-size);
+ * //   line-height: var(--fd-type-body-02-line-height);
+ * //   font-weight: var(--fd-type-body-02-font-weight);
+ * ```
+ */
+export function typeBlock<G extends TypographyGroup>(
+  group: G,
+  key: TypographyKey<G>,
+): string {
+  return [
+    `font-family: ${typeVar(group, key, "font-family")};`,
+    `font-size: ${typeVar(group, key, "font-size")};`,
+    `line-height: ${typeVar(group, key, "line-height")};`,
+    `font-weight: ${typeVar(group, key, "font-weight")};`,
+  ].join("\n    ");
+}
+
 // ---------------------------------------------------------------------------
 // Spacing → CSS custom properties
 // ---------------------------------------------------------------------------

--- a/packages/ui-components/src/components/ui-accordion-item.ts
+++ b/packages/ui-components/src/components/ui-accordion-item.ts
@@ -11,6 +11,7 @@ import {
   BORDER_MODERATE,
   BW_MD,
   DISABLED_TEXT,
+  FONT_PRIMARY,
   HOVER_MINIMAL,
   ICON_PRIMARY,
   SP_1,
@@ -23,6 +24,9 @@ import {
   STATUS_GENERAL_SUCCESS,
   STATUS_GENERAL_WARNING,
   TEXT_PRIMARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
 } from "@maneki/foundation";
 import "./ui-icon.js";
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -61,7 +65,7 @@ const STYLES = /* css */ `
     width: 100%;
     padding: 0;
     margin: 0;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     color: var(--ui-acc-label-color, ${TEXT_PRIMARY});
     transition: background 0.15s ease;
   }
@@ -162,7 +166,7 @@ const STYLES = /* css */ `
     grid-template-rows: 0fr;
     transition: grid-template-rows 0.2s ease;
     color: var(--ui-acc-content-color, ${TEXT_PRIMARY});
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     font-weight: 400;
   }
   :host([expanded]) .content {
@@ -189,8 +193,7 @@ const STYLES = /* css */ `
 
   :host .label,
   :host([size="m"]) .label {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host .leading-icon,
@@ -217,8 +220,7 @@ const STYLES = /* css */ `
   :host([size="m"]) .content-body {
     padding-top: ${SP_1_5};
     padding-bottom: ${SP_2_5};
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
   /* ── Size: s ────────────────────────────────────────────────────────────── */
 
@@ -232,8 +234,7 @@ const STYLES = /* css */ `
   }
 
   :host([size="s"]) .label {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .leading-icon {
@@ -256,8 +257,7 @@ const STYLES = /* css */ `
   :host([size="s"]) .content-body {
     padding-top: ${SP_1};
     padding-bottom: ${SP_2};
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
   /* ── Size: l ────────────────────────────────────────────────────────────── */
 
@@ -271,8 +271,7 @@ const STYLES = /* css */ `
   }
 
   :host([size="l"]) .label {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .leading-icon {
@@ -295,8 +294,7 @@ const STYLES = /* css */ `
   :host([size="l"]) .content-body {
     padding-top: ${SP_1_5};
     padding-bottom: ${SP_3};
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
   /* ── Disabled ───────────────────────────────────────────────────────────── */
 

--- a/packages/ui-components/src/components/ui-alert.ts
+++ b/packages/ui-components/src/components/ui-alert.ts
@@ -12,6 +12,7 @@ export type AlertStatus =
   | "warning";
 
 import {
+  FONT_PRIMARY,
   RADIUS_SM,
   SP_1,
   SP_1_5,
@@ -48,6 +49,9 @@ import {
   STATUS_TEXT_SUCCESS_SUBTLE,
   STATUS_TEXT_WARNING_BOLD,
   STATUS_TEXT_WARNING_SUBTLE,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
 } from "@maneki/foundation";
 import "./ui-icon.js";
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -75,7 +79,7 @@ const STYLES = /* css */ `
     display: flex;
     flex-direction: column;
     border-radius: ${RADIUS_SM};
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   /* ── Top content ─────────────────────────────────────────────────────────── */
@@ -191,14 +195,12 @@ const STYLES = /* css */ `
 
   :host .title,
   :host([size="m"]) .title {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host .description,
   :host([size="m"]) .description {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host .leading-icon,
@@ -221,13 +223,11 @@ const STYLES = /* css */ `
   }
 
   :host([size="s"]) .title {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .description {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .leading-icon {
@@ -248,13 +248,11 @@ const STYLES = /* css */ `
   }
 
   :host([size="l"]) .title {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .description {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .leading-icon {

--- a/packages/ui-components/src/components/ui-avatar.ts
+++ b/packages/ui-components/src/components/ui-avatar.ts
@@ -2,6 +2,7 @@
 import {
   AQUA_60,
   BLUE_60,
+  FONT_PRIMARY,
   GRAY_20,
   GRAY_60,
   GRAY_80,
@@ -22,6 +23,10 @@ import {
   SP_6,
   TEAL_60,
   TURQUOISE_60,
+  TYPE_BODY_01,
+  TYPE_BODY_03,
+  TYPE_HEADING_04,
+  TYPE_UI_01,
   ULTRAMARINE_60,
   YELLOW_30,
 } from "@maneki/foundation";
@@ -74,7 +79,7 @@ const STYLES = /* css */ `
     align-items: center;
     justify-content: center;
     overflow: hidden;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     font-weight: 500;
     color: #ffffff;
   }
@@ -157,8 +162,7 @@ const STYLES = /* css */ `
 
   :host .text,
   :host([size="m"]) .text {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host .icon,
@@ -194,8 +198,7 @@ const STYLES = /* css */ `
   }
 
   :host([size="s"]) .text {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .icon {
@@ -212,8 +215,7 @@ const STYLES = /* css */ `
   }
 
   :host([size="l"]) .text {
-    font-size: 20px;
-    line-height: 28px;
+    ${TYPE_HEADING_04}
   }
 
   :host([size="l"]) .icon {
@@ -230,8 +232,7 @@ const STYLES = /* css */ `
   }
 
   :host([size="xl"]) .text {
-    font-size: 24px;
-    line-height: 32px;
+    ${TYPE_UI_01}
   }
 
   :host([size="xl"]) .icon {

--- a/packages/ui-components/src/components/ui-badge.ts
+++ b/packages/ui-components/src/components/ui-badge.ts
@@ -2,6 +2,7 @@ import {
   AQUA_60,
   BLUE_60,
   BORDER_MODERATE,
+  FONT_PRIMARY,
   GRAY_60,
   GREEN_60,
   LIME_60,
@@ -21,6 +22,9 @@ import {
   TEXT_PRIMARY,
   TEXT_SECONDARY,
   TURQUOISE_60,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
+  TYPE_CAPTION_01,
   ULTRAMARINE_60,
   YELLOW_30,
 } from "@maneki/foundation";
@@ -69,7 +73,7 @@ export const STYLES = /* css */ `
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     font-weight: 500;
     text-transform: uppercase;
     white-space: nowrap;
@@ -79,8 +83,7 @@ export const STYLES = /* css */ `
 
   :host .base,
   :host([size="m"]) .base {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
     padding: ${SP_0_25} ${SP_1};
   }
 
@@ -95,16 +98,14 @@ export const STYLES = /* css */ `
   /* ── Size: s ─────────────────────────────────────────────────────────────── */
 
   :host([size="s"]) .base {
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
     padding: 0 ${SP_0_75};
   }
 
   /* ── Size: l ─────────────────────────────────────────────────────────────── */
 
   :host([size="l"]) .base {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
     padding: ${SP_0_5} ${SP_1_25};
   }
 

--- a/packages/ui-components/src/components/ui-breadcrumb-item.ts
+++ b/packages/ui-components/src/components/ui-breadcrumb-item.ts
@@ -1,5 +1,6 @@
 
 import {
+  FONT_PRIMARY,
   ICON_PRIMARY,
   SP_0_25,
   SP_0_5,
@@ -9,6 +10,9 @@ import {
   TEXT_PRIMARY,
   TEXT_TERTIARY,
   TEXT_VISITED,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
 } from "@maneki/foundation";
 import "./ui-icon.js";
 
@@ -27,7 +31,7 @@ const STYLES = /* css */ `
   :host {
     display: inline-flex;
     align-items: center;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   .base {
@@ -96,8 +100,7 @@ const STYLES = /* css */ `
 
   :host .link,
   :host([size="m"]) .link {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
     padding-left: ${SP_0_25};
     padding-right: ${SP_0_25};
   }
@@ -117,8 +120,7 @@ const STYLES = /* css */ `
   /* ── Size: s ────────────────────────────────────────────────────────────── */
 
   :host([size="s"]) .link {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
     padding-left: ${SP_0_25};
     padding-right: ${SP_0_25};
   }
@@ -136,8 +138,7 @@ const STYLES = /* css */ `
   /* ── Size: l ────────────────────────────────────────────────────────────── */
 
   :host([size="l"]) .link {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
     padding-left: ${SP_0_25};
     padding-right: ${SP_0_25};
   }

--- a/packages/ui-components/src/components/ui-button.ts
+++ b/packages/ui-components/src/components/ui-button.ts
@@ -33,6 +33,9 @@ import {
   SURFACE_SUCCESS,
   SURFACE_TERTIARY,
   TEXT_PRIMARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
 } from "@maneki/foundation";
 import "./ui-icon.js";
 const WHITE = "#ffffff";
@@ -75,8 +78,7 @@ const STYLES = /* css */ `
 
   :host button,
   :host([size="m"]) button {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
     padding: ${SP_0_75} ${SP_2};
   }
 
@@ -88,8 +90,7 @@ const STYLES = /* css */ `
   /* ── Size: s ─────────────────────────────────────────────────────────────── */
 
   :host([size="s"]) button {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
     padding: ${SP_0_5} ${SP_1_5};
   }
 
@@ -100,8 +101,7 @@ const STYLES = /* css */ `
   /* ── Size: l ─────────────────────────────────────────────────────────────── */
 
   :host([size="l"]) button {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
     padding: ${SP_1} ${SP_3};
   }
 
@@ -112,8 +112,7 @@ const STYLES = /* css */ `
   /* ── Size: xl ────────────────────────────────────────────────────────────── */
 
   :host([size="xl"]) button {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
     padding: ${SP_1_5} ${SP_4};
   }
 

--- a/packages/ui-components/src/components/ui-calendar-quicklinks.styles.ts
+++ b/packages/ui-components/src/components/ui-calendar-quicklinks.styles.ts
@@ -9,6 +9,10 @@ import {
   SURFACE_SECONDARY,
   TEXT_PRIMARY,
   TEXT_SECONDARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
+  TYPE_CAPTION_01,
 } from "@maneki/foundation";
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -157,8 +161,7 @@ export const STYLES = /* css */ `
   :host([size="s"]) .link {
     height: 24px;
     padding: 0 8px;
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .section {
@@ -198,16 +201,14 @@ export const STYLES = /* css */ `
   :host(:not([size])) .link {
     height: 32px;
     padding: 0 12px;
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="m"]) .section,
   :host(:not([size])) .section {
     height: 24px;
     padding: 0 12px;
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
   }
 
   /* ═══════════════════════════════════════════════════════════════════════════ */
@@ -235,14 +236,12 @@ export const STYLES = /* css */ `
   :host([size="l"]) .link {
     height: 40px;
     padding: 0 16px;
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .section {
     height: 28px;
     padding: 0 16px;
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 `;

--- a/packages/ui-components/src/components/ui-calendar-time.styles.ts
+++ b/packages/ui-components/src/components/ui-calendar-time.styles.ts
@@ -9,6 +9,9 @@ import {
   SP_1_25,
   SURFACE_PRIMARY,
   TEXT_PRIMARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
 } from "@maneki/foundation";
 
 export const SELECTED_SUBTLE = "rgba(173, 204, 247, 1)"; // #ADCCF7 — switch track
@@ -150,13 +153,11 @@ export const STYLES = /* css */ `
   :host([size="s"]) .time-input {
     width: 28px;
     height: 24px;
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .colon {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .toggle-group {
@@ -164,8 +165,7 @@ export const STYLES = /* css */ `
   }
 
   :host([size="s"]) .toggle-label {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .switch {
@@ -201,14 +201,12 @@ export const STYLES = /* css */ `
   :host(:not([size])) .time-input {
     width: 36px;
     height: 32px;
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="m"]) .colon,
   :host(:not([size])) .colon {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="m"]) .toggle-group,
@@ -218,8 +216,7 @@ export const STYLES = /* css */ `
 
   :host([size="m"]) .toggle-label,
   :host(:not([size])) .toggle-label {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="m"]) .switch,
@@ -255,13 +252,11 @@ export const STYLES = /* css */ `
   :host([size="l"]) .time-input {
     width: 44px;
     height: 40px;
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .colon {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .toggle-group {
@@ -269,8 +264,7 @@ export const STYLES = /* css */ `
   }
 
   :host([size="l"]) .toggle-label {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .switch {

--- a/packages/ui-components/src/components/ui-calendar.styles.ts
+++ b/packages/ui-components/src/components/ui-calendar.styles.ts
@@ -19,6 +19,10 @@ import {
   TEXT_PRIMARY,
   TEXT_SECONDARY,
   TEXT_TERTIARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
+  TYPE_CAPTION_01,
 } from "@maneki/foundation";
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -262,8 +266,7 @@ export const STYLES = /* css */ `
   }
 
   .legend-label {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
     color: ${TEXT_PRIMARY};
   }
 
@@ -289,8 +292,7 @@ export const STYLES = /* css */ `
 
   :host([size="s"]) .header-label {
     height: 16px;
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .dow-row,
@@ -300,20 +302,17 @@ export const STYLES = /* css */ `
 
   :host([size="s"]) .dow-cell {
     height: 16px;
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
   }
 
   :host([size="s"]) .day-cell {
     height: 28px;
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .month-cell {
     height: 28px;
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .month-grid {
@@ -351,8 +350,7 @@ export const STYLES = /* css */ `
   :host([size="m"]) .header-label,
   :host(:not([size])) .header-label {
     height: 20px;
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="m"]) .dow-row,
@@ -365,22 +363,19 @@ export const STYLES = /* css */ `
   :host([size="m"]) .dow-cell,
   :host(:not([size])) .dow-cell {
     height: 16px;
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
   }
 
   :host([size="m"]) .day-cell,
   :host(:not([size])) .day-cell {
     height: 36px;
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="m"]) .month-cell,
   :host(:not([size])) .month-cell {
     height: 36px;
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="m"]) .month-grid,
@@ -416,8 +411,7 @@ export const STYLES = /* css */ `
 
   :host([size="l"]) .header-label {
     height: 24px;
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .dow-row,
@@ -427,20 +421,17 @@ export const STYLES = /* css */ `
 
   :host([size="l"]) .dow-cell {
     height: 20px;
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="l"]) .day-cell {
     height: 44px;
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .month-cell {
     height: 44px;
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .month-grid {

--- a/packages/ui-components/src/components/ui-card.ts
+++ b/packages/ui-components/src/components/ui-card.ts
@@ -5,6 +5,7 @@ import {
   ELEVATION_01,
   ELEVATION_02,
   ELEVATION_04,
+  FONT_PRIMARY,
   RADIUS_NONE,
   RADIUS_SM,
   SP_1,
@@ -31,7 +32,7 @@ const STYLES = /* css */ `
 
   :host {
     display: block;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   /* ── Base ─────────────────────────────────────────────────────────────────── */

--- a/packages/ui-components/src/components/ui-checkbox-item.ts
+++ b/packages/ui-components/src/components/ui-checkbox-item.ts
@@ -5,6 +5,7 @@ import {
   DISABLED_BORDER,
   DISABLED_MINIMAL,
   DISABLED_TEXT,
+  FONT_PRIMARY,
   FORM_INPUT_BORDER,
   HOVER_BORDER_MODERATE,
   RADIUS_SM,
@@ -14,6 +15,9 @@ import {
   STATUS_GENERAL_ERROR,
   STATUS_SURFACE_ERROR_BOLD,
   TEXT_PRIMARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
 } from "@maneki/foundation";
 import "./ui-icon.js";
 import type { UiIcon } from "./ui-icon.js";
@@ -103,7 +107,7 @@ const STYLES = /* css */ `
 
   .label {
     display: none;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     font-weight: 400;
     color: var(--ui-cb-label-color, ${TEXT_PRIMARY});
   }
@@ -147,8 +151,7 @@ const STYLES = /* css */ `
 
   :host .label,
   :host([size="m"]) .label {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host .indeterminate-icon,
@@ -178,8 +181,7 @@ const STYLES = /* css */ `
   }
 
   :host([size="s"]) .label {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .indeterminate-icon {
@@ -207,8 +209,7 @@ const STYLES = /* css */ `
   }
 
   :host([size="l"]) .label {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .indeterminate-icon {

--- a/packages/ui-components/src/components/ui-clock.styles.ts
+++ b/packages/ui-components/src/components/ui-clock.styles.ts
@@ -12,6 +12,9 @@ import {
   SURFACE_PRIMARY,
   SURFACE_SECONDARY,
   TEXT_PRIMARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
 } from "@maneki/foundation";
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -194,8 +197,7 @@ export const STYLES = /* css */ `
   :host([size="s"]) .clock-number {
     width: 24px;
     height: 24px;
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .digital-container {
@@ -216,13 +218,11 @@ export const STYLES = /* css */ `
   :host([size="s"]) .digital-input {
     width: 56px;
     height: 24px;
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .digital-label {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
     width: 56px;
   }
 
@@ -245,8 +245,7 @@ export const STYLES = /* css */ `
   :host(:not([size])) .clock-number {
     width: 28px;
     height: 28px;
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="m"]) .digital-container,
@@ -271,14 +270,12 @@ export const STYLES = /* css */ `
   :host(:not([size])) .digital-input {
     width: 70px;
     height: 32px;
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="m"]) .digital-label,
   :host(:not([size])) .digital-label {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
     width: 70px;
   }
 
@@ -298,8 +295,7 @@ export const STYLES = /* css */ `
   :host([size="l"]) .clock-number {
     width: 32px;
     height: 32px;
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .digital-container {
@@ -320,13 +316,11 @@ export const STYLES = /* css */ `
   :host([size="l"]) .digital-input {
     width: 80px;
     height: 40px;
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .digital-label {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
     width: 80px;
   }
 `;

--- a/packages/ui-components/src/components/ui-datetime-picker-input.styles.ts
+++ b/packages/ui-components/src/components/ui-datetime-picker-input.styles.ts
@@ -15,6 +15,10 @@ import {
   TEXT_PRIMARY,
   TEXT_SECONDARY,
   TEXT_TERTIARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
+  TYPE_CAPTION_01,
 } from "@maneki/foundation";
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -227,8 +231,7 @@ export const STYLES = /* css */ `
 
   .supportive {
     display: none;
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
     color: ${TEXT_SECONDARY};
   }
 
@@ -261,8 +264,7 @@ export const STYLES = /* css */ `
   }
 
   :host([size="s"]) .content {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .spin-btn {
@@ -290,8 +292,7 @@ export const STYLES = /* css */ `
 
   :host([size="m"]) .content,
   :host(:not([size])) .content {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="m"]) .spin-btn,
@@ -316,8 +317,7 @@ export const STYLES = /* css */ `
   }
 
   :host([size="l"]) .content {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .spin-btn {

--- a/packages/ui-components/src/components/ui-dropdown-heading.ts
+++ b/packages/ui-components/src/components/ui-dropdown-heading.ts
@@ -5,6 +5,9 @@ import {
   SP_2,
   SP_3,
   TEXT_SECONDARY,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
+  TYPE_CAPTION_01,
 } from "@maneki/foundation";
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -33,24 +36,21 @@ const STYLES = /* css */ `
 
   :host .heading,
   :host([size="m"]) .heading {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
     padding: ${SP_0_5} ${SP_2};
   }
 
   /* ── Size: s ────────────────────────────────────────────────────────────── */
 
   :host([size="s"]) .heading {
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
     padding: ${SP_0_5} ${SP_1_5};
   }
 
   /* ── Size: l ────────────────────────────────────────────────────────────── */
 
   :host([size="l"]) .heading {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
     padding: ${SP_1} ${SP_3};
   }
 `;

--- a/packages/ui-components/src/components/ui-dropdown-item.styles.ts
+++ b/packages/ui-components/src/components/ui-dropdown-item.styles.ts
@@ -16,6 +16,10 @@ import {
   TEXT_PRIMARY,
   TEXT_SECONDARY,
   TEXT_SELECTED,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
+  TYPE_CAPTION_01,
 } from "@maneki/foundation";
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -79,8 +83,7 @@ export const STYLES = /* css */ `
 
   :host .item,
   :host([size="m"]) .item {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
     padding: ${SP_0_75} ${SP_2};
     gap: ${SP_1};
   }
@@ -93,14 +96,12 @@ export const STYLES = /* css */ `
 
   :host .secondary,
   :host([size="m"]) .secondary {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host .description,
   :host([size="m"]) .description {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host .submenu,
@@ -112,8 +113,7 @@ export const STYLES = /* css */ `
   /* ── Size: s ────────────────────────────────────────────────────────────── */
 
   :host([size="s"]) .item {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
     padding: ${SP_0_75} ${SP_1_5};
     gap: ${SP_1};
   }
@@ -124,13 +124,11 @@ export const STYLES = /* css */ `
   }
 
   :host([size="s"]) .secondary {
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
   }
 
   :host([size="s"]) .description {
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
   }
 
   :host([size="s"]) .submenu {
@@ -141,8 +139,7 @@ export const STYLES = /* css */ `
   /* ── Size: l ────────────────────────────────────────────────────────────── */
 
   :host([size="l"]) .item {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
     padding: ${SP_1_25} ${SP_2} ${SP_1_25} ${SP_3};
     gap: ${SP_1_5};
   }
@@ -153,13 +150,11 @@ export const STYLES = /* css */ `
   }
 
   :host([size="l"]) .secondary {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="l"]) .description {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="l"]) .submenu {

--- a/packages/ui-components/src/components/ui-dropdown-split.styles.ts
+++ b/packages/ui-components/src/components/ui-dropdown-split.styles.ts
@@ -23,6 +23,9 @@ import {
   SURFACE_PRIMARY,
   SURFACE_TERTIARY,
   TEXT_PRIMARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
 } from "@maneki/foundation";
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -110,8 +113,7 @@ export const STYLES = /* css */ `
 
   :host .left,
   :host([size="m"]) .left {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
     padding: ${SP_0_75} ${SP_1_5} ${SP_0_75} ${SP_2};
   }
 
@@ -133,8 +135,7 @@ export const STYLES = /* css */ `
   /* ── Size: s ────────────────────────────────────────────────────────────── */
 
   :host([size="s"]) .left {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
     padding: ${SP_0_5} ${SP_1};
   }
 
@@ -153,8 +154,7 @@ export const STYLES = /* css */ `
   /* ── Size: l ────────────────────────────────────────────────────────────── */
 
   :host([size="l"]) .left {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
     padding: ${SP_1} ${SP_2} ${SP_1} ${SP_2_5};
   }
 
@@ -173,8 +173,7 @@ export const STYLES = /* css */ `
   /* ── Size: xl ───────────────────────────────────────────────────────────── */
 
   :host([size="xl"]) .left {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
     padding: ${SP_1_5} ${SP_4};
   }
 

--- a/packages/ui-components/src/components/ui-file-upload.ts
+++ b/packages/ui-components/src/components/ui-file-upload.ts
@@ -2,6 +2,7 @@ import {
   BORDER_FOCUS,
   DISABLED_BORDER,
   DISABLED_TEXT,
+  FONT_PRIMARY,
   FORM_INPUT_BORDER,
   HOVER_BORDER_MODERATE,
   SP_1,
@@ -26,7 +27,7 @@ const STYLES = /* css */ `
 
   :host {
     display: inline-flex;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   .wrapper {

--- a/packages/ui-components/src/components/ui-input-group.ts
+++ b/packages/ui-components/src/components/ui-input-group.ts
@@ -1,6 +1,7 @@
 import {
   BORDER_FOCUS,
   BW_SM,
+  FONT_PRIMARY,
   FORM_INPUT_BORDER,
   HOVER_BORDER_MODERATE,
   RADIUS_SM,
@@ -26,7 +27,7 @@ const STYLES = /* css */ `
 
   :host {
     display: inline-flex;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   .wrapper {

--- a/packages/ui-components/src/components/ui-input.styles.ts
+++ b/packages/ui-components/src/components/ui-input.styles.ts
@@ -4,6 +4,7 @@ import {
   BW_SM,
   DISABLED_BORDER,
   DISABLED_TEXT,
+  FONT_PRIMARY,
   FORM_INPUT_BORDER,
   HOVER_BORDER_MODERATE,
   ICON_PRIMARY,
@@ -18,6 +19,7 @@ import {
   TEXT_PRIMARY,
   TEXT_SECONDARY,
   TEXT_TERTIARY,
+  TYPE_CAPTION_01,
 } from "@maneki/foundation";
 
 // ─── Status icon map ─────────────────────────────────────────────────────────
@@ -42,7 +44,7 @@ export const STYLES = /* css */ `
     display: inline-flex;
     flex-direction: column;
     gap: ${SP_0_5};
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   /* ── Label row ─────────────────────────────────────────────────────────── */
@@ -252,8 +254,7 @@ export const STYLES = /* css */ `
 
   .supportive-text {
     display: none;
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
     color: var(--ui-input-supportive-color, ${TEXT_SECONDARY});
   }
 

--- a/packages/ui-components/src/components/ui-label.ts
+++ b/packages/ui-components/src/components/ui-label.ts
@@ -1,5 +1,6 @@
 import {
   DISABLED_TEXT,
+  FONT_PRIMARY,
   SP_0_25,
   STATUS_GENERAL_ERROR,
   TEXT_SECONDARY,
@@ -21,7 +22,7 @@ export const STYLES = /* css */ `
   :host {
     display: inline-flex;
     align-items: baseline;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     color: var(--ui-label-color, ${TEXT_SECONDARY});
   }
 

--- a/packages/ui-components/src/components/ui-link.ts
+++ b/packages/ui-components/src/components/ui-link.ts
@@ -1,4 +1,5 @@
 import {
+  FONT_PRIMARY,
   SP_0_25,
   SP_0_5,
   TEXT_LINK,
@@ -46,7 +47,7 @@ const STYLES = /* css */ `
   :host {
     display: inline-flex;
     align-items: center;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   /* ── Link element ─────────────────────────────────────────────────────────── */

--- a/packages/ui-components/src/components/ui-list-header.styles.ts
+++ b/packages/ui-components/src/components/ui-list-header.styles.ts
@@ -3,6 +3,8 @@ import {
   BW_SM,
   ICON_PRIMARY,
   TEXT_PRIMARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
 } from "@maneki/foundation";
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -83,8 +85,7 @@ export const STYLES = /* css */ `
   }
 
   :host([size="s"]) .heading {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="s"]) .collapse-btn {
@@ -105,8 +106,7 @@ export const STYLES = /* css */ `
 
   :host([size="m"]) .heading,
   :host(:not([size])) .heading {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="m"]) .collapse-btn,
@@ -126,8 +126,7 @@ export const STYLES = /* css */ `
   }
 
   :host([size="l"]) .heading {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .collapse-btn {

--- a/packages/ui-components/src/components/ui-list-item.styles.ts
+++ b/packages/ui-components/src/components/ui-list-item.styles.ts
@@ -11,6 +11,10 @@ import {
   SP_2,
   TEXT_PRIMARY,
   TEXT_SECONDARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
+  TYPE_CAPTION_01,
 } from "@maneki/foundation";
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -186,13 +190,11 @@ export const STYLES = /* css */ `
   }
 
   :host([size="s"]) .primary-text {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .description {
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
   }
 
   :host([size="s"]) .leading {
@@ -243,14 +245,12 @@ export const STYLES = /* css */ `
 
   :host([size="m"]) .primary-text,
   :host(:not([size])) .primary-text {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="m"]) .description,
   :host(:not([size])) .description {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="m"]) .leading,
@@ -302,13 +302,11 @@ export const STYLES = /* css */ `
   }
 
   :host([size="l"]) .primary-text {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .description {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="l"]) .leading {

--- a/packages/ui-components/src/components/ui-metric-group.ts
+++ b/packages/ui-components/src/components/ui-metric-group.ts
@@ -10,6 +10,7 @@ import {
   SP_3,
   SP_4,
   TEXT_SECONDARY,
+  TYPE_HEADING_07,
 } from "@maneki/foundation";
 import type { MetricSize } from "./ui-metric.js";
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -56,10 +57,7 @@ const STYLES = /* css */ `
 
   .title {
     display: none;
-    font-family: "Geist", sans-serif;
-    font-size: 12px;
-    line-height: 16px;
-    font-weight: 500;
+    ${TYPE_HEADING_07}
     text-transform: uppercase;
     color: ${TEXT_SECONDARY};
     white-space: nowrap;

--- a/packages/ui-components/src/components/ui-metric.styles.ts
+++ b/packages/ui-components/src/components/ui-metric.styles.ts
@@ -1,5 +1,6 @@
 import {
   ACTIVE_SUBTLE,
+  FONT_PRIMARY,
   GREEN_60,
   HOVER_MINIMAL,
   RADIUS_SM,
@@ -12,6 +13,11 @@ import {
   SP_2,
   TEXT_PRIMARY,
   TEXT_SECONDARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
+  TYPE_HEADING_02,
+  TYPE_HEADING_04,
 } from "@maneki/foundation";
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -33,7 +39,7 @@ export const STYLES = /* css */ `
     display: flex;
     align-items: flex-start;
     border-radius: ${RADIUS_SM};
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   /* Vertical orientation (default) */
@@ -87,9 +93,7 @@ export const STYLES = /* css */ `
   }
 
   .label {
-    font-size: 12px;
-    line-height: 16px;
-    font-weight: 400;
+    ${TYPE_BODY_03}
     color: ${TEXT_SECONDARY};
     white-space: nowrap;
   }
@@ -146,9 +150,7 @@ export const STYLES = /* css */ `
     display: flex;
     align-items: center;
     gap: ${SP_0_5};
-    font-size: 12px;
-    line-height: 16px;
-    font-weight: 400;
+    ${TYPE_BODY_03}
     white-space: nowrap;
   }
 
@@ -214,8 +216,7 @@ export const STYLES = /* css */ `
   }
 
   :host([size="xs"]) .value {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="xs"]) .delta-arrow {
@@ -252,8 +253,7 @@ export const STYLES = /* css */ `
 
   :host .value,
   :host([size="s"]) .value {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host .delta-arrow,
@@ -289,8 +289,7 @@ export const STYLES = /* css */ `
   }
 
   :host([size="m"]) .value {
-    font-size: 20px;
-    line-height: 28px;
+    ${TYPE_HEADING_04}
   }
 
   :host([size="m"]) .delta-arrow {
@@ -313,8 +312,7 @@ export const STYLES = /* css */ `
   }
 
   :host([size="m"][orientation="horizontal"]) .label {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   /* ── Size: l ─────────────────────────────────────────────────────────────── */
@@ -332,8 +330,7 @@ export const STYLES = /* css */ `
   }
 
   :host([size="l"]) .value {
-    font-size: 32px;
-    line-height: 40px;
+    ${TYPE_HEADING_02}
   }
 
   :host([size="l"]) .delta-arrow {

--- a/packages/ui-components/src/components/ui-metric.test.ts
+++ b/packages/ui-components/src/components/ui-metric.test.ts
@@ -253,43 +253,27 @@ describe("ui-metric", () => {
 
   // ── Size CSS: xs ──────────────────────────────────────────────────────────
 
-  it("CSS sets xs value font-size to 14px", () => {
+  it("CSS sets xs value typography token (body-02)", () => {
     expect(STYLES).toContain(':host([size="xs"]) .value');
-    expect(STYLES).toMatch(/\:host\(\[size="xs"\]\) \.value\s*\{[^}]*font-size:\s*14px/);
-  });
-
-  it("CSS sets xs value line-height to 20px", () => {
-    expect(STYLES).toMatch(/\:host\(\[size="xs"\]\) \.value\s*\{[^}]*line-height:\s*20px/);
+    expect(STYLES).toMatch(/\:host\(\[size="xs"\]\) \.value\s*\{[^}]*var\(--fd-type-body-02-font-size\)/);
   });
 
   // ── Size CSS: s ───────────────────────────────────────────────────────────
 
-  it("CSS sets s value font-size to 16px", () => {
-    expect(STYLES).toMatch(/\:host\(\[size="s"\]\) \.value\s*\{[^}]*font-size:\s*16px/);
-  });
-
-  it("CSS sets s value line-height to 24px", () => {
-    expect(STYLES).toMatch(/\:host\(\[size="s"\]\) \.value\s*\{[^}]*line-height:\s*24px/);
+  it("CSS sets s value typography token (body-01)", () => {
+    expect(STYLES).toMatch(/\:host\(\[size="s"\]\) \.value\s*\{[^}]*var\(--fd-type-body-01-font-size\)/);
   });
 
   // ── Size CSS: m ───────────────────────────────────────────────────────────
 
-  it("CSS sets m value font-size to 20px", () => {
-    expect(STYLES).toMatch(/\:host\(\[size="m"\]\) \.value\s*\{[^}]*font-size:\s*20px/);
-  });
-
-  it("CSS sets m value line-height to 28px", () => {
-    expect(STYLES).toMatch(/\:host\(\[size="m"\]\) \.value\s*\{[^}]*line-height:\s*28px/);
+  it("CSS sets m value typography token (heading-04)", () => {
+    expect(STYLES).toMatch(/\:host\(\[size="m"\]\) \.value\s*\{[^}]*var\(--fd-type-heading-04-font-size\)/);
   });
 
   // ── Size CSS: l ───────────────────────────────────────────────────────────
 
-  it("CSS sets l value font-size to 32px", () => {
-    expect(STYLES).toMatch(/\:host\(\[size="l"\]\) \.value\s*\{[^}]*font-size:\s*32px/);
-  });
-
-  it("CSS sets l value line-height to 40px", () => {
-    expect(STYLES).toMatch(/\:host\(\[size="l"\]\) \.value\s*\{[^}]*line-height:\s*40px/);
+  it("CSS sets l value typography token (heading-02)", () => {
+    expect(STYLES).toMatch(/\:host\(\[size="l"\]\) \.value\s*\{[^}]*var\(--fd-type-heading-02-font-size\)/);
   });
 
   // ── Orientation attribute ─────────────────────────────────────────────────

--- a/packages/ui-components/src/components/ui-modal.ts
+++ b/packages/ui-components/src/components/ui-modal.ts
@@ -1,6 +1,7 @@
 
 import {
   ELEVATION_06,
+  FONT_PRIMARY,
   ICON_PRIMARY,
   RADIUS_SM,
   SP_1,
@@ -13,6 +14,11 @@ import {
   SURFACE_PRIMARY,
   TEXT_PRIMARY,
   TEXT_SECONDARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
+  TYPE_CAPTION_01,
+  TYPE_HEADING_04,
 } from "@maneki/foundation";
 import "./ui-icon.js";
 
@@ -61,7 +67,7 @@ const STYLES = /* css */ `
     background-color: var(--ui-modal-bg, ${SURFACE_PRIMARY});
     box-shadow: var(--ui-modal-shadow, ${ELEVATION_06});
     border-radius: ${RADIUS_SM};
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     color: ${TEXT_PRIMARY};
     width: var(--ui-modal-width, 441px);
     opacity: 0;
@@ -128,8 +134,7 @@ const STYLES = /* css */ `
     display: none;
     color: ${TEXT_SECONDARY};
     font-weight: 400;
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
   }
 
   :host([has-subtitle]) .subtitle {
@@ -201,14 +206,12 @@ const STYLES = /* css */ `
 
   :host .title,
   :host([size="m"]) .title {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host .body,
   :host([size="m"]) .body {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host .close-btn,
@@ -228,13 +231,11 @@ const STYLES = /* css */ `
   }
 
   :host([size="s"]) .title {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="s"]) .body {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .close-btn {
@@ -253,13 +254,11 @@ const STYLES = /* css */ `
   }
 
   :host([size="l"]) .title {
-    font-size: 20px;
-    line-height: 28px;
+    ${TYPE_HEADING_04}
   }
 
   :host([size="l"]) .body {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="l"]) .close-btn {

--- a/packages/ui-components/src/components/ui-pagination.styles.ts
+++ b/packages/ui-components/src/components/ui-pagination.styles.ts
@@ -6,6 +6,7 @@ import {
   BW_MD,
   BW_SM,
   DISABLED_TEXT,
+  FONT_PRIMARY,
   HOVER_BOLD,
   RADIUS_SM,
   SELECTED_MINIMAL,
@@ -15,6 +16,8 @@ import {
   SP_2,
   SURFACE_PRIMARY,
   TEXT_PRIMARY,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
 } from "@maneki/foundation";
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -35,7 +38,7 @@ export const STYLES = /* css */ `
   :host {
     display: flex;
     align-items: center;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   /* ── Layout ──────────────────────────────────────────────────────────────── */
@@ -70,7 +73,7 @@ export const STYLES = /* css */ `
     border: none;
     background: transparent;
     cursor: pointer;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     font-weight: 400;
     color: ${TEXT_PRIMARY};
     padding: 0;
@@ -147,7 +150,7 @@ export const STYLES = /* css */ `
     border-color: ${BORDER_MODERATE};
     border-radius: ${RADIUS_SM};
     background: ${SURFACE_PRIMARY};
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     color: ${TEXT_PRIMARY};
     text-align: left;
   }
@@ -163,7 +166,7 @@ export const STYLES = /* css */ `
     border-color: ${BORDER_MODERATE};
     border-radius: ${RADIUS_SM};
     background: ${SURFACE_PRIMARY};
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     color: ${TEXT_PRIMARY};
     cursor: pointer;
     appearance: none;
@@ -189,8 +192,7 @@ export const STYLES = /* css */ `
   :host([size="m"]) .item {
     height: 32px;
     min-width: 32px;
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host .item.nav-btn,
@@ -227,8 +229,7 @@ export const STYLES = /* css */ `
   :host .page-status,
   :host([size="m"]) .goto,
   :host([size="m"]) .page-status {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host .goto-input,
@@ -236,8 +237,7 @@ export const STYLES = /* css */ `
     width: 48px;
     height: 32px;
     padding: 6px 8px;
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host .page-size-select,
@@ -245,8 +245,7 @@ export const STYLES = /* css */ `
     width: auto;
     height: 32px;
     padding: 6px 24px 6px 8px;
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   /* ── Size: s ─────────────────────────────────────────────────────────────── */
@@ -254,8 +253,7 @@ export const STYLES = /* css */ `
   :host([size="s"]) .item {
     height: 24px;
     min-width: 24px;
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .item.nav-btn {
@@ -284,24 +282,21 @@ export const STYLES = /* css */ `
 
   :host([size="s"]) .goto,
   :host([size="s"]) .page-status {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .goto-input {
     width: 40px;
     height: 24px;
     padding: 4px 8px;
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .page-size-select {
     width: auto;
     height: 24px;
     padding: 4px 20px 4px 8px;
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   /* ── Size: xs ────────────────────────────────────────────────────────────── */
@@ -309,8 +304,7 @@ export const STYLES = /* css */ `
   :host([size="xs"]) .item {
     height: 20px;
     min-width: 20px;
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="xs"]) .item.nav-btn {
@@ -339,23 +333,20 @@ export const STYLES = /* css */ `
 
   :host([size="xs"]) .goto,
   :host([size="xs"]) .page-status {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="xs"]) .goto-input {
     width: 32px;
     height: 20px;
     padding: 2px 8px;
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="xs"]) .page-size-select {
     width: auto;
     height: 20px;
     padding: 2px 18px 2px 8px;
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 `;

--- a/packages/ui-components/src/components/ui-person-group.ts
+++ b/packages/ui-components/src/components/ui-person-group.ts
@@ -1,5 +1,10 @@
 
-import { SP_1, TEXT_PRIMARY } from "@maneki/foundation";
+import {
+  FONT_PRIMARY,
+  SP_1,
+  TEXT_PRIMARY,
+  TYPE_BODY_01,
+} from "@maneki/foundation";
 import type { PersonItemSize } from "./ui-person-item.js";
 // ─── Styles ──────────────────────────────────────────────────────────────────
 
@@ -14,13 +19,12 @@ const STYLES = /* css */ `
     display: flex;
     flex-direction: column;
     width: 100%;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   .title {
     font-weight: 500;
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
     color: ${TEXT_PRIMARY};
     padding-bottom: ${SP_1};
   }

--- a/packages/ui-components/src/components/ui-person-item.styles.ts
+++ b/packages/ui-components/src/components/ui-person-item.styles.ts
@@ -1,6 +1,7 @@
 import {
   BORDER_SUBTLE,
   BW_SM,
+  FONT_PRIMARY,
   ICON_PRIMARY,
   SP_1,
   SP_1_25,
@@ -8,6 +9,8 @@ import {
   SP_2,
   TEXT_PRIMARY,
   TEXT_SECONDARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
 } from "@maneki/foundation";
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -30,7 +33,7 @@ export const STYLES = /* css */ `
     flex-direction: column;
     align-items: stretch;
     width: 100%;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   .wrapper {
@@ -62,16 +65,14 @@ export const STYLES = /* css */ `
     overflow: hidden;
     text-overflow: ellipsis;
     width: 100%;
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   .title,
   .location {
     font-weight: 400;
     color: ${TEXT_SECONDARY};
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
     white-space: nowrap;
   }
 

--- a/packages/ui-components/src/components/ui-popover.styles.ts
+++ b/packages/ui-components/src/components/ui-popover.styles.ts
@@ -1,4 +1,5 @@
 import {
+  FONT_PRIMARY,
   ICON_REVERSED,
   RADIUS_SM,
   SP_1,
@@ -7,6 +8,10 @@ import {
   SP_2_5,
   SURFACE_CONTRAST,
   TEXT_REVERSED,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
+  TYPE_HEADING_04,
 } from "@maneki/foundation";
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -28,7 +33,7 @@ export const STYLES = /* css */ `
     display: inline-flex;
     position: relative;
     width: fit-content;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   /* ── Popover panel ───────────────────────────────────────────────────────── */
@@ -132,14 +137,12 @@ export const STYLES = /* css */ `
 
   :host .title-text,
   :host([size="m"]) .title-text {
-    font-size: 20px;
-    line-height: 28px;
+    ${TYPE_HEADING_04}
   }
 
   :host .description-text,
   :host([size="m"]) .description-text {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host .close .material-symbols-outlined,
@@ -159,13 +162,11 @@ export const STYLES = /* css */ `
   }
 
   :host([size="s"]) .title-text {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="s"]) .description-text {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .close .material-symbols-outlined {

--- a/packages/ui-components/src/components/ui-popover.test.ts
+++ b/packages/ui-components/src/components/ui-popover.test.ts
@@ -222,16 +222,12 @@ describe("ui-popover", () => {
     expect(STYLES).toContain("font-size: 20px");
   });
 
-  it("styles contain size m description font-size 14px", () => {
-    expect(STYLES).toContain("font-size: 14px");
+  it("styles contain size m description typography token", () => {
+    expect(STYLES).toContain("var(--fd-type-body-02-font-size)");
   });
 
-  it("styles contain size s title font-size 16px", () => {
-    expect(STYLES).toContain("font-size: 16px");
-  });
-
-  it("styles contain size s description font-size 12px", () => {
-    expect(STYLES).toContain("font-size: 12px");
+  it("styles contain size s description typography token", () => {
+    expect(STYLES).toContain("var(--fd-type-body-03-font-size)");
   });
 
   // ── Placements ────────────────────────────────────────────────────────────

--- a/packages/ui-components/src/components/ui-progress-bar.styles.ts
+++ b/packages/ui-components/src/components/ui-progress-bar.styles.ts
@@ -1,5 +1,6 @@
 import {
   BLUE_40,
+  FONT_PRIMARY,
   GRAY_50,
   SP_0_5,
   SP_1,
@@ -20,6 +21,8 @@ import {
   STATUS_SURFACE_SUSPENDED_SUBTLE,
   STATUS_SURFACE_WARNING_BOLD,
   TEXT_PRIMARY,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
 } from "@maneki/foundation";
 
 // ─── Status color maps ─────────────────────────────────────────────────────────
@@ -95,7 +98,7 @@ export const BAR_STYLES = /* css */ `
   :host {
     display: block;
     width: 100%;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   .wrapper {
@@ -188,8 +191,7 @@ export const BAR_STYLES = /* css */ `
   }
 
   :host([size="s"]) .top-label {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .bar {
@@ -207,8 +209,7 @@ export const BAR_STYLES = /* css */ `
 
   :host .top-label,
   :host([size="m"]) .top-label {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host .bar,
@@ -223,8 +224,7 @@ export const BAR_STYLES = /* css */ `
 
   :host .inner-label,
   :host([size="m"]) .inner-label {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
     padding: ${SP_0_5} ${SP_1};
   }
 
@@ -248,8 +248,7 @@ export const BAR_STYLES = /* css */ `
   }
 
   :host([size="l"]) .inner-label {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
     padding: ${SP_0_5} ${SP_1};
   }
 

--- a/packages/ui-components/src/components/ui-progress-circle.ts
+++ b/packages/ui-components/src/components/ui-progress-circle.ts
@@ -1,8 +1,11 @@
 import {
+  FONT_PRIMARY,
   SP_0_5,
   SP_1,
   SP_3,
   TEXT_PRIMARY,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
 } from "@maneki/foundation";
 import { STATUS_FILL, STATUS_TRACK } from "./ui-progress-bar.styles.js";
 
@@ -19,7 +22,7 @@ export const CIRCLE_STYLES = /* css */ `
     display: inline-flex;
     flex-direction: column;
     align-items: center;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   .container {
@@ -69,8 +72,7 @@ export const CIRCLE_STYLES = /* css */ `
   }
 
   :host([size="s"]) .label {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   /* ── Size: M (default, 52px) ─────────────────────────────────────────────── */
@@ -83,14 +85,12 @@ export const CIRCLE_STYLES = /* css */ `
 
   :host .percentage,
   :host([size="m"]) .percentage {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host .label,
   :host([size="m"]) .label {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   /* ── Label positions ─────────────────────────────────────────────────────── */

--- a/packages/ui-components/src/components/ui-pull-to-refresh.styles.ts
+++ b/packages/ui-components/src/components/ui-pull-to-refresh.styles.ts
@@ -1,4 +1,5 @@
 import {
+  FONT_PRIMARY,
   SP_0_75,
   SP_1,
   SP_1_25,
@@ -7,6 +8,8 @@ import {
   SP_2_5,
   SP_3,
   TEXT_PRIMARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
 } from "@maneki/foundation";
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -30,7 +33,7 @@ export const STYLES = /* css */ `
     align-items: center;
     justify-content: center;
     padding: ${SP_1_5};
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     width: 100%;
   }
 
@@ -89,8 +92,7 @@ export const STYLES = /* css */ `
   }
 
   :host([size="s"]) .text {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   /* ── Size: M (default) ───────────────────────────────────────────────────── */
@@ -119,8 +121,7 @@ export const STYLES = /* css */ `
   :host .text,
   :host([size="m"]) .text {
     font-weight: 500;
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   /* ── Size: L ─────────────────────────────────────────────────────────────── */

--- a/packages/ui-components/src/components/ui-queryfield-tag.styles.ts
+++ b/packages/ui-components/src/components/ui-queryfield-tag.styles.ts
@@ -1,4 +1,5 @@
 import {
+  FONT_PRIMARY,
   RADIUS_PILL,
   SP_0_25,
   SP_0_5,
@@ -8,6 +9,9 @@ import {
   TAG_SUBTLE,
   TAG_TEXT_SUBTLE,
   TEXT_SECONDARY,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
+  TYPE_CAPTION_01,
 } from "@maneki/foundation";
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -28,7 +32,7 @@ export const TAG_STYLES = /* css */ `
   :host {
     display: inline-flex;
     align-items: center;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   .category {
@@ -119,8 +123,7 @@ export const TAG_STYLES = /* css */ `
 
   :host([size="s"]) .category {
     padding: 0 ${SP_1};
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
   }
 
   :host([size="s"]) .value {
@@ -129,8 +132,7 @@ export const TAG_STYLES = /* css */ `
   }
 
   :host([size="s"]) .value-text {
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
   }
 
   :host([size="s"]) .dismiss {
@@ -147,8 +149,7 @@ export const TAG_STYLES = /* css */ `
   :host .category,
   :host([size="m"]) .category {
     padding: ${SP_0_25} ${SP_1_5};
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host .value,
@@ -159,8 +160,7 @@ export const TAG_STYLES = /* css */ `
 
   :host .value-text,
   :host([size="m"]) .value-text {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host .dismiss,
@@ -178,8 +178,7 @@ export const TAG_STYLES = /* css */ `
 
   :host([size="l"]) .category {
     padding: ${SP_0_25} ${SP_1_5};
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="l"]) .value {
@@ -188,8 +187,7 @@ export const TAG_STYLES = /* css */ `
   }
 
   :host([size="l"]) .value-text {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="l"]) .dismiss {

--- a/packages/ui-components/src/components/ui-queryfield.styles.ts
+++ b/packages/ui-components/src/components/ui-queryfield.styles.ts
@@ -2,6 +2,7 @@ import {
   BORDER_FOCUS,
   BORDER_MODERATE,
   ELEVATION_03,
+  FONT_PRIMARY,
   HOVER_BORDER_MODERATE,
   HOVER_MINIMAL,
   ICON_SECONDARY,
@@ -19,6 +20,10 @@ import {
   TEXT_PRIMARY,
   TEXT_SECONDARY,
   TEXT_TERTIARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
+  TYPE_HEADING_07,
 } from "@maneki/foundation";
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -39,7 +44,7 @@ export const FIELD_STYLES = /* css */ `
   :host {
     display: block;
     width: 100%;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   .wrapper {
@@ -97,7 +102,7 @@ export const FIELD_STYLES = /* css */ `
     min-width: 80px;
     border: none;
     background: transparent;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     color: ${TEXT_PRIMARY};
     outline: none;
   }
@@ -124,8 +129,7 @@ export const FIELD_STYLES = /* css */ `
   }
 
   :host([size="s"]) .input {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   /* ── Size: M (default) ───────────────────────────────────────────────────── */
@@ -150,8 +154,7 @@ export const FIELD_STYLES = /* css */ `
 
   :host .input,
   :host([size="m"]) .input {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   /* ── Size: L ─────────────────────────────────────────────────────────────── */
@@ -172,8 +175,7 @@ export const FIELD_STYLES = /* css */ `
   }
 
   :host([size="l"]) .input {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   /* ── Disabled ────────────────────────────────────────────────────────────── */
@@ -216,9 +218,7 @@ export const FIELD_STYLES = /* css */ `
 
   .menu-heading {
     padding: ${SP_0_5} ${SP_2};
-    font-size: 12px;
-    line-height: 16px;
-    font-weight: 500;
+    ${TYPE_HEADING_07}
     color: ${TEXT_SECONDARY};
     text-transform: uppercase;
     white-space: nowrap;
@@ -229,9 +229,7 @@ export const FIELD_STYLES = /* css */ `
     align-items: center;
     gap: ${SP_1};
     padding: ${SP_0_75} ${SP_2};
-    font-size: 14px;
-    line-height: 20px;
-    font-weight: 400;
+    ${TYPE_BODY_02}
     color: ${TEXT_PRIMARY};
     cursor: pointer;
     white-space: nowrap;
@@ -239,7 +237,6 @@ export const FIELD_STYLES = /* css */ `
     background: transparent;
     width: 100%;
     text-align: left;
-    font-family: "Geist", sans-serif;
   }
 
   .menu-item:hover {

--- a/packages/ui-components/src/components/ui-radio-item.ts
+++ b/packages/ui-components/src/components/ui-radio-item.ts
@@ -4,6 +4,7 @@ import {
   DISABLED_BORDER,
   DISABLED_MINIMAL,
   DISABLED_TEXT,
+  FONT_PRIMARY,
   FORM_INPUT_BORDER,
   HOVER_BORDER_MODERATE,
   RADIUS_CIRCLE,
@@ -14,6 +15,9 @@ import {
   STATUS_GENERAL_ERROR,
   STATUS_SURFACE_ERROR_BOLD,
   TEXT_PRIMARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
 } from "@maneki/foundation";
 
 // ─── Type-safe property unions ───────────────────────────────────────────────
@@ -87,7 +91,7 @@ const STYLES = /* css */ `
 
   .label {
     display: none;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     font-weight: 400;
     color: var(--ui-radio-label-color, ${TEXT_PRIMARY});
   }
@@ -131,8 +135,7 @@ const STYLES = /* css */ `
 
   :host .label,
   :host([size="m"]) .label {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host .dot,
@@ -158,8 +161,7 @@ const STYLES = /* css */ `
   }
 
   :host([size="s"]) .label {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .dot {
@@ -184,8 +186,7 @@ const STYLES = /* css */ `
   }
 
   :host([size="l"]) .label {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .dot {

--- a/packages/ui-components/src/components/ui-search.styles.ts
+++ b/packages/ui-components/src/components/ui-search.styles.ts
@@ -2,6 +2,7 @@ import {
   BORDER_FOCUS,
   BORDER_MODERATE,
   ELEVATION_03,
+  FONT_PRIMARY,
   HOVER_MINIMAL,
   ICON_SECONDARY,
   RADIUS_PILL,
@@ -19,6 +20,10 @@ import {
   TEXT_PRIMARY,
   TEXT_SECONDARY,
   TEXT_TERTIARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
+  TYPE_CAPTION_01,
 } from "@maneki/foundation";
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -40,7 +45,7 @@ export const STYLES = /* css */ `
     display: block;
     position: relative;
     width: 100%;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   /* ── Input ───────────────────────────────────────────────────────────────── */
@@ -88,7 +93,7 @@ export const STYLES = /* css */ `
     min-width: 0;
     border: none;
     background: transparent;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     color: ${TEXT_PRIMARY};
     outline: none;
   }
@@ -169,7 +174,7 @@ export const STYLES = /* css */ `
     cursor: pointer;
     border: none;
     background: transparent;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     text-transform: uppercase;
     padding: 0;
   }
@@ -182,7 +187,7 @@ export const STYLES = /* css */ `
     background: ${SURFACE_PRIMARY};
     cursor: pointer;
     border: none;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     text-align: left;
     width: 100%;
     color: ${TEXT_PRIMARY};
@@ -208,7 +213,7 @@ export const STYLES = /* css */ `
     border-radius: ${RADIUS_PILL};
     background: ${SURFACE_BOLD};
     color: #ffffff;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     font-weight: 500;
     font-size: 10px;
     line-height: 1;
@@ -287,8 +292,7 @@ export const STYLES = /* css */ `
   }
 
   :host([size="s"]) .input {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .clear-btn {
@@ -303,13 +307,11 @@ export const STYLES = /* css */ `
   :host([size="s"]) .category-heading {
     height: 24px;
     padding: ${SP_0_5} ${SP_1_5};
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
   }
 
   :host([size="s"]) .category-heading .show-all {
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
   }
 
   :host([size="s"]) .result-item {
@@ -331,18 +333,15 @@ export const STYLES = /* css */ `
   }
 
   :host([size="s"]) .result-title {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .result-info {
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
   }
 
   :host([size="s"]) .result-description {
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
   }
 
   :host([size="s"]) .result-content {
@@ -376,8 +375,7 @@ export const STYLES = /* css */ `
 
   :host .input,
   :host([size="m"]) .input {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host .clear-btn,
@@ -395,14 +393,12 @@ export const STYLES = /* css */ `
   :host([size="m"]) .category-heading {
     height: 24px;
     padding: ${SP_0_5} ${SP_2};
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host .category-heading .show-all,
   :host([size="m"]) .category-heading .show-all {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host .result-item,
@@ -429,20 +425,17 @@ export const STYLES = /* css */ `
 
   :host .result-title,
   :host([size="m"]) .result-title {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host .result-info,
   :host([size="m"]) .result-info {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host .result-description,
   :host([size="m"]) .result-description {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host .result-content,
@@ -468,8 +461,7 @@ export const STYLES = /* css */ `
   }
 
   :host([size="l"]) .input {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .clear-btn {
@@ -484,13 +476,11 @@ export const STYLES = /* css */ `
   :host([size="l"]) .category-heading {
     height: 36px;
     padding: ${SP_1} ${SP_3};
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="l"]) .category-heading .show-all {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="l"]) .result-item {
@@ -512,18 +502,15 @@ export const STYLES = /* css */ `
   }
 
   :host([size="l"]) .result-title {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .result-info {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="l"]) .result-description {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([size="l"]) .result-content {

--- a/packages/ui-components/src/components/ui-select.styles.ts
+++ b/packages/ui-components/src/components/ui-select.styles.ts
@@ -4,6 +4,7 @@ import {
   DISABLED_BORDER,
   DISABLED_TEXT,
   ELEVATION_05,
+  FONT_PRIMARY,
   FORM_INPUT_BORDER,
   HOVER_BORDER_MODERATE,
   ICON_SECONDARY,
@@ -23,6 +24,8 @@ import {
   TEXT_PRIMARY,
   TEXT_SECONDARY,
   TEXT_TERTIARY,
+  TYPE_BODY_03,
+  TYPE_CAPTION_01,
 } from "@maneki/foundation";
 
 // ─── Status icon map ─────────────────────────────────────────────────────────
@@ -46,7 +49,7 @@ export const STYLES = /* css */ `
     display: inline-flex;
     flex-direction: column;
     gap: 0;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   /* ── Label row ─────────────────────────────────────────────────────────── */
@@ -112,8 +115,7 @@ export const STYLES = /* css */ `
     flex-shrink: 0;
   }
   .tag-label {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
     color: ${TAG_TEXT_SUBTLE};
     white-space: nowrap;
   }
@@ -259,8 +261,7 @@ export const STYLES = /* css */ `
   /* ── Supportive text ───────────────────────────────────────────────────── */
   .supportive-text {
     display: none;
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
     color: var(--ui-select-supportive-color, ${TEXT_SECONDARY});
   }
   :host([supportive]) .supportive-text {

--- a/packages/ui-components/src/components/ui-side-panel-menu-item.ts
+++ b/packages/ui-components/src/components/ui-side-panel-menu-item.ts
@@ -3,6 +3,7 @@ import {
   BORDER_FOCUS,
   BW_MD,
   DISABLED_TEXT,
+  FONT_PRIMARY,
   HOVER_MINIMAL,
   HOVER_MODERATE,
   ICON_ACTION,
@@ -47,7 +48,7 @@ const STYLES = /* css */ `
     border: none;
     margin: 0;
     background-color: var(--ui-spmi-bg, ${SURFACE_SECONDARY});
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     font-size: 14px;
     font-weight: 500;
     line-height: 20px;

--- a/packages/ui-components/src/components/ui-side-panel-menu.styles.ts
+++ b/packages/ui-components/src/components/ui-side-panel-menu.styles.ts
@@ -2,6 +2,7 @@ import {
   BORDER_MINIMAL,
   BW_SM,
   ELEVATION_03,
+  FONT_PRIMARY,
   SP_1_25,
   SP_2,
   SP_5,
@@ -46,7 +47,7 @@ export const STYLES = /* css */ `
     box-shadow: var(--ui-spm-flyout-shadow, ${ELEVATION_03});
     flex-direction: column;
     z-index: 10;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   .flyout[open] {

--- a/packages/ui-components/src/components/ui-side-panel.styles.ts
+++ b/packages/ui-components/src/components/ui-side-panel.styles.ts
@@ -4,6 +4,7 @@ import {
   BORDER_SUBTLE,
   BW_MD,
   ELEVATION_03,
+  FONT_PRIMARY,
   ICON_PRIMARY,
   SP_1,
   SP_2,
@@ -31,7 +32,7 @@ export const STYLES = /* css */ `
     width: var(--ui-sp-width, 300px);
     height: 100%;
     background-color: var(--ui-sp-bg, ${SURFACE_SECONDARY});
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     position: relative;
     transition: width 0.2s ease;
   }

--- a/packages/ui-components/src/components/ui-slider.styles.ts
+++ b/packages/ui-components/src/components/ui-slider.styles.ts
@@ -3,6 +3,7 @@ import {
   BORDER_FOCUS,
   BW_MD,
   DISABLED_TEXT,
+  FONT_PRIMARY,
   GRAY_110,
   RADIUS_PILL,
   RADIUS_SM,
@@ -14,6 +15,7 @@ import {
   SP_3,
   SURFACE_BOLD,
   TEXT_PRIMARY,
+  TYPE_BODY_03,
 } from "@maneki/foundation";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -32,7 +34,7 @@ export const STYLES = /* css */ `
   :host {
     display: block;
     width: 100%;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     position: relative;
     user-select: none;
     -webkit-user-select: none;
@@ -105,8 +107,7 @@ export const STYLES = /* css */ `
   .labels {
     display: none;
     justify-content: space-between;
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
     color: ${TEXT_PRIMARY};
   }
 
@@ -125,8 +126,7 @@ export const STYLES = /* css */ `
     margin-bottom: ${SP_1};
     background: ${GRAY_110};
     color: #ffffff;
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
     padding: ${SP_0_5} ${SP_1};
     border-radius: ${RADIUS_SM};
     white-space: nowrap;

--- a/packages/ui-components/src/components/ui-step-group.ts
+++ b/packages/ui-components/src/components/ui-step-group.ts
@@ -1,3 +1,4 @@
+import { FONT_PRIMARY } from "@maneki/foundation";
 import "./ui-step-item.js";
 import type { StepSize, StepOrientation } from "./ui-step-item.styles.js";
 
@@ -8,7 +9,7 @@ const STYLES = /* css */ `
     display: flex;
     align-items: flex-start;
     width: 100%;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   :host([orientation="vertical"]) {

--- a/packages/ui-components/src/components/ui-step-item.styles.ts
+++ b/packages/ui-components/src/components/ui-step-item.styles.ts
@@ -3,6 +3,7 @@ import {
   BW_MD,
   DISABLED_MINIMAL,
   DISABLED_TEXT,
+  FONT_PRIMARY,
   RADIUS_PILL,
   SP_0_5,
   SP_1,
@@ -12,6 +13,9 @@ import {
   SURFACE_BOLD,
   TEXT_PRIMARY,
   TEXT_SECONDARY,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
+  TYPE_CAPTION_01,
 } from "@maneki/foundation";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -39,7 +43,7 @@ export const STEP_ITEM_STYLES = /* css */ `
     display: flex;
     min-width: 0;
     min-height: 0;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   /* ── Horizontal (default) ────────────────────────────────────────────────── */
@@ -187,13 +191,11 @@ export const STEP_ITEM_STYLES = /* css */ `
   }
 
   :host([size="s"]) .label {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .sublabel {
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
   }
 
   :host([size="s"][orientation="horizontal"]) {
@@ -251,14 +253,12 @@ export const STEP_ITEM_STYLES = /* css */ `
 
   :host .label,
   :host([size="m"]) .label {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host .sublabel,
   :host([size="m"]) .sublabel {
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
   }
 
   :host([orientation="horizontal"]),

--- a/packages/ui-components/src/components/ui-switch.ts
+++ b/packages/ui-components/src/components/ui-switch.ts
@@ -2,6 +2,7 @@ import {
   BLUE_30,
   BLUE_60,
   BORDER_FOCUS,
+  FONT_PRIMARY,
   GRAY_30,
   GRAY_40,
   RADIUS_PILL,
@@ -10,6 +11,9 @@ import {
   STATUS_SURFACE_ERROR_BOLD,
   TEXT_PRIMARY,
   TEXT_SECONDARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
 } from "@maneki/foundation";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -30,7 +34,7 @@ const STYLES = /* css */ `
   :host {
     display: inline-flex;
     align-items: center;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     cursor: pointer;
     user-select: none;
     -webkit-user-select: none;
@@ -147,8 +151,7 @@ const STYLES = /* css */ `
   }
 
   :host([size="s"]) .label {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   /* ── Size: M (default) ───────────────────────────────────────────────────── */
@@ -184,8 +187,7 @@ const STYLES = /* css */ `
 
   :host .label,
   :host([size="m"]) .label {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   /* ── Size: L ─────────────────────────────────────────────────────────────── */
@@ -215,8 +217,7 @@ const STYLES = /* css */ `
   }
 
   :host([size="l"]) .label {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/packages/ui-components/src/components/ui-tab-group.ts
+++ b/packages/ui-components/src/components/ui-tab-group.ts
@@ -4,6 +4,7 @@ import {
   BORDER_MINIMAL,
   BW_MD,
   BW_SM,
+  FONT_PRIMARY,
   ICON_ACTION,
   ICON_PRIMARY,
   ICON_SECONDARY,
@@ -208,7 +209,7 @@ const STYLES = /* css */ `
     display: flex;
     align-items: center;
     padding: ${SP_0_75} ${SP_1_5};
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     font-size: 13px;
     line-height: 20px;
     color: ${TEXT_PRIMARY};

--- a/packages/ui-components/src/components/ui-tab-item.ts
+++ b/packages/ui-components/src/components/ui-tab-item.ts
@@ -4,6 +4,7 @@ import {
   BORDER_MINIMAL,
   BW_MD,
   DISABLED_TEXT,
+  FONT_PRIMARY,
   ICON_ACTION,
   ICON_PRIMARY,
   ICON_SECONDARY,
@@ -17,6 +18,8 @@ import {
   SP_5,
   TEXT_LINK,
   TEXT_PRIMARY,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
 } from "@maneki/foundation";
 import "./ui-icon.js";
 
@@ -52,7 +55,7 @@ const STYLES = /* css */ `
     justify-content: center;
     width: 100%;
     flex: 1 1 0%;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     font-weight: var(--ui-tab-font-weight, 400);
     color: var(--ui-tab-text-color, ${TEXT_PRIMARY});
     position: relative;
@@ -154,8 +157,7 @@ const STYLES = /* css */ `
 
   :host .base,
   :host([size="m"]) .base {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
     padding-top: ${SP_0_5};
     padding-bottom: ${SP_0_5};
   }
@@ -184,8 +186,7 @@ const STYLES = /* css */ `
   }
 
   :host([size="s"]) .base {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
     padding-top: ${SP_0_5};
     padding-bottom: ${SP_0_5};
   }

--- a/packages/ui-components/src/components/ui-table-cell.ts
+++ b/packages/ui-components/src/components/ui-table-cell.ts
@@ -2,6 +2,7 @@ import {
   BORDER_MINIMAL,
   BORDER_MODERATE,
   BW_SM,
+  FONT_PRIMARY,
   SP_0_75,
   SP_1_5,
   TEXT_PRIMARY,
@@ -23,7 +24,7 @@ const STYLES = /* css */ `
   :host {
     display: table-cell;
     vertical-align: middle;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     color: var(--ui-table-cell-color, ${TEXT_PRIMARY});
     font-weight: 400;
     text-align: left;

--- a/packages/ui-components/src/components/ui-table.ts
+++ b/packages/ui-components/src/components/ui-table.ts
@@ -2,6 +2,7 @@ import {
   BORDER_MINIMAL,
   BORDER_MODERATE,
   BW_SM,
+  FONT_PRIMARY,
   GRID_ROW_ALT,
   SP_0_75,
   SP_1,
@@ -24,7 +25,7 @@ const STYLES = /* css */ `
 
   :host {
     display: block;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     /* Default size: m */
     --_table-cell-padding: ${SP_0_75} ${SP_1_5};
     --_table-cell-font-size: 14px;

--- a/packages/ui-components/src/components/ui-tag.test.ts
+++ b/packages/ui-components/src/components/ui-tag.test.ts
@@ -500,24 +500,16 @@ describe("ui-tag", () => {
 
   // ── Size CSS specifics ────────────────────────────────────────────────
 
-  it("CSS contains font-size: 11px for xs", () => {
-    expect(STYLES).toContain("font-size: 11px");
+  it("CSS contains caption typography token for xs", () => {
+    expect(STYLES).toContain("var(--fd-type-caption-01-font-size)");
   });
 
-  it("CSS contains font-size: 12px for s", () => {
-    expect(STYLES).toContain("font-size: 12px");
+  it("CSS contains body-03 typography token for s", () => {
+    expect(STYLES).toContain("var(--fd-type-body-03-font-size)");
   });
 
-  it("CSS contains font-size: 14px for m/l", () => {
-    expect(STYLES).toContain("font-size: 14px");
-  });
-
-  it("CSS contains line-height: 16px for xs/s", () => {
-    expect(STYLES).toContain("line-height: 16px");
-  });
-
-  it("CSS contains line-height: 20px for m/l", () => {
-    expect(STYLES).toContain("line-height: 20px");
+  it("CSS contains body-02 typography token for m/l", () => {
+    expect(STYLES).toContain("var(--fd-type-body-02-font-size)");
   });
 
   // ── Multiple instances ────────────────────────────────────────────────

--- a/packages/ui-components/src/components/ui-tag.ts
+++ b/packages/ui-components/src/components/ui-tag.ts
@@ -13,6 +13,7 @@ import {
   BW_SM,
   DISABLED_MINIMAL,
   DISABLED_TEXT,
+  FONT_PRIMARY,
   GREEN_20,
   GREEN_60,
   GREEN_70,
@@ -50,6 +51,9 @@ import {
   TURQUOISE_20,
   TURQUOISE_60,
   TURQUOISE_70,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
+  TYPE_CAPTION_01,
   ULTRAMARINE_20,
   ULTRAMARINE_60,
   ULTRAMARINE_70,
@@ -98,7 +102,7 @@ export const STYLES = /* css */ `
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     white-space: nowrap;
     border: ${BW_SM} solid transparent;
     cursor: default;
@@ -110,8 +114,7 @@ export const STYLES = /* css */ `
 
   :host .base,
   :host([size="m"]) .base {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
     padding: ${SP_0_25} ${SP_1};
     border-radius: ${RADIUS_PILL};
   }
@@ -124,8 +127,7 @@ export const STYLES = /* css */ `
   /* ── Size: xs ────────────────────────────────────────────────────────────── */
 
   :host([size="xs"]) .base {
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
     padding: 0 ${SP_0_75};
     border-radius: ${RADIUS_PILL};
   }
@@ -137,8 +139,7 @@ export const STYLES = /* css */ `
   /* ── Size: s ─────────────────────────────────────────────────────────────── */
 
   :host([size="s"]) .base {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
     padding: ${SP_0_25} ${SP_1};
     border-radius: ${RADIUS_PILL};
   }
@@ -150,8 +151,7 @@ export const STYLES = /* css */ `
   /* ── Size: l ─────────────────────────────────────────────────────────────── */
 
   :host([size="l"]) .base {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
     padding: ${SP_0_75} ${SP_1_25};
     border-radius: ${RADIUS_PILL};
   }

--- a/packages/ui-components/src/components/ui-textarea.styles.ts
+++ b/packages/ui-components/src/components/ui-textarea.styles.ts
@@ -4,6 +4,7 @@ import {
   BW_SM,
   DISABLED_BORDER,
   DISABLED_TEXT,
+  FONT_PRIMARY,
   FORM_INPUT_BORDER,
   HOVER_BORDER_MODERATE,
   RADIUS_SM,
@@ -17,6 +18,7 @@ import {
   TEXT_PRIMARY,
   TEXT_SECONDARY,
   TEXT_TERTIARY,
+  TYPE_CAPTION_01,
 } from "@maneki/foundation";
 
 // ─── Status icon map ─────────────────────────────────────────────────────────
@@ -41,7 +43,7 @@ export const STYLES = /* css */ `
     display: inline-flex;
     flex-direction: column;
     gap: ${SP_0_5};
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   /* ── Label row ─────────────────────────────────────────────────────────── */
@@ -63,8 +65,7 @@ export const STYLES = /* css */ `
 
   .char-count {
     display: none;
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
     color: ${TEXT_SECONDARY};
     flex-shrink: 0;
     white-space: nowrap;
@@ -160,8 +161,7 @@ export const STYLES = /* css */ `
 
   .secondary-label {
     display: none;
-    font-size: 11px;
-    line-height: 16px;
+    ${TYPE_CAPTION_01}
     color: var(--ui-textarea-secondary-color, ${TEXT_SECONDARY});
   }
 

--- a/packages/ui-components/src/components/ui-tooltip.ts
+++ b/packages/ui-components/src/components/ui-tooltip.ts
@@ -1,4 +1,5 @@
 import {
+  FONT_PRIMARY,
   GRAY_110,
   ICON_CLOSE,
   RADIUS_SM,
@@ -9,6 +10,9 @@ import {
   SP_1_25,
   SP_1_5,
   SP_2,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
 } from "@maneki/foundation";
 
 // ─── Types ───────────────────────────────────────────────────────────────
@@ -43,7 +47,7 @@ const STYLES = /* css */ `
     display: inline-flex;
     position: relative;
     width: fit-content;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   /* ── Tooltip panel ───────────────────────────────────────────────────────── */
@@ -262,8 +266,7 @@ const STYLES = /* css */ `
   }
 
   :host([size="xs"]) .text {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="xs"]) .close {
@@ -283,8 +286,7 @@ const STYLES = /* css */ `
   }
 
   :host([size="s"]) .text {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .close {
@@ -306,8 +308,7 @@ const STYLES = /* css */ `
 
   :host .text,
   :host([size="m"]) .text {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host .close,
@@ -329,8 +330,7 @@ const STYLES = /* css */ `
   }
 
   :host([size="l"]) .text {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .close {

--- a/packages/ui-components/src/components/ui-tree-group.ts
+++ b/packages/ui-components/src/components/ui-tree-group.ts
@@ -1,6 +1,7 @@
 import {
   BORDER_FOCUS,
   BORDER_MODERATE,
+  FONT_PRIMARY,
   ICON_SEARCH,
   ICON_SECONDARY,
   RADIUS_SM,
@@ -14,6 +15,9 @@ import {
   SURFACE_PRIMARY,
   TEXT_PRIMARY,
   TEXT_TERTIARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
 } from "@maneki/foundation";
 import "./ui-tree-item.js";
 
@@ -36,7 +40,7 @@ const STYLES = /* css */ `
     display: flex;
     flex-direction: column;
     width: 100%;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
   }
 
   .search {
@@ -84,7 +88,7 @@ const STYLES = /* css */ `
     min-width: 0;
     border: none;
     background: transparent;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     color: ${TEXT_PRIMARY};
     outline: none;
   }
@@ -125,8 +129,7 @@ const STYLES = /* css */ `
   }
 
   :host([size="s"]) .search-input {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) {
@@ -160,8 +163,7 @@ const STYLES = /* css */ `
 
   :host .search-input,
   :host([size="m"]) .search-input {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   /* ── Size: L ─────────────────────────────────────────────────────────────── */
@@ -186,8 +188,7 @@ const STYLES = /* css */ `
   }
 
   :host([size="l"]) .search-input {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 `;
 

--- a/packages/ui-components/src/components/ui-tree-item.styles.ts
+++ b/packages/ui-components/src/components/ui-tree-item.styles.ts
@@ -1,6 +1,7 @@
 import {
   BORDER_FOCUS,
   BW_MD,
+  FONT_PRIMARY,
   HOVER_MINIMAL,
   HOVER_MODERATE,
   ICON_PRIMARY,
@@ -14,6 +15,9 @@ import {
   SP_7,
   TEXT_PRIMARY,
   TEXT_SECONDARY,
+  TYPE_BODY_01,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
 } from "@maneki/foundation";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -42,7 +46,7 @@ export const TREE_ITEM_STYLES = /* css */ `
     display: flex;
     align-items: center;
     width: 100%;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     cursor: pointer;
     overflow: hidden;
     max-height: 100px;
@@ -205,13 +209,11 @@ export const TREE_ITEM_STYLES = /* css */ `
   }
 
   :host([size="s"]) .label {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   :host([size="s"]) .secondary-label {
-    font-size: 12px;
-    line-height: 16px;
+    ${TYPE_BODY_03}
   }
 
   /* Level indents for S */
@@ -251,8 +253,7 @@ export const TREE_ITEM_STYLES = /* css */ `
 
   :host .label,
   :host([size="m"]) .label {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host .secondary-label,
@@ -300,8 +301,7 @@ export const TREE_ITEM_STYLES = /* css */ `
   }
 
   :host([size="l"]) .label {
-    font-size: 16px;
-    line-height: 24px;
+    ${TYPE_BODY_01}
   }
 
   :host([size="l"]) .secondary-label {

--- a/packages/ui-components/src/components/ui-wizard.ts
+++ b/packages/ui-components/src/components/ui-wizard.ts
@@ -2,6 +2,7 @@
 import {
   BORDER_MINIMAL,
   BW_SM,
+  FONT_PRIMARY,
   SP_1,
   SP_1_5,
   SP_2,
@@ -14,6 +15,8 @@ import {
   SURFACE_PRIMARY,
   SURFACE_SECONDARY,
   TEXT_PRIMARY,
+  TYPE_BODY_02,
+  TYPE_HEADING_04,
 } from "@maneki/foundation";
 import "./ui-step-group.js";
 import "./ui-step-item.js";
@@ -35,7 +38,7 @@ const STYLES = /* css */ `
   :host {
     display: flex;
     flex-direction: column;
-    font-family: "Geist", sans-serif;
+    font-family: ${FONT_PRIMARY};
     width: 100%;
     height: 100%;
     background: ${SURFACE_PRIMARY};
@@ -142,8 +145,7 @@ const STYLES = /* css */ `
   }
 
   :host([layout="horizontal"]) .header-title {
-    font-size: 14px;
-    line-height: 20px;
+    ${TYPE_BODY_02}
   }
 
   :host([layout="horizontal"]) .steps-bar {
@@ -164,8 +166,7 @@ const STYLES = /* css */ `
   }
 
   :host([layout="vertical"]) .header-title {
-    font-size: 20px;
-    line-height: 28px;
+    ${TYPE_HEADING_04}
   }
 
   :host([layout="vertical"]) .steps-sidebar {


### PR DESCRIPTION
## Summary

- Adds `typeBlock()` helper to foundation that returns `font-size` + `line-height` + `font-weight` as CSS `var()` references in one call
- Adds 22 `TYPE_*` constants to `token-constants.ts` covering all typography groups (display, heading, body, ui, caption, badge, code)
- Replaces 197 hardcoded font-size/line-height/font-weight blocks across 42 component files with `${TYPE_*}` constants
- 94 remaining hardcoded font-sizes are intentional exceptions (non-standard sizes like 8px/9px/10px/18px, standalone font-size without line-height, or mixed patterns)

## Example

Before:
```css
font-size: 14px;
line-height: 20px;
font-weight: 400;
```

After:
```css
${TYPE_BODY_02}
```

Which resolves to:
```css
font-size: var(--fd-type-body-02-font-size);
line-height: var(--fd-type-body-02-line-height);
font-weight: var(--fd-type-body-02-font-weight);
```

## Test Results

- Foundation: 59 tests ✅
- UI Components: 3583 tests ✅
- Type check: clean