### PR TITLE
feat: add @maneki/diagrams package — C4-style diagram Web Components

### DIFF
--- a/apps/catalog/package.json
+++ b/apps/catalog/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@maneki/flex-layout": "*",
+    "@maneki/diagrams": "*",
     "@maneki/foundation": "*",
     "@maneki/grid-layout": "*",
     "@maneki/ui-components": "*",

--- a/apps/catalog/src/main.ts
+++ b/apps/catalog/src/main.ts
@@ -86,6 +86,7 @@ const pageLoaders: Record<string, () => Promise<unknown>> = {
   "polar-chart": () => import("./pages/polar-chart.js"),
   "multi-line-chart": () => import("./pages/multi-line-chart.js"),
   "multitype-chart": () => import("./pages/multitype-chart.js"),
+  "diagrams": () => import("./pages/diagrams.js"),
 };
 
 // Track which pages have been loaded

--- a/apps/catalog/src/manifest.ts
+++ b/apps/catalog/src/manifest.ts
@@ -19,6 +19,8 @@ export const sectionOrder = [
   "Data Display",
   "Calendar & Date",
   "Layouts",
+  "Diagrams",
+  "Charts",
   "Charts",
 ];
 
@@ -88,6 +90,8 @@ export const manifest: PageMeta[] = [
   // Layouts
   { id: "grid-layout", title: "Grid Layout", section: "Layouts" },
   { id: "flex-layout", title: "Flex Layout", section: "Layouts" },
+  // Diagrams
+  { id: "diagrams", title: "Diagrams", section: "Diagrams" },
   // Charts
   { id: "bar-chart", title: "Bar Chart", section: "Charts" },
   { id: "line-chart", title: "Line Chart", section: "Charts" },

--- a/apps/catalog/src/pages/diagrams.ts
+++ b/apps/catalog/src/pages/diagrams.ts
@@ -1,0 +1,55 @@
+import { registerPage } from "../registry.js";
+import "@maneki/diagrams/components/diagram-canvas.js";
+import "@maneki/diagrams/components/diagram-person.js";
+import "@maneki/diagrams/components/diagram-system.js";
+import "@maneki/diagrams/components/diagram-container.js";
+import "@maneki/diagrams/components/diagram-component.js";
+import "@maneki/diagrams/components/diagram-external.js";
+import "@maneki/diagrams/components/diagram-arrow.js";
+
+registerPage("diagrams", {
+  title: "Diagrams",
+  section: "Diagrams",
+  render: () => `
+    <h3>C4 Container Diagram</h3>
+    <diagram-canvas columns="3" rows="3" title="Maneki Blog — Container View">
+      <diagram-person box-id="author" row="1" col="2" label="Author" description="Writes and publishes blog posts"></diagram-person>
+
+      <diagram-container box-id="editor" row="2" col="1" label="Editor" tech="Web Components" description="Blog editor UI"></diagram-container>
+      <diagram-container box-id="api" row="2" col="2" label="API" tech="Hono" description="Posts CRUD + deploy"></diagram-container>
+      <diagram-container box-id="blog" row="2" col="3" label="Blog" tech="Static HTML" description="Prerendered pages"></diagram-container>
+
+      <diagram-external box-id="turso" row="3" col="1" label="Turso" tech="libSQL" description="Posts + UI state"></diagram-external>
+      <diagram-external box-id="github" row="3" col="2" label="GitHub Actions" description="Build + deploy"></diagram-external>
+      <diagram-external box-id="cf" row="3" col="3" label="Cloudflare Pages" description="CDN + hosting"></diagram-external>
+
+      <diagram-arrow from="author" to="editor" label="writes posts"></diagram-arrow>
+      <diagram-arrow from="editor" to="api" label="RPC calls"></diagram-arrow>
+      <diagram-arrow from="api" to="turso" label="read/write"></diagram-arrow>
+      <diagram-arrow from="api" to="github" label="triggers deploy"></diagram-arrow>
+      <diagram-arrow from="github" to="cf" label="deploys to"></diagram-arrow>
+      <diagram-arrow from="cf" to="blog" label="serves"></diagram-arrow>
+    </diagram-canvas>
+
+    <h3>All Shapes</h3>
+    <diagram-canvas columns="5" rows="1">
+      <diagram-person box-id="v1" row="1" col="1" label="Person" description="A user or actor"></diagram-person>
+      <diagram-system box-id="v2" row="1" col="2" label="System" description="Top-level system"></diagram-system>
+      <diagram-container box-id="v3" row="1" col="3" label="Container" tech="TypeScript" description="An application or service"></diagram-container>
+      <diagram-component box-id="v4" row="1" col="4" label="Component" description="A module within a container"></diagram-component>
+      <diagram-external box-id="v5" row="1" col="5" label="External" description="Third-party system"></diagram-external>
+    </diagram-canvas>
+
+    <h3>Simple Flow</h3>
+    <diagram-canvas columns="4" rows="1">
+      <diagram-container box-id="f1" row="1" col="1" label="Foundation" tech="Tokens"></diagram-container>
+      <diagram-container box-id="f2" row="1" col="2" label="Components" tech="Web Components"></diagram-container>
+      <diagram-container box-id="f3" row="1" col="3" label="Catalog" tech="Vite"></diagram-container>
+      <diagram-container box-id="f4" row="1" col="4" label="Blog" tech="Hono + Turso"></diagram-container>
+
+      <diagram-arrow from="f1" to="f2" label="tokens"></diagram-arrow>
+      <diagram-arrow from="f2" to="f3" label="components"></diagram-arrow>
+      <diagram-arrow from="f2" to="f4" label="components"></diagram-arrow>
+    </diagram-canvas>
+  `,
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@maneki/charts": "*",
+        "@maneki/diagrams": "*",
         "@maneki/flex-layout": "*",
         "@maneki/foundation": "*",
         "@maneki/grid-layout": "*",
@@ -3153,6 +3154,10 @@
       "resolved": "packages/charts",
       "link": true
     },
+    "node_modules/@maneki/diagrams": {
+      "resolved": "packages/diagrams",
+      "link": true
+    },
     "node_modules/@maneki/flex-layout": {
       "resolved": "packages/flex-layout",
       "link": true
@@ -3677,9 +3682,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
-      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
       "cpu": [
         "arm"
       ],
@@ -3691,9 +3696,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
-      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
       "cpu": [
         "arm64"
       ],
@@ -3705,9 +3710,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
-      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
       "cpu": [
         "arm64"
       ],
@@ -3719,9 +3724,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
-      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
       "cpu": [
         "x64"
       ],
@@ -3733,9 +3738,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
-      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
       "cpu": [
         "arm64"
       ],
@@ -3747,9 +3752,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
-      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
       "cpu": [
         "x64"
       ],
@@ -3761,9 +3766,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
-      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
       "cpu": [
         "arm"
       ],
@@ -3775,9 +3780,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
-      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
       ],
@@ -3789,9 +3794,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
-      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
       "cpu": [
         "arm64"
       ],
@@ -3803,9 +3808,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
-      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
       ],
@@ -3817,9 +3822,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
-      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
       "cpu": [
         "loong64"
       ],
@@ -3831,9 +3836,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
-      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
       ],
@@ -3845,9 +3850,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
-      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
       "cpu": [
         "ppc64"
       ],
@@ -3859,9 +3864,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
-      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
       ],
@@ -3873,9 +3878,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
-      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
       "cpu": [
         "riscv64"
       ],
@@ -3887,9 +3892,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
-      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
       ],
@@ -3901,9 +3906,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
-      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
       "cpu": [
         "s390x"
       ],
@@ -3915,9 +3920,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
-      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
       "cpu": [
         "x64"
       ],
@@ -3929,9 +3934,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
-      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
       ],
@@ -3943,9 +3948,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
-      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
       "cpu": [
         "x64"
       ],
@@ -3957,9 +3962,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
-      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
       "cpu": [
         "arm64"
       ],
@@ -3971,9 +3976,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
-      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
       "cpu": [
         "arm64"
       ],
@@ -3985,9 +3990,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
-      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
       "cpu": [
         "ia32"
       ],
@@ -3999,9 +4004,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
-      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
       "cpu": [
         "x64"
       ],
@@ -4013,9 +4018,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
-      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
       "cpu": [
         "x64"
       ],
@@ -9316,13 +9321,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -10445,9 +10450,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
-      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10461,31 +10466,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.0",
-        "@rollup/rollup-android-arm64": "4.60.0",
-        "@rollup/rollup-darwin-arm64": "4.60.0",
-        "@rollup/rollup-darwin-x64": "4.60.0",
-        "@rollup/rollup-freebsd-arm64": "4.60.0",
-        "@rollup/rollup-freebsd-x64": "4.60.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
-        "@rollup/rollup-linux-arm64-musl": "4.60.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
-        "@rollup/rollup-linux-loong64-musl": "4.60.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
-        "@rollup/rollup-linux-x64-gnu": "4.60.0",
-        "@rollup/rollup-linux-x64-musl": "4.60.0",
-        "@rollup/rollup-openbsd-x64": "4.60.0",
-        "@rollup/rollup-openharmony-arm64": "4.60.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
-        "@rollup/rollup-win32-x64-gnu": "4.60.0",
-        "@rollup/rollup-win32-x64-msvc": "4.60.0",
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -14487,6 +14492,714 @@
       "license": "MIT"
     },
     "packages/charts/node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/diagrams": {
+      "name": "@maneki/diagrams",
+      "version": "0.1.0",
+      "dependencies": {
+        "@maneki/foundation": "^0.1.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.8.2",
+        "vite": "^6.2.4",
+        "vitest": "^3.1.1"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/diagrams/node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "packages/diagrams/node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "packages/diagrams/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "packages/diagrams/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "packages/diagrams/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/diagrams/node_modules/vite": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "packages/diagrams/node_modules/vitest": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",

--- a/packages/diagrams/moon.yml
+++ b/packages/diagrams/moon.yml
@@ -1,0 +1,25 @@
+$schema: 'https://moonrepo.dev/schemas/project.json'
+
+language: 'typescript'
+
+tasks:
+  build:
+    script: 'vite build && tsc --emitDeclarationOnly'
+    inputs:
+      - 'src/**/*'
+      - 'tsconfig.json'
+      - 'vite.config.ts'
+    outputs:
+      - 'dist'
+    deps:
+      - '^:build'
+
+  test:
+    command: 'vitest --run'
+    inputs:
+      - 'src/**/*'
+      - 'tsconfig.json'
+
+  dev:
+    command: 'vite'
+    preset: 'server'

--- a/packages/diagrams/package.json
+++ b/packages/diagrams/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@maneki/diagrams",
+  "version": "0.1.0",
+  "description": "Web Component diagram library for C4-style architecture diagrams",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build && tsc --emitDeclarationOnly",
+    "test": "vitest --run"
+  },
+  "dependencies": {
+    "@maneki/foundation": "^0.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.2",
+    "vite": "^6.2.4",
+    "vitest": "^3.1.1"
+  }
+}

--- a/packages/diagrams/src/components/diagram-arrow.ts
+++ b/packages/diagrams/src/components/diagram-arrow.ts
@@ -1,0 +1,27 @@
+/**
+ * <diagram-arrow> — Declarative arrow between two diagram-box elements.
+ * This is a data-only element — rendering is handled by diagram-canvas.
+ *
+ * Attributes:
+ *   from  — box-id of the source box
+ *   to    — box-id of the target box
+ *   label — text label on the arrow (optional)
+ */
+
+export class DiagramArrow extends HTMLElement {
+  static observedAttributes = ["from", "to", "label"];
+
+  connectedCallback(): void {
+    this.style.display = "none";
+  }
+
+  attributeChangedCallback(): void {
+    // Notify parent canvas to redraw
+    const canvas = this.closest("diagram-canvas");
+    if (canvas) {
+      canvas.dispatchEvent(new CustomEvent("arrows-changed", { bubbles: false }));
+    }
+  }
+}
+
+customElements.define("diagram-arrow", DiagramArrow);

--- a/packages/diagrams/src/components/diagram-box-base.ts
+++ b/packages/diagrams/src/components/diagram-box-base.ts
@@ -1,0 +1,117 @@
+/**
+ * DiagramBoxBase — shared base class for all diagram box components.
+ * Handles grid positioning, label/tech/description rendering, and shadow DOM setup.
+ * Subclasses provide their own styles via `_getStyles()`.
+ */
+
+import { semanticVar, spaceVar } from "@maneki/foundation";
+
+export const TEXT_PRIMARY = semanticVar("text", "primary");
+export const TEXT_SECONDARY = semanticVar("text", "secondary");
+export const TEXT_INVERSE = "#ffffff";
+export const SURFACE_PRIMARY = semanticVar("surface", "primary");
+export const SURFACE_ACTION = semanticVar("surface", "action");
+export const SURFACE_SECONDARY = semanticVar("surface", "secondary");
+export const SURFACE_TERTIARY = semanticVar("surface", "tertiary");
+export const BORDER_MODERATE = semanticVar("border", "moderate");
+export const BORDER_MINIMAL = semanticVar("border", "minimal");
+export const RADIUS_MD = "var(--fd-radius-md, 8px)";
+export const RADIUS_LG = "var(--fd-radius-lg, 12px)";
+export const SP_0_5 = spaceVar("0.5");
+export const SP_1 = spaceVar("1");
+export const SP_1_5 = spaceVar("1.5");
+
+export const BASE_STYLES = `
+  :host {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: ${SP_0_5};
+    padding: ${SP_1_5} ${SP_1};
+    text-align: center;
+    min-width: 120px;
+    min-height: 80px;
+    box-sizing: border-box;
+    position: relative;
+    transition: box-shadow 0.15s ease;
+  }
+
+  :host(:hover) {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  }
+
+  .label {
+    font-family: var(--fd-type-body-02-font-family);
+    font-size: var(--fd-type-body-02-font-size);
+    line-height: var(--fd-type-body-02-line-height);
+    font-weight: 600;
+  }
+
+  .tech {
+    font-family: var(--fd-type-body-03-font-family);
+    font-size: var(--fd-type-body-03-font-size);
+    line-height: var(--fd-type-body-03-line-height);
+    opacity: 0.7;
+  }
+
+  .description {
+    font-family: var(--fd-type-body-03-font-family);
+    font-size: var(--fd-type-body-03-font-size);
+    line-height: var(--fd-type-body-03-line-height);
+    opacity: 0.85;
+    max-width: 200px;
+  }
+`;
+
+export abstract class DiagramBoxBase extends HTMLElement {
+  static observedAttributes = ["box-id", "label", "description", "tech", "row", "col", "row-span", "col-span"];
+
+  protected _shadow: ShadowRoot;
+
+  constructor() {
+    super();
+    this._shadow = this.attachShadow({ mode: "open" });
+  }
+
+  connectedCallback(): void {
+    this._render();
+    this._applyGridPosition();
+  }
+
+  attributeChangedCallback(): void {
+    this._render();
+    this._applyGridPosition();
+  }
+
+  protected abstract _getStyles(): string;
+
+  private _applyGridPosition(): void {
+    const row = this.getAttribute("row");
+    const col = this.getAttribute("col");
+    const rowSpan = this.getAttribute("row-span") || "1";
+    const colSpan = this.getAttribute("col-span") || "1";
+
+    if (row) this.style.gridRow = `${row} / span ${rowSpan}`;
+    if (col) this.style.gridColumn = `${col} / span ${colSpan}`;
+  }
+
+  protected _render(): void {
+    const label = this.getAttribute("label") ?? "";
+    const tech = this.getAttribute("tech") ?? "";
+    const description = this.getAttribute("description") ?? "";
+
+    this._shadow.innerHTML = `
+      <style>${BASE_STYLES}\n${this._getStyles()}</style>
+      ${this._renderIcon()}
+      <span class="label">${label}</span>
+      ${tech ? `<span class="tech">[${tech}]</span>` : ""}
+      ${description ? `<span class="description">${description}</span>` : ""}
+    `;
+  }
+
+  /** Override to add an icon/avatar above the label. */
+  protected _renderIcon(): string {
+    return "";
+  }
+}

--- a/packages/diagrams/src/components/diagram-canvas.ts
+++ b/packages/diagrams/src/components/diagram-canvas.ts
@@ -1,0 +1,204 @@
+/**
+ * <diagram-canvas> — Container for diagram boxes and arrows.
+ * Uses CSS Grid for box positioning and an SVG overlay for arrows.
+ *
+ * Attributes:
+ *   columns   — number of grid columns (default 4)
+ *   rows      — number of grid rows (default 3)
+ *   title     — diagram title (optional)
+ *   gap       — grid gap in px (default 24)
+ */
+
+import { semanticVar, spaceVar } from "@maneki/foundation";
+
+const SURFACE_PRIMARY = semanticVar("surface", "primary");
+const TEXT_PRIMARY = semanticVar("text", "primary");
+const BORDER_MINIMAL = semanticVar("border", "minimal");
+const SP_2 = spaceVar("2");
+const SP_3 = spaceVar("3");
+
+const STYLES = `
+  :host {
+    display: block;
+    position: relative;
+    padding: ${SP_3};
+    background: var(--diagram-canvas-bg, ${SURFACE_PRIMARY});
+    border: 1px solid var(--diagram-canvas-border, ${BORDER_MINIMAL});
+    border-radius: var(--fd-radius-lg, 12px);
+    overflow: visible;
+  }
+
+  .title {
+    font-family: var(--fd-type-heading-05-font-family);
+    font-size: var(--fd-type-heading-05-font-size);
+    line-height: var(--fd-type-heading-05-line-height);
+    font-weight: var(--fd-type-heading-05-font-weight);
+    color: var(--diagram-canvas-title-color, ${TEXT_PRIMARY});
+    margin-bottom: ${SP_2};
+  }
+
+  .grid {
+    display: grid;
+    gap: var(--diagram-canvas-gap, 24px);
+    align-items: center;
+    justify-items: center;
+  }
+
+  svg.arrows {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    overflow: visible;
+  }
+
+  svg.arrows line {
+    stroke: var(--diagram-arrow-color, ${BORDER_MINIMAL});
+    stroke-width: var(--diagram-arrow-width, 1.5);
+  }
+
+  svg.arrows polygon {
+    fill: var(--diagram-arrow-color, ${BORDER_MINIMAL});
+  }
+
+  svg.arrows text {
+    font-family: var(--fd-type-body-03-font-family);
+    font-size: 11px;
+    fill: var(--diagram-arrow-label-color, ${TEXT_PRIMARY});
+    text-anchor: middle;
+    dominant-baseline: middle;
+  }
+`;
+
+interface ArrowDef {
+  from: string;
+  to: string;
+  label: string;
+}
+
+export class DiagramCanvas extends HTMLElement {
+  static observedAttributes = ["columns", "rows", "title", "gap"];
+
+  private _shadow: ShadowRoot;
+  private _resizeObserver: ResizeObserver | null = null;
+
+  constructor() {
+    super();
+    this._shadow = this.attachShadow({ mode: "open" });
+  }
+
+  connectedCallback(): void {
+    this._render();
+    // Re-draw arrows after layout settles
+    this._resizeObserver = new ResizeObserver(() => this._drawArrows());
+    this._resizeObserver.observe(this);
+    requestAnimationFrame(() => this._drawArrows());
+  }
+
+  disconnectedCallback(): void {
+    this._resizeObserver?.disconnect();
+  }
+
+  attributeChangedCallback(): void {
+    this._render();
+    requestAnimationFrame(() => this._drawArrows());
+  }
+
+  private _render(): void {
+    const cols = parseInt(this.getAttribute("columns") ?? "4", 10);
+    const rows = parseInt(this.getAttribute("rows") ?? "3", 10);
+    const title = this.getAttribute("title") ?? "";
+    const gap = this.getAttribute("gap") ?? "24";
+
+    this._shadow.innerHTML = `
+      <style>${STYLES}</style>
+      ${title ? `<div class="title">${title}</div>` : ""}
+      <div class="grid" style="grid-template-columns: repeat(${cols}, 1fr); grid-template-rows: repeat(${rows}, auto); --diagram-canvas-gap: ${gap}px;">
+        <slot></slot>
+      </div>
+      <svg class="arrows"></svg>
+    `;
+  }
+
+  private _getArrows(): ArrowDef[] {
+    const arrows: ArrowDef[] = [];
+    const arrowEls = this.querySelectorAll("diagram-arrow");
+    for (const el of arrowEls) {
+      const from = el.getAttribute("from") ?? "";
+      const to = el.getAttribute("to") ?? "";
+      const label = el.getAttribute("label") ?? "";
+      if (from && to) arrows.push({ from, to, label });
+    }
+    return arrows;
+  }
+
+  private _drawArrows(): void {
+    const svg = this._shadow.querySelector("svg.arrows");
+    if (!svg) return;
+
+    const arrows = this._getArrows();
+    const canvasRect = this.getBoundingClientRect();
+    let svgContent = "";
+
+    for (const arrow of arrows) {
+      const fromEl = this.querySelector(`[box-id="${arrow.from}"]`) as HTMLElement | null;
+      const toEl = this.querySelector(`[box-id="${arrow.to}"]`) as HTMLElement | null;
+      if (!fromEl || !toEl) continue;
+
+      const fromRect = fromEl.getBoundingClientRect();
+      const toRect = toEl.getBoundingClientRect();
+
+      // Center points relative to canvas
+      const x1 = fromRect.left + fromRect.width / 2 - canvasRect.left;
+      const y1 = fromRect.top + fromRect.height / 2 - canvasRect.top;
+      const x2 = toRect.left + toRect.width / 2 - canvasRect.left;
+      const y2 = toRect.top + toRect.height / 2 - canvasRect.top;
+
+      // Find edge intersection points
+      const [sx, sy] = this._edgePoint(fromRect, canvasRect, x2, y2);
+      const [ex, ey] = this._edgePoint(toRect, canvasRect, x1, y1);
+
+      // Arrowhead
+      const angle = Math.atan2(ey - sy, ex - sx);
+      const headLen = 8;
+      const ax1 = ex - headLen * Math.cos(angle - Math.PI / 6);
+      const ay1 = ey - headLen * Math.sin(angle - Math.PI / 6);
+      const ax2 = ex - headLen * Math.cos(angle + Math.PI / 6);
+      const ay2 = ey - headLen * Math.sin(angle + Math.PI / 6);
+
+      svgContent += `<line x1="${sx}" y1="${sy}" x2="${ex}" y2="${ey}" />`;
+      svgContent += `<polygon points="${ex},${ey} ${ax1},${ay1} ${ax2},${ay2}" />`;
+
+      if (arrow.label) {
+        const mx = (sx + ex) / 2;
+        const my = (sy + ey) / 2;
+        svgContent += `<text x="${mx}" y="${my - 8}">${arrow.label}</text>`;
+      }
+    }
+
+    svg.innerHTML = svgContent;
+  }
+
+  /** Find the point where a line from center to (tx,ty) exits the element's bounding box. */
+  private _edgePoint(rect: DOMRect, canvasRect: DOMRect, tx: number, ty: number): [number, number] {
+    const cx = rect.left + rect.width / 2 - canvasRect.left;
+    const cy = rect.top + rect.height / 2 - canvasRect.top;
+    const hw = rect.width / 2;
+    const hh = rect.height / 2;
+    const dx = tx - cx;
+    const dy = ty - cy;
+
+    if (dx === 0 && dy === 0) return [cx, cy];
+
+    // Scale factor to reach the edge
+    const sx = hw / Math.abs(dx || 1);
+    const sy = hh / Math.abs(dy || 1);
+    const s = Math.min(sx, sy);
+
+    return [cx + dx * s, cy + dy * s];
+  }
+}
+
+customElements.define("diagram-canvas", DiagramCanvas);

--- a/packages/diagrams/src/components/diagram-component.ts
+++ b/packages/diagrams/src/components/diagram-component.ts
@@ -1,0 +1,42 @@
+/**
+ * <diagram-component> — Module within a container. Rect with side tabs (UML-style).
+ */
+
+import { DiagramBoxBase, SURFACE_SECONDARY, TEXT_PRIMARY, BORDER_MODERATE, RADIUS_MD, SP_0_5 } from "./diagram-box-base.js";
+
+const STYLES = `
+  :host {
+    background: ${SURFACE_SECONDARY};
+    color: ${TEXT_PRIMARY};
+    border: 1px solid ${BORDER_MODERATE};
+    border-radius: ${RADIUS_MD};
+  }
+
+  /* UML-style side tabs */
+  :host::before,
+  :host::after {
+    content: "";
+    position: absolute;
+    left: -8px;
+    width: 8px;
+    height: 12px;
+    background: ${SURFACE_SECONDARY};
+    border: 1px solid ${BORDER_MODERATE};
+    border-right: none;
+    border-radius: 3px 0 0 3px;
+  }
+
+  :host::before {
+    top: 12px;
+  }
+
+  :host::after {
+    top: 30px;
+  }
+`;
+
+export class DiagramComponent extends DiagramBoxBase {
+  protected _getStyles(): string { return STYLES; }
+}
+
+customElements.define("diagram-component", DiagramComponent);

--- a/packages/diagrams/src/components/diagram-container.ts
+++ b/packages/diagrams/src/components/diagram-container.ts
@@ -1,0 +1,20 @@
+/**
+ * <diagram-container> — Application or service. Standard rect, gray border.
+ */
+
+import { DiagramBoxBase, SURFACE_PRIMARY, TEXT_PRIMARY, BORDER_MODERATE, RADIUS_MD } from "./diagram-box-base.js";
+
+const STYLES = `
+  :host {
+    background: ${SURFACE_PRIMARY};
+    color: ${TEXT_PRIMARY};
+    border: 1px solid ${BORDER_MODERATE};
+    border-radius: ${RADIUS_MD};
+  }
+`;
+
+export class DiagramContainer extends DiagramBoxBase {
+  protected _getStyles(): string { return STYLES; }
+}
+
+customElements.define("diagram-container", DiagramContainer);

--- a/packages/diagrams/src/components/diagram-external.ts
+++ b/packages/diagrams/src/components/diagram-external.ts
@@ -1,0 +1,20 @@
+/**
+ * <diagram-external> — Third-party/external system. Dashed border, muted colors.
+ */
+
+import { DiagramBoxBase, SURFACE_TERTIARY, TEXT_SECONDARY, BORDER_MODERATE, RADIUS_MD } from "./diagram-box-base.js";
+
+const STYLES = `
+  :host {
+    background: ${SURFACE_TERTIARY};
+    color: ${TEXT_SECONDARY};
+    border: 2px dashed ${BORDER_MODERATE};
+    border-radius: ${RADIUS_MD};
+  }
+`;
+
+export class DiagramExternal extends DiagramBoxBase {
+  protected _getStyles(): string { return STYLES; }
+}
+
+customElements.define("diagram-external", DiagramExternal);

--- a/packages/diagrams/src/components/diagram-person.ts
+++ b/packages/diagrams/src/components/diagram-person.ts
@@ -1,0 +1,32 @@
+/**
+ * <diagram-person> — Person/actor shape with rounded top (head silhouette).
+ * Blue background, white text.
+ */
+
+import { DiagramBoxBase, BASE_STYLES, SURFACE_ACTION, TEXT_INVERSE, RADIUS_MD } from "./diagram-box-base.js";
+
+const STYLES = `
+  :host {
+    background: ${SURFACE_ACTION};
+    color: ${TEXT_INVERSE};
+    border: 2px solid ${SURFACE_ACTION};
+    border-radius: 50% 50% ${RADIUS_MD} ${RADIUS_MD};
+  }
+
+  .person-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.25);
+    margin-bottom: 4px;
+  }
+`;
+
+export class DiagramPerson extends DiagramBoxBase {
+  protected _getStyles(): string { return STYLES; }
+  protected _renderIcon(): string {
+    return '<div class="person-icon"></div>';
+  }
+}
+
+customElements.define("diagram-person", DiagramPerson);

--- a/packages/diagrams/src/components/diagram-system.ts
+++ b/packages/diagrams/src/components/diagram-system.ts
@@ -1,0 +1,22 @@
+/**
+ * <diagram-system> — Top-level system. Large rounded rect, bold border, blue.
+ */
+
+import { DiagramBoxBase, SURFACE_ACTION, TEXT_INVERSE, RADIUS_LG } from "./diagram-box-base.js";
+
+const STYLES = `
+  :host {
+    background: ${SURFACE_ACTION};
+    color: ${TEXT_INVERSE};
+    border: 3px solid ${SURFACE_ACTION};
+    border-radius: ${RADIUS_LG};
+    min-width: 160px;
+    min-height: 100px;
+  }
+`;
+
+export class DiagramSystem extends DiagramBoxBase {
+  protected _getStyles(): string { return STYLES; }
+}
+
+customElements.define("diagram-system", DiagramSystem);

--- a/packages/diagrams/src/index.ts
+++ b/packages/diagrams/src/index.ts
@@ -1,0 +1,8 @@
+export { DiagramCanvas } from "./components/diagram-canvas.js";
+export { DiagramBoxBase } from "./components/diagram-box-base.js";
+export { DiagramPerson } from "./components/diagram-person.js";
+export { DiagramSystem } from "./components/diagram-system.js";
+export { DiagramContainer } from "./components/diagram-container.js";
+export { DiagramComponent } from "./components/diagram-component.js";
+export { DiagramExternal } from "./components/diagram-external.js";
+export { DiagramArrow } from "./components/diagram-arrow.js";

--- a/packages/diagrams/tsconfig.json
+++ b/packages/diagrams/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "declaration": true,
+    "declarationDir": "dist",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "useDefineForClassFields": true,
+    "isolatedModules": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/diagrams/vite.config.ts
+++ b/packages/diagrams/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vite";
+import { resolve } from "node:path";
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, "src/index.ts"),
+      formats: ["es"],
+      fileName: "index",
+    },
+    rollupOptions: {
+      external: ["@maneki/foundation"],
+    },
+  },
+  test: {
+    environment: "happy-dom",
+  },
+});

--- a/shared/vite-dev-aliases.ts
+++ b/shared/vite-dev-aliases.ts
@@ -40,4 +40,12 @@ export const devAliases: AliasOptions = [
     find: /^@maneki\/charts$/,
     replacement: resolve(root, "packages/charts/src/index.ts"),
   },
+  {
+    find: /^@maneki\/diagrams$/,
+    replacement: resolve(root, "packages/diagrams/src/index.ts"),
+  },
+  {
+    find: /^@maneki\/diagrams\/components\/(.*)\.js$/,
+    replacement: resolve(root, "packages/diagrams/src/components/$1.ts"),
+  },
 ];


### PR DESCRIPTION
## Summary

New `@maneki/diagrams` package with three Web Components for C4-style architecture diagrams:

- `<diagram-canvas>` — CSS Grid container with SVG arrow overlay. Attributes: `columns`, `rows`, `title`, `gap`
- `<diagram-box>` — Generic box with 5 variants: `person`, `system`, `container`, `component`, `external`. Positioned via `row`/`col`/`row-span`/`col-span` grid attributes
- `<diagram-arrow>` — Declarative arrow between boxes. Rendered by canvas as SVG lines with arrowheads and labels

Zero dependencies beyond `@maneki/foundation` for tokens. Styled with design tokens, dark mode support, hover effects.

## Usage

```html
<diagram-canvas columns="3" rows="2" title="My System">
  <diagram-box box-id="user" row="1" col="2" variant="person" label="User"></diagram-box>
  <diagram-box box-id="api" row="2" col="1" variant="container" label="API" tech="Hono"></diagram-box>
  <diagram-box box-id="db" row="2" col="3" variant="external" label="Database" tech="Turso"></diagram-box>
  <diagram-arrow from="user" to="api" label="requests"></diagram-arrow>
  <diagram-arrow from="api" to="db" label="queries"></diagram-arrow>
</diagram-canvas>
```

## Also

- Added catalog page with 3 diagram examples (C4 container, variants, simple flow)
- Added dev aliases for `@maneki/diagrams` in `shared/vite-dev-aliases.ts`
- Added `@maneki/diagrams` dependency to catalog