### PR TITLE
feat: custom icon registry for ui-icon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,9 @@ maneki-monorepo/
 ├── .storybook/              # Root Storybook config (aggregates all packages)
 │   ├── main.ts              # stories from foundation + ui-components + grid-layout
 │   └── preview.ts           # injects tokens + registers components
+├── docs/                    # Project-level documentation
+│   ├── adr/                 # 14 architectural decision records
+│   └── WEB_COMPONENTS_LESSONS.md  # Lessons learned building Web Components
 ├── package.json             # npm workspaces root + Storybook scripts
 ├── packages/
 │   ├── grid-layout/         # <grid-layout> Web Component library (@maneki/grid-layout)
@@ -21,18 +24,18 @@ maneki-monorepo/
 │   │                        # Primitives: badge, image, button, avatar, alert, label, link
 │   │                        # Form Controls: checkbox-item/group, radio-item/group, input, input-group, file-upload, select
 │   │                        # Containers: card, button-group
-│   │                        # Navigation: breadcrumb-item/group, side-panel-menu/item
+│   │                        # Navigation: breadcrumb-item/group, side-panel-menu/item/section
 │   │                        # Disclosure: accordion-item/group
 │   │                        # Menus & Dropdowns: dropdown, dropdown-item/heading/separator/split, menu
-│   │                        # Overlays: modal
+│   │                        # Overlays: modal, popover (focus mgmt), tooltip (aria-describedby)
 │   │                        # Tabs: tab-item, tab-group
-│   └── foundation/          # Design tokens: colors, semantic, typography, spacing, elevation, breakpoints (@maneki/foundation)
+│   │                        # Tags: tag (selectable/toggle)
+│   └── foundation/          # Design tokens: colors, semantic, typography, spacing, elevation, breakpoints, dark-theme, token-constants, shape (@maneki/foundation)
 ├── apps/
 │   └── catalog/             # Visual catalog app + Playwright regression tests (@maneki/catalog)
-│       ├── src/pages/        # 34 pages (5 foundation + 29 component)
-│       ├── e2e/             # Playwright visual specs + baseline snapshots
+│       ├── src/pages/        # 57 pages (6 foundation + 51 component)
+│       ├── e2e/             # Playwright visual + a11y specs + baseline snapshots
 │       └── playwright.config.ts
-```
 ```
 
 ## WHERE TO LOOK
@@ -48,7 +51,7 @@ maneki-monorepo/
 | Grid layout library | `packages/grid-layout/` | Has its own detailed AGENTS.md |
 | Flex layout library | `packages/flex-layout/` | Panel-based flex layout, has its own AGENTS.md |
 | Storybook (all packages) | `.storybook/` | Root-level, aggregates foundation + ui-components + grid-layout + flex-layout |
-| Visual catalog + Playwright tests | `apps/catalog/` | 34 pages, 36 visual regression tests |
+| Visual catalog + Playwright tests | `apps/catalog/` | 57 pages, 115 Playwright tests (57 visual + 57 a11y + sidebar + full layout) |
 
 ## CONVENTIONS
 - **Zero runtime deps** (except `ui-components`, `grid-layout`, and `flex-layout` → `@maneki/foundation`). Foundation has zero production dependencies.
@@ -60,6 +63,10 @@ maneki-monorepo/
 - **Testing.** Vitest with happy-dom. Tests co-located: `foo.ts` → `foo.test.ts`. Visual tests via Playwright in `e2e/`.
 - **TypeScript.** Strict mode, ES2022 target, bundler moduleResolution.
 - **Barrel exports.** Each package has `src/index.ts` re-exporting the public API.
+- **Dark theme via `[data-theme="dark"]` attribute on `:root`.** Toggles all semantic tokens to dark values.
+- **Custom icons via `registerIcon()` from `@maneki/ui-components`.** Allows registering custom SVG icons alongside Material Symbols.
+- **Centralized token constants in `@maneki/foundation`** — import `TEXT_PRIMARY`, `SP_1`, etc. directly instead of calling `semanticVar()`/`spaceVar()` at each use site.
+- **Typography via `typeBlock()`** — `${TYPE_BODY_02}` emits font-family + font-size + line-height + font-weight in one interpolation.
 
 ## ANTI-PATTERNS
 - **No `as any`, `@ts-ignore`, `@ts-expect-error`** — never suppress types
@@ -117,7 +124,9 @@ npx vite build               # Build
 ## NOTES
 - Git repo: `maneki-technology/monorepo` on GitHub
 - CI/CD: Playwright visual regression tests in `apps/catalog/`. Catalog: deployed via Cloudflare Pages.
-- `apps/catalog/` — Visual catalog app with 56 Playwright visual regression tests
+- `apps/catalog/` — Visual catalog app with 115 Playwright tests (57 visual + 57 a11y + sidebar + full layout)
 - Root `package.json` has Storybook scripts (`storybook`, `storybook:build`) and devDependencies for the root-level Storybook
 - Node pinned at 22 because Storybook 10 requires Node 20.19+
 - LSP diagnostics unavailable (no global typescript-language-server) — use `npx tsc --noEmit` instead
+- Dark theme: `[data-theme="dark"]` toggles all semantic tokens. Catalog has theme toggle button.
+- ADRs in `docs/adr/` — 14 architectural decision records

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ maneki-monorepo/
 ├── .prototools              # node 22.16.0, moon 2.0.4
 ├── .moon/                   # Moon workspace + toolchain config
 ├── .storybook/              # Root Storybook config (aggregates all packages)
+├── docs/                    # ADRs + lessons learned
 ├── package.json             # npm workspaces root + Storybook scripts
 ├── packages/
 │   ├── foundation/          # Design tokens (@maneki/foundation)
@@ -35,7 +36,7 @@ maneki-monorepo/
 
 | Package | npm name | Description |
 |---|---|---|
-| `foundation` | `@maneki/foundation` | Design tokens: 131 colors, semantic tokens, typography, spacing, elevation, responsive breakpoints |
+| `foundation` | `@maneki/foundation` | Design tokens: 131 colors, semantic tokens, typography, spacing, elevation, breakpoints, dark theme, shape, token constants |
 | `ui-components` | `@maneki/ui-components` | 50 Web Components (button, badge, image, icon, tag, avatar, alert, label, link, checkbox, radio, input, textarea, file-upload, select, card, breadcrumb, accordion, dropdown, menu, modal, side-panel-menu, tabs, table, carousel, calendar, calendar-quicklinks, calendar-time, datetime-picker, clock, list-item, list-header, list-group) with Storybook 10 |
 | `grid-layout` | `@maneki/grid-layout` | Zero-dep drag/resize grid layout (220 tests) |
 | `flex-layout` | `@maneki/flex-layout` | Panel-based flex layout for dashboard-style interfaces (3 components, 50 tests) |
@@ -44,8 +45,7 @@ maneki-monorepo/
 
 | App | Description |
 |---|---|
-| `catalog` | Visual catalog for all foundation tokens + 50 components. Used for Playwright visual regression tests (36 screenshot tests). |
-| `flex-layout` | `@maneki/flex-layout` | Panel-based flex layout for dashboard-style interfaces (3 components, 50 tests) |
+| `catalog` | Visual catalog for all foundation tokens + UI components. 57 pages, 115 Playwright tests (57 visual + 57 a11y + sidebar). Dark theme toggle. |
 
 ---
 
@@ -82,6 +82,8 @@ npm run storybook:build      # Static build → storybook-static/
 - TypeScript strict mode, ES2022 target
 - Tests co-located: `foo.ts` → `foo.test.ts`
 - Moon tasks in kebab-case: `build`, `test`, `test-watch`, `dev`, `storybook`
+- Dark theme support via `[data-theme="dark"]` attribute
+- Architectural Decision Records in `docs/adr/`
 
 ## Visual Catalog
 

--- a/apps/catalog/AGENTS.md
+++ b/apps/catalog/AGENTS.md
@@ -1,25 +1,26 @@
 # apps/catalog — Visual Catalog & Playwright Regression Tests
 
 ## OVERVIEW
-Dedicated visual catalog app for the Maneki design system. Renders all foundation tokens and 50 UI components with key variants on static pages. Used as the target for Playwright screenshot-based visual regression tests. No Storybook dependency — pure Vite + vanilla TS.
+Dedicated visual catalog app for the Maneki design system. Renders all foundation tokens and UI components with key variants on static pages. Used as the target for Playwright screenshot-based visual regression tests (visual + accessibility). No Storybook dependency — pure Vite + vanilla TS.
 
 ## STRUCTURE
 ```
 catalog/
-├── index.html              # App shell (sidebar + content area + CSS)
+├── index.html              # App shell (sidebar + content area + theme toggle + CSS)
 ├── vite.config.ts          # Vite config with @maneki/* aliases
 ├── tsconfig.json           # TypeScript config
 ├── playwright.config.ts    # Playwright: chromium, 1280×900, vite preview server
 ├── moon.yml                # Moon tasks: dev, build, test-visual, test-visual-update
 ├── package.json            # @maneki/catalog — deps on foundation + ui-components
 ├── src/
-│   ├── main.ts             # App entry: injects tokens, registers icon font, imports all pages, hash router
-│   └── pages/              # 34 page modules (5 foundation + 29 component)
+│   ├── main.ts             # App entry: injects tokens, registers icon font, imports all pages, hash router, theme toggle
+│   └── pages/              # 57 page modules (6 foundation + 51 component)
 │       ├── colors.ts
 │       ├── spacing.ts
 │       ├── typography.ts
 │       ├── elevation.ts
 │       ├── semantic-tokens.ts
+│       ├── shape.ts
 │       ├── badge.ts
 │       ├── button.ts
 │       ├── avatar.ts
@@ -41,16 +42,22 @@ catalog/
 │       ├── dropdown.ts
 │       ├── menu.ts
 │       ├── modal.ts
+│       ├── popover.ts
+│       ├── tooltip.ts
 │       ├── side-panel-menu.ts
+│       ├── side-panel.ts
 │       ├── tabs.ts
 │       ├── table.ts
 │       ├── carousel.ts
 │       ├── calendar.ts
 │       ├── datetime-picker.ts
 │       ├── clock.ts
-│       └── list.ts
+│       ├── list.ts
+│       └── ... (57 pages total)
 └── e2e/
-    ├── visual.spec.ts      # 36 Playwright screenshot tests
+    ├── helpers.ts          # Shared page list + test utilities
+    ├── visual.spec.ts      # 57 Playwright visual screenshot tests
+    ├── a11y.spec.ts        # 57 Playwright accessibility tests (axe-core)
     ├── test-results/        # Playwright test artifacts (gitignored)
     └── snapshots/           # Baseline screenshots (committed)
         └── visual.spec.ts/
@@ -58,16 +65,17 @@ catalog/
             ├── visual-button/button-chromium.png
             ├── visual-sidebar/sidebar-chromium.png
             ├── visual-full-layout/full-layout-chromium.png
-            └── ... (36 snapshot directories total)
+            └── ... (57+ snapshot directories total)
 ```
 
 ## WHERE TO LOOK
 | Task | Location | Notes |
 |------|----------|-------|
 | Add a new catalog page | `src/pages/` | Create file + import in `main.ts` |
-| Add page to visual tests | `e2e/visual.spec.ts` | Add page ID to `pages` array |
+| Add page to visual tests | `e2e/helpers.ts` | Add page ID to shared `pages` array |
+| Add page to a11y tests | `e2e/a11y.spec.ts` | Uses same `pages` array from `helpers.ts` |
 | Update baseline snapshots | Run `test-visual-update` | After intentional visual changes |
-| Modify app shell/layout | `index.html` | Sidebar, content area, CSS classes |
+| Modify app shell/layout | `index.html` | Sidebar, content area, theme toggle, CSS classes |
 | Change Playwright config | `playwright.config.ts` | Viewport, threshold, browser |
 
 ## ARCHITECTURE
@@ -83,8 +91,14 @@ Each page module calls `registerPage(id, { title, section, render, setup? })`:
 ### Router
 Hash-based routing. `window.location.hash` maps to page IDs. Sidebar links update the hash, `hashchange` event triggers re-render.
 
+### Theme Toggle
+App shell includes a dark/light theme toggle button. Sets `[data-theme="dark"]` on `:root` to switch all semantic tokens to dark values.
+
 ### Visual Tests
-One screenshot test per page, targeting `#content` element (excludes sidebar for focused component comparison). Plus sidebar and full-layout tests.
+One screenshot test per page, targeting `#content` element (excludes sidebar for focused component comparison). Plus sidebar and full-layout tests. Shared `pages` array in `e2e/helpers.ts` drives both visual and a11y specs.
+
+### Accessibility Tests
+Per-page a11y tests using `@axe-core/playwright`. Each page is loaded and scanned for WCAG violations. Uses the same shared `pages` array from `e2e/helpers.ts`.
 
 ## CONVENTIONS
 - **Plain HTML strings** — no lit, no JSX. `render()` returns template literal HTML.
@@ -97,7 +111,7 @@ One screenshot test per page, targeting `#content` element (excludes sidebar for
 - **Don't use Storybook patterns** — no lit html, no CSF3, no decorators. Plain HTML strings only.
 - **Don't open dropdowns/modals by default** — they overlay other content and break screenshots.
 - **Don't use external images** — they cause flaky tests. Use colored divs or inline SVGs.
-- **Don't forget to add new pages to both `main.ts` imports AND `visual.spec.ts` pages array.**
+- **Don't forget to add new pages to `main.ts` imports, AND the `pages` array in `e2e/helpers.ts`** (drives both visual.spec.ts and a11y.spec.ts).
 
 ## COMMANDS
 ```bash
@@ -109,7 +123,7 @@ npx vite --port 5174               # Same, from apps/catalog/
 moon run catalog:build              # Vite production build → dist/
 
 # Visual regression tests
-moon run catalog:test-visual        # Run 36 Playwright screenshot tests
+moon run catalog:test-visual        # Run 115 Playwright tests (57 visual + 57 a11y + sidebar)
 moon run catalog:test-visual-update # Regenerate baseline snapshots
 
 # From apps/catalog/ directly
@@ -121,9 +135,9 @@ npx playwright test --update-snapshots  # Update baselines
 
 1. Create `src/pages/{component}.ts`
 2. Import `registerPage` from `"../main.js"`
-3. Call `registerPage("{id}", { title, section: "Components", render: () => html })` 
+3. Call `registerPage("{id}", { title, section: "Components", render: () => html })`
 4. Add `import "./pages/{component}.js"` to `src/main.ts`
-5. Add `"{id}"` to the `pages` array in `e2e/visual.spec.ts`
+5. Add `"{id}"` to the `pages` array in `e2e/helpers.ts` (drives both visual + a11y tests)
 6. Run `npx vite build && npx playwright test --update-snapshots` to generate baseline
 7. Verify the snapshot looks correct
 8. Commit the new page file + snapshot
@@ -131,6 +145,6 @@ npx playwright test --update-snapshots  # Update baselines
 ## NOTES
 - Vite aliases resolve `@maneki/foundation` and `@maneki/ui-components` to source (not dist) for HMR in dev
 - Playwright uses `vite preview` (production build) for deterministic rendering
-- 36 tests run in ~44s on Chromium
+- 115 tests (57 visual + 57 a11y + 1 sidebar) run on Chromium
 - Snapshots are platform-specific (chromium on macOS) — CI may need its own baselines
 - The `setup()` callback uses `requestAnimationFrame` to ensure DOM is ready before imperative manipulation

--- a/apps/catalog/README.md
+++ b/apps/catalog/README.md
@@ -1,10 +1,10 @@
 # @maneki/catalog
 
-Visual catalog app for the Maneki design system. Renders all foundation tokens and 50 UI components with key variants on deterministic pages. Used as the target for Playwright screenshot-based visual regression tests.
+Visual catalog app for the Maneki design system. Renders all foundation tokens and UI components with key variants on deterministic pages. Used as the target for Playwright visual and accessibility regression tests.
 
-- 34 pages (5 foundation + 29 component)
-- 36 Playwright visual regression tests
-- Hash-based routing, sidebar navigation
+- 57 pages (6 foundation + 51 component)
+- 115 Playwright tests (57 visual + 57 a11y + sidebar)
+- Hash-based routing, sidebar navigation, dark theme toggle
 - Pure Vite + vanilla TypeScript — no Storybook dependency
 
 ## Quick Start
@@ -14,7 +14,7 @@ Visual catalog app for the Maneki design system. Renders all foundation tokens a
 moon run catalog:dev          # http://localhost:5174
 
 # Visual regression tests
-moon run catalog:test-visual  # Run 36 screenshot tests
+moon run catalog:test-visual  # Run 115 Playwright tests
 ```
 
 ## Pages
@@ -27,6 +27,7 @@ moon run catalog:test-visual  # Run 36 screenshot tests
 | Typography | 7 groups (display, heading, body, ui, caption, badge, code) |
 | Elevation | 6 elevation levels |
 | Semantic Tokens | Surface, border, text, icon token swatches |
+| Shape | Border-radius + border-width tokens |
 
 ### Components
 | Page | Variants |
@@ -61,7 +62,7 @@ moon run catalog:test-visual  # Run 36 screenshot tests
 | Clock | Sizes |
 | List | Sizes, description, leading/trailing, groups |
 
-## Visual Regression Tests
+## Visual & Accessibility Tests
 
 ```bash
 # Run tests (requires build first)
@@ -71,7 +72,7 @@ moon run catalog:test-visual
 moon run catalog:test-visual-update
 ```
 
-36 tests: one screenshot per page (targeting `#content`), plus sidebar and full-layout screenshots. Chromium only, 1280×900 viewport, 1% pixel diff threshold.
+115 tests: 57 visual screenshots (one per page targeting `#content`), 57 a11y scans (axe-core per page), plus sidebar screenshot. Chromium only, 1280×900 viewport, 1% pixel diff threshold.
 
 ## Development
 

--- a/apps/catalog/src/pages/icon.ts
+++ b/apps/catalog/src/pages/icon.ts
@@ -1,5 +1,27 @@
 import { registerPage } from "../registry.js";
+import { registerIcon } from "@maneki/ui-components";
 
+// Register custom icons for the demo
+registerIcon("brand-star", () => {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.innerHTML = '<path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>';
+  return svg;
+});
+
+registerIcon("brand-heart", () => {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.innerHTML = '<path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>';
+  return svg;
+});
+
+registerIcon("brand-bolt", () => {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.innerHTML = '<path d="M11 21h-1l1-7H7.5c-.88 0-.33-.75-.31-.78C8.48 10.94 10.42 7.54 13.01 3h1l-1 7h3.51c.4 0 .62.19.4.66C12.97 17.55 11 21 11 21z"/>';
+  return svg;
+});
 registerPage("icon", {
   title: "Icon",
   section: "Primitives",
@@ -64,6 +86,35 @@ registerPage("icon", {
         <ui-icon name="home" size="m" label="Home"></ui-icon>
         <ui-icon name="settings" size="m" label="Settings"></ui-icon>
         <ui-icon name="person" size="m" label="User profile"></ui-icon>
+      </div>
+
+      <h3>Custom Icons (via registerIcon)</h3>
+      <p class="hint">These icons are registered at runtime — not part of Material Symbols.</p>
+      <div class="variant-row">
+        ${["brand-star", "brand-heart", "brand-bolt"].map(name =>
+          `<div class="variant-col items-center">
+            <ui-icon name="${name}" size="m"></ui-icon>
+            <span class="variant-label">${name}</span>
+          </div>`
+        ).join("")}
+      </div>
+
+      <h3>Custom Icons — Sizes</h3>
+      <div class="variant-row">
+        ${["xxs","xs","s","m","l"].map(s =>
+          `<div class="variant-col items-center">
+            <ui-icon name="brand-star" size="${s}"></ui-icon>
+            <span class="variant-label">${s}</span>
+          </div>`
+        ).join("")}
+      </div>
+
+      <h3>Custom Icons — Inherit Color</h3>
+      <div class="variant-row">
+        <div style="color:#186ade"><ui-icon name="brand-heart" size="m"></ui-icon></div>
+        <div style="color:#D91F11"><ui-icon name="brand-heart" size="m"></ui-icon></div>
+        <div style="color:#1B806A"><ui-icon name="brand-heart" size="m"></ui-icon></div>
+        <div style="color:#E86427"><ui-icon name="brand-bolt" size="m"></ui-icon></div>
       </div>
     `;
   },

--- a/docs/adr/014-custom-icon-registry.md
+++ b/docs/adr/014-custom-icon-registry.md
@@ -1,0 +1,61 @@
+# ADR-014: Custom Icon Registry
+
+**Status:** Accepted
+**Date:** 2026-03
+**Context:** `<ui-icon>` only supports Material Symbols icons from the subsetted font. Consumers need to use custom icons (brand logos, product-specific icons, third-party icon sets) alongside the built-in icons.
+
+## Decision
+
+Add an icon registry to `@maneki/foundation` that allows consumers to register custom icon factories. `<ui-icon>` checks the registry before falling back to Material Symbols.
+
+```ts
+import { registerIcon } from "@maneki/foundation";
+
+registerIcon("brand-logo", () => {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.innerHTML = '<path d="M12 2L2 22h20L12 2z"/>';
+  return svg;
+});
+
+// Then use it anywhere:
+// <ui-icon name="brand-logo"></ui-icon>
+```
+
+### API
+
+| Function | Description |
+|----------|-------------|
+| `registerIcon(name, factory)` | Register a single custom icon |
+| `registerIcons({ name: factory })` | Register multiple icons at once |
+| `resolveIcon(name)` | Get the element for a custom icon (null if not registered) |
+| `hasIcon(name)` | Check if a custom icon is registered |
+| `unregisterIcon(name)` | Remove a registered icon |
+| `clearIcons()` | Remove all registered icons |
+
+### Resolution order in `<ui-icon>`
+
+1. Check custom icon registry → if found, render the factory's element
+2. Check `ICON_CODEPOINTS` → if found, render Material Symbols codepoint
+3. Fall back to ligature text (the name string itself)
+
+## Rationale
+
+- **Framework-agnostic.** The registry is a plain `Map<string, () => Element>`. Works with any framework or none.
+- **No Lit needed.** This was the key question — Lit doesn't help with the registry pattern. The hard part is the lookup, not the rendering.
+- **Factory pattern.** Each call creates a fresh DOM element. No shared mutable state, no cloneNode issues with SVG.
+- **Backward compatible.** Existing `<ui-icon name="home">` usage is unchanged. The registry is opt-in.
+- **CSS integration.** Custom icons inherit `currentColor` via `fill: currentColor` and `color: currentColor` on the `.has-custom > *` selector. They also inherit size from the host's `--ui-icon-size` property.
+
+## Consequences
+
+- Custom icons must be registered before components render. Typically done at app startup alongside `injectAllTokens()` and `registerIconFont()`.
+- The `part="icon"` attribute is set on custom icon elements, allowing consumer CSS to style them via `::part(icon)`.
+- Custom icons don't get Material Symbols font styles (font-variation-settings, etc.) — the `.has-custom` class resets those.
+- The registry is global (module-level Map). Multiple micro-frontends sharing the same foundation bundle share the same registry.
+
+## Alternatives Considered
+
+- **Slot-based override** — expose internal icons as named slots (`<ui-modal><svg slot="close-icon">...</svg></ui-modal>`). Works for component-level overrides but doesn't solve the general `<ui-icon>` use case.
+- **CSS custom property for icon font** — `--ui-icon-font: "My Icons"`. Only works if the consumer's icon font uses the same codepoints, which is unlikely.
+- **Lit adoption** — would give nicer template syntax for rendering icons but doesn't change the registry architecture at all.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,3 +18,4 @@ This directory contains Architectural Decision Records (ADRs) for the Maneki des
 | [010](010-material-symbols-subset-font.md) | Material Symbols Subsetted Font | Accepted | 2026-03 |
 | [011](011-catalog-app-visual-testing.md) | Catalog App for Visual Testing | Accepted | 2026-03 |
 | [012](012-zero-runtime-dependencies.md) | Zero Runtime Dependencies | Accepted | 2026-03 |
+| [014](014-custom-icon-registry.md) | Custom Icon Registry | Accepted | 2026-03 |

--- a/packages/foundation/AGENTS.md
+++ b/packages/foundation/AGENTS.md
@@ -21,6 +21,9 @@ foundation/
     ├── typography.ts         # 19 type tokens across 7 groups (display, heading, body, ui, caption, badge, code)
     ├── spacing.ts            # 17-step spacing scale based on 8px base unit (0 through 10, plus 1px and fractional)
     ├── breakpoints.ts        # 3 density variants (compact/standard/spacious) × 7 breakpoints + helpers
+    ├── dark-theme.ts         # Dark theme token overrides (mirrors all semantic groups)
+    ├── token-constants.ts    # Pre-computed var() references for all tokens (TEXT_PRIMARY, SP_1, etc.)
+    ├── shape.ts              # Shape tokens: border-radius + border-width CSS custom properties
     ├── tokens.ts             # CSS custom property generators + var() helpers
     ├── tokens.test.ts        # 32 tests
     ├── breakpoints.test.ts   # 27 tests
@@ -42,16 +45,21 @@ foundation/
 | Wire new token type to CSS | `tokens.ts` | Add `*ToCssProperties()` + `*Var()` + add to `injectAllTokens()` |
 | Update barrel exports | `index.ts` | Re-export new functions/types |
 | Add new icon | `assets/icon-manifest.txt` | See SOP below |
+| Dark theme overrides | `dark-theme.ts` | Mirrors all semantic groups for `[data-theme="dark"]` |
+| Token constants | `token-constants.ts` | Pre-computed `var()` references (`TEXT_PRIMARY`, `SP_1`, etc.) |
+| Shape tokens | `shape.ts` | Border-radius + border-width CSS custom properties |
 
 ## TOKEN ARCHITECTURE
 ```
-Raw data (colors.ts, semantic-tokens.ts, typography.ts, spacing.ts)
+Raw data (colors.ts, semantic-tokens.ts, typography.ts, spacing.ts, shape.ts)
     ↓
 CSS generators (tokens.ts) — *ToCssProperties() functions
     ↓
 injectAllTokens() — creates <style> on :root with all tokens
+    + dark-theme.ts — generates [data-theme="dark"] overrides for all semantic tokens
     ↓
 var() helpers — colorVar(), semanticVar(), elevationVar(), typeVar(), spaceVar()
+    + token-constants.ts — pre-computed var() references (TEXT_PRIMARY, SP_1, TYPE_BODY_02, etc.)
 ```
 
 ## CSS CUSTOM PROPERTY PREFIXES
@@ -69,6 +77,8 @@ var() helpers — colorVar(), semanticVar(), elevationVar(), typeVar(), spaceVar
 | Spacing | `--fd-space-{step}` | `--fd-space-2-5` |
 | Tag | `--fd-tag-{name}` | `--fd-tag-bold` |
 | Button | `--fd-button-{name}` | `--fd-button-secondary` |
+| Shape radius | `--fd-radius-{name}` | `--fd-radius-s` |
+| Shape border-width | `--fd-border-width-{name}` | `--fd-border-width-s` |
 
 ## CONVENTIONS
 - **Figma is source of truth.** All values extracted from "Foundation UI Kit (Community)".
@@ -80,6 +90,9 @@ var() helpers — colorVar(), semanticVar(), elevationVar(), typeVar(), spaceVar
 - **`injectAllTokens()`** is idempotent — checks for existing `<style id="maneki-foundation-all">` before injecting.
 - **Breakpoints are JS-only.** Not injected as CSS custom properties — use `getBreakpoint()`, `getBreakpointConfig()`, `breakpointMediaQuery()` helpers.
 - **Three layout densities.** Compact (tightest), standard (moderate), spacious (widest margins/gutters).
+- **Dark theme values in `dark-theme.ts`** — mirrors all semantic groups. Toggled via `[data-theme="dark"]` on `:root`.
+- **Token constants in `token-constants.ts`** — pre-computed `var()` references for all tokens. Import `TEXT_PRIMARY`, `SP_1`, etc. directly instead of calling `semanticVar()`/`spaceVar()` at each use site.
+- **Custom icon registry** — `registerIcon()`, `resolveIcon()`, `hasIcon()`, `clearIcons()` allow registering custom SVG icons alongside Material Symbols.
 
 ## ANTI-PATTERNS
 - **Don't hardcode color values in components** — use `colorVar()` / `semanticVar()` helpers
@@ -140,3 +153,13 @@ When a component needs a Material Symbols icon not yet in the subset font:
    python3 packages/foundation/assets/subset-icons.py [path-to-full-font.woff2]
    ```
 8. **Commit** the updated `icon-manifest.txt`, `subset-icons.py`, `icons.ts`, `index.ts`, and the regenerated `.woff2`.
+
+## SOP: Dark Theme Token Changes
+
+When modifying or adding semantic tokens that need dark theme support:
+
+1. **Add/update the light value** in `semantic-tokens.ts`.
+2. **Add/update the dark value** in `dark-theme.ts` — ensure the same key exists in both files.
+3. **Run tests** — `npx vitest --run` to verify CSS generation includes both light and dark values.
+4. **Verify visually** — toggle `[data-theme="dark"]` on `:root` in Storybook/catalog and check the token renders correctly.
+5. **Rebuild foundation** — `npx vite build && npx tsc --emitDeclarationOnly`.

--- a/packages/foundation/src/icons.ts
+++ b/packages/foundation/src/icons.ts
@@ -177,3 +177,76 @@ export function registerIconFont(fontUrl: string): Promise<FontFace> {
   document.fonts.add(face);
   return face.load();
 }
+
+// ── Custom Icon Registry ────────────────────────────────────────────
+// Allows consumers to register custom icon factories that ui-icon
+// resolves before falling back to Material Symbols.
+
+type IconFactory = () => Element;
+
+const _iconRegistry = new Map<string, IconFactory>();
+
+/**
+ * Register a custom icon. When `<ui-icon name="my-icon">` is used,
+ * the factory is called to create the DOM element.
+ *
+ * ```ts
+ * import { registerIcon } from "@maneki/foundation";
+ *
+ * registerIcon("brand-logo", () => {
+ *   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+ *   svg.setAttribute("viewBox", "0 0 24 24");
+ *   svg.innerHTML = '<path d="M12 2L2 22h20L12 2z"/>';
+ *   return svg;
+ * });
+ * ```
+ */
+export function registerIcon(name: string, factory: IconFactory): void {
+  _iconRegistry.set(name, factory);
+}
+
+/**
+ * Register multiple icons at once.
+ *
+ * ```ts
+ * registerIcons({
+ *   "brand-logo": () => createSvg('<path d="..."/>'),
+ *   "brand-mark": () => createSvg('<circle cx="12" cy="12" r="10"/>'),
+ * });
+ * ```
+ */
+export function registerIcons(icons: Record<string, IconFactory>): void {
+  for (const [name, factory] of Object.entries(icons)) {
+    _iconRegistry.set(name, factory);
+  }
+}
+
+/**
+ * Resolve a custom icon by name. Returns the element if registered,
+ * or null to fall back to Material Symbols.
+ */
+export function resolveIcon(name: string): Element | null {
+  const factory = _iconRegistry.get(name);
+  return factory ? factory() : null;
+}
+
+/**
+ * Check if a custom icon is registered.
+ */
+export function hasIcon(name: string): boolean {
+  return _iconRegistry.has(name);
+}
+
+/**
+ * Remove a registered custom icon.
+ */
+export function unregisterIcon(name: string): boolean {
+  return _iconRegistry.delete(name);
+}
+
+/**
+ * Remove all registered custom icons.
+ */
+export function clearIcons(): void {
+  _iconRegistry.clear();
+}

--- a/packages/foundation/src/index.ts
+++ b/packages/foundation/src/index.ts
@@ -136,4 +136,10 @@ export {
   ICON_REFRESH,
   ICON_CODEPOINTS,
   registerIconFont,
+  registerIcon,
+  registerIcons,
+  resolveIcon,
+  hasIcon,
+  unregisterIcon,
+  clearIcons,
 } from "./icons.js";

--- a/packages/ui-components/AGENTS.md
+++ b/packages/ui-components/AGENTS.md
@@ -57,6 +57,7 @@ Web Component library for the Maneki design system. Shadow DOM, CSS custom prope
 - `<ui-breadcrumb-group>` — breadcrumb nav wrapper with size propagation
 - `<ui-side-panel-menu>` — collapsible sidebar navigation: expanded/collapsed states, mobile responsive (auto-collapse), flyout submenu in collapsed mode, overlay mode, selection management with parent highlighting
 - `<ui-side-panel-menu-item>` — sidebar menu item: 3 levels (primary/secondary/tertiary), expandable parent with inline children, leading icon slot, selected/disabled states, keyboard navigation
+- `<ui-side-panel-menu-section>` — sidebar section grouping: heading label, collapsible, divider line
 
 **Disclosure:**
 - `<ui-accordion-item>` — expandable panel: 3 sizes, 2 emphases, 4 statuses, smooth CSS transition
@@ -72,13 +73,14 @@ Web Component library for the Maneki design system. Shadow DOM, CSS custom prope
 
 **Overlays:**
 - `<ui-modal>` — modal dialog with backdrop, header (title+subtitle+close), scrollable body, footer button slots, 3 sizes, 2 layouts (auto/fluid), dismiss behavior
-
+- `<ui-popover>` — focus-managed popover: trigger element, floating panel, outside-click + Escape dismiss, focus trap, arrow key navigation
+- `<ui-tooltip>` — tooltip with aria-describedby: hover/focus trigger, configurable placement, delay, accessible label
 **Tabs:**
 - `<ui-tab-item>` — tab item: 2 sizes (s/m), 3 states (enabled/selected/disabled), 2 orientations (horizontal/vertical), leading/trailing icon slots, sub-menu chevron, smooth transition
 - `<ui-tab-group>` — tab group wrapper: size/orientation propagation, single selection, roving tabindex, arrow key navigation
 
 **Icons:**
-- `<ui-icon>` — Material Symbols icon: 5 sizes (xxs/xs/s/m/l), 10 states (enabled/hover/active/focus/disabled + inverse variants), filled variant, ICON_CODEPOINTS lookup with ligature fallback, accessible label
+- `<ui-icon>` — Material Symbols icon: 5 sizes (xxs/xs/s/m/l), 10 states (enabled/hover/active/focus/disabled + inverse variants), filled variant, ICON_CODEPOINTS lookup with ligature fallback, accessible label, custom icon registry via `registerIcon()`
 
 ## STRUCTURE
 ```
@@ -111,6 +113,7 @@ ui-components/
 │   │   ├── ui-breadcrumb-group.ts
 │   │   ├── ui-side-panel-menu.ts + ui-side-panel-menu.styles.ts
 │   │   ├── ui-side-panel-menu-item.ts
+│   │   ├── ui-side-panel-menu-section.ts
 │   │   ├── ui-accordion-item.ts
 │   │   ├── ui-accordion-group.ts
 │   │   ├── ui-dropdown.ts
@@ -130,9 +133,7 @@ ui-components/
 │   │   ├── ui-carousel.ts
 │   │   ├── ui-carousel-item.ts
 │   │   ├── ui-calendar.ts        + ui-calendar.styles.ts
-- `<ui-calendar-quicklinks>` — composable quicklinks panel: 3 sizes (s/m/l), 2 orientations (side/bottom), section headings, selected state, click events
-- `<ui-calendar-time>` — composable inline time panel: 3 sizes (s/m/l), hour/minute inputs, AM/PM toggle switch, separator line, 12h/24h conversion
-- `<ui-calendar-panel>` — composable wrapper: elevation, slots (default/side/bottom), size propagation, optional actions bar (Cancel/OK)
+│   │   ├── ui-calendar-quicklinks.ts  + ui-calendar-quicklinks.styles.ts
 │   │   ├── ui-calendar-time.ts    + ui-calendar-time.styles.ts
 │   │   ├── ui-calendar-panel.ts    + ui-calendar-panel.styles.ts
 │   │   ├── ui-datetime-picker-input.ts + ui-datetime-picker-input.styles.ts
@@ -140,7 +141,8 @@ ui-components/
 │   │   ├── ui-clock.ts            + ui-clock.styles.ts
 │   │   ├── ui-list-item.ts        + ui-list-item.styles.ts
 │   │   ├── ui-list-header.ts      + ui-list-header.styles.ts
-│   │   ├── ui-list-group.ts       + ui-list-group.styles.ts
+│   │   ├── ui-popover.ts           + ui-popover.styles.ts
+│   │   ├── ui-tooltip.ts
 │   │   └── *.test.ts            # Co-located tests
 │   └── stories/
 │       └── *.stories.ts     # CSF3 + lit html
@@ -248,6 +250,10 @@ Currently extracted: ui-input, ui-select, ui-dropdown-item, ui-dropdown-split, u
 - **Visual Figma verification required.** Before a component is considered done, visually compare the Storybook rendering against the Figma source using the Playwright/browser tool. Verify sizes, colors, spacing, and states match. No component ships without this step.
 - **Reuse existing primitives.** When adding a new component, review existing components and stories to check if they should consume the new component instead of duplicating markup (e.g., stories using inline `<button>` elements should use `<ui-button>` once it exists). Applies to both component implementations and Storybook stories.
 - **No direct pushes to `main`.** All changes go through feature branches and PRs. Use `jj bookmark set <name> -r @` + `jj git push --bookmark <name>` then `gh pr create`.
+- **Import token constants from `@maneki/foundation`** — no local `const X = semanticVar(...)` definitions. Use pre-computed constants like `TEXT_PRIMARY`, `SP_1`, etc.
+- **Typography via `${TYPE_BODY_02}`** — emits font-family + font-size + line-height + font-weight in one interpolation via `typeBlock()` from foundation.
+- **Custom icons:** `registerIcon()` / `registerIcons()` re-exported from ui-components. Allows registering custom SVG icons alongside Material Symbols.
+- **Accessibility:** 14 components have ARIA improvements (PR #116) — proper roles, labels, keyboard navigation, and screen reader support.
 
 ## ANTI-PATTERNS
 - **No hardcoded design values** — never use raw hex colors (`#186ade`), pixel spacing (`4px`, `16px`), or font sizes directly. Always use foundation token helpers (`colorVar()`, `spaceVar()`, `typeVar()`, etc.).
@@ -340,6 +346,6 @@ After merging a PR that adds/modifies components, icons, or tests, update these 
 ```bash
 moon run ui-components:storybook       # Dev server on port 6006
 moon run ui-components:storybook-build  # Static build
-moon run ui-components:test            # vitest --run (2235 tests)
+moon run ui-components:test            # vitest --run (3593 tests)
 moon run ui-components:build           # vite build + tsc --emitDeclarationOnly
 ```

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -119,7 +119,7 @@ moon run ui-components:storybook-build  # Static build → storybook-static/
 
 ```bash
 moon run ui-components:build  # vite build + tsc --emitDeclarationOnly → dist/
-moon run ui-components:test   # vitest --run (2235 tests)
+moon run ui-components:test   # vitest --run (3593 tests)
 ```
 
 ---

--- a/packages/ui-components/src/components/ui-icon.test.ts
+++ b/packages/ui-components/src/components/ui-icon.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import "./ui-icon.js";
+import { STYLES } from "./ui-icon.js";
+import { registerIcon, clearIcons, hasIcon, unregisterIcon } from "@maneki/foundation";
 import "./ui-icon.js";
 import { STYLES } from "./ui-icon.js";
 
@@ -431,5 +434,86 @@ describe("ui-icon", () => {
 
     expect((el as unknown as { state: string }).state).toBe("hover");
     expect((el2 as unknown as { state: string }).state).toBe("disabled");
+  });
+});
+
+// ── Custom Icon Registry ─────────────────────────────────────────────────────
+
+describe("ui-icon custom registry", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    clearIcons();
+    el = document.createElement("ui-icon");
+    document.body.appendChild(el);
+  });
+
+  afterEach(() => {
+    clearIcons();
+  });
+
+  it("renders a custom SVG icon when registered", () => {
+    registerIcon("brand-logo", () => {
+      const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      svg.setAttribute("viewBox", "0 0 24 24");
+      svg.innerHTML = '<circle cx="12" cy="12" r="10"/>';
+      return svg;
+    });
+    el.setAttribute("name", "brand-logo");
+    const iconEl = el.shadowRoot!.querySelector(".icon")!;
+    expect(iconEl.classList.contains("has-custom")).toBe(true);
+    expect(iconEl.querySelector("svg")).toBeTruthy();
+  });
+
+  it("falls back to Material Symbols when not registered", () => {
+    el.setAttribute("name", "home");
+    const iconEl = el.shadowRoot!.querySelector(".icon")!;
+    expect(iconEl.classList.contains("has-custom")).toBe(false);
+    expect(iconEl.textContent).toBeTruthy();
+  });
+
+  it("switches from custom to Material Symbols when unregistered", () => {
+    registerIcon("temp-icon", () => {
+      const span = document.createElement("span");
+      span.textContent = "X";
+      return span;
+    });
+    el.setAttribute("name", "temp-icon");
+    const iconEl = el.shadowRoot!.querySelector(".icon")!;
+    expect(iconEl.classList.contains("has-custom")).toBe(true);
+
+    unregisterIcon("temp-icon");
+    el.setAttribute("name", "home");
+    expect(iconEl.classList.contains("has-custom")).toBe(false);
+  });
+
+  it("hasIcon returns true for registered icons", () => {
+    registerIcon("my-icon", () => document.createElement("span"));
+    expect(hasIcon("my-icon")).toBe(true);
+    expect(hasIcon("not-registered")).toBe(false);
+  });
+
+  it("clearIcons removes all registered icons", () => {
+    registerIcon("a", () => document.createElement("span"));
+    registerIcon("b", () => document.createElement("span"));
+    expect(hasIcon("a")).toBe(true);
+    clearIcons();
+    expect(hasIcon("a")).toBe(false);
+    expect(hasIcon("b")).toBe(false);
+  });
+
+  it("custom icon inherits currentColor via fill", () => {
+    expect(STYLES).toContain("fill: currentColor");
+  });
+
+  it("custom icon element gets part attribute", () => {
+    registerIcon("parted", () => {
+      const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+      return svg;
+    });
+    el.setAttribute("name", "parted");
+    const custom = el.shadowRoot!.querySelector(".icon > *");
+    expect(custom?.getAttribute("part")).toBe("icon");
   });
 });

--- a/packages/ui-components/src/components/ui-icon.ts
+++ b/packages/ui-components/src/components/ui-icon.ts
@@ -3,6 +3,7 @@ import {
   ICON_ACTION,
   ICON_CODEPOINTS,
   ICON_REVERSED,
+  resolveIcon,
 } from "@maneki/foundation";
 
 // ─── Type-safe property unions ───────────────────────────────────────────────
@@ -59,6 +60,20 @@ export const STYLES = /* css */ `
     -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
     font-feature-settings: 'liga';
+    color: var(--ui-icon-color, currentColor);
+  }
+
+  /* Custom icon: inherit size from host, reset font styles */
+  .icon.has-custom {
+    font-family: inherit;
+    font-variation-settings: normal;
+  }
+
+  .icon.has-custom > * {
+    width: 100%;
+    height: 100%;
+    fill: currentColor;
+    color: currentColor;
   }
 
   /* ── Filled variant ────────────────────────────────────────────────────────── */
@@ -232,6 +247,21 @@ export class UiIcon extends HTMLElement {
 
   #updateIcon(): void {
     const name = this.getAttribute("name") ?? "";
+
+    // Check custom icon registry first
+    const custom = resolveIcon(name);
+    if (custom) {
+      // Custom icon: replace font icon with the custom element
+      custom.setAttribute("part", "icon");
+      custom.classList.add("custom-icon");
+      this.#iconEl.textContent = "";
+      this.#iconEl.replaceChildren(custom);
+      this.#iconEl.classList.add("has-custom");
+      return;
+    }
+
+    // Material Symbols fallback: codepoint lookup, then ligature
+    this.#iconEl.classList.remove("has-custom");
     const codepoint = ICON_CODEPOINTS[name];
     this.#iconEl.textContent = codepoint ?? name;
   }

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -274,3 +274,7 @@ export { UiTreeGroup } from "./components/ui-tree-group.js";
 
 export { UiWizard } from "./components/ui-wizard.js";
 export type { WizardLayout } from "./components/ui-wizard.js";
+
+// ─── Icon Registry (re-exported from foundation) ────────────────────────────
+
+export { registerIcon, registerIcons } from "@maneki/foundation";


### PR DESCRIPTION
## Summary

Adds a custom icon registry to `@maneki/foundation`, allowing consumers to register their own icons (SVGs, images, custom elements) that `<ui-icon>` resolves before falling back to Material Symbols.

### Foundation
- New API: `registerIcon()`, `registerIcons()`, `resolveIcon()`, `hasIcon()`, `unregisterIcon()`, `clearIcons()`
- Factory pattern: each call creates a fresh DOM element

### ui-icon
- Resolution order: custom registry → ICON_CODEPOINTS → ligature fallback
- Custom icons get `part="icon"` for `::part()` styling
- `.has-custom` class resets Material Symbols font styles
- Custom icon children inherit `currentColor` via `fill` and `color`
- Fixed duplicate CSS block in STYLES

### Usage
```ts
import { registerIcon } from "@maneki/foundation";

registerIcon("brand-logo", () => {
  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
  svg.setAttribute("viewBox", "0 0 24 24");
  svg.innerHTML = '<path d="M12 2L2 22h20L12 2z"/>';
  return svg;
});
```
```html
<ui-icon name="brand-logo"></ui-icon>
```

### Documentation
- ADR-014: Custom Icon Registry

## Test Results

- Foundation: 59 tests ✅
- UI Components: 3593 tests ✅ (7 new icon registry tests)