### PR TITLE
feat(ui-components): add ui-dropzone component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ Thumbs.db
 test-results/
 e2e/test-results/
 playwright-report/
+.playwright-mcp/
+
 
 # Playwright MCP sessions
 .playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ maneki-monorepo/
 | Package | npm name | Description |
 |---|---|---|
 | `foundation` | `@maneki/foundation` | Design tokens: 131 colors, semantic tokens, typography, spacing, elevation, breakpoints, dark theme, shape, token constants |
-| `ui-components` | `@maneki/ui-components` | 50 Web Components (button, badge, image, icon, tag, avatar, alert, label, link, checkbox, radio, input, textarea, file-upload, select, card, breadcrumb, accordion, dropdown, menu, modal, side-panel-menu, tabs, table, carousel, calendar, calendar-quicklinks, calendar-time, datetime-picker, clock, list-item, list-header, list-group) |
+| `ui-components` | `@maneki/ui-components` | 51 Web Components (button, badge, image, icon, tag, avatar, alert, label, link, checkbox, radio, input, textarea, file-upload, dropzone, select, card, breadcrumb, accordion, dropdown, menu, modal, side-panel-menu, tabs, table, carousel, calendar, calendar-quicklinks, calendar-time, datetime-picker, clock, list-item, list-header, list-group) |
 | `grid-layout` | `@maneki/grid-layout` | Zero-dep drag/resize grid layout (220 tests) |
 | `flex-layout` | `@maneki/flex-layout` | Panel-based flex layout for dashboard-style interfaces (3 components, 50 tests) |
 

--- a/apps/catalog/e2e/helpers.ts
+++ b/apps/catalog/e2e/helpers.ts
@@ -25,6 +25,7 @@ export const pages = [
   "input",
   "textarea",
   "file-upload",
+  "dropzone",
   "select",
   "queryfield",
   "search",

--- a/apps/catalog/src/main.ts
+++ b/apps/catalog/src/main.ts
@@ -41,6 +41,7 @@ const pageLoaders: Record<string, () => Promise<unknown>> = {
   "input": () => import("./pages/input.js"),
   "textarea": () => import("./pages/textarea.js"),
   "file-upload": () => import("./pages/file-upload.js"),
+  "dropzone": () => import("./pages/dropzone.js"),
   "select": () => import("./pages/select.js"),
   "queryfield": () => import("./pages/queryfield.js"),
   "search": () => import("./pages/search.js"),

--- a/apps/catalog/src/manifest.ts
+++ b/apps/catalog/src/manifest.ts
@@ -47,6 +47,7 @@ export const manifest: PageMeta[] = [
   { id: "input", title: "Input", section: "Form Controls" },
   { id: "textarea", title: "Textarea", section: "Form Controls" },
   { id: "file-upload", title: "File Upload", section: "Form Controls" },
+  { id: "dropzone", title: "Dropzone", section: "Form Controls" },
   { id: "select", title: "Select", section: "Form Controls" },
   { id: "queryfield", title: "Queryfield", section: "Form Controls" },
   { id: "search", title: "Search", section: "Form Controls" },

--- a/apps/catalog/src/pages/dropzone.ts
+++ b/apps/catalog/src/pages/dropzone.ts
@@ -1,0 +1,55 @@
+import { registerPage } from "../registry.js";
+import "@maneki/ui-components/components/ui-dropzone.js";
+import "@maneki/ui-components/components/ui-label.js";
+
+registerPage("dropzone", {
+  title: "Dropzone",
+  section: "Form Controls",
+  render: () => `
+    <h3>Sizes</h3>
+    <div class="stack-m w-320">
+      <ui-dropzone size="s" hint="PNG, JPG up to 5MB" multiple>
+        <ui-label slot="label" size="s">Small</ui-label>
+      </ui-dropzone>
+      <ui-dropzone size="m" hint="Drag images or click to browse" multiple>
+        <ui-label slot="label" size="m">Medium</ui-label>
+      </ui-dropzone>
+      <ui-dropzone size="l" hint="Supports PNG, JPG, WebP up to 10MB" multiple>
+        <ui-label slot="label" size="l">Large</ui-label>
+      </ui-dropzone>
+    </div>
+
+    <h3>With Accept Filter</h3>
+    <div class="stack-m w-320">
+      <ui-dropzone size="m" accept="image/*" hint="Images only (PNG, JPG, WebP)" multiple>
+        <ui-label slot="label" size="m">Image Upload</ui-label>
+      </ui-dropzone>
+      <ui-dropzone size="m" accept=".pdf,.doc,.docx" hint="PDF and Word documents">
+        <ui-label slot="label" size="m">Document Upload</ui-label>
+      </ui-dropzone>
+    </div>
+
+    <h3>Disabled</h3>
+    <div class="stack-m w-320">
+      <ui-dropzone size="s" disabled hint="Upload unavailable">
+        <ui-label slot="label" size="s">Disabled S</ui-label>
+      </ui-dropzone>
+      <ui-dropzone size="m" disabled hint="Upload unavailable">
+        <ui-label slot="label" size="m">Disabled M</ui-label>
+      </ui-dropzone>
+      <ui-dropzone size="l" disabled hint="Upload unavailable">
+        <ui-label slot="label" size="l">Disabled L</ui-label>
+      </ui-dropzone>
+    </div>
+
+    <h3>Custom Text</h3>
+    <div class="stack-m w-320">
+      <ui-dropzone size="m" text="Click or drag photos to " hint="WebP recommended"></ui-dropzone>
+    </div>
+
+    <h3>Without Label</h3>
+    <div class="stack-m w-320">
+      <ui-dropzone size="m" hint="Any file type, max 25MB" multiple></ui-dropzone>
+    </div>
+  `,
+});

--- a/packages/ui-components/AGENTS.md
+++ b/packages/ui-components/AGENTS.md
@@ -21,6 +21,7 @@ Web Component library for the Maneki design system. Shadow DOM, CSS custom prope
 - `<ui-input>` — text input: 3 sizes (s/m/l), 4 types (text/numeric/clearable/password), 7 states (enabled/hover/focus/active/filled/disabled/readonly), 5 statuses (none/warning/error/success/loading), label, secondary label, supportive text, leading/trailing slots
 - `<ui-input-group>` — input group wrapper: 3 sizes (s/m/l), prefix/suffix slots with separators, composes `<ui-input>`
 - `<ui-file-upload>` — file upload input: 3 sizes (s/m/l), Browse button, accept/multiple attributes, disabled state
+- `<ui-dropzone>` — drag-and-drop file upload zone: 3 sizes (s/m/l), drag-over visual feedback, accept/multiple filtering, browse link, hint text, label slot, disabled state
 - `<ui-select>` — select dropdown: 3 sizes (s/m/l), 7 states, 5 statuses, single/multi-select with tag pills, WAI-ARIA combobox pattern, leading slot, clearable, label/supportive text
 - `<ui-textarea>` — textarea: 3 sizes (s/m/l), 7 states (enabled/hover/focus/active/filled/disabled/readonly), 5 statuses (none/warning/error/success/loading), label with char count, secondary label, resize handle
 
@@ -103,6 +104,7 @@ ui-components/
 │   │   ├── ui-input.ts          + ui-input.styles.ts
 │   │   ├── ui-input-group.ts
 │   │   ├── ui-file-upload.ts
+│   │   ├── ui-dropzone.ts
 │   │   ├── ui-select.ts         + ui-select.styles.ts
 │   │   ├── ui-textarea.ts        + ui-textarea.styles.ts
 │   │   ├── ui-card.ts

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -47,6 +47,7 @@ npm install @maneki/ui-components
 | `<ui-input>` | Text input: 3 sizes, 4 types (text/numeric/clearable/password), 7 states, 5 statuses, label/supportive |
 | `<ui-input-group>` | Input group wrapper: 3 sizes, prefix/suffix slots with separators |
 | `<ui-file-upload>` | File upload: 3 sizes, Browse button, accept/multiple, disabled |
+| `<ui-dropzone>` | Drag-and-drop file upload zone: 3 sizes, accept/multiple filtering, browse link, hint, label slot |
 | `<ui-select>` | Select dropdown: 3 sizes, 7 states, 5 statuses, single/multi-select, tag pills, combobox ARIA |
 | `<ui-textarea>` | Textarea: 3 sizes, 7 states, 5 statuses, label with char count, secondary label, resize |
 | | **Containers** |

--- a/packages/ui-components/src/components/ui-dropzone.test.ts
+++ b/packages/ui-components/src/components/ui-dropzone.test.ts
@@ -1,0 +1,477 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import "./ui-dropzone.js";
+
+describe("ui-dropzone", () => {
+  let el: HTMLElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    el = document.createElement("ui-dropzone");
+    document.body.appendChild(el);
+  });
+
+  // Helper: happy-dom doesn't pass dataTransfer through DragEvent constructor
+  function createDropEvent(files: File[]): DragEvent {
+    const dt = new DataTransfer();
+    for (const f of files) dt.items.add(f);
+    const event = new DragEvent("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "dataTransfer", { value: dt });
+    return event;
+  }
+
+  // ── Registration ─────────────────────────────────────────────────────────
+
+  it("registers as a custom element", () => {
+    expect(customElements.get("ui-dropzone")).toBeDefined();
+  });
+
+  it("creates a shadow root", () => {
+    expect(el.shadowRoot).toBeTruthy();
+  });
+
+  // ── Default attributes ───────────────────────────────────────────────────
+
+  it("defaults size to 'm'", () => {
+    expect((el as unknown as { size: string }).size).toBe("m");
+  });
+
+  it("defaults accept to empty string", () => {
+    expect((el as unknown as { accept: string }).accept).toBe("");
+  });
+
+  it("defaults multiple to false", () => {
+    expect((el as unknown as { multiple: boolean }).multiple).toBe(false);
+  });
+
+  it("defaults disabled to false", () => {
+    expect((el as unknown as { disabled: boolean }).disabled).toBe(false);
+  });
+
+  it("defaults text to 'Drag and drop files here, or '", () => {
+    expect((el as unknown as { text: string }).text).toBe("Drag and drop files here, or ");
+  });
+
+  it("defaults hint to empty string", () => {
+    expect((el as unknown as { hint: string }).hint).toBe("");
+  });
+
+  it("defaults files to empty FileList", () => {
+    const files = (el as unknown as { files: FileList | null }).files;
+    expect(files).toBeTruthy();
+    expect(files!.length).toBe(0);
+  });
+
+  // ── Size attribute ───────────────────────────────────────────────────────
+
+  it("reflects size='s' to attribute", () => {
+    (el as unknown as { size: string }).size = "s";
+    expect(el.getAttribute("size")).toBe("s");
+  });
+
+  it("reflects size='m' to attribute", () => {
+    (el as unknown as { size: string }).size = "m";
+    expect(el.getAttribute("size")).toBe("m");
+  });
+
+  it("reflects size='l' to attribute", () => {
+    (el as unknown as { size: string }).size = "l";
+    expect(el.getAttribute("size")).toBe("l");
+  });
+
+  // ── Text attribute ──────────────────────────────────────────────────────
+
+  it("shows default text in zone", () => {
+    const textEl = el.shadowRoot!.querySelector(".zone-text");
+    expect(textEl!.textContent).toContain("Drag and drop files here, or ");
+  });
+
+  it("updates text via property", () => {
+    (el as unknown as { text: string }).text = "Drop images here, or ";
+    const textEl = el.shadowRoot!.querySelector(".zone-text");
+    expect(textEl!.textContent).toContain("Drop images here, or ");
+  });
+
+  it("updates text via attribute", () => {
+    el.setAttribute("text", "Upload files, or ");
+    const textEl = el.shadowRoot!.querySelector(".zone-text");
+    expect(textEl!.textContent).toContain("Upload files, or ");
+  });
+
+  it("always shows browse link inside text", () => {
+    const linkEl = el.shadowRoot!.querySelector(".zone-link");
+    expect(linkEl).toBeTruthy();
+    expect(linkEl!.textContent).toBe("browse");
+  });
+
+  // ── Hint attribute ──────────────────────────────────────────────────────
+
+  it("hides hint when empty", () => {
+    const hintEl = el.shadowRoot!.querySelector(".zone-hint") as HTMLElement;
+    expect(hintEl.style.display).toBe("none");
+  });
+
+  it("shows hint when set via property", () => {
+    (el as unknown as { hint: string }).hint = "Max 10MB per file";
+    const hintEl = el.shadowRoot!.querySelector(".zone-hint") as HTMLElement;
+    expect(hintEl.textContent).toBe("Max 10MB per file");
+    expect(hintEl.style.display).not.toBe("none");
+  });
+
+  it("shows hint when set via attribute", () => {
+    el.setAttribute("hint", "PNG, JPG only");
+    const hintEl = el.shadowRoot!.querySelector(".zone-hint") as HTMLElement;
+    expect(hintEl.textContent).toBe("PNG, JPG only");
+  });
+
+  // ── Accept attribute ─────────────────────────────────────────────────────
+
+  it("passes accept to hidden input", () => {
+    (el as unknown as { accept: string }).accept = "image/*";
+    const hiddenInput = el.shadowRoot!.querySelector(".hidden-input") as HTMLInputElement;
+    expect(hiddenInput.accept).toBe("image/*");
+  });
+
+  it("sets accept via attribute", () => {
+    el.setAttribute("accept", ".pdf,.doc");
+    const hiddenInput = el.shadowRoot!.querySelector(".hidden-input") as HTMLInputElement;
+    expect(hiddenInput.accept).toBe(".pdf,.doc");
+  });
+
+  // ── Multiple attribute ───────────────────────────────────────────────────
+
+  it("passes multiple to hidden input", () => {
+    (el as unknown as { multiple: boolean }).multiple = true;
+    const hiddenInput = el.shadowRoot!.querySelector(".hidden-input") as HTMLInputElement;
+    expect(hiddenInput.multiple).toBe(true);
+  });
+
+  it("sets multiple attribute", () => {
+    (el as unknown as { multiple: boolean }).multiple = true;
+    expect(el.hasAttribute("multiple")).toBe(true);
+  });
+
+  it("removes multiple attribute when set to false", () => {
+    (el as unknown as { multiple: boolean }).multiple = true;
+    (el as unknown as { multiple: boolean }).multiple = false;
+    expect(el.hasAttribute("multiple")).toBe(false);
+  });
+
+  // ── Disabled state ───────────────────────────────────────────────────────
+
+  it("sets disabled attribute when property is true", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    expect(el.hasAttribute("disabled")).toBe(true);
+  });
+
+  it("removes disabled attribute when property is false", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    (el as unknown as { disabled: boolean }).disabled = false;
+    expect(el.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("disables hidden input when disabled", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    const hiddenInput = el.shadowRoot!.querySelector(".hidden-input") as HTMLInputElement;
+    expect(hiddenInput.disabled).toBe(true);
+  });
+
+  it("does not open file picker when disabled", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    const hiddenInput = el.shadowRoot!.querySelector(".hidden-input") as HTMLInputElement;
+    const spy = vi.spyOn(hiddenInput, "click");
+    (el as unknown as { _openPicker: () => void })._openPicker();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  // ── File selection event ─────────────────────────────────────────────────
+
+  it("dispatches change event when files are selected", () => {
+    let detail: { files: FileList } | null = null;
+    el.addEventListener("change", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+    const hiddenInput = el.shadowRoot!.querySelector(".hidden-input") as HTMLInputElement;
+    hiddenInput.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(detail).toBeTruthy();
+    expect(detail!.files).toBeDefined();
+  });
+
+  it("change event bubbles and is composed", () => {
+    let event: CustomEvent | null = null;
+    el.addEventListener("change", ((e: CustomEvent) => {
+      event = e;
+    }) as EventListener);
+    const hiddenInput = el.shadowRoot!.querySelector(".hidden-input") as HTMLInputElement;
+    hiddenInput.dispatchEvent(new Event("change", { bubbles: true }));
+    expect(event).toBeTruthy();
+    expect(event!.bubbles).toBe(true);
+    expect(event!.composed).toBe(true);
+  });
+
+  // ── Reset method ─────────────────────────────────────────────────────────
+
+  it("reset clears the hidden input value", () => {
+    const hiddenInput = el.shadowRoot!.querySelector(".hidden-input") as HTMLInputElement;
+    (el as unknown as { reset: () => void }).reset();
+    expect(hiddenInput.value).toBe("");
+  });
+
+  it("reset hides file list", () => {
+    (el as unknown as { reset: () => void }).reset();
+    const fileList = el.shadowRoot!.querySelector(".file-list") as HTMLElement;
+    expect(fileList.style.display).toBe("none");
+  });
+
+  // ── Shadow DOM structure ─────────────────────────────────────────────────
+
+  it("has .zone element", () => {
+    expect(el.shadowRoot!.querySelector(".zone")).toBeTruthy();
+  });
+
+  it("has .zone-icon element", () => {
+    expect(el.shadowRoot!.querySelector(".zone-icon")).toBeTruthy();
+  });
+
+  it("has .zone-text element", () => {
+    expect(el.shadowRoot!.querySelector(".zone-text")).toBeTruthy();
+  });
+
+  it("has .zone-link element", () => {
+    expect(el.shadowRoot!.querySelector(".zone-link")).toBeTruthy();
+  });
+
+  it("has .zone-hint element", () => {
+    expect(el.shadowRoot!.querySelector(".zone-hint")).toBeTruthy();
+  });
+
+  it("has .file-list element", () => {
+    expect(el.shadowRoot!.querySelector(".file-list")).toBeTruthy();
+  });
+
+  it("has .hidden-input element", () => {
+    expect(el.shadowRoot!.querySelector(".hidden-input")).toBeTruthy();
+  });
+
+  it("hidden input is type file", () => {
+    const hiddenInput = el.shadowRoot!.querySelector(".hidden-input") as HTMLInputElement;
+    expect(hiddenInput.type).toBe("file");
+  });
+
+  it("has upload icon", () => {
+    const icon = el.shadowRoot!.querySelector(".material-symbols-outlined");
+    expect(icon).toBeTruthy();
+    expect(icon!.textContent).toBe("\uF09B"); // ICON_UPLOAD
+  });
+
+  // ── Accessibility ────────────────────────────────────────────────────────
+
+  it("sets tabindex='0' on connected", () => {
+    expect(el.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("sets aria-disabled='true' when disabled", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    expect(el.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("removes aria-disabled when not disabled", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    (el as unknown as { disabled: boolean }).disabled = false;
+    expect(el.hasAttribute("aria-disabled")).toBe(false);
+  });
+
+  it("hidden input has aria-hidden='true'", () => {
+    const hiddenInput = el.shadowRoot!.querySelector(".hidden-input") as HTMLInputElement;
+    expect(hiddenInput.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("zone has role='button'", () => {
+    const zone = el.shadowRoot!.querySelector(".zone");
+    expect(zone!.getAttribute("role")).toBe("button");
+  });
+
+  // ── Click behavior ───────────────────────────────────────────────────────
+
+  it("opens file picker when zone is clicked", () => {
+    const hiddenInput = el.shadowRoot!.querySelector(".hidden-input") as HTMLInputElement;
+    const spy = vi.spyOn(hiddenInput, "click");
+    const zone = el.shadowRoot!.querySelector(".zone") as HTMLDivElement;
+    zone.click();
+    expect(spy).toHaveBeenCalled();
+  });
+
+  // ── Keyboard behavior ────────────────────────────────────────────────────
+
+  it("opens file picker on Enter key", () => {
+    const hiddenInput = el.shadowRoot!.querySelector(".hidden-input") as HTMLInputElement;
+    const spy = vi.spyOn(hiddenInput, "click");
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter" }));
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("opens file picker on Space key", () => {
+    const hiddenInput = el.shadowRoot!.querySelector(".hidden-input") as HTMLInputElement;
+    const spy = vi.spyOn(hiddenInput, "click");
+    el.dispatchEvent(new KeyboardEvent("keydown", { key: " " }));
+    expect(spy).toHaveBeenCalled();
+  });
+
+  // ── Drag and drop ───────────────────────────────────────────────────────
+
+  it("adds drag-over class on dragenter", () => {
+    const zone = el.shadowRoot!.querySelector(".zone") as HTMLDivElement;
+    zone.dispatchEvent(new DragEvent("dragenter", { bubbles: true }));
+    expect(zone.classList.contains("drag-over")).toBe(true);
+  });
+
+  it("removes drag-over class on dragleave when leaving zone", () => {
+    const zone = el.shadowRoot!.querySelector(".zone") as HTMLDivElement;
+    zone.dispatchEvent(new DragEvent("dragenter", { bubbles: true }));
+    expect(zone.classList.contains("drag-over")).toBe(true);
+    // Simulate leaving the zone entirely (relatedTarget outside zone)
+    zone.dispatchEvent(
+      new DragEvent("dragleave", {
+        bubbles: true,
+        relatedTarget: document.body,
+      }),
+    );
+    expect(zone.classList.contains("drag-over")).toBe(false);
+  });
+
+  it("removes drag-over class on drop", () => {
+    const zone = el.shadowRoot!.querySelector(".zone") as HTMLDivElement;
+    zone.classList.add("drag-over");
+    zone.dispatchEvent(new DragEvent("drop", { bubbles: true, cancelable: true }));
+    expect(zone.classList.contains("drag-over")).toBe(false);
+  });
+
+  it("dispatches drop-files event on drop with files", () => {
+    let detail: { files: File[] } | null = null;
+    el.addEventListener("drop-files", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+
+    const file = new File(["content"], "test.png", { type: "image/png" });
+    const zone = el.shadowRoot!.querySelector(".zone") as HTMLDivElement;
+    zone.dispatchEvent(createDropEvent([file]));
+
+    expect(detail).toBeTruthy();
+    expect(detail!.files).toHaveLength(1);
+    expect(detail!.files[0].name).toBe("test.png");
+  });
+
+  it("drop-files event bubbles and is composed", () => {
+    let event: CustomEvent | null = null;
+    el.addEventListener("drop-files", ((e: CustomEvent) => {
+      event = e;
+    }) as EventListener);
+
+    const file = new File(["content"], "test.png", { type: "image/png" });
+    const zone = el.shadowRoot!.querySelector(".zone") as HTMLDivElement;
+    zone.dispatchEvent(createDropEvent([file]));
+
+    expect(event).toBeTruthy();
+    expect(event!.bubbles).toBe(true);
+    expect(event!.composed).toBe(true);
+  });
+
+  it("does not dispatch drop-files when disabled", () => {
+    (el as unknown as { disabled: boolean }).disabled = true;
+    let detail: { files: File[] } | null = null;
+    el.addEventListener("drop-files", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+
+    const file = new File(["content"], "test.png", { type: "image/png" });
+    const zone = el.shadowRoot!.querySelector(".zone") as HTMLDivElement;
+    zone.dispatchEvent(createDropEvent([file]));
+
+    expect(detail).toBeNull();
+  });
+
+  it("filters dropped files by accept attribute (mime wildcard)", () => {
+    el.setAttribute("accept", "image/*");
+    let detail: { files: File[] } | null = null;
+    el.addEventListener("drop-files", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+
+    const img = new File(["img"], "photo.png", { type: "image/png" });
+    const txt = new File(["txt"], "readme.txt", { type: "text/plain" });
+    const zone = el.shadowRoot!.querySelector(".zone") as HTMLDivElement;
+    zone.dispatchEvent(createDropEvent([img, txt]));
+
+    expect(detail).toBeTruthy();
+    expect(detail!.files).toHaveLength(1);
+    expect(detail!.files[0].name).toBe("photo.png");
+  });
+
+  it("limits to single file when multiple is not set", () => {
+    let detail: { files: File[] } | null = null;
+    el.addEventListener("drop-files", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+
+    const file1 = new File(["a"], "a.png", { type: "image/png" });
+    const file2 = new File(["b"], "b.png", { type: "image/png" });
+    const zone = el.shadowRoot!.querySelector(".zone") as HTMLDivElement;
+    zone.dispatchEvent(createDropEvent([file1, file2]));
+
+    expect(detail).toBeTruthy();
+    expect(detail!.files).toHaveLength(1);
+  });
+
+  it("allows multiple files when multiple is set", () => {
+    (el as unknown as { multiple: boolean }).multiple = true;
+    let detail: { files: File[] } | null = null;
+    el.addEventListener("drop-files", ((e: CustomEvent) => {
+      detail = e.detail;
+    }) as EventListener);
+
+    const file1 = new File(["a"], "a.png", { type: "image/png" });
+    const file2 = new File(["b"], "b.png", { type: "image/png" });
+    const zone = el.shadowRoot!.querySelector(".zone") as HTMLDivElement;
+    zone.dispatchEvent(createDropEvent([file1, file2]));
+
+    expect(detail).toBeTruthy();
+    expect(detail!.files).toHaveLength(2);
+  });
+
+  // ── Property accessors roundtrip ─────────────────────────────────────────
+
+  it("exposes all typed property accessors", () => {
+    const component = el as unknown as {
+      size: string;
+      accept: string;
+      multiple: boolean;
+      disabled: boolean;
+      text: string;
+      hint: string;
+    };
+
+    component.size = "l";
+    expect(component.size).toBe("l");
+
+    component.accept = ".png";
+    expect(component.accept).toBe(".png");
+
+    component.multiple = true;
+    expect(component.multiple).toBe(true);
+
+    component.disabled = true;
+    expect(component.disabled).toBe(true);
+
+    component.text = "Drop here, or ";
+    expect(component.text).toBe("Drop here, or ");
+
+    component.hint = "Max 5MB";
+    expect(component.hint).toBe("Max 5MB");
+  });
+
+  // ── Label slot ──────────────────────────────────────────────────────────
+
+  it("has a label slot", () => {
+    const slot = el.shadowRoot!.querySelector('slot[name="label"]');
+    expect(slot).toBeTruthy();
+  });
+});

--- a/packages/ui-components/src/components/ui-dropzone.ts
+++ b/packages/ui-components/src/components/ui-dropzone.ts
@@ -1,0 +1,582 @@
+import {
+  BORDER_FOCUS,
+  BORDER_MINIMAL,
+  DISABLED_BORDER,
+  DISABLED_TEXT,
+  FONT_PRIMARY,
+  ICON_SECONDARY,
+  RADIUS_SM,
+  SP_1,
+  SP_1_5,
+  SP_2,
+  SP_3,
+  SURFACE_PRIMARY,
+  SURFACE_SECONDARY,
+  TEXT_LINK,
+  TEXT_PRIMARY,
+  TEXT_SECONDARY,
+  TYPE_BODY_02,
+  TYPE_BODY_03,
+  TYPE_CAPTION_01,
+} from "@maneki/foundation";
+
+// ─── Type-safe property unions ───────────────────────────────────────────────
+
+export type DropzoneSize = "s" | "m" | "l";
+
+// ─── Styles ──────────────────────────────────────────────────────────────────
+
+const STYLES = /* css */ `
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  @font-face {
+    font-family: "Material Symbols Outlined";
+    font-style: normal;
+    src: local("Material Symbols Outlined");
+  }
+
+  .material-symbols-outlined {
+    font-family: "Material Symbols Outlined";
+    font-variation-settings: "FILL" 0;
+    display: inline-block;
+    line-height: 1;
+    vertical-align: middle;
+  }
+
+  :host {
+    display: block;
+    font-family: ${FONT_PRIMARY};
+  }
+
+  .label-row {
+    display: flex;
+    align-items: baseline;
+    gap: ${SP_1};
+    margin-bottom: ${SP_1};
+  }
+
+  .label-row:empty {
+    display: none;
+  }
+
+  .label-row ::slotted(ui-label) {
+    display: inline;
+  }
+
+  .zone {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    border: 2px dashed var(--ui-dz-border, ${BORDER_MINIMAL});
+    border-radius: ${RADIUS_SM};
+    background-color: var(--ui-dz-bg, ${SURFACE_PRIMARY});
+    cursor: pointer;
+    text-align: center;
+    transition:
+      border-color 0.15s ease,
+      background-color 0.15s ease;
+  }
+
+  .zone-icon {
+    color: var(--ui-dz-icon-color, ${ICON_SECONDARY});
+  }
+
+  .zone-text {
+    color: var(--ui-dz-text-color, ${TEXT_SECONDARY});
+  }
+
+  .zone-link {
+    color: var(--ui-dz-link-color, ${TEXT_LINK});
+    font-weight: 500;
+    cursor: pointer;
+  }
+
+  .zone-hint {
+    color: var(--ui-dz-hint-color, ${TEXT_SECONDARY});
+  }
+
+  .hidden-input {
+    position: absolute;
+    width: 0;
+    height: 0;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  /* ── Size: m (default) ─────────────────────────────────────────────────── */
+
+  :host,
+  :host([size="m"]) {
+    --_dz-padding: ${SP_3};
+    --_dz-gap: ${SP_1};
+    --_dz-icon-size: 32px;
+  }
+
+  :host .zone-text,
+  :host([size="m"]) .zone-text {
+    ${TYPE_BODY_02}
+  }
+
+  :host .zone-link,
+  :host([size="m"]) .zone-link {
+    ${TYPE_BODY_02}
+  }
+
+  :host .zone-hint,
+  :host([size="m"]) .zone-hint {
+    ${TYPE_CAPTION_01}
+  }
+
+  /* ── Size: s ───────────────────────────────────────────────────────────── */
+
+  :host([size="s"]) {
+    --_dz-padding: ${SP_1_5};
+    --_dz-gap: ${SP_1};
+    --_dz-icon-size: 24px;
+  }
+
+  :host([size="s"]) .zone-text {
+    ${TYPE_BODY_03}
+  }
+
+  :host([size="s"]) .zone-link {
+    ${TYPE_BODY_03}
+  }
+
+  :host([size="s"]) .zone-hint {
+    ${TYPE_CAPTION_01}
+  }
+
+  /* ── Size: l ───────────────────────────────────────────────────────────── */
+
+  :host([size="l"]) {
+    --_dz-padding: ${SP_3};
+    --_dz-gap: ${SP_1_5};
+    --_dz-icon-size: 40px;
+  }
+
+  :host([size="l"]) .zone-text {
+    ${TYPE_BODY_02}
+  }
+
+  :host([size="l"]) .zone-link {
+    ${TYPE_BODY_02}
+  }
+
+  :host([size="l"]) .zone-hint {
+    ${TYPE_CAPTION_01}
+  }
+
+  .zone {
+    padding: var(--_dz-padding);
+    gap: var(--_dz-gap);
+  }
+
+  .zone-icon .material-symbols-outlined {
+    font-size: var(--_dz-icon-size);
+  }
+
+  /* ── Hover ─────────────────────────────────────────────────────────────── */
+
+  :host(:hover:not([disabled])) .zone {
+    border-color: var(--ui-dz-hover-border, ${TEXT_LINK});
+    background-color: var(--ui-dz-hover-bg, ${SURFACE_SECONDARY});
+  }
+
+  /* ── Drag over ─────────────────────────────────────────────────────────── */
+
+  .zone.drag-over {
+    border-color: var(--ui-dz-active-border, ${BORDER_FOCUS});
+    background-color: var(--ui-dz-active-bg, ${SURFACE_SECONDARY});
+  }
+
+  /* ── Focus ─────────────────────────────────────────────────────────────── */
+
+  :host(:focus-within:not([disabled])) .zone {
+    border-color: var(--ui-dz-focus-border, ${BORDER_FOCUS});
+    outline: 1px solid var(--ui-dz-focus-border, ${BORDER_FOCUS});
+  }
+
+  /* ── Has files ─────────────────────────────────────────────────────────── */
+
+  .file-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: ${SP_1};
+    justify-content: center;
+    color: ${TEXT_PRIMARY};
+  }
+
+  .file-list .file-name {
+    ${TYPE_BODY_03}
+    background: ${SURFACE_SECONDARY};
+    padding: 2px ${SP_1};
+    border-radius: ${RADIUS_SM};
+  }
+
+  /* ── Disabled ──────────────────────────────────────────────────────────── */
+
+  :host([disabled]) {
+    pointer-events: none;
+  }
+
+  :host([disabled]) .zone {
+    border-color: ${DISABLED_BORDER};
+    background-color: ${SURFACE_SECONDARY};
+  }
+
+  :host([disabled]) .zone-text,
+  :host([disabled]) .zone-link,
+  :host([disabled]) .zone-hint,
+  :host([disabled]) .zone-icon {
+    color: ${DISABLED_TEXT};
+  }
+
+  /* ── Reduced motion ────────────────────────────────────────────────────── */
+
+  @media (prefers-reduced-motion: reduce) {
+    .zone {
+      transition-duration: 0.01ms !important;
+    }
+  }
+`;
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(STYLES);
+
+const UPLOAD_ICON = "\uF09B"; // ICON_UPLOAD codepoint
+
+export class UiDropzone extends HTMLElement {
+  static readonly observedAttributes = ["size", "accept", "multiple", "disabled", "text", "hint"];
+
+  private _hiddenInput: HTMLInputElement;
+  private _zoneEl: HTMLDivElement;
+  private _textEl: HTMLSpanElement;
+  private _linkEl: HTMLSpanElement;
+  private _hintEl: HTMLSpanElement;
+  private _fileListEl: HTMLDivElement;
+  private _iconEl: HTMLSpanElement;
+  private _labelRow: HTMLDivElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [sheet];
+
+    // Hidden file input
+    this._hiddenInput = document.createElement("input");
+    this._hiddenInput.type = "file";
+    this._hiddenInput.className = "hidden-input";
+    this._hiddenInput.tabIndex = -1;
+    this._hiddenInput.setAttribute("aria-hidden", "true");
+    shadow.appendChild(this._hiddenInput);
+
+    // Label slot
+    this._labelRow = document.createElement("div");
+    this._labelRow.className = "label-row";
+    const labelSlot = document.createElement("slot");
+    labelSlot.name = "label";
+    this._labelRow.appendChild(labelSlot);
+    shadow.appendChild(this._labelRow);
+
+    // Drop zone
+    this._zoneEl = document.createElement("div");
+    this._zoneEl.className = "zone";
+    this._zoneEl.setAttribute("role", "button");
+
+    // Icon
+    const iconWrap = document.createElement("div");
+    iconWrap.className = "zone-icon";
+    this._iconEl = document.createElement("span");
+    this._iconEl.className = "material-symbols-outlined";
+    this._iconEl.textContent = UPLOAD_ICON;
+    this._iconEl.setAttribute("aria-hidden", "true");
+    iconWrap.appendChild(this._iconEl);
+    this._zoneEl.appendChild(iconWrap);
+
+    // Text
+    this._textEl = document.createElement("span");
+    this._textEl.className = "zone-text";
+    this._textEl.textContent = "Drag and drop files here, or ";
+    this._zoneEl.appendChild(this._textEl);
+
+    // Browse link (inside text)
+    this._linkEl = document.createElement("span");
+    this._linkEl.className = "zone-link";
+    this._linkEl.textContent = "browse";
+    this._textEl.appendChild(this._linkEl);
+
+    // Hint
+    this._hintEl = document.createElement("span");
+    this._hintEl.className = "zone-hint";
+    this._zoneEl.appendChild(this._hintEl);
+
+    // File list (shown after selection)
+    this._fileListEl = document.createElement("div");
+    this._fileListEl.className = "file-list";
+    this._fileListEl.style.display = "none";
+    this._zoneEl.appendChild(this._fileListEl);
+
+    shadow.appendChild(this._zoneEl);
+
+    // Event listeners
+    this._zoneEl.addEventListener("click", this._openPicker.bind(this));
+    this._hiddenInput.addEventListener("change", this._handleChange.bind(this));
+    this._zoneEl.addEventListener("dragover", this._onDragOver.bind(this));
+    this._zoneEl.addEventListener("dragenter", this._onDragEnter.bind(this));
+    this._zoneEl.addEventListener("dragleave", this._onDragLeave.bind(this));
+    this._zoneEl.addEventListener("drop", this._onDrop.bind(this));
+  }
+
+  connectedCallback(): void {
+    if (!this.hasAttribute("tabindex")) {
+      this.setAttribute("tabindex", "0");
+    }
+    this._syncAll();
+    this.addEventListener("keydown", this._handleKeydown);
+  }
+
+  disconnectedCallback(): void {
+    this.removeEventListener("keydown", this._handleKeydown);
+  }
+
+  attributeChangedCallback(name: string, _oldValue: string | null, _newValue: string | null): void {
+    switch (name) {
+      case "accept":
+        this._hiddenInput.accept = this.getAttribute("accept") ?? "";
+        break;
+      case "multiple":
+        this._hiddenInput.multiple = this.hasAttribute("multiple");
+        break;
+      case "disabled":
+        this._syncDisabled();
+        break;
+      case "text":
+        this._syncText();
+        break;
+      case "hint":
+        this._syncHint();
+        break;
+    }
+  }
+
+  // ── Property accessors ──────────────────────────────────────────────────
+
+  get size(): DropzoneSize {
+    return (this.getAttribute("size") as DropzoneSize) ?? "m";
+  }
+
+  set size(value: DropzoneSize) {
+    this.setAttribute("size", value);
+  }
+
+  get accept(): string {
+    return this.getAttribute("accept") ?? "";
+  }
+
+  set accept(value: string) {
+    if (value) {
+      this.setAttribute("accept", value);
+    } else {
+      this.removeAttribute("accept");
+    }
+  }
+
+  get multiple(): boolean {
+    return this.hasAttribute("multiple");
+  }
+
+  set multiple(value: boolean) {
+    if (value) {
+      this.setAttribute("multiple", "");
+    } else {
+      this.removeAttribute("multiple");
+    }
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute("disabled");
+  }
+
+  set disabled(value: boolean) {
+    if (value) {
+      this.setAttribute("disabled", "");
+    } else {
+      this.removeAttribute("disabled");
+    }
+  }
+
+  get text(): string {
+    return this.getAttribute("text") ?? "Drag and drop files here, or ";
+  }
+
+  set text(value: string) {
+    if (value) {
+      this.setAttribute("text", value);
+    } else {
+      this.removeAttribute("text");
+    }
+  }
+
+  get hint(): string {
+    return this.getAttribute("hint") ?? "";
+  }
+
+  set hint(value: string) {
+    if (value) {
+      this.setAttribute("hint", value);
+    } else {
+      this.removeAttribute("hint");
+    }
+  }
+
+  get files(): FileList | null {
+    return this._hiddenInput.files;
+  }
+
+  // ── Public methods ─────────────────────────────────────────────────────
+
+  reset(): void {
+    this._hiddenInput.value = "";
+    this._syncFileDisplay();
+  }
+
+  // ── Private methods ────────────────────────────────────────────────────
+
+  private _syncAll(): void {
+    this._hiddenInput.accept = this.getAttribute("accept") ?? "";
+    this._hiddenInput.multiple = this.hasAttribute("multiple");
+    this._syncDisabled();
+    this._syncText();
+    this._syncHint();
+    this._syncFileDisplay();
+  }
+
+  private _syncText(): void {
+    const text = this.getAttribute("text") ?? "Drag and drop files here, or ";
+    // Clear text node, keep link child
+    this._textEl.textContent = "";
+    this._textEl.appendChild(document.createTextNode(text));
+    this._textEl.appendChild(this._linkEl);
+  }
+
+  private _syncHint(): void {
+    const hint = this.getAttribute("hint") ?? "";
+    this._hintEl.textContent = hint;
+    this._hintEl.style.display = hint ? "" : "none";
+  }
+
+  private _syncDisabled(): void {
+    this._hiddenInput.disabled = this.disabled;
+    if (this.disabled) {
+      this.setAttribute("aria-disabled", "true");
+    } else {
+      this.removeAttribute("aria-disabled");
+    }
+  }
+
+  private _syncFileDisplay(): void {
+    const files = this._hiddenInput.files;
+    if (files && files.length > 0) {
+      this._fileListEl.innerHTML = "";
+      for (let i = 0; i < files.length; i++) {
+        const chip = document.createElement("span");
+        chip.className = "file-name";
+        chip.textContent = files[i].name;
+        this._fileListEl.appendChild(chip);
+      }
+      this._fileListEl.style.display = "";
+    } else {
+      this._fileListEl.style.display = "none";
+      this._fileListEl.innerHTML = "";
+    }
+  }
+
+  private _openPicker(): void {
+    if (this.disabled) return;
+    this._hiddenInput.click();
+  }
+
+  private _handleChange(): void {
+    this._syncFileDisplay();
+    this.dispatchEvent(
+      new CustomEvent("change", {
+        bubbles: true,
+        composed: true,
+        detail: { files: this._hiddenInput.files },
+      }),
+    );
+  }
+
+  private _onDragOver(e: DragEvent): void {
+    e.preventDefault();
+    if (e.dataTransfer) {
+      e.dataTransfer.dropEffect = "copy";
+    }
+  }
+
+  private _onDragEnter(e: DragEvent): void {
+    e.preventDefault();
+    this._zoneEl.classList.add("drag-over");
+  }
+
+  private _onDragLeave(e: DragEvent): void {
+    // Only remove if leaving the zone entirely
+    if (!this._zoneEl.contains(e.relatedTarget as Node)) {
+      this._zoneEl.classList.remove("drag-over");
+    }
+  }
+
+  private _onDrop(e: DragEvent): void {
+    e.preventDefault();
+    this._zoneEl.classList.remove("drag-over");
+    if (this.disabled) return;
+
+    const dt = e.dataTransfer;
+    if (!dt?.files.length) return;
+
+    // Filter by accept if specified
+    const accept = this.accept;
+    let files: File[];
+    if (accept) {
+      const types = accept.split(",").map((t) => t.trim().toLowerCase());
+      files = Array.from(dt.files).filter((f) => {
+        const mime = f.type.toLowerCase();
+        const ext = "." + f.name.split(".").pop()?.toLowerCase();
+        return types.some((t) => t === mime || (t.endsWith("/*") && mime.startsWith(t.slice(0, -1))) || t === ext);
+      });
+    } else {
+      files = Array.from(dt.files);
+    }
+
+    if (!this.multiple && files.length > 1) {
+      files = [files[0]];
+    }
+
+    if (files.length === 0) return;
+
+    this.dispatchEvent(
+      new CustomEvent("drop-files", {
+        bubbles: true,
+        composed: true,
+        detail: { files },
+      }),
+    );
+  }
+
+  private _handleKeydown = (e: KeyboardEvent): void => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      this._openPicker();
+    }
+  };
+}
+
+customElements.define("ui-dropzone", UiDropzone);

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -51,6 +51,8 @@ export { UiInputGroup } from "./components/ui-input-group.js";
 export type { InputGroupSize } from "./components/ui-input-group.js";
 export { UiFileUpload } from "./components/ui-file-upload.js";
 export type { FileUploadSize } from "./components/ui-file-upload.js";
+export { UiDropzone } from "./components/ui-dropzone.js";
+export type { DropzoneSize } from "./components/ui-dropzone.js";
 export { UiSelect } from "./components/ui-select.js";
 export type { SelectSize, SelectStatus } from "./components/ui-select.js";
 export { UiTextarea } from "./components/ui-textarea.js";


### PR DESCRIPTION
## Summary

- New `<ui-dropzone>` Web Component in `@maneki/ui-components` — drag-and-drop file upload zone with Shadow DOM, foundation tokens, 3 sizes (s/m/l), accept/multiple filtering, browse link, hint text, label slot, disabled state
- 60 unit tests (all passing)
- Catalog page added under Form Controls with 5 variant sections (sizes, accept filter, disabled, custom text, no label)
- Docs updated: ui-components AGENTS.md, README.md, root README.md (51 components)

## Files Changed

**packages/ui-components:**
- `src/components/ui-dropzone.ts` — component implementation
- `src/components/ui-dropzone.test.ts` — 60 tests
- `src/index.ts` — barrel export
- `AGENTS.md`, `README.md` — docs

**apps/catalog:**
- `src/pages/dropzone.ts` — catalog page
- `src/manifest.ts` — sidebar entry
- `src/main.ts` — lazy loader
- `e2e/helpers.ts` — test pages array

**Root:**
- `README.md` — component count 50 → 51