### PR TITLE
fix(ui-components): radio input missing border in HeroUI light mode

### DIFF
--- a/packages/foundation/src/heroui-theme.ts
+++ b/packages/foundation/src/heroui-theme.ts
@@ -692,6 +692,7 @@ const herouiComponentCssLight = [
   "--ui-tab-selected-shadow: 0px 2px 8px 0px rgba(0,0,0,0.06);",
   "--ui-project-card-border: none;",
   "--ui-cb-border: #dedee0;",
+  "--ui-radio-border: #dedee0;",
 ].join("\n");
 
 // Dark-only component overrides
@@ -707,6 +708,7 @@ const herouiComponentCssDark = [
   "--ui-card-border-width: 1px;",
   "--ui-modal-body-bg: #27272a;",  // zinc-800 — warmer modal body in dark
   "--ui-cb-border: #3f3f46;",
+  "--ui-radio-border: #3f3f46;",
   "--ui-spmi-hover-bg: rgba(255, 255, 255, 0.06);",
   "--ui-spmi-active-bg: rgba(255, 255, 255, 0.1);",
   "--ui-spmi-selected-bg: rgba(4, 133, 247, 0.15);",


### PR DESCRIPTION
Closes #243.

## Summary
- Added `--ui-radio-border` override to HeroUI theme (light: `#dedee0`, dark: `#3f3f46`)
- Matches existing `--ui-cb-border` checkbox border treatment

## Root Cause
HeroUI sets `--ui-cb-border` for checkboxes but had no `--ui-radio-border` override. Radio fell back to `FORM_INPUT_BORDER` which HeroUI sets to transparent.

## Files
- `packages/foundation/src/heroui-theme.ts` — added radio border overrides for both light and dark