### PR TITLE
fix(blog): unify border-radius to --fd-radius-md for post cards and project cards

### DIFF
--- a/apps/blog/index.html
+++ b/apps/blog/index.html
@@ -255,7 +255,7 @@
       margin-right: calc(-1 * var(--fd-space-2));
       position: relative;
       isolation: isolate;
-      border-radius: var(--fd-radius-sm);
+      border-radius: var(--fd-radius-md);
     }
 
     .post-card::before,
@@ -464,7 +464,8 @@
     /* ─── Card hover ─── */
 
     ui-card {
-      border-radius: var(--ui-card-radius, var(--fd-radius-lg));
+      --ui-card-radius: var(--fd-radius-md);
+      border-radius: var(--fd-radius-md);
       transition: transform 200ms ease, box-shadow 200ms ease;
     }
 


### PR DESCRIPTION
## Summary

- Post cards: `--fd-radius-sm` → `--fd-radius-md` (12px)
- Project cards: `--fd-radius-lg` → `--fd-radius-md` (12px)
- Both card types now share the same border-radius for visual consistency

Single file change: `apps/blog/index.html`