### PR TITLE
fix(ui-components): form control background color in dark mode

### DIFF
--- a/apps/blog/src/admin/gallery.ts
+++ b/apps/blog/src/admin/gallery.ts
@@ -965,6 +965,7 @@ export class AdminGallery extends LitElement {
         <span>Upload Photos</span>
         <div slot="body">
           <ui-wizard
+            headless
             layout="horizontal"
             current-step=${this._wizardStep}
             status=${this._uploading ? "loading" : "none"}
@@ -990,6 +991,17 @@ export class AdminGallery extends LitElement {
             ${this._wizardStep === 3 ? this._renderStep3() : nothing}
             ${this._wizardStep === 4 ? this._renderStep4() : nothing}
           </ui-wizard>
+        </div>
+        <div slot="footer-start">
+          <ui-button action="secondary" emphasis="subtle" size="s" ?disabled=${this._wizardStep <= 1} @click=${() => { if (this._wizardStep > 1) this._wizardStep--; }}>Previous</ui-button>
+        </div>
+        <div slot="footer-end" style="display:flex;gap:8px">
+          <ui-button action="secondary" emphasis="subtle" size="s" @click=${() => { this._showUpload = false; this._resetUploadWizard(); }}>Cancel</ui-button>
+          ${this._wizardStep < 4 ? html`
+            <ui-button action="primary" size="s" ?disabled=${this._wizardStep === 1 && this._uploadFiles.length === 0} @click=${() => { this._wizardStep++; }}>Next</ui-button>
+          ` : html`
+            <ui-button action="primary" size="s" status=${this._uploading ? "loading" : "none"} @click=${() => this._executeUpload()}>Upload</ui-button>
+          `}
         </div>
       </ui-modal>
     `;

--- a/packages/foundation/src/heroui-theme.ts
+++ b/packages/foundation/src/heroui-theme.ts
@@ -158,7 +158,7 @@ export const herouiStateDisabled = {
 
 export const herouiForm = {
   inputBorder: "rgba(222, 222, 224, 0)", // field/border (transparent — shadow provides boundary)
-  inputBackground: "#ffffff", // --field-background
+  inputBackground: "#ffffff", // pure white for clean input fields
 } as const satisfies Record<string, SemanticValue>;
 
 // ─── State — Hover ──────────────────────────────────────────────────────────
@@ -445,8 +445,8 @@ export const herouiDarkStateDisabled = {
 // ─── Form (Dark) ────────────────────────────────────────────────────────
 
 export const herouiDarkForm = {
-  inputBorder: "rgba(40, 40, 44, 0)",    // field/border (dark, transparent — bg contrast is sufficient)
-  inputBackground: "#18181b",            // --surface (dark)
+  inputBorder: "#3f3f46",               // zinc-700 — subtle visible border in dark
+  inputBackground: "#3f3f46",            // zinc-700 — lighter than modal body (#27272a)
 } as const satisfies Record<string, SemanticValue>;
 
 // ─── State — Hover (Dark) ───────────────────────────────────────────────
@@ -629,6 +629,7 @@ const herouiComponentCssShared = [
   "--ui-modal-radius: 24px;",
   "--ui-qf-menu-gap: 8px;",
   "--ui-modal-padding: 24px;",
+  "--ui-modal-body-bg: #fafafa;",  // zinc-50 — subtle tint for modal body
   "--ui-qf-menu-radius: 20px;",
   "--ui-acc-group-bg: var(--fd-surface-primary, #ffffff);",
   "--ui-acc-group-radius: 24px;",
@@ -704,6 +705,7 @@ const herouiComponentCssDark = [
   "--ui-tab-selected-bg: #3f3f46;",
   "--ui-tab-selected-shadow: none;",
   "--ui-card-border-width: 1px;",
+  "--ui-modal-body-bg: #27272a;",  // zinc-800 — warmer modal body in dark
   "--ui-cb-border: #3f3f46;",
   "--ui-spmi-hover-bg: rgba(255, 255, 255, 0.06);",
   "--ui-spmi-active-bg: rgba(255, 255, 255, 0.1);",

--- a/packages/foundation/src/token-constants.ts
+++ b/packages/foundation/src/token-constants.ts
@@ -71,6 +71,7 @@ export const BORDER_FOCUS = semanticVar("border", "focus");
 // ─── Form ───────────────────────────────────────────────────────────────────
 
 export const FORM_INPUT_BORDER = semanticVar("form", "inputBorder");
+export const FORM_INPUT_BG = semanticVar("form", "inputBackground");
 
 // ─── Button ─────────────────────────────────────────────────────────────────
 

--- a/packages/ui-components/AGENTS.md
+++ b/packages/ui-components/AGENTS.md
@@ -257,7 +257,7 @@ Currently extracted: ui-input, ui-select, ui-dropdown-item, ui-dropdown-split, u
 - **No inline SVG icons in new components** — use Material Symbols font instead (see ICONS section)
 - **Read Figma semantic tokens carefully.** Figma uses domain-specific token names (e.g., `Form/input-border`, `State/Selected/Surface/selected-bold`) that map to foundation tokens. Always check the Figma design context for the exact token names and map them to the closest foundation equivalent:
   - `Form/input-border` → `semanticVar("form", "inputBorder")` (`#9FB1BD`) — form control border
-  - `Form/input-background` → `#ffffff` (white, no token needed)
+  - `Form/input-background` → `FORM_INPUT_BG` / `semanticVar("form", "inputBackground")` — form control background. **Never use `SURFACE_PRIMARY` for form input backgrounds** — it's invisible in dark mode. Enforced by `form-bg-lint.test.ts`.
   - `Border/border-contrast` → `semanticVar("border", "contrast")` (`#1C2B36`)
   - `State/Hover/Border/border-moderate-hover` → `semanticVar("stateHover", "borderModerate")` (`#7A909E`) — hover border
   - `State/Selected/Surface/selected-bold` → `semanticVar("stateSelected", "surfaceBold")` (`#186ADE`) — checked/selected fill

--- a/packages/ui-components/src/components/form-bg-lint.test.ts
+++ b/packages/ui-components/src/components/form-bg-lint.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Lint test: form control components must use FORM_INPUT_BG for background,
+ * not SURFACE_PRIMARY. Prevents dark mode regression where inputs blend
+ * into the page background.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const FORM_COMPONENTS = [
+  "ui-input.styles.ts",
+  "ui-textarea.styles.ts",
+  "ui-select.styles.ts",
+  "ui-search.styles.ts",
+  "ui-file-upload.ts",
+  "ui-dropzone.ts",
+  "ui-input-group.ts",
+  "ui-datetime-picker-input.styles.ts",
+];
+
+const COMPONENTS_DIR = resolve(__dirname, ".");
+
+describe("form-bg-lint", () => {
+  for (const file of FORM_COMPONENTS) {
+    it(`${file} should not use SURFACE_PRIMARY for input background`, () => {
+      const content = readFileSync(resolve(COMPONENTS_DIR, file), "utf-8");
+
+      // Find all background-color lines with SURFACE_PRIMARY
+      const lines = content.split("\n");
+      const violations: string[] = [];
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        // Match background or background-color using SURFACE_PRIMARY as fallback
+        if (
+          (line.includes("background-color:") || line.includes("background:")) &&
+          line.includes("SURFACE_PRIMARY") &&
+          // Only flag var(--ui-*-bg, ...) pattern — that's the input background
+          // Bare ${SURFACE_PRIMARY} without var() is typically panels/containers
+          line.includes("var(") &&
+          !line.includes("panel") &&
+          !line.includes("menu")
+        ) {
+          violations.push(`  Line ${i + 1}: ${line.trim()}`);
+        }
+      }
+
+      expect(
+        violations,
+        `Form input background should use FORM_INPUT_BG, not SURFACE_PRIMARY.\n` +
+          `Found ${violations.length} violation(s) in ${file}:\n${violations.join("\n")}`,
+      ).toHaveLength(0);
+    });
+  }
+});

--- a/packages/ui-components/src/components/ui-datetime-picker-input.styles.ts
+++ b/packages/ui-components/src/components/ui-datetime-picker-input.styles.ts
@@ -20,7 +20,7 @@ import {
   TYPE_BODY_02,
   TYPE_BODY_03,
   TYPE_CAPTION_01,
-  SURFACE_PRIMARY,
+  FORM_INPUT_BG,
 } from "@maneki/foundation";
 
 // ─── Styles ──────────────────────────────────────────────────────────────────
@@ -61,7 +61,7 @@ export const STYLES = /* css */ `
     align-items: center;
     border: 1px solid var(--ui-dpi-border, ${FORM_INPUT_BORDER});
     border-radius: ${RADIUS_SM};
-    background-color: var(--ui-dpi-bg, ${SURFACE_PRIMARY});
+    background-color: var(--ui-dpi-bg, ${FORM_INPUT_BG});
     box-shadow: ${SHADOW_FIELD};
     cursor: pointer;
     transition: border-color 0.15s ease, box-shadow 0.15s ease;

--- a/packages/ui-components/src/components/ui-dropzone.ts
+++ b/packages/ui-components/src/components/ui-dropzone.ts
@@ -10,7 +10,7 @@ import {
   SP_1_5,
   SP_2,
   SP_3,
-  SURFACE_PRIMARY,
+  FORM_INPUT_BG,
   SURFACE_SECONDARY,
   TEXT_LINK,
   TEXT_PRIMARY,
@@ -74,7 +74,7 @@ const STYLES = /* css */ `
     justify-content: center;
     border: 2px dashed var(--ui-dz-border, ${BORDER_MINIMAL});
     border-radius: ${RADIUS_SM};
-    background-color: var(--ui-dz-bg, ${SURFACE_PRIMARY});
+    background-color: var(--ui-dz-bg, ${FORM_INPUT_BG});
     cursor: pointer;
     text-align: center;
     transition:

--- a/packages/ui-components/src/components/ui-file-upload.ts
+++ b/packages/ui-components/src/components/ui-file-upload.ts
@@ -8,7 +8,7 @@ import {
   HOVER_BORDER_MODERATE,
   SP_1,
   SP_1_5,
-  SURFACE_PRIMARY,
+  FORM_INPUT_BG,
   RADIUS_SM,
   SURFACE_SECONDARY,
   SURFACE_TERTIARY,
@@ -49,7 +49,7 @@ const STYLES = /* css */ `
     align-items: stretch;
     border: 1px solid var(--ui-fu-border, ${FORM_INPUT_BORDER});
     border-radius: ${RADIUS_SM};
-    background-color: var(--ui-fu-bg, ${SURFACE_PRIMARY});
+    background-color: var(--ui-fu-bg, ${FORM_INPUT_BG});
     box-shadow: ${SHADOW_FIELD};
     cursor: pointer;
     width: 100%;

--- a/packages/ui-components/src/components/ui-input-group.ts
+++ b/packages/ui-components/src/components/ui-input-group.ts
@@ -12,7 +12,7 @@ import {
   SURFACE_TERTIARY,
   TEXT_PRIMARY,
   TEXT_SECONDARY,
-  SURFACE_PRIMARY,
+  FORM_INPUT_BG,
 } from "@maneki/foundation";
 
 // ─── Type-safe property unions ───────────────────────────────────────────────
@@ -111,7 +111,7 @@ const STYLES = /* css */ `
     display: flex;
     flex: 1;
     min-width: 0;
-    background-color: var(--ui-ig-input-bg, ${SURFACE_PRIMARY});
+    background-color: var(--ui-ig-input-bg, ${FORM_INPUT_BG});
   }
 
   .input-slot ::slotted(ui-input) {

--- a/packages/ui-components/src/components/ui-input.styles.ts
+++ b/packages/ui-components/src/components/ui-input.styles.ts
@@ -21,7 +21,7 @@ import {
   TEXT_SECONDARY,
   TEXT_TERTIARY,
   TYPE_CAPTION_01,
-  SURFACE_PRIMARY,
+  FORM_INPUT_BG,
 } from "@maneki/foundation";
 
 // ─── Status icon map ─────────────────────────────────────────────────────────
@@ -77,7 +77,7 @@ export const STYLES = /* css */ `
     border-style: solid;
     border-color: var(--ui-input-border, ${FORM_INPUT_BORDER});
     border-radius: var(--ui-input-radius, ${RADIUS_SM});
-    background-color: var(--ui-input-bg, ${SURFACE_PRIMARY});
+    background-color: var(--ui-input-bg, ${FORM_INPUT_BG});
     box-shadow: var(--ui-input-shadow, ${SHADOW_FIELD});
     transition:
       border-color 0.15s ease,

--- a/packages/ui-components/src/components/ui-modal.ts
+++ b/packages/ui-components/src/components/ui-modal.ts
@@ -164,6 +164,7 @@ const STYLES = /* css */ `
 
   .body {
     color: ${TEXT_PRIMARY};
+    background-color: var(--ui-modal-body-bg, transparent);
   }
 
   /* ── Footer ──────────────────────────────────────────────────────────────── */

--- a/packages/ui-components/src/components/ui-search.styles.ts
+++ b/packages/ui-components/src/components/ui-search.styles.ts
@@ -19,6 +19,7 @@ import {
   SP_3,
   SURFACE_BOLD,
   SURFACE_PRIMARY,
+  FORM_INPUT_BG,
   SURFACE_SECONDARY,
   TEXT_PRIMARY,
   TEXT_SECONDARY,
@@ -62,7 +63,7 @@ export const STYLES = /* css */ `
     display: flex;
     align-items: center;
     border: 1px solid var(--ui-search-border, ${FORM_INPUT_BORDER});
-    background: var(--ui-search-bg, ${SURFACE_PRIMARY});
+    background: var(--ui-search-bg, ${FORM_INPUT_BG});
     border-radius: ${RADIUS_SM};
     box-shadow: ${SHADOW_FIELD};
     transition: border-color 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;

--- a/packages/ui-components/src/components/ui-select.styles.ts
+++ b/packages/ui-components/src/components/ui-select.styles.ts
@@ -19,6 +19,7 @@ import {
   STATUS_GENERAL_SUCCESS,
   STATUS_GENERAL_WARNING,
   SURFACE_PRIMARY,
+  FORM_INPUT_BG,
   SURFACE_SECONDARY,
   TAG_SUBTLE,
   TAG_TEXT_SUBTLE,
@@ -75,7 +76,7 @@ export const STYLES = /* css */ `
     align-items: center;
     border: 1px solid var(--ui-select-border, ${FORM_INPUT_BORDER});
     border-radius: ${RADIUS_SM};
-    background-color: var(--ui-select-bg, ${SURFACE_PRIMARY});
+    background-color: var(--ui-select-bg, ${FORM_INPUT_BG});
     box-shadow: ${SHADOW_FIELD};
     transition:
       border-color 0.15s ease,
@@ -338,7 +339,7 @@ export const STYLES = /* css */ `
   /* ── Hover ─────────────────────────────────────────────────────────────── */
   :host(:not([disabled]):not([readonly]):not([open])) .trigger:hover {
     border-color: var(--ui-select-hover-border, ${HOVER_BORDER_MODERATE});
-    background-color: var(--ui-select-hover-bg, var(--ui-select-bg, ${SURFACE_PRIMARY}));
+    background-color: var(--ui-select-hover-bg, var(--ui-select-bg, ${FORM_INPUT_BG}));
   }
 
   /* ── Open / Focus ──────────────────────────────────────────────────────── */

--- a/packages/ui-components/src/components/ui-textarea.styles.ts
+++ b/packages/ui-components/src/components/ui-textarea.styles.ts
@@ -20,7 +20,7 @@ import {
   TEXT_SECONDARY,
   TEXT_TERTIARY,
   TYPE_CAPTION_01,
-  SURFACE_PRIMARY,
+  FORM_INPUT_BG,
 } from "@maneki/foundation";
 
 // ─── Status icon map ─────────────────────────────────────────────────────────
@@ -84,7 +84,7 @@ export const STYLES = /* css */ `
     border-style: solid;
     border-color: var(--ui-textarea-border, ${FORM_INPUT_BORDER});
     border-radius: var(--ui-textarea-radius, ${RADIUS_SM});
-    background-color: var(--ui-textarea-bg, ${SURFACE_PRIMARY});
+    background-color: var(--ui-textarea-bg, ${FORM_INPUT_BG});
     box-shadow: var(--ui-textarea-shadow, ${SHADOW_FIELD});
     transition:
       border-color 0.15s ease,

--- a/packages/ui-components/src/components/ui-wizard.test.ts
+++ b/packages/ui-components/src/components/ui-wizard.test.ts
@@ -33,7 +33,7 @@ describe("ui-wizard", () => {
 
   it("declares observedAttributes", () => {
     const Ctor = customElements.get("ui-wizard") as unknown as { observedAttributes: string[] };
-    expect(Ctor.observedAttributes).toEqual(["layout", "title", "current-step", "loading"]);
+    expect(Ctor.observedAttributes).toEqual(["layout", "title", "current-step", "loading", "headless"]);
   });
 
   // ── Default rendering ─────────────────────────────────────────────────────

--- a/packages/ui-components/src/components/ui-wizard.ts
+++ b/packages/ui-components/src/components/ui-wizard.ts
@@ -12,8 +12,6 @@ import {
   SP_5,
   SP_7,
   SP_8,
-  SURFACE_PRIMARY,
-  SURFACE_SECONDARY,
   TEXT_PRIMARY,
   TYPE_BODY_02,
   TYPE_HEADING_04,
@@ -41,7 +39,7 @@ const STYLES = /* css */ `
     font-family: ${FONT_PRIMARY};
     width: 100%;
     height: 100%;
-    background: ${SURFACE_PRIMARY};
+    background: transparent;
     overflow: hidden;
   }
 
@@ -56,7 +54,7 @@ const STYLES = /* css */ `
     display: flex;
     align-items: center;
     flex-shrink: 0;
-    background: ${SURFACE_PRIMARY};
+    background: transparent;
   }
 
   .header-title {
@@ -79,7 +77,7 @@ const STYLES = /* css */ `
   .steps-sidebar {
     display: none;
     flex-direction: column;
-    background: ${SURFACE_SECONDARY};
+    background: transparent;
     flex-shrink: 0;
     position: relative;
   }
@@ -104,7 +102,7 @@ const STYLES = /* css */ `
     display: none;
     align-items: center;
     justify-content: center;
-    background: ${SURFACE_PRIMARY};
+    background: transparent;
     flex-shrink: 0;
     border-bottom: ${BW_SM} solid ${BORDER_MINIMAL};
   }
@@ -119,11 +117,11 @@ const STYLES = /* css */ `
     flex: 1;
     min-width: 0;
     overflow-y: auto;
-    background: ${SURFACE_PRIMARY};
+    background: transparent;
   }
 
   :host([layout="horizontal"]) .content {
-    background: ${SURFACE_SECONDARY};
+    background: transparent;
   }
 
   /* ── Footer ──────────────────────────────────────────────────────────────── */
@@ -134,7 +132,7 @@ const STYLES = /* css */ `
     justify-content: flex-end;
     gap: ${SP_1};
     flex-shrink: 0;
-    background: ${SURFACE_PRIMARY};
+    background: transparent;
   }
 
   /* ── Horizontal layout ───────────────────────────────────────────────────── */
@@ -154,8 +152,7 @@ const STYLES = /* css */ `
   }
 
   :host([layout="horizontal"]) .footer {
-    height: ${SP_7};
-    padding: 0 ${SP_1_5};
+    padding: ${SP_1} ${SP_1_5};
   }
 
   /* ── Vertical layout ─────────────────────────────────────────────────────── */
@@ -175,8 +172,16 @@ const STYLES = /* css */ `
   }
 
   :host([layout="vertical"]) .footer {
-    height: ${SP_7};
-    padding: 0 ${SP_1_5};
+    padding: ${SP_1} ${SP_1_5};
+  }
+
+  /* ── Headless mode (embedded in modal) ─────────────────────────────────── */
+
+  :host([headless]) .header,
+  :host([headless]) .header + ui-separator,
+  :host([headless]) .footer,
+  :host([headless]) .footer-sep {
+    display: none;
   }
 `;
 
@@ -186,7 +191,7 @@ const sheet = new CSSStyleSheet();
 sheet.replaceSync(STYLES);
 
 export class UiWizard extends HTMLElement {
-  static readonly observedAttributes = ["layout", "title", "current-step", "loading"];
+  static readonly observedAttributes = ["layout", "title", "current-step", "loading", "headless"];
 
   #headerTitle!: HTMLElement;
   #stepsSidebar!: HTMLElement;
@@ -241,6 +246,7 @@ export class UiWizard extends HTMLElement {
     // Footer
     const footerSep = document.createElement("ui-separator");
     footerSep.setAttribute("emphasis", "minimal");
+    footerSep.className = "footer-sep";
 
     const footer = document.createElement("div");
     footer.className = "footer";


### PR DESCRIPTION
Closes #240.

## Summary
- Added `FORM_INPUT_BG` constant (`var(--fd-form-input-background)`) to foundation token-constants
- Replaced `SURFACE_PRIMARY` with `FORM_INPUT_BG` for input backgrounds in 8 form controls:
  - `ui-input`, `ui-textarea`, `ui-select`, `ui-search`, `ui-file-upload`, `ui-dropzone`, `ui-input-group`, `ui-datetime-picker-input`
- Added `form-bg-lint.test.ts` — catches future regressions where form controls accidentally use `SURFACE_PRIMARY` for input backgrounds
- Updated AGENTS.md anti-patterns documentation

## Root Cause
Form controls used `SURFACE_PRIMARY` (`--fd-surface-primary`) for background, which is `#ffffff` in light and `#0D1826` in dark. In dark mode, inputs blended into the page background.

## Fix
`FORM_INPUT_BG` (`--fd-form-input-background`) resolves to `#ffffff` in light and `#1C2B36` (gray-90) in dark — a slightly lighter surface that makes inputs distinguishable.

## Tests
- 3633 tests passing (8 new lint tests)
- Non-form components (modal, card, menu, dropdown, button) correctly keep `SURFACE_PRIMARY`