### PR TITLE
refactor(blog): migrate editor sidebar + tabbar to Lit components

### DIFF
--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -18,6 +18,7 @@
     "@maneki/foundation": "*",
     "@maneki/ui-components": "*",
     "hono": "^4.12.9",
+    "lit": "^3.3.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/blog/src/pages/editor/editor-store.ts
+++ b/apps/blog/src/pages/editor/editor-store.ts
@@ -1,0 +1,21 @@
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import { state, onSidebarRender, onTabBarRender, onFormRender, type EditorState } from "./state.js";
+
+export class EditorStoreController implements ReactiveController {
+  host: ReactiveControllerHost;
+
+  constructor(host: ReactiveControllerHost) {
+    this.host = host;
+    host.addController(this);
+  }
+
+  hostConnected(): void {
+    onSidebarRender(() => this.host.requestUpdate());
+    onTabBarRender(() => this.host.requestUpdate());
+    onFormRender(() => this.host.requestUpdate());
+  }
+
+  get state(): EditorState {
+    return state;
+  }
+}

--- a/apps/blog/src/pages/editor/sidebar.ts
+++ b/apps/blog/src/pages/editor/sidebar.ts
@@ -1,613 +1,479 @@
+import { LitElement, html, nothing } from "lit";
+import { customElement } from "lit/decorators.js";
+import { repeat } from "lit/directives/repeat.js";
 import { api } from "../../lib/api.js";
-import { state, setState, onSidebarRender, hasUnpublishedChanges } from "./state.js";
+import { state, setState, hasUnpublishedChanges } from "./state.js";
 import type { Post, Project } from "./types.js";
+import { EditorStoreController } from "./editor-store.js";
 
-export class SidebarRenderer {
-  private postItems = new Map<string, HTMLElement>();
-  private projectItems = new Map<string, HTMLElement>();
-  private postList: HTMLElement | null = null;
-  private projectList: HTMLElement | null = null;
+// Inject deploy-spinner keyframes once into the document
+if (!document.getElementById("editor-sidebar-styles")) {
+  const style = document.createElement("style");
+  style.id = "editor-sidebar-styles";
+  style.textContent = `@keyframes editor-spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } } .deploy-spinner { animation: editor-spin 700ms linear infinite; }`;
+  document.head.appendChild(style);
+}
 
-  init(postListEl: HTMLElement, projectListEl: HTMLElement): void {
-    this.postList = postListEl;
-    this.projectList = projectListEl;
-    onSidebarRender(() => this.sync());
+@customElement("editor-sidebar")
+export class EditorSidebar extends LitElement {
+  private store = new EditorStoreController(this);
+
+  createRenderRoot(): this {
+    this.style.display = "contents";
+    return this;
   }
 
-  sync(): void {
-    this.syncPosts();
-    this.syncProjects();
-    this.syncBulkBar();
-    this.syncToolbarButtons();
+  // ─── Render ──────────────────────────────────────────────────────────────────
+
+  protected render(): unknown {
+    const s = this.store.state;
+    return html`
+      <ui-side-panel-menu-section separator>
+        <span style="display:flex;align-items:center;justify-content:space-between;width:100%;">
+          Posts
+          <ui-button
+            id="admin-new-post"
+            action="primary"
+            emphasis="minimal"
+            size="s"
+            icon="icon-only"
+            aria-label="New Post"
+            ><ui-icon name="add" size="s" slot="icon-start"></ui-icon
+          ></ui-button>
+        </span>
+      </ui-side-panel-menu-section>
+      <div id="admin-post-list">
+        ${repeat(
+          s.allPosts,
+          (p) => p.slug,
+          (post) => this.renderPostItem(post),
+        )}
+      </div>
+      <ui-side-panel-menu-section separator>
+        <span style="display:flex;align-items:center;justify-content:space-between;width:100%;">
+          Projects
+          <ui-button
+            id="admin-new-project"
+            action="primary"
+            emphasis="minimal"
+            size="s"
+            icon="icon-only"
+            aria-label="New Project"
+            ><ui-icon name="add" size="s" slot="icon-start"></ui-icon
+          ></ui-button>
+        </span>
+      </ui-side-panel-menu-section>
+      <div id="admin-project-list">
+        ${repeat(
+          s.allProjects,
+          (p) => p.slug,
+          (project) => this.renderProjectItem(project),
+        )}
+      </div>
+      ${this.renderBulkBar()}
+    `;
   }
 
-  private syncPosts(): void {
-    if (!this.postList) return;
-    const currentSlugs = new Set(state.allPosts.map((p) => p.slug));
+  // ─── Post item ───────────────────────────────────────────────────────────────
 
-    // Remove items no longer in allPosts
-    for (const [slug, el] of this.postItems) {
-      if (!currentSlugs.has(slug)) {
-        el.remove();
-        this.postItems.delete(slug);
-      }
-    }
-
-    // Add new items or patch existing
-    for (let i = 0; i < state.allPosts.length; i++) {
-      const post = state.allPosts[i];
-      const existing = this.postItems.get(post.slug);
-      if (existing) {
-        this.patchPostItem(existing, post);
-      } else {
-        const el = this.createPostItem(post);
-        this.postItems.set(post.slug, el);
-        const nextSibling = i + 1 < state.allPosts.length
-          ? this.postItems.get(state.allPosts[i + 1].slug) ?? null
-          : null;
-        if (nextSibling) {
-          this.postList.insertBefore(el, nextSibling);
-        } else {
-          this.postList.appendChild(el);
-        }
-      }
-    }
-  }
-
-  private syncProjects(): void {
-    if (!this.projectList) return;
-    const currentSlugs = new Set(state.allProjects.map((p) => p.slug));
-
-    for (const [slug, el] of this.projectItems) {
-      if (!currentSlugs.has(slug)) {
-        el.remove();
-        this.projectItems.delete(slug);
-      }
-    }
-
-    for (let i = 0; i < state.allProjects.length; i++) {
-      const project = state.allProjects[i];
-      const existing = this.projectItems.get(project.slug);
-      if (existing) {
-        this.patchProjectItem(existing, project);
-      } else {
-        const el = this.createProjectItem(project);
-        this.projectItems.set(project.slug, el);
-        const nextSibling = i + 1 < state.allProjects.length
-          ? this.projectItems.get(state.allProjects[i + 1].slug) ?? null
-          : null;
-        if (nextSibling) {
-          this.projectList.insertBefore(el, nextSibling);
-        } else {
-          this.projectList.appendChild(el);
-        }
-      }
-    }
-
-    // Reorder DOM to match state order
-    for (const project of state.allProjects) {
-      const el = this.projectItems.get(project.slug);
-      if (el) this.projectList.appendChild(el);
-    }
-  }
-
-  private syncToolbarButtons(): void {
-    const isDeploying = state.deployingSlugs.size > 0;
-    const saveBtn = document.getElementById("admin-save-btn");
-    const publishSplit = document.getElementById("admin-publish-split");
-    if (saveBtn) { if (isDeploying) saveBtn.setAttribute("disabled", ""); else saveBtn.removeAttribute("disabled"); }
-    if (publishSplit) { if (isDeploying) publishSplit.setAttribute("disabled", ""); else publishSplit.removeAttribute("disabled"); }
-  }
-
-  // ─── Post item helpers ──────────────────────────────────────────────────────
-
-  private patchPostItem(wrapper: HTMLElement, post: Post): void {
-    const item = wrapper.querySelector("ui-side-panel-menu-item") as HTMLElement;
-    if (!item) return;
-
-    if (post.slug === state.currentSlug && state.activeTabType === "post") item.setAttribute("selected", "");
-    else item.removeAttribute("selected");
-
-    const titleEl = wrapper.querySelector(".sidebar-title") as HTMLElement;
-    const newTitle = (post.title || "Untitled") + (hasUnpublishedChanges(post) ? " *" : "");
-    if (titleEl && titleEl.textContent !== newTitle) titleEl.textContent = newTitle;
-
-    const badge = wrapper.querySelector("ui-badge") as HTMLElement;
-    if (badge) {
-      let badgeStatus = "warning";
-      let badgeLabel: string = post.status;
-      if (post.status === "published") badgeStatus = "success";
-      if (state.deployingSlugs.has(post.slug) && state.deployingAction) {
-        badgeStatus = "information";
-        badgeLabel = state.deployingAction;
-      }
-      if (badge.getAttribute("status") !== badgeStatus) badge.setAttribute("status", badgeStatus);
-      if (badge.textContent !== badgeLabel) badge.textContent = badgeLabel;
-    }
-
-    const metaSpan = wrapper.querySelector(".sidebar-meta") as HTMLElement;
-    const existingSpinner = wrapper.querySelector(".deploy-spinner");
-    const shouldSpin = state.deployingSlugs.has(post.slug);
-    if (shouldSpin && !existingSpinner && metaSpan) {
-      const spinner = document.createElement("ui-icon");
-      spinner.setAttribute("name", "progress_activity");
-      spinner.setAttribute("size", "xs");
-      spinner.className = "deploy-spinner";
-      spinner.animate([{ transform: "rotate(0deg)" }, { transform: "rotate(360deg)" }], {
-        duration: 700,
-        iterations: Infinity,
-      });
-      metaSpan.appendChild(document.createTextNode(" "));
-      metaSpan.appendChild(spinner);
-    } else if (!shouldSpin && existingSpinner) {
-      if (existingSpinner.previousSibling?.nodeType === Node.TEXT_NODE) {
-        existingSpinner.previousSibling.remove();
-      }
-      existingSpinner.remove();
-    }
-
-    const checkbox = wrapper.querySelector("ui-checkbox-item") as HTMLElement;
-    if (checkbox) {
-      const isChecked = state.selectedSlugs.has(post.slug);
-      if (isChecked && !checkbox.hasAttribute("checked")) checkbox.setAttribute("checked", "");
-      else if (!isChecked && checkbox.hasAttribute("checked")) checkbox.removeAttribute("checked");
-
-      if (state.selectedSlugs.size > 0) {
-        checkbox.style.cssText = "flex-shrink:0;align-self:flex-start;margin-top:2px;";
-      }
-    }
-
-    const deleteBtn = wrapper.querySelector("[slot='actions']") as HTMLElement;
-    if (deleteBtn) {
-      if (state.deployingSlugs.has(post.slug)) deleteBtn.setAttribute("disabled", "");
-      else deleteBtn.removeAttribute("disabled");
-    }
-  }
-
-  private createPostItem(post: Post): HTMLElement {
-    const wrapper = document.createElement("div");
-    wrapper.setAttribute("data-slug", post.slug);
-    wrapper.setAttribute("data-type", "post");
-
-    const item = document.createElement("ui-side-panel-menu-item");
-    item.setAttribute("value", post.slug);
-    if (post.slug === state.currentSlug && state.activeTabType === "post") {
-      item.setAttribute("selected", "");
-    }
-
-    const label = document.createElement("span");
-    label.style.cssText = "display:flex;flex-direction:column;gap:2px;overflow:hidden;";
-
-    const titleSpan = document.createElement("span");
-    titleSpan.className = "sidebar-title";
-    titleSpan.style.cssText = "white-space:nowrap;overflow:hidden;text-overflow:ellipsis;";
-    titleSpan.textContent = (post.title || "Untitled") + (hasUnpublishedChanges(post) ? " *" : "");
-
-    const metaSpan = document.createElement("span");
-    metaSpan.className = "sidebar-meta";
-    metaSpan.style.cssText = "font-size:11px;color:var(--fd-text-secondary, #52525b);display:flex;align-items:center;gap:6px;";
+  private renderPostItem(post: Post): unknown {
+    const s = this.store.state;
+    const isSelected = post.slug === s.currentSlug && s.activeTabType === "post";
+    const isChecked = s.selectedSlugs.has(post.slug);
+    const deploying = s.deployingSlugs.has(post.slug);
+    const title = (post.title || "Untitled") + (hasUnpublishedChanges(post) ? " *" : "");
 
     let badgeStatus = "warning";
     let badgeLabel: string = post.status;
     if (post.status === "published") badgeStatus = "success";
-    if (state.deployingSlugs.has(post.slug) && state.deployingAction) {
+    if (deploying && s.deployingAction) {
       badgeStatus = "information";
-      badgeLabel = state.deployingAction;
+      badgeLabel = s.deployingAction;
     }
 
-    metaSpan.innerHTML = `${post.date} <ui-badge size="xs" status="${badgeStatus}">${badgeLabel}</ui-badge>`;
+    const checkboxStyle =
+      (s.selectedSlugs.size > 0 ? "flex-shrink:0;" : "flex-shrink:0;opacity:0;transition:opacity 0.15s;") +
+      "align-self:flex-start;margin-top:2px;";
 
-    if (state.deployingSlugs.has(post.slug)) {
-      const spinner = document.createElement("ui-icon");
-      spinner.setAttribute("name", "progress_activity");
-      spinner.setAttribute("size", "xs");
-      spinner.className = "deploy-spinner";
-      spinner.animate([{ transform: "rotate(0deg)" }, { transform: "rotate(360deg)" }], {
-        duration: 700,
-        iterations: Infinity,
-      });
-      metaSpan.appendChild(document.createTextNode(" "));
-      metaSpan.appendChild(spinner);
-    }
-
-    // Checkbox for multi-select
-    const checkbox = document.createElement("ui-checkbox-item");
-    checkbox.setAttribute("size", "s");
-    if (state.selectedSlugs.has(post.slug)) {
-      checkbox.setAttribute("checked", "");
-    }
-    checkbox.style.cssText = (state.selectedSlugs.size > 0
-      ? "flex-shrink:0;"
-      : "flex-shrink:0;opacity:0;transition:opacity 0.15s;") + "align-self:flex-start;margin-top:2px;";
-    checkbox.addEventListener("change", (e) => {
-      e.stopPropagation();
-      const newSelected = new Set(state.selectedSlugs);
-      if (newSelected.has(post.slug)) {
-        newSelected.delete(post.slug);
-      } else {
-        newSelected.add(post.slug);
-      }
-      setState({ selectedSlugs: newSelected });
-    });
-
-    label.appendChild(titleSpan);
-    label.appendChild(metaSpan);
-    item.appendChild(label);
-    checkbox.setAttribute("slot", "icon");
-    item.setAttribute("leading-icon", "");
-    item.appendChild(checkbox);
-
-    const deleteBtn = document.createElement("ui-button");
-    if (state.deployingSlugs.has(post.slug)) deleteBtn.setAttribute("disabled", "");
-    deleteBtn.setAttribute("action", "destructive");
-    deleteBtn.setAttribute("emphasis", "minimal");
-    deleteBtn.setAttribute("size", "s");
-    deleteBtn.setAttribute("icon", "icon-only");
-    deleteBtn.setAttribute("slot", "actions");
-    deleteBtn.style.cssText = "flex-shrink:0;opacity:0;transition:opacity 0.15s;";
-    const trashIcon = document.createElement("ui-icon");
-    trashIcon.setAttribute("name", "delete");
-    trashIcon.setAttribute("size", "s");
-    trashIcon.setAttribute("slot", "icon-start");
-    deleteBtn.appendChild(trashIcon);
-    deleteBtn.onclick = (e) => {
-      e.stopPropagation();
-      setState({ pendingDeleteSlug: post.slug });
-      const modal = document.getElementById("admin-delete-modal") as any;
-      if (modal) modal.show();
-    };
-    item.appendChild(deleteBtn);
-    item.onmouseenter = () => { deleteBtn.style.opacity = "1"; checkbox.style.opacity = "1"; };
-    item.onmouseleave = () => { deleteBtn.style.opacity = "0"; if (state.selectedSlugs.size === 0 && !checkbox.hasAttribute("checked")) checkbox.style.opacity = "0"; };
-
-    wrapper.appendChild(item);
-    return wrapper;
+    return html`
+      <div data-slug=${post.slug} data-type="post">
+        <ui-side-panel-menu-item
+          value=${post.slug}
+          ?selected=${isSelected}
+          leading-icon
+          @mouseenter=${this.handleItemMouseEnter}
+          @mouseleave=${this.handleItemMouseLeave}
+        >
+          <ui-checkbox-item
+            slot="icon"
+            size="s"
+            ?checked=${isChecked}
+            style=${checkboxStyle}
+            @change=${(e: Event) => this.handleCheckboxChange(e, post.slug)}
+          ></ui-checkbox-item>
+          <span style="display:flex;flex-direction:column;gap:2px;overflow:hidden;">
+            <span class="sidebar-title" style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis;"
+              >${title}</span
+            >
+            <span
+              class="sidebar-meta"
+              style="font-size:11px;color:var(--fd-text-secondary, #52525b);display:flex;align-items:center;gap:6px;"
+            >
+              ${post.date}
+              <ui-badge size="xs" status=${badgeStatus}>${badgeLabel}</ui-badge>
+              ${deploying
+                ? html`<ui-icon name="progress_activity" size="xs" class="deploy-spinner"></ui-icon>`
+                : nothing}
+            </span>
+          </span>
+          <ui-button
+            slot="actions"
+            action="destructive"
+            emphasis="minimal"
+            size="s"
+            icon="icon-only"
+            ?disabled=${deploying}
+            style="flex-shrink:0;opacity:0;transition:opacity 0.15s;"
+            @click=${(e: Event) => this.handleDelete(e, post.slug)}
+          >
+            <ui-icon name="delete" size="s" slot="icon-start"></ui-icon>
+          </ui-button>
+        </ui-side-panel-menu-item>
+      </div>
+    `;
   }
 
-  // ─── Project item helpers ───────────────────────────────────────────────────
+  // ─── Project item ────────────────────────────────────────────────────────────
 
-  private patchProjectItem(wrapper: HTMLElement, project: Project): void {
-    const item = wrapper.querySelector("ui-side-panel-menu-item") as HTMLElement;
-    if (!item) return;
-
-    if (project.slug === state.currentSlug && state.activeTabType === "project") item.setAttribute("selected", "");
-    else item.removeAttribute("selected");
-
-    const titleEl = wrapper.querySelector(".sidebar-title") as HTMLElement;
+  private renderProjectItem(project: Project): unknown {
+    const s = this.store.state;
+    const isSelected = project.slug === s.currentSlug && s.activeTabType === "project";
+    const isChecked = s.selectedSlugs.has(project.slug);
+    const deploying = s.deployingSlugs.has(project.slug);
     const prefix = project.pinned ? "📌 " : "";
-    const newTitle = prefix + (project.title || "Untitled") + (hasUnpublishedChanges(project) ? " *" : "");
-    if (titleEl && titleEl.textContent !== newTitle) titleEl.textContent = newTitle;
-
-    const badge = wrapper.querySelector("ui-badge") as HTMLElement;
-    if (badge) {
-      let badgeStatus = "warning";
-      let badgeLabel: string = project.status;
-      if (project.status === "published") badgeStatus = "success";
-      if (state.deployingSlugs.has(project.slug) && state.deployingAction) {
-        badgeStatus = "information";
-        badgeLabel = state.deployingAction;
-      }
-      if (badge.getAttribute("status") !== badgeStatus) badge.setAttribute("status", badgeStatus);
-      if (badge.textContent !== badgeLabel) badge.textContent = badgeLabel;
-    }
-
-    const deleteBtn = wrapper.querySelector("[slot='actions']") as HTMLElement;
-    if (deleteBtn) {
-      if (state.deployingSlugs.has(project.slug)) deleteBtn.setAttribute("disabled", "");
-      else deleteBtn.removeAttribute("disabled");
-    }
-
-    const checkbox = wrapper.querySelector("ui-checkbox-item") as HTMLElement;
-    if (checkbox) {
-      const isChecked = state.selectedSlugs.has(project.slug);
-      if (isChecked && !checkbox.hasAttribute("checked")) checkbox.setAttribute("checked", "");
-      else if (!isChecked && checkbox.hasAttribute("checked")) checkbox.removeAttribute("checked");
-
-      if (state.selectedSlugs.size > 0) {
-        checkbox.style.cssText = "flex-shrink:0;align-self:flex-start;";
-      }
-    }
-  }
-
-  private createProjectItem(project: Project): HTMLElement {
-    const wrapper = document.createElement("div");
-    wrapper.setAttribute("data-slug", project.slug);
-    wrapper.setAttribute("data-type", "project");
-
-    const item = document.createElement("ui-side-panel-menu-item");
-    item.setAttribute("value", `project:${project.slug}`);
-    if (project.slug === state.currentSlug && state.activeTabType === "project") {
-      item.setAttribute("selected", "");
-    }
-
-    const label = document.createElement("span");
-    label.style.cssText = "display:flex;flex-direction:column;gap:2px;overflow:hidden;";
-
-    const titleSpan = document.createElement("span");
-    titleSpan.className = "sidebar-title";
-    titleSpan.style.cssText = "white-space:nowrap;overflow:hidden;text-overflow:ellipsis;";
-    const prefix = project.pinned ? "📌 " : "";
-    titleSpan.textContent = prefix + (project.title || "Untitled") + (hasUnpublishedChanges(project) ? " *" : "");
-
-    const metaSpan = document.createElement("span");
-    metaSpan.className = "sidebar-meta";
-    metaSpan.style.cssText = "font-size:11px;color:var(--fd-text-secondary, #52525b);display:flex;align-items:center;gap:6px;";
+    const title = prefix + (project.title || "Untitled") + (hasUnpublishedChanges(project) ? " *" : "");
 
     let badgeStatus = "warning";
     let badgeLabel: string = project.status;
     if (project.status === "published") badgeStatus = "success";
-    if (state.deployingSlugs.has(project.slug) && state.deployingAction) {
+    if (deploying && s.deployingAction) {
       badgeStatus = "information";
-      badgeLabel = state.deployingAction;
+      badgeLabel = s.deployingAction;
     }
 
-    metaSpan.innerHTML = `<ui-badge size="xs" status="${badgeStatus}">${badgeLabel}</ui-badge>`;
+    const checkboxStyle =
+      (s.selectedSlugs.size > 0 ? "flex-shrink:0;" : "flex-shrink:0;opacity:0;transition:opacity 0.15s;") +
+      "align-self:flex-start;";
 
-    // Checkbox for multi-select
-    const checkbox = document.createElement("ui-checkbox-item");
-    checkbox.setAttribute("size", "s");
-    if (state.selectedSlugs.has(project.slug)) {
-      checkbox.setAttribute("checked", "");
-    }
-    checkbox.style.cssText = (state.selectedSlugs.size > 0
-      ? "flex-shrink:0;"
-      : "flex-shrink:0;opacity:0;transition:opacity 0.15s;") + "align-self:flex-start;";
-    checkbox.addEventListener("change", (e) => {
-      e.stopPropagation();
-      const newSelected = new Set(state.selectedSlugs);
-      if (newSelected.has(project.slug)) {
-        newSelected.delete(project.slug);
-      } else {
-        newSelected.add(project.slug);
-      }
-      setState({ selectedSlugs: newSelected });
-    });
-    checkbox.setAttribute("slot", "icon");
-    item.setAttribute("leading-icon", "");
-    item.appendChild(checkbox);
-
-    label.appendChild(titleSpan);
-    label.appendChild(metaSpan);
-    item.appendChild(label);
-
-    const deleteBtn = document.createElement("ui-button");
-    if (state.deployingSlugs.has(project.slug)) deleteBtn.setAttribute("disabled", "");
-    deleteBtn.setAttribute("action", "destructive");
-    deleteBtn.setAttribute("emphasis", "minimal");
-    deleteBtn.setAttribute("size", "s");
-    deleteBtn.setAttribute("icon", "icon-only");
-    deleteBtn.setAttribute("slot", "actions");
-    deleteBtn.style.cssText = "flex-shrink:0;opacity:0;transition:opacity 0.15s;";
-    const trashIcon = document.createElement("ui-icon");
-    trashIcon.setAttribute("name", "delete");
-    trashIcon.setAttribute("size", "s");
-    trashIcon.setAttribute("slot", "icon-start");
-    deleteBtn.appendChild(trashIcon);
-    deleteBtn.onclick = (e) => {
-      e.stopPropagation();
-      setState({ pendingDeleteSlug: `project:${project.slug}` });
-      const modal = document.getElementById("admin-delete-modal") as any;
-      if (modal) modal.show();
-    };
-    item.appendChild(deleteBtn);
-    item.onmouseenter = () => { deleteBtn.style.opacity = "1"; checkbox.style.opacity = "1"; };
-    item.onmouseleave = () => { deleteBtn.style.opacity = "0"; if (state.selectedSlugs.size === 0 && !checkbox.hasAttribute("checked")) checkbox.style.opacity = "0"; };
-
-    wrapper.appendChild(item);
-    return wrapper;
+    return html`
+      <div data-slug=${project.slug} data-type="project">
+        <ui-side-panel-menu-item
+          value=${"project:" + project.slug}
+          ?selected=${isSelected}
+          leading-icon
+          @mouseenter=${this.handleItemMouseEnter}
+          @mouseleave=${this.handleItemMouseLeave}
+        >
+          <ui-checkbox-item
+            slot="icon"
+            size="s"
+            ?checked=${isChecked}
+            style=${checkboxStyle}
+            @change=${(e: Event) => this.handleCheckboxChange(e, project.slug)}
+          ></ui-checkbox-item>
+          <span style="display:flex;flex-direction:column;gap:2px;overflow:hidden;">
+            <span class="sidebar-title" style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis;"
+              >${title}</span
+            >
+            <span
+              class="sidebar-meta"
+              style="font-size:11px;color:var(--fd-text-secondary, #52525b);display:flex;align-items:center;gap:6px;"
+            >
+              <ui-badge size="xs" status=${badgeStatus}>${badgeLabel}</ui-badge>
+            </span>
+          </span>
+          <ui-button
+            slot="actions"
+            action="destructive"
+            emphasis="minimal"
+            size="s"
+            icon="icon-only"
+            ?disabled=${deploying}
+            style="flex-shrink:0;opacity:0;transition:opacity 0.15s;"
+            @click=${(e: Event) => this.handleDelete(e, "project:" + project.slug)}
+          >
+            <ui-icon name="delete" size="s" slot="icon-start"></ui-icon>
+          </ui-button>
+        </ui-side-panel-menu-item>
+      </div>
+    `;
   }
 
-  // ─── Bulk actions (posts and projects) ──────────────────────────────────────────────
+  // ─── Bulk actions bar ────────────────────────────────────────────────────────
 
-  private syncBulkBar(): void {
-    const existingBar = document.getElementById("admin-bulk-actions");
-    if (existingBar) existingBar.remove();
-
-    if (state.selectedSlugs.size === 0) return;
+  private renderBulkBar(): unknown {
+    const s = this.store.state;
+    if (s.selectedSlugs.size === 0) return nothing;
 
     // Determine if selected items are posts or projects
-    let isProject = false;
-    for (const slug of state.selectedSlugs) {
-      const wrapper = document.querySelector(`[data-slug="${slug}"]`);
-      if (wrapper?.getAttribute("data-type") === "project") {
-        isProject = true;
-        break;
+    const isProject = s.allProjects.some((p) => s.selectedSlugs.has(p.slug));
+    const allItems = isProject ? s.allProjects : s.allPosts;
+    const selectAllLabel = s.selectedSlugs.size === allItems.length ? "Deselect All" : "Select All";
+
+    return html`
+      <div id="admin-bulk-actions" class="admin-bulk-actions">
+        <span class="admin-bulk-count">${s.selectedSlugs.size} selected</span>
+        <ui-toolbar aria-label="Bulk actions">
+          <ui-button-group action="secondary" emphasis="subtle" size="s">
+            <ui-button action="secondary" emphasis="subtle" size="s" @click=${() => this.handleSelectAll(allItems)}
+              >${selectAllLabel}</ui-button
+            >
+          </ui-button-group>
+          <ui-toolbar-separator></ui-toolbar-separator>
+          <ui-button-group action="secondary" emphasis="subtle" size="s">
+            <ui-button
+              action="secondary"
+              emphasis="subtle"
+              size="s"
+              icon="icon-only"
+              aria-label="Delete selected"
+              @click=${() => this.handleBulkDelete(isProject)}
+            >
+              <ui-icon
+                name="delete"
+                size="s"
+                slot="icon-start"
+                style="--ui-icon-color: var(--fd-text-destructive)"
+              ></ui-icon>
+            </ui-button>
+            <ui-button
+              action="secondary"
+              emphasis="subtle"
+              size="s"
+              icon="icon-only"
+              aria-label="Publish selected"
+              @click=${() => this.handleBulkPublish(isProject)}
+            >
+              <ui-icon
+                name="upload"
+                size="s"
+                slot="icon-start"
+                style="--ui-icon-color: var(--fd-icon-action)"
+              ></ui-icon>
+            </ui-button>
+            <ui-button
+              action="secondary"
+              emphasis="subtle"
+              size="s"
+              icon="icon-only"
+              aria-label="Unpublish selected"
+              @click=${() => this.handleBulkUnpublish(isProject)}
+            >
+              <ui-icon name="download" size="s" slot="icon-start"></ui-icon>
+            </ui-button>
+          </ui-button-group>
+        </ui-toolbar>
+      </div>
+    `;
+  }
+
+  // ─── Toolbar button sync ─────────────────────────────────────────────────────
+
+  protected updated(): void {
+    const isDeploying = this.store.state.deployingSlugs.size > 0;
+    const saveBtn = document.getElementById("admin-save-btn");
+    const publishSplit = document.getElementById("admin-publish-split");
+    if (saveBtn) {
+      if (isDeploying) saveBtn.setAttribute("disabled", "");
+      else saveBtn.removeAttribute("disabled");
+    }
+    if (publishSplit) {
+      if (isDeploying) publishSplit.setAttribute("disabled", "");
+      else publishSplit.removeAttribute("disabled");
+    }
+  }
+
+  // ─── Event handlers ──────────────────────────────────────────────────────────
+
+  private handleItemMouseEnter(e: Event): void {
+    const item = e.currentTarget as HTMLElement;
+    const deleteBtn = item.querySelector("[slot='actions']") as HTMLElement | null;
+    const checkbox = item.querySelector("ui-checkbox-item") as HTMLElement | null;
+    if (deleteBtn) deleteBtn.style.opacity = "1";
+    if (checkbox) checkbox.style.opacity = "1";
+  }
+
+  private handleItemMouseLeave(e: Event): void {
+    const item = e.currentTarget as HTMLElement;
+    const deleteBtn = item.querySelector("[slot='actions']") as HTMLElement | null;
+    const checkbox = item.querySelector("ui-checkbox-item") as HTMLElement | null;
+    if (deleteBtn) deleteBtn.style.opacity = "0";
+    if (checkbox && state.selectedSlugs.size === 0 && !checkbox.hasAttribute("checked")) {
+      checkbox.style.opacity = "0";
+    }
+  }
+
+  private handleCheckboxChange(e: Event, slug: string): void {
+    e.stopPropagation();
+    const newSelected = new Set(state.selectedSlugs);
+    if (newSelected.has(slug)) newSelected.delete(slug);
+    else newSelected.add(slug);
+    setState({ selectedSlugs: newSelected });
+  }
+
+  private handleDelete(e: Event, slug: string): void {
+    e.stopPropagation();
+    setState({ pendingDeleteSlug: slug });
+    const modal = document.getElementById("admin-delete-modal") as (HTMLElement & { show(): void }) | null;
+    if (modal) modal.show();
+  }
+
+  private handleSelectAll(allItems: (Post | Project)[]): void {
+    if (state.selectedSlugs.size === allItems.length) {
+      setState({ selectedSlugs: new Set() });
+    } else {
+      setState({ selectedSlugs: new Set(allItems.map((p) => p.slug)) });
+    }
+  }
+
+  // ─── Bulk operations ─────────────────────────────────────────────────────────
+
+  private async handleBulkDelete(isProject: boolean): Promise<void> {
+    const slugs = [...state.selectedSlugs];
+    const btn = this.querySelector("#admin-bulk-actions ui-button[aria-label='Delete selected']") as HTMLElement | null;
+    if (btn) btn.setAttribute("status", "loading");
+    try {
+      if (isProject) {
+        await api.api.projects.batch.delete.$post({ json: { slugs } });
+        setState({
+          allProjects: state.allProjects.filter((p) => !state.selectedSlugs.has(p.slug)),
+          openProjectTabs: state.openProjectTabs.filter((t) => !state.selectedSlugs.has(t.slug)),
+          selectedSlugs: new Set(),
+          currentSlug: state.selectedSlugs.has(state.currentSlug ?? "")
+            ? (state.openProjectTabs.filter((t) => !state.selectedSlugs.has(t.slug)).pop()?.slug ?? null)
+            : state.currentSlug,
+        });
+      } else {
+        await api.api.posts.batch.delete.$post({ json: { slugs } });
+        setState({
+          allPosts: state.allPosts.filter((p) => !state.selectedSlugs.has(p.slug)),
+          openTabs: state.openTabs.filter((t) => !state.selectedSlugs.has(t.slug)),
+          selectedSlugs: new Set(),
+          currentSlug: state.selectedSlugs.has(state.currentSlug ?? "")
+            ? (state.openTabs.filter((t) => !state.selectedSlugs.has(t.slug)).pop()?.slug ?? null)
+            : state.currentSlug,
+        });
+      }
+    } catch {
+      if (btn) {
+        btn.setAttribute("status", "error");
+        setTimeout(() => btn.setAttribute("status", "none"), 2000);
       }
     }
+  }
 
-    const bar = document.createElement("div");
-    bar.id = "admin-bulk-actions";
-    bar.className = "admin-bulk-actions";
-
-    const count = document.createElement("span");
-    count.className = "admin-bulk-count";
-    count.textContent = `${state.selectedSlugs.size} selected`;
-
-    const selectAllBtn = document.createElement("ui-button");
-    selectAllBtn.setAttribute("action", "secondary");
-    selectAllBtn.setAttribute("emphasis", "subtle");
-    selectAllBtn.setAttribute("size", "s");
-    const allItems = isProject ? state.allProjects : state.allPosts;
-    selectAllBtn.textContent = state.selectedSlugs.size === allItems.length ? "Deselect All" : "Select All";
-    selectAllBtn.onclick = () => {
-      if (state.selectedSlugs.size === allItems.length) {
-        setState({ selectedSlugs: new Set() });
+  private async handleBulkPublish(isProject: boolean): Promise<void> {
+    const slugs = [...state.selectedSlugs];
+    const btn = this.querySelector(
+      "#admin-bulk-actions ui-button[aria-label='Publish selected']",
+    ) as HTMLElement | null;
+    if (btn) btn.setAttribute("status", "loading");
+    try {
+      if (isProject) {
+        await api.api.projects.batch.publish.$post({ json: { slugs } });
+        for (const p of state.allProjects) {
+          if (state.selectedSlugs.has(p.slug)) {
+            p.status = "published";
+            p.publishedAt = new Date().toISOString();
+          }
+        }
       } else {
-        setState({ selectedSlugs: new Set(allItems.map((p) => p.slug)) });
-      }
-    };
-
-    const deleteBtn = document.createElement("ui-button");
-    deleteBtn.setAttribute("action", "secondary");
-    deleteBtn.setAttribute("emphasis", "subtle");
-    deleteBtn.setAttribute("size", "s");
-    deleteBtn.setAttribute("icon", "icon-only");
-    deleteBtn.setAttribute("aria-label", "Delete selected");
-    const delIcon = document.createElement("ui-icon");
-    delIcon.setAttribute("name", "delete");
-    delIcon.setAttribute("size", "s");
-    delIcon.setAttribute("slot", "icon-start");
-    delIcon.style.setProperty("--ui-icon-color", "var(--fd-text-destructive)");
-    deleteBtn.appendChild(delIcon);
-    deleteBtn.onclick = async () => {
-      const slugs = [...state.selectedSlugs];
-      deleteBtn.setAttribute("status", "loading");
-      try {
-        if (isProject) {
-          await api.api.projects.batch.delete.$post({ json: { slugs } });
-          setState({
-            allProjects: state.allProjects.filter((p) => !state.selectedSlugs.has(p.slug)),
-            openProjectTabs: state.openProjectTabs.filter((t) => !state.selectedSlugs.has(t.slug)),
-            selectedSlugs: new Set(),
-            currentSlug: state.selectedSlugs.has(state.currentSlug ?? "")
-              ? (state.openProjectTabs.filter((t) => !state.selectedSlugs.has(t.slug)).pop()?.slug ?? null)
-              : state.currentSlug,
-          });
-        } else {
-          await api.api.posts.batch.delete.$post({ json: { slugs } });
-          setState({
-            allPosts: state.allPosts.filter((p) => !state.selectedSlugs.has(p.slug)),
-            openTabs: state.openTabs.filter((t) => !state.selectedSlugs.has(t.slug)),
-            selectedSlugs: new Set(),
-            currentSlug: state.selectedSlugs.has(state.currentSlug ?? "")
-              ? (state.openTabs.filter((t) => !state.selectedSlugs.has(t.slug)).pop()?.slug ?? null)
-              : state.currentSlug,
-          });
-        }
-      } catch {
-        deleteBtn.setAttribute("status", "error");
-        setTimeout(() => deleteBtn.setAttribute("status", "none"), 2000);
-      }
-    };
-
-    const publishBtn = document.createElement("ui-button");
-    publishBtn.setAttribute("action", "secondary");
-    publishBtn.setAttribute("emphasis", "subtle");
-    publishBtn.setAttribute("size", "s");
-    publishBtn.setAttribute("icon", "icon-only");
-    publishBtn.setAttribute("aria-label", "Publish selected");
-    const pubIcon = document.createElement("ui-icon");
-    pubIcon.setAttribute("name", "upload");
-    pubIcon.setAttribute("size", "s");
-    pubIcon.setAttribute("slot", "icon-start");
-    pubIcon.style.setProperty("--ui-icon-color", "var(--fd-icon-action)");
-    publishBtn.appendChild(pubIcon);
-    publishBtn.onclick = async () => {
-      const slugs = [...state.selectedSlugs];
-      publishBtn.setAttribute("status", "loading");
-      try {
-        if (isProject) {
-          await api.api.projects.batch.publish.$post({ json: { slugs } });
-          for (const p of state.allProjects) {
-            if (state.selectedSlugs.has(p.slug)) {
-              p.status = "published";
-              p.publishedAt = new Date().toISOString();
-            }
-          }
-        } else {
-          await api.api.posts.batch.publish.$post({ json: { slugs } });
-          for (const p of state.allPosts) {
-            if (state.selectedSlugs.has(p.slug)) {
-              p.status = "published";
-              p.publishedAt = new Date().toISOString();
-            }
+        await api.api.posts.batch.publish.$post({ json: { slugs } });
+        for (const p of state.allPosts) {
+          if (state.selectedSlugs.has(p.slug)) {
+            p.status = "published";
+            p.publishedAt = new Date().toISOString();
           }
         }
-        setState({ selectedSlugs: new Set(), deployingSlugs: new Set(slugs), deployingAction: "publishing" });
-        const pollInterval = setInterval(async () => {
-          try {
-            const res = await api.api.deploy.status.$get();
-            if (!res.ok) return;
-            const { status: s } = await res.json();
-            if (s === "success" || s === "failure") {
-              clearInterval(pollInterval);
-              setState({ deployingSlugs: new Set(), deployingAction: null });
-            }
-          } catch {
-            clearInterval(pollInterval);
-            setState({ deployingSlugs: new Set(), deployingAction: null });
-          }
-        }, 5000);
-      } catch {
-        publishBtn.setAttribute("status", "error");
-        setTimeout(() => publishBtn.setAttribute("status", "none"), 2000);
       }
-    };
+      setState({ selectedSlugs: new Set(), deployingSlugs: new Set(slugs), deployingAction: "publishing" });
+      this.pollDeployStatus();
+    } catch {
+      if (btn) {
+        btn.setAttribute("status", "error");
+        setTimeout(() => btn.setAttribute("status", "none"), 2000);
+      }
+    }
+  }
 
-    const unpublishBtn = document.createElement("ui-button");
-    unpublishBtn.setAttribute("action", "secondary");
-    unpublishBtn.setAttribute("emphasis", "subtle");
-    unpublishBtn.setAttribute("size", "s");
-    unpublishBtn.setAttribute("icon", "icon-only");
-    unpublishBtn.setAttribute("aria-label", "Unpublish selected");
-    const unpubIcon = document.createElement("ui-icon");
-    unpubIcon.setAttribute("name", "download");
-    unpubIcon.setAttribute("size", "s");
-    unpubIcon.setAttribute("slot", "icon-start");
-    unpublishBtn.appendChild(unpubIcon);
-    unpublishBtn.onclick = async () => {
-      const slugs = [...state.selectedSlugs];
-      unpublishBtn.setAttribute("status", "loading");
-      try {
-        if (isProject) {
-          await api.api.projects.batch.unpublish.$post({ json: { slugs } });
-          for (const p of state.allProjects) {
-            if (state.selectedSlugs.has(p.slug)) p.status = "draft";
-          }
-        } else {
-          await api.api.posts.batch.unpublish.$post({ json: { slugs } });
-          for (const p of state.allPosts) {
-            if (state.selectedSlugs.has(p.slug)) p.status = "draft";
-          }
+  private async handleBulkUnpublish(isProject: boolean): Promise<void> {
+    const slugs = [...state.selectedSlugs];
+    const btn = this.querySelector(
+      "#admin-bulk-actions ui-button[aria-label='Unpublish selected']",
+    ) as HTMLElement | null;
+    if (btn) btn.setAttribute("status", "loading");
+    try {
+      if (isProject) {
+        await api.api.projects.batch.unpublish.$post({ json: { slugs } });
+        for (const p of state.allProjects) {
+          if (state.selectedSlugs.has(p.slug)) p.status = "draft";
         }
-        setState({ selectedSlugs: new Set(), deployingSlugs: new Set(slugs), deployingAction: "unpublishing" });
-        const pollInterval = setInterval(async () => {
-          try {
-            const res = await api.api.deploy.status.$get();
-            if (!res.ok) return;
-            const { status: s } = await res.json();
-            if (s === "success" || s === "failure") {
-              clearInterval(pollInterval);
-              setState({ deployingSlugs: new Set(), deployingAction: null });
-            }
-          } catch {
-            clearInterval(pollInterval);
-            setState({ deployingSlugs: new Set(), deployingAction: null });
-          }
-        }, 5000);
-      } catch {
-        unpublishBtn.setAttribute("status", "error");
-        setTimeout(() => unpublishBtn.setAttribute("status", "none"), 2000);
+      } else {
+        await api.api.posts.batch.unpublish.$post({ json: { slugs } });
+        for (const p of state.allPosts) {
+          if (state.selectedSlugs.has(p.slug)) p.status = "draft";
+        }
       }
-    };
+      setState({ selectedSlugs: new Set(), deployingSlugs: new Set(slugs), deployingAction: "unpublishing" });
+      this.pollDeployStatus();
+    } catch {
+      if (btn) {
+        btn.setAttribute("status", "error");
+        setTimeout(() => btn.setAttribute("status", "none"), 2000);
+      }
+    }
+  }
 
-    const toolbar = document.createElement("ui-toolbar");
-    toolbar.setAttribute("aria-label", "Bulk actions");
-
-    const selectGroup = document.createElement("ui-button-group");
-    selectGroup.setAttribute("action", "secondary");
-    selectGroup.setAttribute("emphasis", "subtle");
-    selectGroup.setAttribute("size", "s");
-    selectGroup.appendChild(selectAllBtn);
-    toolbar.appendChild(selectGroup);
-
-    const sep = document.createElement("ui-toolbar-separator");
-    toolbar.appendChild(sep);
-
-    const actionGroup = document.createElement("ui-button-group");
-    actionGroup.setAttribute("action", "secondary");
-    actionGroup.setAttribute("emphasis", "subtle");
-    actionGroup.setAttribute("size", "s");
-    actionGroup.appendChild(deleteBtn);
-    actionGroup.appendChild(publishBtn);
-    actionGroup.appendChild(unpublishBtn);
-    toolbar.appendChild(actionGroup);
-
-    bar.appendChild(count);
-    bar.appendChild(toolbar);
-
-    const sidebar = document.getElementById("admin-sidebar");
-    if (sidebar) sidebar.appendChild(bar);
+  private pollDeployStatus(): void {
+    const pollInterval = setInterval(async () => {
+      try {
+        const res = await api.api.deploy.status.$get();
+        if (!res.ok) return;
+        const { status: s } = await res.json();
+        if (s === "success" || s === "failure") {
+          clearInterval(pollInterval);
+          setState({ deployingSlugs: new Set(), deployingAction: null });
+        }
+      } catch {
+        clearInterval(pollInterval);
+        setState({ deployingSlugs: new Set(), deployingAction: null });
+      }
+    }, 5000);
+  }
 }
 
+// ─── Backward compatibility wrapper ──────────────────────────────────────────
+
+export class SidebarRenderer {
+  init(postListEl: HTMLElement, projectListEl: HTMLElement): void {
+    const sidebar = postListEl.closest("ui-side-panel-menu");
+    if (!sidebar) return;
+
+    // Remove the static section headers and list containers — the Lit component renders them
+    const header = sidebar.querySelector("[slot='header']");
+    const sections = sidebar.querySelectorAll("ui-side-panel-menu-section");
+    sections.forEach((s) => s.remove());
+    postListEl.remove();
+    projectListEl.remove();
+
+    // Insert the Lit component (renders sections + items + bulk bar)
+    const el = document.createElement("editor-sidebar");
+
+    // Insert after the header slot
+    if (header && header.nextSibling) {
+      sidebar.insertBefore(el, header.nextSibling);
+    } else {
+      sidebar.appendChild(el);
+    }
+  }
 }

--- a/apps/blog/src/pages/editor/tabbar.ts
+++ b/apps/blog/src/pages/editor/tabbar.ts
@@ -1,208 +1,179 @@
-import { state, setState, onTabBarRender, hasUnpublishedChanges } from "./state.js";
+import { LitElement, html, nothing } from "lit";
+import { customElement } from "lit/decorators.js";
+import { repeat } from "lit/directives/repeat.js";
+import { state, setState, hasUnpublishedChanges } from "./state.js";
 import { saveUIState, loadPostIntoEditor, loadProjectIntoEditor, clearEditor } from "./api.js";
 import type { Post, Project } from "./types.js";
+import { EditorStoreController } from "./editor-store.js";
+
+@customElement("editor-tabbar")
+export class EditorTabbar extends LitElement {
+  private store = new EditorStoreController(this);
+
+  createRenderRoot(): this {
+    this.style.display = "contents";
+    return this;
+  }
+
+  // ─── Render ──────────────────────────────────────────────────────────────────
+
+  protected render(): unknown {
+    const s = this.store.state;
+    const isDark = document.documentElement.getAttribute("data-theme") === "heroui-dark";
+    const themeIcon = isDark ? "\u263E" : "\u2600\uFE0F";
+
+    return html`
+      <ui-tab-group
+        size="m"
+        closable
+        addable
+        @tab-close=${this._onTabClose}
+        @tab-change=${this._onTabChange}
+        @tab-add=${this._onTabAdd}
+      >
+        ${repeat(
+          s.openTabs,
+          (tab) => tab.slug,
+          (tab) => this._renderPostTab(tab),
+        )}
+        ${repeat(
+          s.openProjectTabs,
+          (tab) => tab.slug,
+          (tab) => this._renderProjectTab(tab),
+        )}
+      </ui-tab-group>
+      <div class="admin-tab-bar-actions">
+        <ui-button
+          id="admin-theme-toggle"
+          action="secondary"
+          emphasis="minimal"
+          size="s"
+          aria-label="Toggle dark mode"
+          @click=${this._toggleTheme}
+          >${themeIcon}</ui-button
+        >
+      </div>
+    `;
+  }
+
+  // ─── Tab templates ─────────────────────────────────────────────────────────
+
+  private _renderPostTab(tab: Post): unknown {
+    const s = this.store.state;
+    const isActive = tab.slug === s.currentSlug && s.activeTabType === "post";
+    const dirty = hasUnpublishedChanges(tab)
+      ? html`<span style="color:var(--fd-surface-destructive, #d91f11)">*</span> `
+      : nothing;
+
+    return html`
+      <ui-tab-item value=${tab.slug} label=${tab.title || "Untitled"} ?selected=${isActive}>
+        <span slot="prefix">${dirty}📝</span>
+      </ui-tab-item>
+    `;
+  }
+
+  private _renderProjectTab(tab: Project): unknown {
+    const s = this.store.state;
+    const isActive = tab.slug === s.currentSlug && s.activeTabType === "project";
+    const dirty = hasUnpublishedChanges(tab)
+      ? html`<span style="color:var(--fd-surface-destructive, #d91f11)">*</span> `
+      : nothing;
+
+    return html`
+      <ui-tab-item value=${"project:" + tab.slug} label=${tab.title || "Untitled"} ?selected=${isActive}>
+        <span slot="prefix">${dirty}📦</span>
+      </ui-tab-item>
+    `;
+  }
+
+  // ─── Event handlers ──────────────────────────────────────────────────────────
+
+  private _onTabClose(e: CustomEvent): void {
+    const value = e.detail?.value as string;
+    if (!value) return;
+
+    if (value.startsWith("project:")) {
+      const slug = value.slice(8);
+      setState({ openProjectTabs: state.openProjectTabs.filter((d) => d.slug !== slug) });
+      saveUIState();
+      if (state.currentSlug === slug && state.activeTabType === "project") {
+        if (state.openProjectTabs.length > 0) {
+          loadProjectIntoEditor(state.openProjectTabs[state.openProjectTabs.length - 1]);
+        } else if (state.openTabs.length > 0) {
+          loadPostIntoEditor(state.openTabs[state.openTabs.length - 1]);
+        } else {
+          clearEditor();
+        }
+      }
+    } else {
+      setState({ openTabs: state.openTabs.filter((d) => d.slug !== value) });
+      saveUIState();
+      if (state.currentSlug === value && state.activeTabType === "post") {
+        if (state.openTabs.length > 0) {
+          loadPostIntoEditor(state.openTabs[state.openTabs.length - 1]);
+        } else if (state.openProjectTabs.length > 0) {
+          loadProjectIntoEditor(state.openProjectTabs[state.openProjectTabs.length - 1]);
+        } else {
+          clearEditor();
+        }
+      }
+    }
+  }
+
+  private _onTabChange(e: CustomEvent): void {
+    const value = e.detail?.value as string;
+    if (!value) return;
+
+    if (value.startsWith("project:")) {
+      const slug = value.slice(8);
+      if (slug === state.currentSlug && state.activeTabType === "project") return;
+      const project = state.openProjectTabs.find((d) => d.slug === slug);
+      if (project) loadProjectIntoEditor(project);
+    } else {
+      if (value === state.currentSlug && state.activeTabType === "post") return;
+      const post = state.openTabs.find((d) => d.slug === value);
+      if (post) loadPostIntoEditor(post);
+    }
+    saveUIState();
+  }
+
+  private _onTabAdd(): void {
+    const post: Post = {
+      slug: `draft-${Date.now().toString(36)}`,
+      title: "",
+      date: new Date().toISOString().split("T")[0],
+      tags: "",
+      excerpt: "",
+      content: "",
+      status: "draft",
+      updatedAt: new Date().toISOString(),
+      publishedAt: null,
+      persisted: false,
+      publishedContent: null,
+    };
+    setState({ allPosts: [post, ...state.allPosts], openTabs: [...state.openTabs, post] });
+    loadPostIntoEditor(post);
+    saveUIState();
+  }
+
+  private _toggleTheme(): void {
+    const dark = document.documentElement.getAttribute("data-theme") === "heroui-dark";
+    if (dark) {
+      document.documentElement.setAttribute("data-theme", "heroui");
+    } else {
+      document.documentElement.setAttribute("data-theme", "heroui-dark");
+    }
+    setState({}); // trigger render for theme icon update
+    saveUIState();
+  }
+}
+
+// ─── Backward compatibility wrapper ──────────────────────────────────────────
 
 export class TabBarRenderer {
-  private tabs = new Map<string, HTMLElement>();
-  private tabGroup: HTMLElement | null = null;
-  private actionsContainer: HTMLElement | null = null;
-  private bar: HTMLElement | null = null;
-
   init(barEl: HTMLElement): void {
-    this.bar = barEl;
-    onTabBarRender(() => this.sync());
-  }
-
-  sync(): void {
-    if (!this.bar) return;
-
-    // Create tab group on first sync if needed
-    if (!this.tabGroup) {
-      this.bar.innerHTML = "";
-
-      this.tabGroup = document.createElement("ui-tab-group");
-      this.tabGroup.setAttribute("size", "m");
-      this.tabGroup.setAttribute("closable", "");
-      this.tabGroup.setAttribute("addable", "");
-
-      this.actionsContainer = document.createElement("div");
-      this.actionsContainer.className = "admin-tab-bar-actions";
-
-      const themeBtn = document.createElement("ui-button");
-      themeBtn.setAttribute("action", "secondary");
-      themeBtn.setAttribute("emphasis", "minimal");
-      themeBtn.setAttribute("size", "s");
-      themeBtn.id = "admin-theme-toggle";
-      themeBtn.setAttribute("aria-label", "Toggle dark mode");
-      this.actionsContainer.appendChild(themeBtn);
-
-      this.bar.appendChild(this.tabGroup);
-      this.bar.appendChild(this.actionsContainer);
-
-      // Tab close
-      this.tabGroup.addEventListener("tab-close", ((e: CustomEvent) => {
-        const value = e.detail?.value as string;
-        if (!value) return;
-
-        if (value.startsWith("project:")) {
-          const slug = value.slice(8);
-          setState({ openProjectTabs: state.openProjectTabs.filter((d) => d.slug !== slug) });
-          saveUIState();
-          if (state.currentSlug === slug && state.activeTabType === "project") {
-            if (state.openProjectTabs.length > 0) {
-              loadProjectIntoEditor(state.openProjectTabs[state.openProjectTabs.length - 1]);
-            } else if (state.openTabs.length > 0) {
-              loadPostIntoEditor(state.openTabs[state.openTabs.length - 1]);
-            } else {
-              clearEditor();
-            }
-          }
-        } else {
-          setState({ openTabs: state.openTabs.filter((d) => d.slug !== value) });
-          saveUIState();
-          if (state.currentSlug === value && state.activeTabType === "post") {
-            if (state.openTabs.length > 0) {
-              loadPostIntoEditor(state.openTabs[state.openTabs.length - 1]);
-            } else if (state.openProjectTabs.length > 0) {
-              loadProjectIntoEditor(state.openProjectTabs[state.openProjectTabs.length - 1]);
-            } else {
-              clearEditor();
-            }
-          }
-        }
-      }) as EventListener);
-
-      // Tab select
-      this.tabGroup.addEventListener("tab-change", ((e: CustomEvent) => {
-        const value = e.detail?.value as string;
-        if (!value) return;
-
-        if (value.startsWith("project:")) {
-          const slug = value.slice(8);
-          if (slug === state.currentSlug && state.activeTabType === "project") return;
-          const project = state.openProjectTabs.find((d) => d.slug === slug);
-          if (project) loadProjectIntoEditor(project);
-        } else {
-          if (value === state.currentSlug && state.activeTabType === "post") return;
-          const post = state.openTabs.find((d) => d.slug === value);
-          if (post) loadPostIntoEditor(post);
-        }
-        saveUIState();
-      }) as EventListener);
-
-      // New draft (via addable "+" button)
-      this.tabGroup.addEventListener("tab-add", () => {
-        const post: Post = {
-          slug: `draft-${Date.now().toString(36)}`,
-          title: "",
-          date: new Date().toISOString().split("T")[0],
-          tags: "",
-          excerpt: "",
-          content: "",
-          status: "draft",
-          updatedAt: new Date().toISOString(),
-          publishedAt: null,
-          persisted: false,
-          publishedContent: null,
-        };
-        setState({ allPosts: [post, ...state.allPosts], openTabs: [...state.openTabs, post] });
-        loadPostIntoEditor(post);
-        saveUIState();
-      });
-
-      // Theme toggle
-      themeBtn.onclick = () => {
-        const dark = document.documentElement.getAttribute("data-theme") === "heroui-dark";
-        if (dark) {
-          document.documentElement.setAttribute("data-theme", "heroui");
-        } else {
-          document.documentElement.setAttribute("data-theme", "heroui-dark");
-        }
-        setState({});  // trigger render for theme icon update
-        saveUIState();
-      };
-    }
-
-    // Build combined tab list: posts then projects
-    const allTabKeys = new Set<string>();
-    for (const tab of state.openTabs) allTabKeys.add(tab.slug);
-    for (const tab of state.openProjectTabs) allTabKeys.add(`project:${tab.slug}`);
-
-    // Remove closed tabs
-    for (const [key, el] of this.tabs) {
-      if (!allTabKeys.has(key)) {
-        el.remove();
-        this.tabs.delete(key);
-      }
-    }
-
-    // Add/patch post tabs
-    for (const tab of state.openTabs) {
-      const existing = this.tabs.get(tab.slug);
-      if (existing) {
-        this.patchTab(existing, tab, "post");
-      } else {
-        const el = this.createTab(tab, "post");
-        this.tabs.set(tab.slug, el);
-        this.tabGroup!.appendChild(el);
-      }
-    }
-
-    // Add/patch project tabs
-    for (const tab of state.openProjectTabs) {
-      const key = `project:${tab.slug}`;
-      const existing = this.tabs.get(key);
-      if (existing) {
-        this.patchTab(existing, tab, "project");
-      } else {
-        const el = this.createTab(tab, "project");
-        this.tabs.set(key, el);
-        this.tabGroup!.appendChild(el);
-      }
-    }
-
-    // Update theme toggle icon
-    const themeBtn = document.getElementById("admin-theme-toggle");
-    if (themeBtn) {
-      const themeIcon = document.documentElement.getAttribute("data-theme") === "heroui-dark" ? "\u263E" : "\u2600\uFE0F";
-      if (themeBtn.textContent !== themeIcon) themeBtn.textContent = themeIcon;
-    }
-  }
-
-  private patchTab(el: HTMLElement, item: Post | Project, type: "post" | "project"): void {
-    const newLabel = item.title || "Untitled";
-    if (el.getAttribute("label") !== newLabel) el.setAttribute("label", newLabel);
-
-    let prefixEl = el.querySelector("[slot=\"prefix\"]") as HTMLElement;
-    if (!prefixEl) {
-      prefixEl = document.createElement("span");
-      prefixEl.setAttribute("slot", "prefix");
-      el.appendChild(prefixEl);
-    }
-    const icon = type === "project" ? "📦" : "📝";
-    const dirty = hasUnpublishedChanges(item) ? '<span style="color:var(--fd-surface-destructive, #d91f11)">*</span> ' : "";
-    prefixEl.innerHTML = dirty + icon;
-
-    const isActive = item.slug === state.currentSlug && state.activeTabType === type;
-    if (isActive) el.setAttribute("selected", "");
-    else el.removeAttribute("selected");
-  }
-
-  private createTab(item: Post | Project, type: "post" | "project"): HTMLElement {
-    const tabItem = document.createElement("ui-tab-item");
-    const value = type === "project" ? `project:${item.slug}` : item.slug;
-    tabItem.setAttribute("value", value);
-    const icon = type === "project" ? "📦" : "📝";
-    const dirty = hasUnpublishedChanges(item) ? '<span style="color:var(--fd-surface-destructive, #d91f11)">*</span> ' : "";
-    const prefixEl = document.createElement("span");
-    prefixEl.setAttribute("slot", "prefix");
-    prefixEl.innerHTML = dirty + icon;
-    tabItem.appendChild(prefixEl);
-    tabItem.setAttribute("label", item.title || "Untitled");
-    const isActive = item.slug === state.currentSlug && state.activeTabType === type;
-    if (isActive) {
-      tabItem.setAttribute("selected", "");
-    }
-    return tabItem;
+    barEl.innerHTML = "";
+    const el = document.createElement("editor-tabbar");
+    barEl.appendChild(el);
   }
 }

--- a/apps/blog/tsconfig.json
+++ b/apps/blog/tsconfig.json
@@ -10,6 +10,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
     "types": ["@cloudflare/workers-types"]
   },
   "include": ["src/**/*.ts", "functions/**/*.ts"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@maneki/foundation": "*",
         "@maneki/ui-components": "*",
         "hono": "^4.12.9",
+        "lit": "^3.3.2",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -3274,6 +3275,21 @@
         "win32"
       ]
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
     "node_modules/@maneki/blog": {
       "resolved": "apps/blog",
       "link": true
@@ -4065,7 +4081,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/unist": {
@@ -8236,6 +8251,37 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/lit": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
       }
     },
     "node_modules/locate-path": {


### PR DESCRIPTION
## Summary

- Add `lit@3.3.2` as a dependency — reactive templating replaces ~800 lines of manual `createElement`/`setAttribute`/`Map` diffing
- Create `EditorStoreController` — Lit `ReactiveController` bridging the existing `state.ts` reactive store to Lit's update cycle
- Rewrite `sidebar.ts`: 613-line `SidebarRenderer` class → 478-line `<editor-sidebar>` Lit component
- Rewrite `tabbar.ts`: 208-line `TabBarRenderer` class → 178-line `<editor-tabbar>` Lit component
- Both use light DOM (`createRenderRoot() { return this }`) for full compatibility with existing editor code
- Backward-compat `SidebarRenderer`/`TabBarRenderer` wrappers exported — `init.ts` unchanged
- Net: -95 lines, zero changes to editor behavior

## Changed files

- `apps/blog/package.json` — add `lit` dependency
- `apps/blog/tsconfig.json` — add `experimentalDecorators`, `useDefineForClassFields: false`
- `apps/blog/src/pages/editor/editor-store.ts` — new ReactiveController
- `apps/blog/src/pages/editor/sidebar.ts` — rewritten as Lit component
- `apps/blog/src/pages/editor/tabbar.ts` — rewritten as Lit component

## Migration strategy

This is the first step toward a Lit-based admin system. The editor's 20 files stay untouched except sidebar + tabbar. The `EditorStoreController` enables incremental extraction of more components in future PRs.