### PR TITLE
docs: add architectural decision records (ADRs)

### DIFF
--- a/docs/WEB_COMPONENTS_LESSONS.md
+++ b/docs/WEB_COMPONENTS_LESSONS.md
@@ -1,0 +1,137 @@
+# Web Components & Shadow DOM — Lessons Learned
+
+After building 50+ components, a catalog app, dark theme, and accessibility audit, these are the practical lessons learned about Web Components with Shadow DOM.
+
+## Shadow DOM: Encapsulation vs Integration
+
+### What works well
+
+- **Style isolation is bulletproof.** No CSS conflicts across 50+ components, ever. Consumer stylesheets cannot break component internals.
+- **CSS custom properties pierce the boundary.** Dark mode was implemented as a pure token swap — no component code changes needed for the core theme switch.
+- **True portability.** Components work identically in the catalog app, Storybook, and any consumer application. No framework adapter needed.
+- **Composition via slots.** `<slot>` elements provide clean content projection without inheritance hierarchies.
+
+### What causes recurring pain
+
+**1. Fonts must be re-declared in every Shadow DOM.**
+
+The icon font requires `@font-face { src: local("Material Symbols Outlined") }` in 14 separate component files. If you forget one, icons silently render as empty boxes. There's no way to inherit a global `@font-face` into Shadow DOM.
+
+```css
+/* Required in EVERY component that uses icons */
+@font-face {
+  font-family: "Material Symbols Outlined";
+  font-style: normal;
+  src: local("Material Symbols Outlined");
+  font-display: swap;
+}
+```
+
+**2. Focus management breaks at shadow boundaries.**
+
+`document.activeElement` stops at the shadow root — it returns the host element, not the focused element inside. The modal focus trap required a recursive walker:
+
+```ts
+private _getDeepActiveElement(): Element | null {
+  let active: Element | null = document.activeElement;
+  while (active?.shadowRoot?.activeElement) {
+    active = active.shadowRoot.activeElement;
+  }
+  return active;
+}
+```
+
+Every overlay component (modal, popover, dropdown, select) needs this pattern.
+
+**3. Accessibility tooling can't see through Shadow DOM.**
+
+axe-core cannot detect `disabled` state on custom elements — it sees the host element but not the internal `<button disabled>`. We had to exclude `color-contrast` checks from the a11y test suite because it flagged every disabled component as a violation.
+
+ARIA attributes must be set on the host element (light DOM) for screen readers, even when the interactive element is inside Shadow DOM.
+
+**4. DOM queries don't cross boundaries.**
+
+`document.getElementById()`, `document.querySelector()` — none of these reach into Shadow DOM. A button placed as a child of a Web Component (via slot) is accessible, but one created inside Shadow DOM is invisible to the parent document.
+
+We hit this when the theme toggle button was placed inside `<ui-side-panel-menu>` — `getElementById("theme-toggle")` returned null. Had to move it outside the component.
+
+**5. Event retargeting.**
+
+Events from inside Shadow DOM are retargeted — `event.target` becomes the host element, not the actual clicked element. Components must use `event.composedPath()` or handle events internally and re-dispatch composed events.
+
+## Imperative DOM Construction
+
+Without Lit or a template DSL, every component builds its DOM with `document.createElement()` chains. A 50-line HTML template becomes 150+ lines of imperative code:
+
+```ts
+// What we write (no template DSL)
+const btn = document.createElement("button");
+btn.className = "base";
+btn.type = "button";
+const slot = document.createElement("slot");
+btn.appendChild(slot);
+shadow.appendChild(btn);
+
+// What Lit would give us
+render() { return html`<button class="base" type="button"><slot></slot></button>`; }
+```
+
+We accepted this tradeoff for zero runtime dependencies (ADR-012), but it's the single biggest DX cost. Components average 400-600 lines where a Lit equivalent would be 200-300.
+
+## CSS Custom Properties: The Two-Layer Tax
+
+Every customizable property needs nested `var()`:
+
+```css
+background: var(--ui-btn-bg, var(--fd-surface-action));
+/*           ↑ consumer API    ↑ foundation default     */
+```
+
+With 50 components × 10+ customizable properties each, this is ~500 `var()` declarations. It's the right architecture (ADR-002) but verbose. The centralized token constants (ADR-004) helped reduce the boilerplate at the default value layer.
+
+## Server-Side Rendering Compatibility
+
+**Current status: NOT SSR-compatible.**
+
+### Why
+
+1. **DOM required.** `attachShadow()`, `document.createElement()`, `customElements.define()` all require a browser DOM. There is no HTML string output path.
+
+2. **No Declarative Shadow DOM.** The platform supports `<template shadowrootmode="open">` for static Shadow DOM in HTML, but our components build DOM imperatively — they don't generate `<template>` tags.
+
+3. **No hydration.** Even if we pre-rendered HTML, there's no mechanism to adopt an existing Shadow DOM. The component would rebuild it from scratch in `connectedCallback()`, causing a flash.
+
+### What SSR would require
+
+```html
+<!-- Declarative Shadow DOM (what SSR needs to emit) -->
+<ui-button action="primary">
+  <template shadowrootmode="open">
+    <style>/* component styles */</style>
+    <button class="base"><slot></slot></button>
+  </template>
+  Click me
+</ui-button>
+```
+
+Options to get there:
+- **Add Lit** — provides `@lit-labs/ssr` for free, but adds a runtime dependency (contradicts ADR-012)
+- **Custom `renderToString()`** — per-component server rendering function. Huge effort, fragile to maintain.
+- **Accept client-side hydration** — the pragmatic choice. Framework SSR renders `<ui-button>` as an empty tag, component hydrates client-side.
+
+### Practical impact
+
+For SPAs (React, Vue, Next.js, Nuxt), client-side hydration works fine:
+- Server emits `<ui-button>Click me</ui-button>` as a string
+- Browser registers the custom element and upgrades it
+- Brief flash of unstyled content (FOUC) until JS loads
+- Most Web Component design systems (Shoelace, Spectrum Web Components, FAST) work this way
+
+For content-heavy sites where FOUC is unacceptable, Web Components with Shadow DOM are not the right choice today.
+
+## Recommendations for Future Work
+
+1. **Consider Lit adoption** if SSR becomes a requirement. The DX improvement (templates, reactive properties) would also reduce component code by ~40%.
+2. **Declarative Shadow DOM** support is improving in browsers. When all target browsers support it, a build-time pre-renderer could generate static Shadow DOM without Lit.
+3. **CSS `@scope`** (shipping in Chrome/Edge) may eventually replace Shadow DOM for style encapsulation without the integration pain points.
+4. **`ElementInternals`** can improve form participation — custom elements can participate in native `<form>` validation without wrapper hacks.

--- a/docs/adr/001-web-components-shadow-dom.md
+++ b/docs/adr/001-web-components-shadow-dom.md
@@ -1,0 +1,29 @@
+# ADR-001: Web Components + Shadow DOM
+
+**Status:** Accepted
+**Date:** 2026-03
+**Context:** Choosing a component technology for the Maneki design system.
+
+## Decision
+
+All UI components are built as native Web Components using `customElements.define()` with Shadow DOM (`attachShadow({ mode: "open" })`).
+
+## Rationale
+
+- **Framework-agnostic.** Web Components work in any framework (React, Vue, Svelte, vanilla) or no framework at all. The design system shouldn't force a framework choice on consumers.
+- **Style encapsulation.** Shadow DOM prevents component styles from leaking out and external styles from leaking in. Each component is a self-contained unit.
+- **Native platform.** No build step required for consumers. Components register themselves and work in any HTML page with a `<script>` tag.
+- **Composition over inheritance.** Components compose via slots and CSS custom properties, not class inheritance. This avoids fragile base class hierarchies.
+
+## Consequences
+
+- **CSS custom properties are the theming API.** Shadow DOM blocks external CSS selectors, so all customization happens through `var(--ui-*)` properties that pierce the shadow boundary.
+- **Constructable stylesheets** (`new CSSStyleSheet()`) are used for performance — one shared stylesheet instance per component class, not per instance.
+- **No light DOM components.** Every component uses Shadow DOM, no exceptions.
+- **Font loading requires `@font-face` in Shadow DOM.** The Material Symbols icon font must be declared via `@font-face { src: local(...) }` inside each component that uses icons, since Shadow DOM can't see global `@font-face` rules.
+
+## Alternatives Considered
+
+- **React components** — would limit adoption to React projects.
+- **Lit** — considered as a Web Component base class, but adds a runtime dependency. Raw `HTMLElement` keeps the bundle smaller and avoids framework lock-in.
+- **Light DOM** — would allow global CSS but loses encapsulation. Components would be fragile in consumer applications with conflicting styles.

--- a/docs/adr/002-css-custom-properties-theming.md
+++ b/docs/adr/002-css-custom-properties-theming.md
@@ -1,0 +1,35 @@
+# ADR-002: CSS Custom Properties for Theming
+
+**Status:** Accepted
+**Date:** 2026-03
+**Context:** Defining how consumers customize component appearance.
+
+## Decision
+
+All design tokens are injected as CSS custom properties on `:root` via `injectAllTokens()`. Components reference tokens through a two-layer `var()` pattern:
+
+```css
+background: var(--ui-btn-bg, var(--fd-surface-action));
+```
+
+- `--ui-btn-bg` — component-level override (consumer API)
+- `--fd-surface-action` — foundation token (default)
+
+## Rationale
+
+- **Pierces Shadow DOM.** CSS custom properties are the only CSS mechanism that crosses shadow boundaries. External stylesheets can't target Shadow DOM internals, but custom properties inherit through.
+- **Two-layer pattern.** Consumers override specific components (`--ui-btn-bg`) without touching the design system tokens (`--fd-*`). Foundation tokens provide sensible defaults.
+- **Runtime themeable.** Changing a custom property value instantly updates all components — no rebuild needed. This enables dark mode, density variants, and brand customization.
+- **Predictable naming.** `--fd-*` for foundation tokens, `--ui-*` for component overrides. No collisions.
+
+## Consequences
+
+- Every visual property that should be customizable must be wrapped in `var()`.
+- Foundation must generate and inject all token CSS before components render.
+- Token names are part of the public API — renaming is a breaking change.
+
+## Alternatives Considered
+
+- **CSS parts (`::part()`)** — exposes internal elements for styling but is verbose and fragile. Custom properties are more ergonomic.
+- **JS-based theming** — setting properties via JavaScript. Works but loses the cascade and doesn't integrate with CSS tooling.
+- **CSS-in-JS** — adds runtime overhead and framework dependency.

--- a/docs/adr/003-semantic-token-architecture.md
+++ b/docs/adr/003-semantic-token-architecture.md
@@ -1,0 +1,33 @@
+# ADR-003: Semantic Token Architecture
+
+**Status:** Accepted
+**Date:** 2026-03
+**Context:** Bridging the gap between raw color palette values and component usage.
+
+## Decision
+
+Design tokens are organized in three layers:
+
+1. **Palette** (`colors.ts`) — raw color values: 13 families × 10 steps (e.g., `blue-60: #186ADE`)
+2. **Semantic** (`semantic-tokens.ts`) — purpose-driven references: `surface.primary`, `text.link`, `border.focus`
+3. **Component** — CSS custom properties: `--ui-btn-bg` defaulting to a semantic token
+
+Semantic tokens reference palette values via `PaletteRef` objects (`{ family: "blue", step: 60 }`), resolved to hex at CSS generation time.
+
+## Rationale
+
+- **Figma alignment.** The Figma source file uses the same three-layer architecture. Semantic tokens map 1:1 to Figma's token groups (Surface, Border, Text, Icon, Status, State).
+- **Theme independence.** Components reference `surface.primary` not `#ffffff`. In dark mode, `surface.primary` resolves to `gray-100` instead — no component code changes.
+- **Semantic clarity.** `border.focus` communicates intent better than `blue-60`. When the focus color changes, only the token mapping updates.
+- **Group-based organization.** Tokens are grouped by domain: `surface.*`, `text.*`, `stateHover.*`, `statusSurface.*`. Each group is independently overridable for theming.
+
+## Consequences
+
+- Adding a new semantic purpose requires a new token, not reusing an existing one (even if the resolved color is the same today).
+- The `resolveSemanticValue()` function must handle both `PaletteRef` objects and raw strings (hex, rgba).
+- All 17 semantic groups must have dark theme counterparts in `dark-theme.ts`.
+
+## Alternatives Considered
+
+- **Flat token list** — simpler but loses the semantic grouping. Hard to maintain at scale.
+- **Runtime palette references** — resolve `PaletteRef` at runtime instead of build time. Adds complexity for no benefit since palette values don't change at runtime.

--- a/docs/adr/004-centralized-token-constants.md
+++ b/docs/adr/004-centralized-token-constants.md
@@ -1,0 +1,45 @@
+# ADR-004: Centralized Token Constants
+
+**Status:** Accepted
+**Date:** 2026-03
+**Context:** Every component file defined its own local token constants (e.g., `const TEXT_PRIMARY = semanticVar("text", "primary")`), duplicated across 70+ files.
+
+## Decision
+
+All pre-computed token constants are defined once in `packages/foundation/src/token-constants.ts` and exported from `@maneki/foundation`. Components import constants directly instead of calling helper functions.
+
+```ts
+// Before (in every component)
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const SP_1 = spaceVar("1");
+
+// After (single import)
+import { TEXT_PRIMARY, SP_1 } from "@maneki/foundation";
+```
+
+## Rationale
+
+- **DRY.** 791 local constant definitions removed across 72 files.
+- **Consistent naming.** Canonical names enforced: `SP_0_5` (not `SP_05`), `STATUS_SURFACE_ERROR_BOLD` (not `SURF_ERROR_BOLD`), `HOVER_BORDER_MODERATE` (not `HOVER_BORDER`).
+- **Discoverability.** One file to see all available tokens. IDE autocomplete works across the entire design system.
+- **Tree-shakeable.** Unused constants are eliminated by Vite's bundler — no bundle size penalty.
+
+## Naming Conventions
+
+- Spacing: `SP_` + scale step, underscores for decimals (`SP_1_25` = step 1.25)
+- Colors: `{FAMILY}_{STEP}` (`BLUE_60`, `GRAY_110`)
+- Semantic: descriptive name matching token group/key (`TEXT_PRIMARY`, `BORDER_FOCUS`)
+- Status: full prefix (`STATUS_SURFACE_ERROR_BOLD`, `STATUS_GENERAL_WARNING`)
+- Shape: `RADIUS_*`, `BW_*` (border-width)
+- Elevation: `ELEVATION_*`
+
+## Consequences
+
+- Helper functions (`semanticVar`, `colorVar`, etc.) are no longer needed in component files — only in `token-constants.ts` itself.
+- Adding a new token requires updating `token-constants.ts` and rebuilding foundation.
+- Naming conflicts must be resolved at the constant level (e.g., `ICON_PRIMARY` for semantic icon vs `ICON_*` codepoint constants).
+
+## Alternatives Considered
+
+- **Shared module in ui-components** — keeps constants local to the package. Rejected because grid-layout and other packages also need them.
+- **Keep local constants** — simpler per-file but 791 duplicates is unmaintainable.

--- a/docs/adr/005-typography-typeblock-helper.md
+++ b/docs/adr/005-typography-typeblock-helper.md
@@ -1,0 +1,41 @@
+# ADR-005: Typography typeBlock() Helper
+
+**Status:** Accepted
+**Date:** 2026-03
+**Context:** Components hardcoded `font-size`, `line-height`, and `font-weight` as raw pixel values (478 occurrences). These need to reference typography tokens for consistency and dark mode font-family support.
+
+## Decision
+
+A `typeBlock()` helper returns all four typography CSS properties as a single interpolatable string:
+
+```ts
+${typeBlock("body", "02")}
+// → font-family: var(--fd-type-body-02-font-family);
+//   font-size: var(--fd-type-body-02-font-size);
+//   line-height: var(--fd-type-body-02-line-height);
+//   font-weight: var(--fd-type-body-02-font-weight);
+```
+
+Pre-computed `TYPE_*` constants wrap `typeBlock()` for use in component styles:
+
+```ts
+export const TYPE_BODY_02 = typeBlock("body", "02");
+```
+
+## Rationale
+
+- **One line replaces four.** `${TYPE_BODY_02}` instead of separate font-size + line-height + font-weight + font-family declarations.
+- **Font-family included.** Adding `font-family` to `typeBlock()` means components automatically get the correct font without hardcoding `"Geist"` everywhere.
+- **CSS var() references.** Typography values are runtime-overridable via CSS custom properties, enabling future typography customization.
+- **197 blocks replaced** across 42 component files.
+
+## Consequences
+
+- 94 hardcoded font-sizes remain as intentional exceptions (non-standard sizes like 8/9/10/18px, standalone font-size without line-height).
+- `FONT_PRIMARY` constant (`'Geist', sans-serif`) handles the remaining 84 `font-family` declarations in `:host` base blocks.
+- Tests that asserted raw pixel values now assert `var(--fd-type-*)` references.
+
+## Alternatives Considered
+
+- **Per-property replacement** — three `typeVar()` calls per location. More verbose, same result.
+- **CSS `font` shorthand** — `font: 400 14px/20px 'Geist'`. Compact but resets unspecified properties (`font-variant`, `font-stretch`), causing subtle bugs.

--- a/docs/adr/006-shape-tokens-css-custom-properties.md
+++ b/docs/adr/006-shape-tokens-css-custom-properties.md
@@ -1,0 +1,30 @@
+# ADR-006: Shape Tokens as CSS Custom Properties
+
+**Status:** Accepted
+**Date:** 2026-03
+**Context:** `radiusVar()` and `borderWidthVar()` originally returned raw values (`"2px"`, `"999px"`) instead of CSS `var()` references, unlike all other token helpers.
+
+## Decision
+
+Wire shape tokens through CSS custom properties, consistent with all other token types:
+
+- `radiusVar("sm")` → `var(--fd-radius-sm)` (was `"2px"`)
+- `borderWidthVar("md")` → `var(--fd-border-width-md)` (was `"2px"`)
+- `radiusToCssProperties()` and `borderWidthToCssProperties()` generate the `:root` declarations
+- Both are included in `injectAllTokens()`
+
+## Rationale
+
+- **Consistency.** Every other token type (`colorVar`, `semanticVar`, `spaceVar`, `elevationVar`, `typeVar`) returns a `var()` reference. Shape tokens were the exception.
+- **Runtime themeable.** Consumers can override `--fd-radius-sm: 4px` to change all component radii globally. Not possible with raw values.
+- **Negative values work correctly.** `outline-offset: calc(-1 * var(--fd-border-width-md))` is valid CSS. The previous `-${BW_MD}` produced `-2px` which worked by accident but was semantically wrong.
+
+## Consequences
+
+- All `outline-offset: -2px` patterns changed to `calc(-1 * var(--fd-border-width-md))` across 11 files.
+- Tests checking for raw values like `border-radius: 999px` updated to check for `var(--fd-radius-pill)`.
+- Foundation barrel exports updated to include `radiusToCssProperties` and `borderWidthToCssProperties`.
+
+## Alternatives Considered
+
+- **Keep raw values** — simpler but inconsistent. Consumers can't override shape tokens at runtime.

--- a/docs/adr/007-dark-theme-data-attribute.md
+++ b/docs/adr/007-dark-theme-data-attribute.md
@@ -1,0 +1,34 @@
+# ADR-007: Dark Theme via data-theme Attribute
+
+**Status:** Accepted
+**Date:** 2026-03
+**Context:** Adding dark mode support to the design system.
+
+## Decision
+
+Dark theme is activated by setting `data-theme="dark"` on any ancestor element (typically `<html>`). The foundation injects both light and dark CSS in a single `<style>` block:
+
+```css
+:root { --fd-surface-primary: #ffffff; ... }
+[data-theme="dark"] { --fd-surface-primary: #0D1826; ... }
+```
+
+## Rationale
+
+- **No component changes needed.** Components already reference semantic tokens via `var()`. Dark mode just overrides the token values — the cascade handles the rest.
+- **Attribute selector over media query.** `[data-theme="dark"]` allows programmatic toggling (user preference stored in localStorage) independent of OS settings. Can be combined with `prefers-color-scheme` if desired.
+- **Single injection point.** `injectAllTokens()` generates both light and dark CSS. No separate dark mode initialization step.
+- **Scoped theming possible.** `data-theme="dark"` on a `<div>` creates a dark island within a light page.
+
+## Consequences
+
+- All semantic token groups need dark counterparts in `dark-theme.ts` (17 groups + elevation).
+- Components using hardcoded `#ffffff` for backgrounds must be migrated to `SURFACE_PRIMARY`.
+- Accent colors (blue-60, red-60, etc.) stay the same in both themes — they work on both light and dark backgrounds.
+- The catalog app includes a theme toggle button that persists preference to localStorage.
+
+## Alternatives Considered
+
+- **`prefers-color-scheme` media query only** — no user override, tied to OS setting.
+- **CSS class (`.dark`)** — works but `data-*` attributes are more semantic and don't conflict with utility classes.
+- **Separate stylesheet** — requires loading/unloading CSS files. More complex, slower theme switching.

--- a/docs/adr/008-no-white-token.md
+++ b/docs/adr/008-no-white-token.md
@@ -1,0 +1,34 @@
+# ADR-008: No Generic "White" Token
+
+**Status:** Accepted
+**Date:** 2026-03
+**Context:** 109 hardcoded `#ffffff` values across components. Should there be a `WHITE` or `text.inverse` semantic token?
+
+## Decision
+
+No generic "white" token. The `#ffffff` values fall into two categories, each handled differently:
+
+1. **Surface backgrounds** (cards, inputs, panels) → `SURFACE_PRIMARY`, which flips to dark in dark mode
+2. **Text on colored backgrounds** (badge, tag, avatar bold text) → stays `#ffffff`, handled by per-ramp color maps
+
+## Rationale
+
+Verified against Figma specs for badge, tag, avatar, and dropdown-split:
+
+- Each color ramp has its own text token: `Ramp/Text/blue-ramp-bold-text: #FFFFFF`
+- **Yellow is the exception**: `Ramp/Text/yellow-ramp-bold-text: #1C2B36` (dark text on light yellow)
+- This proves `#ffffff` is not a single semantic concept — it's per-ramp, and yellow proves the values can diverge
+
+A generic "white" token would be wrong for yellow badges and would prevent future per-ramp customization in dark mode (e.g., lighter purple background with dark text).
+
+## Consequences
+
+- `#ffffff` in badge/tag/avatar color maps stays as raw values — they're intentionally per-ramp.
+- `#ffffff` for backgrounds is replaced with `SURFACE_PRIMARY` (flips in dark mode).
+- `#ffffff` in focus rings is replaced with `SURFACE_PRIMARY`.
+- `#ffffff` for text on dark overlays (tooltip, popover) stays as raw values — these overlays don't change between themes.
+
+## Alternatives Considered
+
+- **`text.reversed` token** — exists but maps to `#ffffff` in light and `gray-110` in dark. Wrong for badge text which should stay white on blue-60 in both themes.
+- **`WHITE` constant** — a named constant for `#ffffff`. Doesn't solve the semantic problem and suggests it should be tokenized.

--- a/docs/adr/009-dark-elevation-stronger-shadows.md
+++ b/docs/adr/009-dark-elevation-stronger-shadows.md
@@ -1,0 +1,35 @@
+# ADR-009: Dark Elevation: Stronger Shadows
+
+**Status:** Accepted
+**Date:** 2026-03
+**Context:** Choosing how elevation hierarchy is communicated in dark mode.
+
+## Decision
+
+Dark mode uses stronger box-shadows (higher opacity: 0.3–0.5 vs light mode's 0.14–0.24) to remain visible against dark backgrounds.
+
+## Rationale
+
+Two approaches were evaluated:
+
+### Option 1: Stronger shadows (chosen)
+- Same visual language as light mode — shadows indicate depth
+- Works through existing `--fd-elevation-*` CSS custom properties
+- No component changes needed
+
+### Option 2: Surface tint (rejected)
+- Material Design 3 approach: higher elevation = lighter surface color via white overlay
+- Attempted using `inset 0 0 0 9999px rgba(255,255,255, 0.05–0.16)` as box-shadow
+- **Failed** because `box-shadow` doesn't tint the background — it renders on top, creating a visible overlay edge on rounded corners and clipping with `overflow: hidden`
+- Would require component-level changes (background-color per elevation) rather than working through the existing CSS custom property
+
+## Consequences
+
+- Dark shadows use 0.3–0.5 opacity (vs 0.14–0.24 in light mode)
+- Elevation hierarchy is subtler in dark mode but still perceptible
+- No component code changes — purely a token value change in `dark-theme.ts`
+
+## Alternatives Considered
+
+- **No shadows in dark mode** — loses elevation hierarchy entirely
+- **Border-based elevation** — `border: 1px solid rgba(255,255,255,0.1)` for higher elevations. Viable but changes the visual language from shadows to borders.

--- a/docs/adr/010-material-symbols-subset-font.md
+++ b/docs/adr/010-material-symbols-subset-font.md
@@ -1,0 +1,34 @@
+# ADR-010: Material Symbols Subsetted Font
+
+**Status:** Accepted
+**Date:** 2026-03
+**Context:** Components need icons. The full Material Symbols Outlined font is ~300 KB.
+
+## Decision
+
+Ship a subsetted Material Symbols Outlined font (~24 KB) containing only the icons used by the design system. Icons are referenced by Unicode codepoint constants, not ligature text.
+
+```ts
+import { ICON_CLOSE } from "@maneki/foundation";
+clearIcon.textContent = ICON_CLOSE; // "\uE5CD"
+```
+
+## Rationale
+
+- **24 KB vs 300 KB.** The subset font is 92% smaller than the full font. Only ~32 icons are included.
+- **Codepoints over ligatures.** Ligature text (`"close"`) requires the browser to perform OpenType substitution, which can flash the raw text before the font loads. Codepoints (`"\uE5CD"`) render as empty boxes (invisible) until the font loads — no FOUT.
+- **Single font file.** One `.woff2` file registered globally via `registerIconFont()`. Shadow DOM components access it through `@font-face { src: local("Material Symbols Outlined") }`.
+- **Deterministic subset.** `assets/subset-icons.py` + `assets/icon-manifest.txt` define exactly which icons are included. Adding a new icon is a documented SOP.
+
+## Consequences
+
+- New icons require running the subset script and committing the updated `.woff2`.
+- `<ui-icon>` component handles both codepoint lookup (via `name` attribute) and ligature fallback.
+- Shadow DOM requires a local `@font-face` declaration in every component that uses icons (with `font-display: swap`).
+- The font is preloaded in the catalog app via a Vite plugin that injects `<link rel="preload">` with the hashed URL.
+
+## Alternatives Considered
+
+- **Inline SVG icons** — no font dependency but increases bundle size per icon, harder to style with `currentColor`, and requires SVG management.
+- **Full Material Symbols font** — simpler (no subsetting) but 300 KB is too large for a design system that uses ~32 icons.
+- **Icon sprites** — SVG sprite sheet. Works but doesn't integrate with Shadow DOM's `currentColor` inheritance as cleanly as a font.

--- a/docs/adr/011-catalog-app-visual-testing.md
+++ b/docs/adr/011-catalog-app-visual-testing.md
@@ -1,0 +1,37 @@
+# ADR-011: Catalog App for Visual Testing
+
+**Status:** Accepted
+**Date:** 2026-03
+**Context:** Need a reliable way to visually verify all components and catch regressions. Chromatic (cloud-based Storybook visual testing) was previously used.
+
+## Decision
+
+Replace Chromatic with a dedicated catalog app (`apps/catalog/`) that renders all components as static pages, tested via Playwright screenshot comparison + axe-core accessibility audits.
+
+## Rationale
+
+- **Deterministic rendering.** The catalog is a plain Vite SPA — no Storybook runtime, no addon interference. What you see is what Playwright screenshots.
+- **Local-first.** Tests run locally in ~50 seconds. No cloud dependency, no API keys, no per-snapshot billing.
+- **Dogfooding.** The catalog itself uses the design system components (sidebar = `<ui-side-panel-menu>`, cards = `<ui-card>`, etc.), catching integration issues that isolated Storybook stories miss.
+- **Accessibility built-in.** axe-core scans every page for WCAG 2.1 AA violations as part of the test suite — not a separate tool.
+- **PWA.** The catalog is deployed as a PWA on Cloudflare Pages, accessible to designers and stakeholders without running a dev server.
+
+## Architecture
+
+- 57 page modules (6 foundation + 51 component), each calling `registerPage()`
+- Hash-based router (`/#button`, `/#colors`)
+- Playwright tests: 57 visual screenshots + 57 axe-core a11y audits + sidebar + full layout = ~115 tests
+- Shared `e2e/helpers.ts` with page list and navigation helper
+
+## Consequences
+
+- Storybook is still available for development (interactive props, controls) but is not the source of truth for visual testing.
+- Chromatic integration removed (PR #112).
+- Baseline snapshots are platform-specific (Chromium on macOS). CI may need its own baselines.
+- New components must be added to both `main.ts` (page import), `manifest.ts` (sidebar entry), `helpers.ts` (page list), and `visual.spec.ts`/`a11y.spec.ts` (test coverage).
+
+## Alternatives Considered
+
+- **Chromatic** — cloud-based, per-snapshot pricing, depends on Storybook rendering which can differ from production.
+- **Storybook test runner** — runs in Storybook's iframe context, not representative of real usage.
+- **Percy/Applitools** — similar cloud-based visual testing with vendor lock-in.

--- a/docs/adr/012-zero-runtime-dependencies.md
+++ b/docs/adr/012-zero-runtime-dependencies.md
@@ -1,0 +1,36 @@
+# ADR-012: Zero Runtime Dependencies
+
+**Status:** Accepted
+**Date:** 2026-03
+**Context:** Deciding the dependency policy for the design system packages.
+
+## Decision
+
+Foundation (`@maneki/foundation`) has zero production dependencies. UI components (`@maneki/ui-components`) depend only on `@maneki/foundation`. Grid layout and flex layout depend only on `@maneki/foundation`.
+
+No external runtime libraries (Lit, Stencil, FAST, etc.) are used.
+
+## Rationale
+
+- **Bundle size.** Every dependency adds weight. A design system is imported by every page in an application — its size impact is multiplied across the entire product.
+- **No version conflicts.** External dependencies create version resolution issues when consumers use different versions of the same library. Zero deps = zero conflicts.
+- **Long-term stability.** Framework churn is real. Lit 2→3, Stencil 3→4, FAST deprecation — each migration is a breaking change for consumers. Native `HTMLElement` is stable forever.
+- **Simplicity.** The Web Components API is small enough that a base class adds more complexity than it removes. `attachShadow()`, `observedAttributes`, `attributeChangedCallback` — that's the entire API.
+
+## Consequences
+
+- More boilerplate per component (no `@property` decorators, no reactive updates, no template DSL).
+- DOM is built imperatively with `document.createElement()` — more verbose than template literals but avoids `innerHTML` security concerns.
+- CSS is defined as template literal strings with constructable stylesheets (`new CSSStyleSheet()`).
+- Testing uses Vitest + happy-dom directly, no component-specific test utilities.
+
+## Exceptions
+
+- **Dev dependencies** are unrestricted: Vite, Vitest, Storybook, Playwright, TypeScript.
+- **`@maneki/foundation`** is a production dependency of `@maneki/ui-components` — this is internal, not external.
+
+## Alternatives Considered
+
+- **Lit** — excellent DX with decorators and reactive properties. Rejected because it adds ~7 KB to every consumer's bundle and creates a framework dependency.
+- **Stencil** — compiler-based approach. Rejected because the compiler adds build complexity and the output is harder to debug.
+- **FAST** — Microsoft's Web Component library. Rejected due to smaller community and uncertain long-term support.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,20 @@
+# Architectural Decision Records
+
+This directory contains Architectural Decision Records (ADRs) for the Maneki design system monorepo.
+
+## Index
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [001](001-web-components-shadow-dom.md) | Web Components + Shadow DOM | Accepted | 2026-03 |
+| [002](002-css-custom-properties-theming.md) | CSS Custom Properties for Theming | Accepted | 2026-03 |
+| [003](003-semantic-token-architecture.md) | Semantic Token Architecture | Accepted | 2026-03 |
+| [004](004-centralized-token-constants.md) | Centralized Token Constants | Accepted | 2026-03 |
+| [005](005-typography-typeblock-helper.md) | Typography typeBlock() Helper | Accepted | 2026-03 |
+| [006](006-shape-tokens-css-custom-properties.md) | Shape Tokens as CSS Custom Properties | Accepted | 2026-03 |
+| [007](007-dark-theme-data-attribute.md) | Dark Theme via data-theme Attribute | Accepted | 2026-03 |
+| [008](008-no-white-token.md) | No Generic "White" Token | Accepted | 2026-03 |
+| [009](009-dark-elevation-stronger-shadows.md) | Dark Elevation: Stronger Shadows | Accepted | 2026-03 |
+| [010](010-material-symbols-subset-font.md) | Material Symbols Subsetted Font | Accepted | 2026-03 |
+| [011](011-catalog-app-visual-testing.md) | Catalog App for Visual Testing | Accepted | 2026-03 |
+| [012](012-zero-runtime-dependencies.md) | Zero Runtime Dependencies | Accepted | 2026-03 |


### PR DESCRIPTION
## Summary

Adds 12 Architectural Decision Records documenting the key design decisions made during the Maneki design system build-out.

| ADR | Title |
|-----|-------|
| 001 | Web Components + Shadow DOM |
| 002 | CSS Custom Properties for Theming |
| 003 | Semantic Token Architecture |
| 004 | Centralized Token Constants |
| 005 | Typography typeBlock() Helper |
| 006 | Shape Tokens as CSS Custom Properties |
| 007 | Dark Theme via data-theme Attribute |
| 008 | No Generic "White" Token |
| 009 | Dark Elevation: Stronger Shadows |
| 010 | Material Symbols Subsetted Font |
| 011 | Catalog App for Visual Testing |
| 012 | Zero Runtime Dependencies |

Each ADR follows a consistent format: Status, Date, Context, Decision, Rationale, Consequences, Alternatives Considered.