### PR TITLE
feat(blog): use Pretext for precise FLIP animation with GPU-composited transforms

### DIFF
--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -13,6 +13,7 @@
     "dev:pages": "wrangler pages dev dist --compatibility-date 2024-12-01"
   },
   "dependencies": {
+    "@chenglou/pretext": "^0.0.5",
     "@hono/zod-validator": "^0.7.6",
     "@libsql/client": "^0.17.2",
     "@maneki/foundation": "*",

--- a/apps/blog/src/router.ts
+++ b/apps/blog/src/router.ts
@@ -1,4 +1,5 @@
 import { SITE_URL, SITE_TITLE } from "./config.js";
+import { prepareWithSegments, measureNaturalWidth } from "@chenglou/pretext";
 /** Minimal History API router for the blog app. */
 
 export interface Route {
@@ -77,7 +78,8 @@ async function resolveRoute(routeId: string): Promise<Route | undefined> {
 
 type FlipDirection = "forward" | "reverse";
 
-/** FLIP shared element: animate signature between hero and header site-name. */
+/** FLIP shared element: animate signature between hero and header site-name.
+ *  Uses Pretext for precise text measurement + GPU-composited transform animation. */
 function flipSignature(
   clone: HTMLElement,
   sourceRect: DOMRect,
@@ -99,28 +101,40 @@ function flipSignature(
   const sourceStyles = getComputedStyle(clone);
   const sourceFontFamily = sourceStyles.fontFamily;
   const sourceColor = sourceStyles.color;
+  const sourceFontSize = sourceStyles.fontSize;
+  const targetFontSize = targetStyles.fontSize;
 
-  // Strip classes that apply text-stroke (hero-accent, site-name) to avoid CSS conflicts
+  // Use Pretext for precise width measurement at both sizes (no DOM reflow)
+  const fontBase = sourceFontFamily.split(",")[0].replace(/["']/g, "").trim();
+  const sourcePrep = prepareWithSegments("Kien Nguyen", `${sourceFontSize} ${fontBase}`);
+  const targetPrep = prepareWithSegments("Kien Nguyen", `${targetFontSize} ${fontBase}`);
+  const sourceWidth = measureNaturalWidth(sourcePrep);
+  const targetWidth = measureNaturalWidth(targetPrep);
+
+  // Precise scale ratios from Pretext measurements
+  const scaleX = targetWidth / sourceWidth;
+  const scaleY = parseFloat(targetFontSize) / parseFloat(sourceFontSize);
+
+  // Strip classes that apply text-stroke to avoid CSS conflicts
   clone.classList.remove("hero-accent", "site-name");
 
-  // Forward: stroke looks disproportionately thick on shrinking text, so zero it.
-  // Reverse: target stroke (2px) looks natural on growing text.
+  // Forward: zero stroke (looks thick on shrinking text). Reverse: target stroke.
   const targetStroke = direction === "forward" ? "0" : (targetStyles.webkitTextStrokeWidth || "0");
-  clone.classList.remove("hero-accent", "site-name");
 
-  // Style the clone as fixed overlay at source position
   Object.assign(clone.style, {
-    top: `${sourceRect.top}px`,
-    left: `${sourceRect.left}px`,
+    top: "0",
+    left: "0",
     margin: "0",
     zIndex: "9999",
     pointerEvents: "none",
-    willChange: "font-size, top, left",
+    willChange: "transform",
     lineHeight: "1",
     fontFamily: sourceFontFamily,
+    fontSize: sourceFontSize,
     color: sourceColor,
     textDecoration: "none",
     visibility: "visible",
+    transformOrigin: "left top",
     webkitTextStrokeWidth: targetStroke,
     webkitTextStrokeColor: "currentColor",
   });
@@ -141,19 +155,11 @@ function flipSignature(
   const duration = 400;
   const easing = "cubic-bezier(0.33, 0, 0.2, 1)";
 
-  const sourceFontSize = `${sourceRect.height}px`;
+  // GPU-composited animation: transform only (no layout reflow per frame)
   const anim = clone.animate(
     [
-      {
-        fontSize: sourceFontSize,
-        top: `${sourceRect.top}px`,
-        left: `${sourceRect.left}px`,
-      },
-      {
-        fontSize: targetStyles.fontSize,
-        top: `${targetRect.top}px`,
-        left: `${targetRect.left}px`,
-      },
+      { transform: `translate(${sourceRect.left}px, ${sourceRect.top}px) scale(1)` },
+      { transform: `translate(${targetRect.left}px, ${targetRect.top}px) scale(${scaleX}, ${scaleY})` },
     ],
     { duration, easing, fill: "forwards" },
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "name": "@maneki/blog",
       "version": "0.1.0",
       "dependencies": {
+        "@chenglou/pretext": "^0.0.5",
         "@hono/zod-validator": "^0.7.6",
         "@libsql/client": "^0.17.2",
         "@maneki/foundation": "*",
@@ -1699,6 +1700,12 @@
         "hashery": "^1.5.0",
         "keyv": "^5.6.0"
       }
+    },
+    "node_modules/@chenglou/pretext": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.5.tgz",
+      "integrity": "sha512-A8GZN10REdFGsyuiUgLV8jjPDDFMg5GmgxGWV0I3igxBOnzj+jgz2VMmVD7g+SFyoctfeqHFxbNatKSzVRWtRg==",
+      "license": "MIT"
     },
     "node_modules/@cloudflare/kv-asset-handler": {
       "version": "0.4.0",


### PR DESCRIPTION
## Summary

- Replace `font-size` animation (triggers layout reflow every frame) with `transform: scale()` (GPU-composited, zero reflow)
- Use `@chenglou/pretext` for precise text width measurement at both hero and header font sizes — `measureNaturalWidth()` gives exact pixel widths without DOM
- Separate `scaleX` (from Pretext width ratio) and `scaleY` (from font-size ratio) for accurate non-uniform scaling
- Text will be slightly less crisp mid-flight (bitmap scaling) but the animation is now fully compositor-thread — smoother on lower-end devices

## Changed files

- `apps/blog/src/router.ts` — rewritten `flipSignature` to use Pretext + transform instead of font-size
- `apps/blog/package.json` — added `@chenglou/pretext` dependency