### PR TITLE
fix(blog): preload Homeland font to prevent FOUT on direct page visits

### DIFF
--- a/apps/blog/index.html
+++ b/apps/blog/index.html
@@ -7,6 +7,7 @@
   <meta name="description" content="Personal blog and portfolio — fullstack development, design systems, and more." />
   <link rel="icon" type="image/png" href="/favicon.png" />
   <link rel="alternate" type="application/rss+xml" title="Kien Nguyen's blog" href="/feed.xml" />
+  <link rel="preload" href="/fonts/Homeland-subset.woff2" as="font" type="font/woff2" crossorigin />
   <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
   <meta name="theme-color" content="#1c2b36" media="(prefers-color-scheme: dark)" />
 


### PR DESCRIPTION
## Summary

- Add `<link rel="preload">` for the Homeland subset woff2 font (4.6KB)
- Prevents flash of unstyled text (FOUT) on the site-name when refreshing non-home pages
- The font was loading via `font-display: swap`, causing the site-name to briefly render in the fallback font before swapping to Homeland

Single line addition in `apps/blog/index.html`.