### PR TITLE
feat(blog): add photography section — DB schema, API routes, masonry grid page

### DIFF
--- a/apps/blog/plugins/photography.ts
+++ b/apps/blog/plugins/photography.ts
@@ -1,0 +1,115 @@
+/**
+ * Vite plugin that fetches published photos and albums from Turso
+ * and exposes them as virtual modules.
+ *
+ * Usage:
+ *   import { photos, featuredPhotos, categories } from "virtual:photos";
+ *   import { albums } from "virtual:albums";
+ *
+ * Requires TURSO_URL + TURSO_AUTH_TOKEN env vars at build time.
+ * Falls back to empty arrays if DB is unavailable (dev without DB).
+ */
+
+import { type Plugin } from "vite";
+import { createClient } from "@libsql/client";
+
+const PHOTOS_MODULE_ID = "virtual:photos";
+const PHOTOS_RESOLVED_ID = "\0" + PHOTOS_MODULE_ID;
+
+const ALBUMS_MODULE_ID = "virtual:albums";
+const ALBUMS_RESOLVED_ID = "\0" + ALBUMS_MODULE_ID;
+
+const EMPTY_PHOTOS = "export const photos = [];\nexport const featuredPhotos = [];\nexport const categories = [];";
+const EMPTY_ALBUMS = "export const albums = [];";
+
+export function photographyPlugin(): Plugin {
+  async function loadPhotos(): Promise<string> {
+    const url = process.env.TURSO_URL;
+    const authToken = process.env.TURSO_AUTH_TOKEN;
+
+    if (!url) {
+      console.warn("[photography] TURSO_URL not set — returning empty photos");
+      return EMPTY_PHOTOS;
+    }
+
+    try {
+      const db = createClient({ url, authToken: authToken || undefined });
+      const result = await db.execute(
+        "SELECT id, r2_key, url, title, caption, album_id, category, width, height, thumbhash, exif_json, sort_order, featured FROM photos WHERE status = 'published' ORDER BY sort_order ASC, created_at DESC",
+      );
+
+      const photos = result.rows.map((row) => ({
+        id: row.id as number,
+        r2Key: row.r2_key as string,
+        url: row.url as string,
+        title: row.title as string,
+        caption: row.caption as string,
+        albumId: (row.album_id as number) ?? null,
+        category: row.category as string,
+        width: row.width as number,
+        height: row.height as number,
+        thumbhash: row.thumbhash as string,
+        exif: JSON.parse((row.exif_json as string) || "{}"),
+        sortOrder: (row.sort_order as number) ?? 0,
+        featured: !!row.featured,
+      }));
+
+      const featured = photos.filter((p) => p.featured);
+      const categorySet = new Set(photos.map((p) => p.category).filter(Boolean));
+      const categories = [...categorySet].sort();
+
+      console.log(
+        `[photography] Loaded ${photos.length} published photos (${featured.length} featured, ${categories.length} categories)`,
+      );
+      return `export const photos = ${JSON.stringify(photos)};\nexport const featuredPhotos = ${JSON.stringify(featured)};\nexport const categories = ${JSON.stringify(categories)};`;
+    } catch (err) {
+      console.error("[photography] Failed to fetch photos from Turso:", err);
+      return EMPTY_PHOTOS;
+    }
+  }
+
+  async function loadAlbums(): Promise<string> {
+    const url = process.env.TURSO_URL;
+    const authToken = process.env.TURSO_AUTH_TOKEN;
+
+    if (!url) {
+      console.warn("[photography] TURSO_URL not set — returning empty albums");
+      return EMPTY_ALBUMS;
+    }
+
+    try {
+      const db = createClient({ url, authToken: authToken || undefined });
+      const result = await db.execute(
+        "SELECT a.id, a.slug, a.title, a.description, a.cover_photo_id, a.sort_order, (SELECT COUNT(*) FROM photos p WHERE p.album_id = a.id AND p.status = 'published') AS photo_count FROM albums a WHERE a.status = 'published' ORDER BY a.sort_order ASC, a.created_at DESC",
+      );
+
+      const albums = result.rows.map((row) => ({
+        id: row.id as number,
+        slug: row.slug as string,
+        title: row.title as string,
+        description: row.description as string,
+        coverPhotoId: (row.cover_photo_id as number) ?? null,
+        sortOrder: (row.sort_order as number) ?? 0,
+        photoCount: (row.photo_count as number) ?? 0,
+      }));
+
+      console.log(`[photography] Loaded ${albums.length} published albums`);
+      return `export const albums = ${JSON.stringify(albums)};`;
+    } catch (err) {
+      console.error("[photography] Failed to fetch albums from Turso:", err);
+      return EMPTY_ALBUMS;
+    }
+  }
+
+  return {
+    name: "photography",
+    resolveId(id) {
+      if (id === PHOTOS_MODULE_ID) return PHOTOS_RESOLVED_ID;
+      if (id === ALBUMS_MODULE_ID) return ALBUMS_RESOLVED_ID;
+    },
+    async load(id) {
+      if (id === PHOTOS_RESOLVED_ID) return loadPhotos();
+      if (id === ALBUMS_RESOLVED_ID) return loadAlbums();
+    },
+  };
+}

--- a/apps/blog/plugins/sitemap.ts
+++ b/apps/blog/plugins/sitemap.ts
@@ -23,6 +23,7 @@ export function sitemapPlugin(): Plugin {
         { loc: `${SITE_URL}/`, priority: "1.0" },
         { loc: `${SITE_URL}/blog`, priority: "0.9" },
         { loc: `${SITE_URL}/portfolio`, priority: "0.7" },
+        { loc: `${SITE_URL}/photography`, priority: "0.7" },
         { loc: `${SITE_URL}/resume`, priority: "0.6" },
         { loc: `${SITE_URL}/about`, priority: "0.5" },
       ];
@@ -46,7 +47,20 @@ export function sitemapPlugin(): Plugin {
             urls.push({ loc: `${SITE_URL}/project/${row.slug as string}`, priority: "0.7" });
           }
         } catch (err) {
-          console.error("[sitemap] Failed to fetch from Turso:", err);
+          console.error("[sitemap] Failed to fetch posts/projects from Turso:", err);
+        }
+
+        // Albums query is separate — table may not exist yet
+        try {
+          const db = createClient({ url, authToken: authToken || undefined });
+          const albumsResult = await db.execute(
+            "SELECT slug FROM albums WHERE status = 'published' ORDER BY sort_order ASC, created_at DESC",
+          );
+          for (const row of albumsResult.rows) {
+            urls.push({ loc: `${SITE_URL}/photography/${row.slug as string}`, priority: "0.6" });
+          }
+        } catch {
+          // albums table may not exist yet — silently skip
         }
       } else {
         console.warn("[sitemap] TURSO_URL not set — sitemap will only have static routes");

--- a/apps/blog/src/api/db/schema.ts
+++ b/apps/blog/src/api/db/schema.ts
@@ -52,4 +52,42 @@ CREATE TABLE IF NOT EXISTS projects (
 
 CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status);
 CREATE INDEX IF NOT EXISTS idx_projects_slug ON projects(slug);
+
+CREATE TABLE IF NOT EXISTS albums (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug TEXT UNIQUE NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  cover_photo_id INTEGER,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'published', 'deleted')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_albums_status ON albums(status);
+CREATE INDEX IF NOT EXISTS idx_albums_slug ON albums(slug);
+
+CREATE TABLE IF NOT EXISTS photos (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  r2_key TEXT NOT NULL,
+  url TEXT NOT NULL,
+  title TEXT NOT NULL DEFAULT '',
+  caption TEXT NOT NULL DEFAULT '',
+  album_id INTEGER REFERENCES albums(id),
+  category TEXT NOT NULL DEFAULT '',
+  width INTEGER NOT NULL DEFAULT 0,
+  height INTEGER NOT NULL DEFAULT 0,
+  thumbhash TEXT NOT NULL DEFAULT '',
+  exif_json TEXT NOT NULL DEFAULT '{}',
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  featured INTEGER NOT NULL DEFAULT 0,
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'published', 'deleted')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_photos_status ON photos(status);
+CREATE INDEX IF NOT EXISTS idx_photos_album ON photos(album_id);
+CREATE INDEX IF NOT EXISTS idx_photos_featured ON photos(featured);
 `;

--- a/apps/blog/src/api/index.ts
+++ b/apps/blog/src/api/index.ts
@@ -13,6 +13,8 @@ import { uiState } from "./routes/ui-state.js";
 import { deploy } from "./routes/deploy.js";
 import { images } from "./routes/images.js";
 import { projects } from "./routes/projects.js";
+import { photos } from "./routes/photos.js";
+import { albums } from "./routes/albums.js";
 
 /** Env bindings available in CF Pages Functions. */
 export type Env = {
@@ -47,7 +49,9 @@ const app = new Hono<Env>()
   .route("/ui-state", uiState)
   .route("/deploy", deploy)
   .route("/images", images)
-  .route("/projects", projects);
+  .route("/projects", projects)
+  .route("/photos", photos)
+  .route("/albums", albums);
 
 export type AppType = typeof app;
 export default app;

--- a/apps/blog/src/api/routes/albums.ts
+++ b/apps/blog/src/api/routes/albums.ts
@@ -1,0 +1,133 @@
+/**
+ * Albums CRUD routes.
+ * All routes are protected by CF Access auth middleware (applied at app level).
+ */
+
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import type { Env } from "../index.js";
+
+const createAlbumSchema = z.object({
+  title: z.string().min(1),
+  slug: z
+    .string()
+    .min(1)
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "Slug must be lowercase kebab-case"),
+  description: z.string().default(""),
+  cover_photo_id: z.number().nullable().default(null),
+  sort_order: z.number().default(0),
+  status: z.enum(["draft", "published"]).default("draft"),
+});
+
+const updateAlbumSchema = z.object({
+  title: z.string().min(1).optional(),
+  slug: z
+    .string()
+    .min(1)
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+    .optional(),
+  description: z.string().optional(),
+  cover_photo_id: z.number().nullable().optional(),
+  sort_order: z.number().optional(),
+  status: z.enum(["draft", "published"]).optional(),
+});
+
+export const albums = new Hono<Env>()
+  // List albums (optionally filter by status)
+  .get("/", async (c) => {
+    const status = c.req.query("status");
+    const db = c.get("db");
+
+    const sql = status
+      ? "SELECT a.*, (SELECT COUNT(*) FROM photos p WHERE p.album_id = a.id AND p.status = 'published') AS photo_count FROM albums a WHERE a.status = ? ORDER BY a.sort_order ASC, a.created_at DESC"
+      : "SELECT a.*, (SELECT COUNT(*) FROM photos p WHERE p.album_id = a.id AND p.status = 'published') AS photo_count FROM albums a WHERE a.status != 'deleted' ORDER BY a.sort_order ASC, a.created_at DESC";
+    const args = status ? [status] : [];
+
+    const result = await db.execute({ sql, args });
+    return c.json({ albums: result.rows });
+  })
+
+  // Get single album by slug (includes photo count)
+  .get("/:slug", async (c) => {
+    const db = c.get("db");
+    const result = await db.execute({
+      sql: "SELECT a.*, (SELECT COUNT(*) FROM photos p WHERE p.album_id = a.id AND p.status = 'published') AS photo_count FROM albums a WHERE a.slug = ?",
+      args: [c.req.param("slug")],
+    });
+    if (!result.rows.length) {
+      return c.json({ error: "not found" }, 404);
+    }
+    return c.json({ album: result.rows[0] });
+  })
+
+  // Create album
+  .post("/", zValidator("json", createAlbumSchema), async (c) => {
+    const { title, slug, description, cover_photo_id, sort_order, status } = c.req.valid("json");
+    const db = c.get("db");
+
+    await db.execute({
+      sql: `INSERT INTO albums (title, slug, description, cover_photo_id, sort_order, status, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, datetime('now'))`,
+      args: [title, slug, description, cover_photo_id, sort_order, status],
+    });
+    return c.json({ ok: true, slug }, 201);
+  })
+
+  // Update album by slug
+  .put("/:slug", zValidator("json", updateAlbumSchema), async (c) => {
+    const slug = c.req.param("slug");
+    const updates = c.req.valid("json");
+    const db = c.get("db");
+
+    const setClauses: string[] = [];
+    const args: (string | number | null)[] = [];
+
+    if (updates.title !== undefined) {
+      setClauses.push("title = ?");
+      args.push(updates.title);
+    }
+    if (updates.slug !== undefined) {
+      setClauses.push("slug = ?");
+      args.push(updates.slug);
+    }
+    if (updates.description !== undefined) {
+      setClauses.push("description = ?");
+      args.push(updates.description);
+    }
+    if (updates.cover_photo_id !== undefined) {
+      setClauses.push("cover_photo_id = ?");
+      args.push(updates.cover_photo_id);
+    }
+    if (updates.sort_order !== undefined) {
+      setClauses.push("sort_order = ?");
+      args.push(updates.sort_order);
+    }
+    if (updates.status !== undefined) {
+      setClauses.push("status = ?");
+      args.push(updates.status);
+    }
+
+    if (setClauses.length === 0) {
+      return c.json({ error: "no fields to update" }, 400);
+    }
+
+    setClauses.push("updated_at = datetime('now')");
+    args.push(slug);
+
+    await db.execute({
+      sql: `UPDATE albums SET ${setClauses.join(", ")} WHERE slug = ?`,
+      args,
+    });
+    return c.json({ ok: true });
+  })
+
+  // Soft delete album by slug
+  .delete("/:slug", async (c) => {
+    const db = c.get("db");
+    await db.execute({
+      sql: "UPDATE albums SET status = 'deleted', updated_at = datetime('now') WHERE slug = ?",
+      args: [c.req.param("slug")],
+    });
+    return c.json({ ok: true });
+  });

--- a/apps/blog/src/api/routes/photos.ts
+++ b/apps/blog/src/api/routes/photos.ts
@@ -1,0 +1,201 @@
+/**
+ * Photos CRUD routes.
+ * All routes are protected by CF Access auth middleware (applied at app level).
+ */
+
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import type { Env } from "../index.js";
+
+const createPhotoSchema = z.object({
+  r2_key: z.string().min(1),
+  url: z.string().min(1),
+  title: z.string().default(""),
+  caption: z.string().default(""),
+  album_id: z.number().nullable().default(null),
+  category: z.string().default(""),
+  width: z.number().default(0),
+  height: z.number().default(0),
+  thumbhash: z.string().default(""),
+  exif_json: z.string().default("{}"),
+  sort_order: z.number().default(0),
+  featured: z.boolean().default(false),
+  status: z.enum(["draft", "published"]).default("draft"),
+});
+
+const updatePhotoSchema = z.object({
+  title: z.string().optional(),
+  caption: z.string().optional(),
+  album_id: z.number().nullable().optional(),
+  category: z.string().optional(),
+  width: z.number().optional(),
+  height: z.number().optional(),
+  thumbhash: z.string().optional(),
+  exif_json: z.string().optional(),
+  sort_order: z.number().optional(),
+  featured: z.boolean().optional(),
+  status: z.enum(["draft", "published"]).optional(),
+});
+
+export const photos = new Hono<Env>()
+  // List published photos (public-facing, supports ?album=slug and ?category=name)
+  .get("/", async (c) => {
+    const status = c.req.query("status");
+    const albumSlug = c.req.query("album");
+    const category = c.req.query("category");
+    const db = c.get("db");
+
+    let sql: string;
+    const args: (string | number)[] = [];
+
+    if (albumSlug) {
+      sql = status
+        ? "SELECT p.* FROM photos p JOIN albums a ON p.album_id = a.id WHERE a.slug = ? AND p.status = ? ORDER BY p.sort_order ASC, p.created_at DESC"
+        : "SELECT p.* FROM photos p JOIN albums a ON p.album_id = a.id WHERE a.slug = ? AND p.status != 'deleted' ORDER BY p.sort_order ASC, p.created_at DESC";
+      args.push(albumSlug);
+      if (status) args.push(status);
+    } else if (category) {
+      sql = status
+        ? "SELECT * FROM photos WHERE category = ? AND status = ? ORDER BY sort_order ASC, created_at DESC"
+        : "SELECT * FROM photos WHERE category = ? AND status != 'deleted' ORDER BY sort_order ASC, created_at DESC";
+      args.push(category);
+      if (status) args.push(status);
+    } else {
+      sql = status
+        ? "SELECT * FROM photos WHERE status = ? ORDER BY sort_order ASC, created_at DESC"
+        : "SELECT * FROM photos WHERE status != 'deleted' ORDER BY sort_order ASC, created_at DESC";
+      if (status) args.push(status);
+    }
+
+    const result = await db.execute({ sql, args });
+    const rows = result.rows.map((r) => ({
+      ...r,
+      featured: !!r.featured,
+      exif_json: JSON.parse((r.exif_json as string) || "{}"),
+    }));
+    return c.json({ photos: rows });
+  })
+
+  // Get single photo by id
+  .get("/:id", async (c) => {
+    const db = c.get("db");
+    const result = await db.execute({
+      sql: "SELECT * FROM photos WHERE id = ?",
+      args: [Number(c.req.param("id"))],
+    });
+    if (!result.rows.length) {
+      return c.json({ error: "not found" }, 404);
+    }
+    const photo = {
+      ...result.rows[0],
+      featured: !!result.rows[0].featured,
+      exif_json: JSON.parse((result.rows[0].exif_json as string) || "{}"),
+    };
+    return c.json({ photo });
+  })
+
+  // Create photo
+  .post("/", zValidator("json", createPhotoSchema), async (c) => {
+    const data = c.req.valid("json");
+    const db = c.get("db");
+
+    await db.execute({
+      sql: `INSERT INTO photos (r2_key, url, title, caption, album_id, category, width, height, thumbhash, exif_json, sort_order, featured, status, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`,
+      args: [
+        data.r2_key,
+        data.url,
+        data.title,
+        data.caption,
+        data.album_id,
+        data.category,
+        data.width,
+        data.height,
+        data.thumbhash,
+        data.exif_json,
+        data.sort_order,
+        data.featured ? 1 : 0,
+        data.status,
+      ],
+    });
+    return c.json({ ok: true }, 201);
+  })
+
+  // Update photo by id
+  .put("/:id", zValidator("json", updatePhotoSchema), async (c) => {
+    const id = Number(c.req.param("id"));
+    const updates = c.req.valid("json");
+    const db = c.get("db");
+
+    const setClauses: string[] = [];
+    const args: (string | number | null)[] = [];
+
+    if (updates.title !== undefined) {
+      setClauses.push("title = ?");
+      args.push(updates.title);
+    }
+    if (updates.caption !== undefined) {
+      setClauses.push("caption = ?");
+      args.push(updates.caption);
+    }
+    if (updates.album_id !== undefined) {
+      setClauses.push("album_id = ?");
+      args.push(updates.album_id);
+    }
+    if (updates.category !== undefined) {
+      setClauses.push("category = ?");
+      args.push(updates.category);
+    }
+    if (updates.width !== undefined) {
+      setClauses.push("width = ?");
+      args.push(updates.width);
+    }
+    if (updates.height !== undefined) {
+      setClauses.push("height = ?");
+      args.push(updates.height);
+    }
+    if (updates.thumbhash !== undefined) {
+      setClauses.push("thumbhash = ?");
+      args.push(updates.thumbhash);
+    }
+    if (updates.exif_json !== undefined) {
+      setClauses.push("exif_json = ?");
+      args.push(updates.exif_json);
+    }
+    if (updates.sort_order !== undefined) {
+      setClauses.push("sort_order = ?");
+      args.push(updates.sort_order);
+    }
+    if (updates.featured !== undefined) {
+      setClauses.push("featured = ?");
+      args.push(updates.featured ? 1 : 0);
+    }
+    if (updates.status !== undefined) {
+      setClauses.push("status = ?");
+      args.push(updates.status);
+    }
+
+    if (setClauses.length === 0) {
+      return c.json({ error: "no fields to update" }, 400);
+    }
+
+    setClauses.push("updated_at = datetime('now')");
+    args.push(id);
+
+    await db.execute({
+      sql: `UPDATE photos SET ${setClauses.join(", ")} WHERE id = ?`,
+      args,
+    });
+    return c.json({ ok: true });
+  })
+
+  // Soft delete photo by id
+  .delete("/:id", async (c) => {
+    const db = c.get("db");
+    await db.execute({
+      sql: "UPDATE photos SET status = 'deleted', updated_at = datetime('now') WHERE id = ?",
+      args: [Number(c.req.param("id"))],
+    });
+    return c.json({ ok: true });
+  });

--- a/apps/blog/src/router.ts
+++ b/apps/blog/src/router.ts
@@ -309,6 +309,7 @@ function updateMeta(routeId: string, route: Route | undefined): void {
       el.dataset.route === routeId ||
       (routeId === "home" && !el.dataset.route) ||
       (routeId.startsWith("post/") && el.dataset.route === "blog");
+      (routeId.startsWith("photography/") && el.dataset.route === "photography");
     if (isActive) newIndex = i;
   });
   const dir = oldIndex >= 0 && newIndex >= 0 && oldIndex !== newIndex ? (newIndex > oldIndex ? "right" : "left") : null;
@@ -317,6 +318,7 @@ function updateMeta(routeId: string, route: Route | undefined): void {
       el.dataset.route === routeId ||
       (routeId === "home" && !el.dataset.route) ||
       (routeId.startsWith("post/") && el.dataset.route === "blog");
+      (routeId.startsWith("photography/") && el.dataset.route === "photography");
     if (dir) {
       // Outgoing: shrink toward the new item. Incoming: grow from the old item.
       el.dataset.navDir = i === oldIndex ? dir : i === newIndex ? (dir === "right" ? "left" : "right") : "";

--- a/apps/blog/vite.config.ts
+++ b/apps/blog/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
 import { markdownPostsPlugin } from "./plugins/markdown-posts.js";
 import { portfolioProjectsPlugin } from "./plugins/portfolio-projects.js";
+import { photographyPlugin } from "./plugins/photography.js";
 import { autoUiComponentsPlugin } from "./plugins/auto-ui-components.js";
 import { sitemapPlugin } from "./plugins/sitemap.js";
 import { rssFeedPlugin } from "./plugins/rss-feed.js";
@@ -29,6 +30,7 @@ export default defineConfig(({ command }) => ({
     injectTokensPlugin(),
     markdownPostsPlugin(),
     portfolioProjectsPlugin(),
+    photographyPlugin(),
     autoUiComponentsPlugin(),
     sitemapPlugin(),
     rssFeedPlugin(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -6171,9 +6171,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6938,9 +6938,9 @@
       "license": "MIT"
     },
     "node_modules/html-validate/node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Add `albums` and `photos` tables to Turso schema with full indexes
- Add `/api/photos` and `/api/albums` CRUD routes (Hono + Zod validation, soft delete, album/category filters)
- Add `virtual:photos` and `virtual:albums` Vite plugins for build-time data from Turso
- Add `/photography` page with category filter tabs + CSS masonry grid (`@supports` fallback)
- Add `/photography/:album` detail page with back link and photo grid
- Add Photography nav link between Portfolio and About
- Add photography + album routes to sitemap.xml
- CSS: masonry grid, filter tabs with accent color, photo hover lift, album cards, hero overlay

## Changed files

- `apps/blog/src/api/db/schema.ts` — albums + photos tables
- `apps/blog/src/api/routes/photos.ts` — new CRUD routes
- `apps/blog/src/api/routes/albums.ts` — new CRUD routes
- `apps/blog/src/api/index.ts` — mount new routes
- `apps/blog/plugins/photography.ts` — virtual modules plugin
- `apps/blog/src/virtual-photography.d.ts` — type declarations
- `apps/blog/vite.config.ts` — register plugin
- `apps/blog/src/routes.ts` — photography routes
- `apps/blog/src/pages/photography.ts` — main page
- `apps/blog/src/pages/photography-album.ts` — album detail page
- `apps/blog/src/main.ts` — route pattern registration
- `apps/blog/src/router.ts` — nav active state for photography
- `apps/blog/index.html` — CSS + nav link
- `apps/blog/plugins/sitemap.ts` — photography routes in sitemap