### PR TITLE
feat: add new tokens to foundation catalog pages

### DIFF
--- a/apps/catalog/e2e/visual.spec.ts
+++ b/apps/catalog/e2e/visual.spec.ts
@@ -7,6 +7,7 @@ const pages = [
   "spacing",
   "typography",
   "elevation",
+  "shape",
   "semantic-tokens",
   // Components
   "badge",

--- a/apps/catalog/src/main.ts
+++ b/apps/catalog/src/main.ts
@@ -27,6 +27,7 @@ const pageLoaders: Record<string, () => Promise<unknown>> = {
   "spacing": () => import("./pages/spacing.js"),
   "typography": () => import("./pages/typography.js"),
   "elevation": () => import("./pages/elevation.js"),
+  "shape": () => import("./pages/shape.js"),
   "semantic-tokens": () => import("./pages/semantic-tokens.js"),
   "badge": () => import("./pages/badge.js"),
   "button": () => import("./pages/button.js"),

--- a/apps/catalog/src/manifest.ts
+++ b/apps/catalog/src/manifest.ts
@@ -27,6 +27,7 @@ export const manifest: PageMeta[] = [
   { id: "spacing", title: "Spacing", section: "Foundation" },
   { id: "typography", title: "Typography", section: "Foundation" },
   { id: "elevation", title: "Elevation", section: "Foundation" },
+  { id: "shape", title: "Shape", section: "Foundation" },
   { id: "semantic-tokens", title: "Semantic Tokens", section: "Foundation" },
   // Primitives
   { id: "badge", title: "Badge", section: "Primitives" },

--- a/apps/catalog/src/pages/semantic-tokens.ts
+++ b/apps/catalog/src/pages/semantic-tokens.ts
@@ -2,6 +2,8 @@ import { registerPage } from "../registry.js";
 import {
   surface, border, text, icon, global,
   statusSurface, statusText, statusIcon, statusGeneral,
+  stateDisabled, stateHover, stateActive, stateSelected,
+  form, tag, button, gridRow,
   resolveSemanticValue,
 } from "@maneki/foundation";
 
@@ -52,9 +54,17 @@ registerPage("semantic-tokens", {
       renderGroup("Text", text, "text", "text") +
       renderGroup("Icon", icon, "icon", "icon") +
       renderGroup("Global", global, "global", "surface") +
-      renderGroup("Status \u2014 General", statusGeneral, "status-general", "surface") +
-      renderGroup("Status \u2014 Surface", statusSurface, "status-surface", "surface") +
-      renderGroup("Status \u2014 Text", statusText, "status-text", "text") +
-      renderGroup("Status \u2014 Icon", statusIcon, "status-icon", "icon");
+      renderGroup("Form", form, "form", "border") +
+      renderGroup("Button", button, "button", "surface") +
+      renderGroup("Tag", tag, "tag", "surface") +
+      renderGroup("Grid Row", gridRow, "grid-row", "surface") +
+      renderGroup("State — Hover", stateHover, "state-hover", "surface") +
+      renderGroup("State — Active", stateActive, "state-active", "surface") +
+      renderGroup("State — Selected", stateSelected, "state-selected", "surface") +
+      renderGroup("State — Disabled", stateDisabled, "state-disabled", "surface") +
+      renderGroup("Status — General", statusGeneral, "status-general", "surface") +
+      renderGroup("Status — Surface", statusSurface, "status-surface", "surface") +
+      renderGroup("Status — Text", statusText, "status-text", "text") +
+      renderGroup("Status — Icon", statusIcon, "status-icon", "icon");
   },
 });

--- a/apps/catalog/src/pages/shape.ts
+++ b/apps/catalog/src/pages/shape.ts
@@ -1,0 +1,61 @@
+import { registerPage } from "../registry.js";
+import { radius, borderWidth } from "@maneki/foundation";
+
+registerPage("shape", {
+  title: "Shape",
+  section: "Foundation",
+  render: () => {
+    let html = `
+      <style>
+        .shape-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 24px; margin-bottom: 40px; }
+        .shape-card {
+          background: #fff; border: 1px solid var(--fd-border-minimal, #dce3e8);
+          border-radius: 8px; padding: 20px; display: flex; flex-direction: column; align-items: center; gap: 12px;
+        }
+        .shape-preview { display: flex; align-items: center; justify-content: center; }
+        .shape-name { font-size: 13px; font-weight: 500; color: var(--fd-text-primary, #1c2b36); }
+        .shape-value { font-size: 11px; font-family: monospace; color: #5b7282; }
+        .shape-var { font-size: 10px; font-family: monospace; color: #9fb1bd; }
+      </style>
+
+      <h3>Border Radius</h3>
+      <div class="shape-grid">`;
+
+    for (const [step, value] of Object.entries(radius)) {
+      const isCircle = value === "50%";
+      const isPill = value === "999px";
+      const previewRadius = isCircle ? "50%" : isPill ? "24px" : value;
+      const previewWidth = isPill ? "80px" : "48px";
+
+      html += `
+        <div class="shape-card">
+          <div class="shape-preview">
+            <div style="width:${previewWidth};height:48px;background:#186ade;opacity:0.7;border-radius:${previewRadius};"></div>
+          </div>
+          <div class="shape-name">${step}</div>
+          <div class="shape-value">${value}</div>
+          <div class="shape-var">--fd-radius-${step}</div>
+        </div>`;
+    }
+
+    html += `</div>
+
+      <h3>Border Width</h3>
+      <div class="shape-grid">`;
+
+    for (const [step, value] of Object.entries(borderWidth)) {
+      html += `
+        <div class="shape-card">
+          <div class="shape-preview">
+            <div style="width:80px;height:48px;background:#fff;border:${value} solid #186ade;border-radius:4px;"></div>
+          </div>
+          <div class="shape-name">${step}</div>
+          <div class="shape-value">${value}</div>
+          <div class="shape-var">--fd-border-width-${step}</div>
+        </div>`;
+    }
+
+    html += `</div>`;
+    return html;
+  },
+});

--- a/packages/foundation/src/index.ts
+++ b/packages/foundation/src/index.ts
@@ -32,6 +32,7 @@ export {
   stateDisabled,
   form,
   stateHover,
+  stateActive,
   stateSelected,
   tag,
   button,


### PR DESCRIPTION
## Summary

- Adds 8 missing semantic token groups to the catalog's Semantic Tokens page:
  - Form, Button, Tag, Grid Row
  - State — Hover, Active, Selected, Disabled
- Adds new **Shape** catalog page showing border-radius and border-width tokens with visual previews
- Exports `stateActive` from foundation barrel (was missing)
- 57 visual tests (up from 56 — new shape page)

## Test Results

- Foundation: builds ✅
- Catalog: builds ✅
- Playwright visual: 57/57 ✅