### PR TITLE
feat: dark theme support

### DIFF
--- a/apps/catalog/index.html
+++ b/apps/catalog/index.html
@@ -267,8 +267,15 @@
 <body>
   <a href="#content" class="skip-link">Skip to content</a>
   <div id="app">
-    <nav aria-label="Component navigation">
-      <ui-side-panel-menu id="sidebar" title="Maneki" state="expanded" no-collapse></ui-side-panel-menu>
+    <nav aria-label="Component navigation" style="display:flex;flex-direction:column;height:100vh">
+      <ui-side-panel-menu id="sidebar" title="Maneki" state="expanded" no-collapse style="flex:1;overflow-y:auto"></ui-side-panel-menu>
+      <div style="padding:8px 12px;border-top:1px solid var(--fd-border-minimal,#dce3e8);display:flex;justify-content:center">
+        <button id="theme-toggle" aria-label="Toggle dark mode" style="
+          background:none;border:none;cursor:pointer;
+          font-size:18px;padding:6px 12px;border-radius:4px;
+          color:var(--fd-text-secondary,#3e5463);
+        ">☀️</button>
+      </div>
     </nav>
     <main id="content" tabindex="0"></main>
   </div>

--- a/apps/catalog/src/main.ts
+++ b/apps/catalog/src/main.ts
@@ -96,6 +96,8 @@ async function ensurePageLoaded(pageId: string): Promise<boolean> {
 
 function buildSidebar(): void {
   const sidebar = document.getElementById("sidebar")!;
+  // Clear any existing items (prevents duplication on re-run)
+  sidebar.querySelectorAll("ui-side-panel-menu-item, ui-side-panel-menu-section").forEach(el => el.remove());
   const sections: Record<string, { id: string; title: string }[]> = {};
 
   for (const entry of manifest) {
@@ -185,7 +187,33 @@ function onHashChange(): void {
   renderPage(hash || manifest[0].id);
 }
 
+// ─── Theme Toggle ─────────────────────────────────────────────────────────
+
+function initThemeToggle(): void {
+  const btn = document.getElementById("theme-toggle")!;
+  const saved = localStorage.getItem("maneki-theme");
+  if (saved === "dark") {
+    document.documentElement.setAttribute("data-theme", "dark");
+    btn.textContent = "\u263E";
+  }
+  btn.addEventListener("click", () => {
+    const isDark = document.documentElement.getAttribute("data-theme") === "dark";
+    if (isDark) {
+      document.documentElement.removeAttribute("data-theme");
+      localStorage.setItem("maneki-theme", "light");
+      btn.textContent = "\u2600\uFE0F";
+    } else {
+      document.documentElement.setAttribute("data-theme", "dark");
+      localStorage.setItem("maneki-theme", "dark");
+      btn.textContent = "\u263E";
+    }
+  });
+}
+
 // ─── Init ────────────────────────────────────────────────────────────────────
+
+buildSidebar();
+initThemeToggle();
 
 buildSidebar();
 window.addEventListener("hashchange", onHashChange);

--- a/apps/catalog/src/pages/elevation.ts
+++ b/apps/catalog/src/pages/elevation.ts
@@ -10,19 +10,19 @@ registerPage("elevation", {
       <style>
         .elev-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 32px; }
         .elev-card {
-          background: #fff; border-radius: 8px; padding: 24px;
+          background: var(--fd-surface-primary, #fff); border-radius: 8px; padding: 24px;
           display: flex; flex-direction: column; gap: 8px;
           border: 1px solid var(--fd-border-minimal, #dce3e8);
         }
         .elev-level { font-size: 20px; font-weight: 600; color: var(--fd-text-primary, #1c2b36); }
-        .elev-var { font-size: 11px; font-family: monospace; color: #5b7282; }
-        .elev-shadow { font-size: 10px; font-family: monospace; color: #5b7282; word-break: break-all; }
+        .elev-var { font-size: 11px; font-family: monospace; color: var(--fd-text-secondary, #3e5463); }
+        .elev-shadow { font-size: 10px; font-family: monospace; color: var(--fd-text-secondary, #3e5463); word-break: break-all; }
       </style>
       <div class="elev-grid">`;
 
     for (const [level, token] of levels) {
       html += `
-        <div class="elev-card" style="box-shadow:${token.boxShadow}">
+        <div class="elev-card" style="box-shadow:var(--fd-elevation-${level})">
           <div class="elev-level">${level}</div>
           <div class="elev-var">--fd-elevation-${level}</div>
           <div class="elev-shadow">${token.boxShadow || "none"}</div>

--- a/apps/catalog/src/pages/image.ts
+++ b/apps/catalog/src/pages/image.ts
@@ -45,6 +45,7 @@ registerPage("image", {
     const png = createLandscapePng();
     const container = document.getElementById("object-fit-demo");
     if (!container) return;
+    container.innerHTML = "";
     for (const f of ["cover", "contain", "fill", "none"]) {
       const col = document.createElement("div");
       col.className = "flex-1";

--- a/apps/catalog/src/pages/semantic-tokens.ts
+++ b/apps/catalog/src/pages/semantic-tokens.ts
@@ -19,13 +19,13 @@ function renderSwatch(name: string, cssVar: string, value: any, mode: string): s
   if (mode === "surface") {
     swatchHtml = `<div style="width:44px;height:44px;border-radius:6px;flex-shrink:0;background:${resolved};${isLight ? "border:1px solid #dce3e8;" : ""}"></div>`;
   } else if (mode === "border") {
-    swatchHtml = `<div style="width:44px;height:44px;border-radius:6px;flex-shrink:0;background:#fff;border:2px solid ${resolved};"></div>`;
+    swatchHtml = `<div style="width:44px;height:44px;border-radius:6px;flex-shrink:0;background:var(--fd-surface-tertiary,#f8f9fa);border:2px solid ${resolved};"></div>`;
   } else {
-    swatchHtml = `<div style="width:44px;height:44px;border-radius:6px;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-size:20px;font-weight:600;background:#fff;border:1px solid #dce3e8;color:${resolved};">${mode === "icon" ? "\u2605" : "Aa"}</div>`;
+    swatchHtml = `<div style="width:44px;height:44px;border-radius:6px;flex-shrink:0;display:flex;align-items:center;justify-content:center;font-size:20px;font-weight:600;background:var(--fd-surface-tertiary,#f8f9fa);border:1px solid var(--fd-border-minimal,#dce3e8);color:${resolved};">${mode === "icon" ? "\u2605" : "Aa"}</div>`;
   }
 
   return `
-    <div style="display:flex;align-items:center;gap:12px;padding:8px;border-radius:8px;background:#f8f9fa;">
+    <div style="display:flex;align-items:center;gap:12px;padding:8px;border-radius:8px;background:var(--fd-surface-secondary,#f8f9fa);">
       ${swatchHtml}
       <div style="min-width:0;">
         <div style="font-size:12px;font-weight:500;margin-bottom:2px;">${name}</div>

--- a/apps/catalog/src/pages/shape.ts
+++ b/apps/catalog/src/pages/shape.ts
@@ -9,7 +9,7 @@ registerPage("shape", {
       <style>
         .shape-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 24px; margin-bottom: 40px; }
         .shape-card {
-          background: #fff; border: 1px solid var(--fd-border-minimal, #dce3e8);
+          background: var(--fd-surface-tertiary, #f8f9fa); border: 1px solid var(--fd-border-minimal, #dce3e8);
           border-radius: 8px; padding: 20px; display: flex; flex-direction: column; align-items: center; gap: 12px;
         }
         .shape-preview { display: flex; align-items: center; justify-content: center; }
@@ -47,7 +47,7 @@ registerPage("shape", {
       html += `
         <div class="shape-card">
           <div class="shape-preview">
-            <div style="width:80px;height:48px;background:#fff;border:${value} solid #186ade;border-radius:4px;"></div>
+            <div style="width:80px;height:48px;background:var(--fd-surface-tertiary,#f8f9fa);border:${value} solid #186ade;border-radius:4px;"></div>
           </div>
           <div class="shape-name">${step}</div>
           <div class="shape-value">${value}</div>

--- a/packages/foundation/src/dark-theme.ts
+++ b/packages/foundation/src/dark-theme.ts
@@ -1,0 +1,277 @@
+/**
+ * Dark theme semantic token overrides.
+ *
+ * Each group mirrors the light theme structure but with inverted values
+ * suitable for dark backgrounds. Accent colors (blue, red, green, etc.)
+ * stay the same — they work on both light and dark backgrounds.
+ *
+ * Applied via `[data-theme="dark"]` selector on `:root` or any ancestor.
+ */
+
+import type { SemanticValue, ElevationToken } from "./semantic-tokens.js";
+import { colors, type ColorFamily } from "./colors.js";
+
+function ref(family: ColorFamily, step: number): { family: ColorFamily; step: number } {
+  return { family, step };
+}
+
+// ─── Surface ────────────────────────────────────────────────────────────────
+
+export const darkSurface = {
+  primary: ref("gray", 100),           // #0D1826 — main background
+  secondary: ref("gray", 110),         // #090F14 — sidebar, panels
+  tertiary: ref("gray", 90),           // #1C2B36 — cards, elevated surfaces
+  moderate: ref("gray", 80),           // #2C3E4C
+  bold: ref("gray", 60),              // #5B7282
+  strong: ref("gray", 40),            // #9FB1BD
+  action: ref("blue", 60),            // stays
+  actionContrast: ref("blue", 100),   // stays
+  destructive: ref("red", 60),        // stays
+  success: ref("green", 60),          // stays
+  contrast: "#ffffff",                 // inverted
+  overlay: "rgba(0, 0, 0, 0.7)",      // darker overlay
+  light: "#ffffff",                    // stays (structural)
+  dark: ref("gray", 110),             // stays
+} as const satisfies Record<string, SemanticValue>;
+
+// ─── Border ─────────────────────────────────────────────────────────────────
+
+export const darkBorder = {
+  minimal: ref("gray", 80),           // #2C3E4C
+  subtle: ref("gray", 70),            // #3E5463
+  moderate: ref("gray", 60),          // #5B7282
+  bold: ref("gray", 40),              // #9FB1BD
+  focus: ref("blue", 50),             // #4D94FF — slightly lighter for visibility
+  contrast: ref("gray", 10),          // #EEF1F4
+  light: "#ffffff",
+  dark: ref("gray", 110),
+} as const satisfies Record<string, SemanticValue>;
+
+// ─── Text ───────────────────────────────────────────────────────────────────
+
+export const darkText = {
+  primary: ref("gray", 20),           // #DCE3E8 — softer than pure white
+  secondary: ref("gray", 30),         // #C1CCD6
+  tertiary: ref("gray", 50),          // #7A909E
+  link: ref("blue", 40),              // #5BA3F5 — lighter blue for readability
+  linkHover: ref("blue", 30),         // #A3C9F9
+  linkActive: ref("blue", 20),        // #D4E4FA
+  visited: ref("purple", 40),         // lighter purple
+  selected: ref("blue", 40),
+  destructive: ref("red", 40),
+  reversed: "#ffffff",                // stays white — used on colored backgrounds that don't change
+  light: "#ffffff",
+  dark: ref("gray", 110),
+} as const satisfies Record<string, SemanticValue>;
+
+// ─── Icon ───────────────────────────────────────────────────────────────────
+
+export const darkIcon = {
+  action: ref("blue", 40),            // lighter blue
+  primary: ref("gray", 10),           // #EEF1F4
+  secondary: ref("gray", 50),         // #7A909E
+  destructive: ref("red", 40),
+  contrast: "#ffffff",                 // inverted
+  reversed: "#ffffff",                // stays white — used on colored backgrounds
+  light: "#ffffff",
+  dark: ref("gray", 110),
+} as const satisfies Record<string, SemanticValue>;
+
+// ─── Global ─────────────────────────────────────────────────────────────────
+
+export const darkGlobal = {
+  brand: "#7399c6",                    // stays
+  globalHeader: ref("blue", 100),     // stays dark
+} as const satisfies Record<string, SemanticValue>;
+
+// ─── Status Surface ─────────────────────────────────────────────────────────
+// Bold backgrounds stay the same — they're accent colors that work on dark.
+// Subtle backgrounds use darker shades.
+
+export const darkStatusSurface = {
+  noneBold: ref("gray", 60),
+  informationBold: ref("blue", 60),
+  successBold: ref("green", 60),
+  errorBold: ref("red", 60),
+  warningBold: ref("yellow", 30),
+  openBold: ref("green", 40),
+  completeBold: ref("green", 60),
+  suspendedBold: ref("yellow", 20),
+  cancelledBold: ref("red", 20),
+  noneSubtle: ref("gray", 80),
+  informationSubtle: ref("blue", 90),
+  successSubtle: ref("green", 90),
+  errorSubtle: ref("red", 90),
+  warningSubtle: ref("yellow", 90),
+  openSubtle: ref("green", 80),
+  completeSubtle: ref("gray", 80),
+  suspendedSubtle: ref("yellow", 80),
+  cancelledSubtle: ref("red", 80),
+} as const satisfies Record<string, SemanticValue>;
+
+// ─── Status Text ────────────────────────────────────────────────────────────
+// Bold text on bold backgrounds stays the same.
+// Subtle text uses lighter shades for readability on dark subtle backgrounds.
+
+export const darkStatusText = {
+  noneBoldText: "#ffffff",
+  informationBoldText: "#ffffff",
+  successBoldText: "#ffffff",
+  errorBoldText: "#ffffff",
+  warningBoldText: ref("gray", 110),
+  noneSubtleText: ref("gray", 30),
+  informationSubtleText: ref("blue", 30),
+  successSubtleText: ref("green", 30),
+  errorSubtleText: ref("red", 30),
+  warningSubtleText: ref("yellow", 20),
+} as const satisfies Record<string, SemanticValue>;
+
+// ─── Status Icon ────────────────────────────────────────────────────────────
+
+export const darkStatusIcon = {
+  noneBoldIcon: "#ffffff",
+  informationBoldIcon: "#ffffff",
+  successBoldIcon: "#ffffff",
+  errorBoldIcon: "#ffffff",
+  warningBoldIcon: ref("gray", 110),
+  noneSubtleIcon: ref("gray", 30),
+  informationSubtleIcon: ref("blue", 30),
+  successSubtleIcon: ref("green", 30),
+  errorSubtleIcon: ref("red", 30),
+  warningSubtleIcon: ref("orange", 30),
+} as const satisfies Record<string, SemanticValue>;
+
+// ─── Status General ─────────────────────────────────────────────────────────
+
+export const darkStatusGeneral = {
+  none: ref("gray", 50),
+  information: ref("blue", 50),
+  success: ref("green", 50),
+  error: ref("red", 50),
+  warning: ref("orange", 40),
+} as const satisfies Record<string, SemanticValue>;
+
+// ─── State — Disabled ───────────────────────────────────────────────────────
+
+export const darkStateDisabled = {
+  border: "rgba(159, 177, 189, 0.3)",
+  minimal: "rgba(159, 177, 189, 0.15)",
+  text: "rgba(159, 177, 189, 0.4)",
+} as const satisfies Record<string, SemanticValue>;
+
+// ─── Form ───────────────────────────────────────────────────────────────────
+
+export const darkForm = {
+  inputBorder: ref("gray", 60),
+  inputBackground: ref("gray", 90),   // dark input bg
+} as const satisfies Record<string, SemanticValue>;
+
+// ─── State — Hover ──────────────────────────────────────────────────────────
+
+export const darkStateHover = {
+  borderModerate: ref("gray", 50),
+  surfaceMinimal: "rgba(159, 177, 189, 0.08)",
+  surfaceModerate: "rgba(159, 177, 189, 0.15)",
+  surfaceBold: "rgba(255, 255, 255, 0.1)",
+  surfaceSubtle: "rgba(255, 255, 255, 0.06)",
+} as const satisfies Record<string, SemanticValue>;
+
+// ─── State — Active ─────────────────────────────────────────────────────────
+
+export const darkStateActive = {
+  surfaceBold: "rgba(255, 255, 255, 0.2)",
+  surfaceSubtle: "rgba(255, 255, 255, 0.12)",
+} as const satisfies Record<string, SemanticValue>;
+
+// ─── State — Selected ───────────────────────────────────────────────────────
+
+export const darkStateSelected = {
+  surfaceBold: ref("blue", 60),
+  surfaceMinimal: ref("blue", 90),
+  surfaceOverlay: "rgba(24, 106, 222, 0.25)",
+} as const satisfies Record<string, SemanticValue>;
+
+// ─── Tag ────────────────────────────────────────────────────────────────────
+
+export const darkTag = {
+  bold: ref("blue", 60),
+  subtle: ref("blue", 80),
+  minimal: ref("gray", 90),
+  textBold: "#ffffff",
+  textSubtle: ref("blue", 30),
+  textMinimal: ref("gray", 30),
+} as const satisfies Record<string, SemanticValue>;
+
+// ─── Button ─────────────────────────────────────────────────────────────────
+
+export const darkButton = {
+  secondary: ref("gray", 80),
+} as const satisfies Record<string, SemanticValue>;
+
+// ─── Grid Row ───────────────────────────────────────────────────────────────
+
+export const darkGridRow = {
+  rowDefault: ref("gray", 100),
+  rowAlt: ref("gray", 90),
+  rowSelected: ref("blue", 90),
+} as const satisfies Record<string, SemanticValue>;
+
+// Stronger shadows for dark backgrounds (higher opacity than light theme)
+export const darkElevation = {
+  "00": { boxShadow: "none" },
+  "01": {
+    boxShadow:
+      "0px 1px 2px 0px rgba(0,0,0,0.5), 0px 1px 3px 1px rgba(0,0,0,0.3)",
+  },
+  "02": {
+    boxShadow:
+      "0px 1px 2px 0px rgba(0,0,0,0.5), 0px 2px 6px 2px rgba(0,0,0,0.3)",
+  },
+  "03": {
+    boxShadow:
+      "0px 4px 8px 3px rgba(0,0,0,0.3), 0px 1px 3px 0px rgba(0,0,0,0.5)",
+  },
+  "04": {
+    boxShadow:
+      "0px 6px 10px 4px rgba(0,0,0,0.3), 0px 2px 3px 0px rgba(0,0,0,0.5)",
+  },
+  "05": {
+    boxShadow:
+      "0px 8px 12px 6px rgba(0,0,0,0.3), 0px 4px 4px 0px rgba(0,0,0,0.5)",
+  },
+  "06": {
+    boxShadow:
+      "0px 12px 17px 2px rgba(0,0,0,0.4), 0px 5px 22px 4px rgba(0,0,0,0.3), 0px 7px 8px -4px rgba(0,0,0,0.5)",
+  },
+  "07": {
+    boxShadow:
+      "0px 16px 24px 2px rgba(0,0,0,0.4), 0px 6px 30px 5px rgba(0,0,0,0.3), 0px 8px 10px -5px rgba(0,0,0,0.5)",
+  },
+  "08": {
+    boxShadow:
+      "0px 24px 38px 3px rgba(0,0,0,0.4), 0px 9px 46px 8px rgba(0,0,0,0.3), 0px 11px 15px -7px rgba(0,0,0,0.5)",
+  },
+} as const satisfies Record<string, ElevationToken>;
+
+// ─── Aggregate ──────────────────────────────────────────────────────────────
+
+export const darkSemanticTokens = {
+  surface: darkSurface,
+  border: darkBorder,
+  text: darkText,
+  icon: darkIcon,
+  global: darkGlobal,
+  statusSurface: darkStatusSurface,
+  statusText: darkStatusText,
+  statusIcon: darkStatusIcon,
+  statusGeneral: darkStatusGeneral,
+  stateDisabled: darkStateDisabled,
+  form: darkForm,
+  stateHover: darkStateHover,
+  stateActive: darkStateActive,
+  stateSelected: darkStateSelected,
+  tag: darkTag,
+  button: darkButton,
+  gridRow: darkGridRow,
+} as const;
+

--- a/packages/foundation/src/index.ts
+++ b/packages/foundation/src/index.ts
@@ -5,6 +5,8 @@ export {
   colorVar,
   semanticToCssProperties,
   elevationToCssProperties,
+  darkSemanticToCssProperties,
+  darkElevationToCssProperties,
   injectAllTokens,
   semanticVar,
   elevationVar,

--- a/packages/foundation/src/tokens.ts
+++ b/packages/foundation/src/tokens.ts
@@ -1,4 +1,12 @@
 import { colors, type ColorFamily } from "./colors.js";
+import {
+  semanticTokens,
+  elevation,
+  resolveSemanticValue,
+  type SemanticValue,
+  type SemanticTokenGroup,
+} from "./semantic-tokens.js";
+import { darkSemanticTokens, darkElevation } from "./dark-theme.js";
 
 /**
  * Generates CSS custom properties string from the color tokens.
@@ -41,18 +49,6 @@ export function colorVar<F extends ColorFamily>(
   return `var(--fd-color-${family}-${String(step)})`;
 }
 
-// ---------------------------------------------------------------------------
-// Semantic tokens → CSS custom properties
-// ---------------------------------------------------------------------------
-
-import {
-  semanticTokens,
-  elevation,
-  resolveSemanticValue,
-  type SemanticValue,
-  type SemanticTokenGroup,
-} from "./semantic-tokens.js";
-
 /** Convert a camelCase key to kebab-case. */
 function toKebab(s: string): string {
   return s.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
@@ -92,6 +88,32 @@ export function elevationToCssProperties(): string {
 }
 
 /**
+ * Generates CSS custom properties for dark theme semantic token overrides.
+ */
+export function darkSemanticToCssProperties(): string {
+  const lines: string[] = [];
+  for (const [group, tokens] of Object.entries(darkSemanticTokens)) {
+    const prefix = `--fd-${toKebab(group)}`;
+    for (const [name, value] of Object.entries(tokens)) {
+      lines.push(
+        `${prefix}-${toKebab(name)}: ${resolveSemanticValue(value as SemanticValue)};`,
+      );
+    }
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Generates CSS custom properties for dark theme elevation overrides.
+ */
+export function darkElevationToCssProperties(): string {
+  const lines: string[] = [];
+  for (const [level, token] of Object.entries(darkElevation)) {
+    lines.push(`--fd-elevation-${level}: ${token.boxShadow};`);
+  }
+  return lines.join("\n");
+}
+/**
  * Injects all foundation tokens (palette + semantic + elevation) on :root.
  * Call once at app startup.
  */
@@ -110,9 +132,14 @@ export function injectAllTokens(): void {
     radiusToCssProperties(),
     borderWidthToCssProperties(),
   ].join("\n");
+  const darkCss = [
+    darkSemanticToCssProperties(),
+    darkElevationToCssProperties(),
+  ].join("\n");
+
   const style = document.createElement("style");
   style.id = id;
-  style.textContent = `:root {\n${css}\n}`;
+  style.textContent = `:root {\n${css}\n}\n\n[data-theme="dark"] {\n${darkCss}\n}`;
   document.head.appendChild(style);
 }
 

--- a/packages/ui-components/src/components/ui-button.ts
+++ b/packages/ui-components/src/components/ui-button.ts
@@ -29,7 +29,9 @@ import {
   SP_4,
   SURFACE_ACTION,
   SURFACE_ACTION_CONTRAST,
+  SURFACE_CONTRAST,
   SURFACE_DESTRUCTIVE,
+  SURFACE_PRIMARY,
   SURFACE_SUCCESS,
   SURFACE_TERTIARY,
   TEXT_PRIMARY,
@@ -243,9 +245,9 @@ const STYLES = /* css */ `
 
   :host([action="contrast"]) button,
   :host([action="contrast"][emphasis="bold"]) button {
-    background-color: var(--ui-btn-bg, ${WHITE});
-    color: var(--ui-btn-color, ${TEXT_PRIMARY});
-    border-color: var(--ui-btn-border-color, ${WHITE});
+    background-color: var(--ui-btn-bg, ${SURFACE_PRIMARY});
+    color: var(--ui-btn-color, ${SURFACE_CONTRAST});
+    border-color: var(--ui-btn-border-color, ${SURFACE_PRIMARY});
   }
 
   :host([action="contrast"][emphasis="subtle"]) button {

--- a/packages/ui-components/src/components/ui-checkbox-item.ts
+++ b/packages/ui-components/src/components/ui-checkbox-item.ts
@@ -18,6 +18,7 @@ import {
   TYPE_BODY_01,
   TYPE_BODY_02,
   TYPE_BODY_03,
+  SURFACE_PRIMARY,
 } from "@maneki/foundation";
 import "./ui-icon.js";
 import type { UiIcon } from "./ui-icon.js";
@@ -74,7 +75,7 @@ const STYLES = /* css */ `
     border-style: solid;
     border-color: var(--ui-cb-border, ${FORM_INPUT_BORDER});
     border-radius: ${RADIUS_SM};
-    background-color: var(--ui-cb-bg, #ffffff);
+    background-color: var(--ui-cb-bg, ${SURFACE_PRIMARY});
     color: #ffffff;
     transition:
       background-color 0.15s ease,

--- a/packages/ui-components/src/components/ui-datetime-picker-input.styles.ts
+++ b/packages/ui-components/src/components/ui-datetime-picker-input.styles.ts
@@ -19,6 +19,7 @@ import {
   TYPE_BODY_02,
   TYPE_BODY_03,
   TYPE_CAPTION_01,
+  SURFACE_PRIMARY,
 } from "@maneki/foundation";
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -60,7 +61,7 @@ export const STYLES = /* css */ `
     align-items: center;
     border: 1px solid var(--ui-dpi-border, ${FORM_INPUT_BORDER});
     border-radius: ${RADIUS_SM};
-    background-color: var(--ui-dpi-bg, #ffffff);
+    background-color: var(--ui-dpi-bg, ${SURFACE_PRIMARY});
     cursor: pointer;
     transition: border-color 0.15s ease, box-shadow 0.15s ease;
     overflow: hidden;

--- a/packages/ui-components/src/components/ui-dropdown-split.styles.ts
+++ b/packages/ui-components/src/components/ui-dropdown-split.styles.ts
@@ -322,14 +322,13 @@ export const STYLES = /* css */ `
   /* ── Action × Emphasis: CONTRAST ──────────────────────────────────────── */
   :host([action="contrast"]) .base,
   :host([action="contrast"][emphasis="bold"]) .base {
-    background-color: var(--ui-dds-bg, #ffffff);
     color: var(--ui-dds-color, ${TEXT_PRIMARY});
-    border-color: var(--ui-dds-border-color, #ffffff);
+    border-color: var(--ui-dds-border-color, ${SURFACE_PRIMARY});
   }
   :host([action="contrast"][emphasis="subtle"]) .base {
     background-color: transparent;
     color: var(--ui-dds-color, #ffffff);
-    border-color: var(--ui-dds-border-color, #ffffff);
+    border-color: var(--ui-dds-border-color, ${SURFACE_PRIMARY});
   }
   :host([action="contrast"][emphasis="minimal"]) .base {
     background-color: transparent;
@@ -364,23 +363,23 @@ export const STYLES = /* css */ `
   .left:focus-visible,
   .right:focus-visible {
     outline: none;
-    box-shadow: 0 0 0 1px #ffffff, 0 0 0 2px ${BORDER_FOCUS};
+    box-shadow: 0 0 0 1px ${SURFACE_PRIMARY}, 0 0 0 2px ${BORDER_FOCUS};
   }
   :host([action="secondary"]) .left:focus-visible,
   :host([action="secondary"]) .right:focus-visible {
-    box-shadow: 0 0 0 1px #ffffff, 0 0 0 2px ${TEXT_PRIMARY};
+    box-shadow: 0 0 0 1px ${SURFACE_PRIMARY}, 0 0 0 2px ${TEXT_PRIMARY};
   }
   :host([action="destructive"]) .left:focus-visible,
   :host([action="destructive"]) .right:focus-visible {
-    box-shadow: 0 0 0 1px #ffffff, 0 0 0 2px ${SURFACE_DESTRUCTIVE};
+    box-shadow: 0 0 0 1px ${SURFACE_PRIMARY}, 0 0 0 2px ${SURFACE_DESTRUCTIVE};
   }
   :host([action="info"]) .left:focus-visible,
   :host([action="info"]) .right:focus-visible {
-    box-shadow: 0 0 0 1px #ffffff, 0 0 0 2px ${SURFACE_ACTION_CONTRAST};
+    box-shadow: 0 0 0 1px ${SURFACE_PRIMARY}, 0 0 0 2px ${SURFACE_ACTION_CONTRAST};
   }
   :host([action="contrast"]) .left:focus-visible,
   :host([action="contrast"]) .right:focus-visible {
-    box-shadow: 0 0 0 1px ${TEXT_PRIMARY}, 0 0 0 2px #ffffff;
+    box-shadow: 0 0 0 1px ${TEXT_PRIMARY}, 0 0 0 2px ${SURFACE_PRIMARY};
   }
   /* ── Disabled ────────────────────────────────────────────────────────── */
   :host([disabled]) .base {
@@ -476,7 +475,6 @@ export const STYLES = /* css */ `
     z-index: 1000;
     min-width: 240px;
     padding: ${SP_0_5} 0;
-    background-color: var(--ui-dds-menu-bg, ${SURFACE_PRIMARY});
     box-shadow: var(--ui-dds-menu-shadow, ${ELEVATION_05});
     border-radius: ${RADIUS_SM};
     overflow: visible;

--- a/packages/ui-components/src/components/ui-file-upload.ts
+++ b/packages/ui-components/src/components/ui-file-upload.ts
@@ -7,6 +7,7 @@ import {
   HOVER_BORDER_MODERATE,
   SP_1,
   SP_1_5,
+  SURFACE_PRIMARY,
   SURFACE_SECONDARY,
   SURFACE_TERTIARY,
   TEXT_PRIMARY,
@@ -35,7 +36,7 @@ const STYLES = /* css */ `
     align-items: stretch;
     border: 1px solid var(--ui-fu-border, ${FORM_INPUT_BORDER});
     border-radius: 2px;
-    background-color: var(--ui-fu-bg, #ffffff);
+    background-color: var(--ui-fu-bg, ${SURFACE_PRIMARY});
     overflow: hidden;
     cursor: pointer;
     width: 100%;

--- a/packages/ui-components/src/components/ui-input-group.ts
+++ b/packages/ui-components/src/components/ui-input-group.ts
@@ -11,6 +11,7 @@ import {
   SURFACE_TERTIARY,
   TEXT_PRIMARY,
   TEXT_SECONDARY,
+  SURFACE_PRIMARY,
 } from "@maneki/foundation";
 
 // ─── Type-safe property unions ───────────────────────────────────────────────
@@ -107,7 +108,7 @@ const STYLES = /* css */ `
     display: flex;
     flex: 1;
     min-width: 0;
-    background-color: var(--ui-ig-input-bg, #ffffff);
+    background-color: var(--ui-ig-input-bg, ${SURFACE_PRIMARY});
   }
 
   ::slotted(ui-input) {

--- a/packages/ui-components/src/components/ui-input.styles.ts
+++ b/packages/ui-components/src/components/ui-input.styles.ts
@@ -20,6 +20,7 @@ import {
   TEXT_SECONDARY,
   TEXT_TERTIARY,
   TYPE_CAPTION_01,
+  SURFACE_PRIMARY,
 } from "@maneki/foundation";
 
 // ─── Status icon map ─────────────────────────────────────────────────────────
@@ -72,7 +73,7 @@ export const STYLES = /* css */ `
     border-style: solid;
     border-color: var(--ui-input-border, ${FORM_INPUT_BORDER});
     border-radius: ${RADIUS_SM};
-    background-color: var(--ui-input-bg, #ffffff);
+    background-color: var(--ui-input-bg, ${SURFACE_PRIMARY});
     transition:
       border-color 0.15s ease,
       box-shadow 0.15s ease;

--- a/packages/ui-components/src/components/ui-popover.styles.ts
+++ b/packages/ui-components/src/components/ui-popover.styles.ts
@@ -1,12 +1,12 @@
 import {
   FONT_PRIMARY,
+  GRAY_110,
   ICON_REVERSED,
   RADIUS_SM,
   SP_1,
   SP_1_5,
   SP_2,
   SP_2_5,
-  SURFACE_CONTRAST,
   TEXT_REVERSED,
   TYPE_BODY_01,
   TYPE_BODY_02,
@@ -56,7 +56,7 @@ export const STYLES = /* css */ `
   .base {
     display: flex;
     align-items: flex-start;
-    background: ${SURFACE_CONTRAST};
+    background: ${GRAY_110};
     border-radius: ${RADIUS_SM};
     color: ${TEXT_REVERSED};
   }
@@ -114,7 +114,7 @@ export const STYLES = /* css */ `
     position: absolute;
     width: 10px;
     height: 10px;
-    background: ${SURFACE_CONTRAST};
+    background: ${GRAY_110};
     transform: rotate(45deg);
   }
 

--- a/packages/ui-components/src/components/ui-radio-item.ts
+++ b/packages/ui-components/src/components/ui-radio-item.ts
@@ -18,6 +18,7 @@ import {
   TYPE_BODY_01,
   TYPE_BODY_02,
   TYPE_BODY_03,
+  SURFACE_PRIMARY,
 } from "@maneki/foundation";
 
 // ─── Type-safe property unions ───────────────────────────────────────────────
@@ -69,7 +70,7 @@ const STYLES = /* css */ `
     justify-content: center;
     border: 1px solid var(--ui-radio-border, ${FORM_INPUT_BORDER});
     border-radius: ${RADIUS_CIRCLE};
-    background-color: var(--ui-radio-bg, #ffffff);
+    background-color: var(--ui-radio-bg, ${SURFACE_PRIMARY});
     transition:
       background-color 0.15s ease,
       border-color 0.15s ease;
@@ -198,7 +199,7 @@ const STYLES = /* css */ `
 
   :host([checked]) .radio {
     border-color: var(--ui-radio-checked-border, ${BORDER_CONTRAST});
-    background-color: var(--ui-radio-bg, #ffffff);
+    background-color: var(--ui-radio-bg, ${SURFACE_PRIMARY});
   }
 
   /* ── Hover ──────────────────────────────────────────────────────────────── */

--- a/packages/ui-components/src/components/ui-select.styles.ts
+++ b/packages/ui-components/src/components/ui-select.styles.ts
@@ -77,7 +77,6 @@ export const STYLES = /* css */ `
     align-items: center;
     border: 1px solid var(--ui-select-border, ${FORM_INPUT_BORDER});
     border-radius: ${RADIUS_SM};
-    background-color: var(--ui-select-bg, #ffffff);
     transition:
       border-color 0.15s ease,
       box-shadow 0.15s ease;
@@ -240,10 +239,9 @@ export const STYLES = /* css */ `
     z-index: 1000;
     min-width: 100%;
     padding: ${SP_0_5} 0;
-    background-color: var(--ui-select-panel-bg, ${SURFACE_PRIMARY});
+    background: var(--ui-select-panel-bg, ${SURFACE_PRIMARY});
     box-shadow: var(--ui-select-panel-shadow, ${ELEVATION_05});
     border-radius: ${RADIUS_SM};
-    overflow: visible;
     margin-top: ${SP_0_25};
     opacity: 0;
     visibility: hidden;

--- a/packages/ui-components/src/components/ui-slider.styles.ts
+++ b/packages/ui-components/src/components/ui-slider.styles.ts
@@ -16,6 +16,7 @@ import {
   SURFACE_BOLD,
   TEXT_PRIMARY,
   TYPE_BODY_03,
+  SURFACE_PRIMARY,
 } from "@maneki/foundation";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -89,7 +90,7 @@ export const STYLES = /* css */ `
     position: absolute;
     inset: ${BW_MD};
     border-radius: ${RADIUS_PILL};
-    background: #ffffff;
+    background: ${SURFACE_PRIMARY};
     transition: background 0.1s ease;
   }
 

--- a/packages/ui-components/src/components/ui-tab-group.ts
+++ b/packages/ui-components/src/components/ui-tab-group.ts
@@ -16,6 +16,7 @@ import {
   SP_2,
   TEXT_LINK,
   TEXT_PRIMARY,
+  SURFACE_PRIMARY,
 } from "@maneki/foundation";
 import "./ui-icon.js";
 import type { TabItemSize, TabItemOrientation } from "./ui-tab-item.js";
@@ -161,7 +162,7 @@ const STYLES = /* css */ `
     display: none;
     position: absolute;
     z-index: 100;
-    background: #ffffff;
+    background: ${SURFACE_PRIMARY};
     border: ${BW_SM} solid ${BORDER_MINIMAL};
     border-radius: ${RADIUS_MD};
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
@@ -222,7 +223,7 @@ const STYLES = /* css */ `
   }
 
   .overflow-menu-item:hover {
-    background: rgba(0, 0, 0, 0.04);
+    background: var(--fd-state-hover-surface-minimal, rgba(0, 0, 0, 0.04));
   }
 
   .overflow-menu-item.selected {

--- a/packages/ui-components/src/components/ui-tab-item.ts
+++ b/packages/ui-components/src/components/ui-tab-item.ts
@@ -272,7 +272,7 @@ const STYLES = /* css */ `
 
   .close-btn:hover {
     color: var(--ui-tab-text-color, ${TEXT_PRIMARY});
-    background: rgba(0, 0, 0, 0.08);
+    background: var(--fd-state-hover-surface-moderate, rgba(0, 0, 0, 0.08));
   }
 
   .close-btn:focus-visible {

--- a/packages/ui-components/src/components/ui-table-row.ts
+++ b/packages/ui-components/src/components/ui-table-row.ts
@@ -17,7 +17,7 @@ const STYLES = /* css */ `
   /* ── Hover ────────────────────────────────────────────────────────────── */
 
   :host(:hover:not([disabled]):not([header])) {
-    background: linear-gradient(0deg, rgba(159, 177, 189, 0.20) 0%, rgba(159, 177, 189, 0.20) 100%), #fff;
+    background: linear-gradient(0deg, rgba(159, 177, 189, 0.20) 0%, rgba(159, 177, 189, 0.20) 100%), var(--fd-surface-primary, #fff);
   }
 
   /* ── Selected ─────────────────────────────────────────────────────────── */

--- a/packages/ui-components/src/components/ui-tag.ts
+++ b/packages/ui-components/src/components/ui-tag.ts
@@ -59,6 +59,7 @@ import {
   ULTRAMARINE_70,
   YELLOW_10,
   YELLOW_30,
+  SURFACE_PRIMARY,
 } from "@maneki/foundation";
 import "./ui-icon.js";
 import type { UiIcon } from "./ui-icon.js";
@@ -483,7 +484,7 @@ export const STYLES = /* css */ `
   /* ── Editable: editing state ─────────────────────────────────────────── */
 
   :host([editable]) .base.editing {
-    background-color: #ffffff;
+    background-color: ${SURFACE_PRIMARY};
     border: ${BW_MD} solid var(--ui-tag-border, ${BORDER_FOCUS});
     cursor: text;
   }

--- a/packages/ui-components/src/components/ui-textarea.styles.ts
+++ b/packages/ui-components/src/components/ui-textarea.styles.ts
@@ -19,6 +19,7 @@ import {
   TEXT_SECONDARY,
   TEXT_TERTIARY,
   TYPE_CAPTION_01,
+  SURFACE_PRIMARY,
 } from "@maneki/foundation";
 
 // ─── Status icon map ─────────────────────────────────────────────────────────
@@ -84,7 +85,7 @@ export const STYLES = /* css */ `
     border-style: solid;
     border-color: var(--ui-textarea-border, ${FORM_INPUT_BORDER});
     border-radius: ${RADIUS_SM};
-    background-color: var(--ui-textarea-bg, #ffffff);
+    background-color: var(--ui-textarea-bg, ${SURFACE_PRIMARY});
     transition:
       border-color 0.15s ease,
       box-shadow 0.15s ease;


### PR DESCRIPTION
## Summary

Adds dark theme support to the Maneki design system via CSS custom property overrides.

### Foundation
- New `dark-theme.ts` with dark values for all 17 semantic token groups + elevation
- `injectAllTokens()` now generates both `:root` (light) and `[data-theme="dark"]` (dark) CSS blocks
- New exports: `darkSemanticToCssProperties()`, `darkElevationToCssProperties()`

### Components
- Replaced `#ffffff` backgrounds with `SURFACE_PRIMARY` in 10 components:
  - Form controls: input, select, textarea, checkbox, radio, datetime-picker
  - Interactive: dropdown-split, slider, tab-group, tag

### Catalog
- Theme toggle button (☀️/☾) in sidebar footer
- Persists preference to localStorage
- Toggles `data-theme="dark"` on `<html>`

### Dark theme approach
- Semantic tokens flip (surface.primary: #fff → gray-100, text.primary: gray-90 → gray-10)
- Accent colors stay (blue-60, red-60, green-60 work on both light and dark)
- Per-ramp text colors stay white (badge/tag/avatar text on colored backgrounds)
- Hover/active overlays invert (gray-90 @10% → white @10%)
- Elevation shadows get stronger opacity for dark backgrounds

## Test Results

- Foundation: 59 tests ✅
- UI Components: 3586 tests ✅
- Playwright: 101 tests (57 a11y + 44 visual) ✅