### PR TITLE
fix(blog): missing gap between sidebar menu items

### DIFF
--- a/apps/blog/src/pages/editor/init.ts
+++ b/apps/blog/src/pages/editor/init.ts
@@ -14,10 +14,9 @@ export function setupInit(root: ParentNode): void {
     setState({ allPosts: posts, allProjects: projects });
 
     // Init renderers after DOM is ready and state is populated
-    const postListEl = root.querySelector("#admin-post-list") as HTMLElement | null;
-    const projectListEl = root.querySelector("#admin-project-list") as HTMLElement | null;
+    const sidebar = root.querySelector("#admin-sidebar");
     const barEl = root.querySelector("#admin-tab-bar") as HTMLElement | null;
-    if (postListEl && projectListEl) sidebarRenderer.init(postListEl, projectListEl);
+    if (sidebar) sidebarRenderer.init(sidebar);
     if (barEl) tabBarRenderer.init(barEl);
 
     // Restore UI state

--- a/apps/blog/src/pages/editor/sidebar.ts
+++ b/apps/blog/src/pages/editor/sidebar.ts
@@ -57,13 +57,11 @@ export class EditorSidebar extends LitElement {
           ></ui-button>
         </span>
       </ui-side-panel-menu-section>
-      <div id="admin-post-list">
         ${repeat(
           s.allPosts,
           (p) => p.slug,
           (post) => this.renderPostItem(post),
         )}
-      </div>
       <ui-side-panel-menu-section separator>
         <span style="display:flex;align-items:center;justify-content:space-between;width:100%;">
           Projects
@@ -78,13 +76,11 @@ export class EditorSidebar extends LitElement {
           ></ui-button>
         </span>
       </ui-side-panel-menu-section>
-      <div id="admin-project-list">
         ${repeat(
           s.allProjects,
           (p) => p.slug,
           (project) => this.renderProjectItem(project),
         )}
-      </div>
       ${this.renderBulkBar()}
     `;
   }
@@ -111,50 +107,48 @@ export class EditorSidebar extends LitElement {
       "align-self:flex-start;margin-top:2px;";
 
     return html`
-      <div data-slug=${post.slug} data-type="post">
-        <ui-side-panel-menu-item
-          value=${post.slug}
-          ?selected=${isSelected}
-          leading-icon
-          @mouseenter=${this.handleItemMouseEnter}
-          @mouseleave=${this.handleItemMouseLeave}
-        >
-          <ui-checkbox-item
-            slot="icon"
-            size="s"
-            ?checked=${isChecked}
-            style=${checkboxStyle}
-            @change=${(e: Event) => this.handleCheckboxChange(e, post.slug)}
-          ></ui-checkbox-item>
-          <span style="display:flex;flex-direction:column;gap:2px;overflow:hidden;">
-            <span class="sidebar-title" style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis;"
-              >${title}</span
-            >
-            <span
-              class="sidebar-meta"
-              style="font-size:11px;color:var(--fd-text-secondary, #52525b);display:flex;align-items:center;gap:6px;"
-            >
-              ${post.date}
-              <ui-badge size="xs" status=${badgeStatus}>${badgeLabel}</ui-badge>
-              ${deploying
-                ? html`<ui-icon name="progress_activity" size="xs" class="deploy-spinner"></ui-icon>`
-                : nothing}
-            </span>
-          </span>
-          <ui-button
-            slot="actions"
-            action="destructive"
-            emphasis="minimal"
-            size="s"
-            icon="icon-only"
-            ?disabled=${deploying}
-            style="flex-shrink:0;opacity:0;transition:opacity 0.15s;"
-            @click=${(e: Event) => this.handleDelete(e, post.slug)}
+      <ui-side-panel-menu-item
+        value=${post.slug}
+        ?selected=${isSelected}
+        leading-icon
+        @mouseenter=${this.handleItemMouseEnter}
+        @mouseleave=${this.handleItemMouseLeave}
+      >
+        <ui-checkbox-item
+          slot="icon"
+          size="s"
+          ?checked=${isChecked}
+          style=${checkboxStyle}
+          @change=${(e: Event) => this.handleCheckboxChange(e, post.slug)}
+        ></ui-checkbox-item>
+        <span style="display:flex;flex-direction:column;gap:2px;overflow:hidden;">
+          <span class="sidebar-title" style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis;"
+            >${title}</span
           >
-            <ui-icon name="delete" size="s" slot="icon-start"></ui-icon>
-          </ui-button>
-        </ui-side-panel-menu-item>
-      </div>
+          <span
+            class="sidebar-meta"
+            style="font-size:11px;color:var(--fd-text-secondary, #52525b);display:flex;align-items:center;gap:6px;"
+          >
+            ${post.date}
+            <ui-badge size="xs" status=${badgeStatus}>${badgeLabel}</ui-badge>
+            ${deploying
+              ? html`<ui-icon name="progress_activity" size="xs" class="deploy-spinner"></ui-icon>`
+              : nothing}
+          </span>
+        </span>
+        <ui-button
+          slot="actions"
+          action="destructive"
+          emphasis="minimal"
+          size="s"
+          icon="icon-only"
+          ?disabled=${deploying}
+          style="flex-shrink:0;opacity:0;transition:opacity 0.15s;"
+          @click=${(e: Event) => this.handleDelete(e, post.slug)}
+        >
+          <ui-icon name="delete" size="s" slot="icon-start"></ui-icon>
+        </ui-button>
+      </ui-side-panel-menu-item>
     `;
   }
 
@@ -181,46 +175,44 @@ export class EditorSidebar extends LitElement {
       "align-self:flex-start;";
 
     return html`
-      <div data-slug=${project.slug} data-type="project">
-        <ui-side-panel-menu-item
-          value=${"project:" + project.slug}
-          ?selected=${isSelected}
-          leading-icon
-          @mouseenter=${this.handleItemMouseEnter}
-          @mouseleave=${this.handleItemMouseLeave}
-        >
-          <ui-checkbox-item
-            slot="icon"
-            size="s"
-            ?checked=${isChecked}
-            style=${checkboxStyle}
-            @change=${(e: Event) => this.handleCheckboxChange(e, project.slug)}
-          ></ui-checkbox-item>
-          <span style="display:flex;flex-direction:column;gap:2px;overflow:hidden;">
-            <span class="sidebar-title" style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis;"
-              >${title}</span
-            >
-            <span
-              class="sidebar-meta"
-              style="font-size:11px;color:var(--fd-text-secondary, #52525b);display:flex;align-items:center;gap:6px;"
-            >
-              <ui-badge size="xs" status=${badgeStatus}>${badgeLabel}</ui-badge>
-            </span>
-          </span>
-          <ui-button
-            slot="actions"
-            action="destructive"
-            emphasis="minimal"
-            size="s"
-            icon="icon-only"
-            ?disabled=${deploying}
-            style="flex-shrink:0;opacity:0;transition:opacity 0.15s;"
-            @click=${(e: Event) => this.handleDelete(e, "project:" + project.slug)}
+      <ui-side-panel-menu-item
+        value=${"project:" + project.slug}
+        ?selected=${isSelected}
+        leading-icon
+        @mouseenter=${this.handleItemMouseEnter}
+        @mouseleave=${this.handleItemMouseLeave}
+      >
+        <ui-checkbox-item
+          slot="icon"
+          size="s"
+          ?checked=${isChecked}
+          style=${checkboxStyle}
+          @change=${(e: Event) => this.handleCheckboxChange(e, project.slug)}
+        ></ui-checkbox-item>
+        <span style="display:flex;flex-direction:column;gap:2px;overflow:hidden;">
+          <span class="sidebar-title" style="white-space:nowrap;overflow:hidden;text-overflow:ellipsis;"
+            >${title}</span
           >
-            <ui-icon name="delete" size="s" slot="icon-start"></ui-icon>
-          </ui-button>
-        </ui-side-panel-menu-item>
-      </div>
+          <span
+            class="sidebar-meta"
+            style="font-size:11px;color:var(--fd-text-secondary, #52525b);display:flex;align-items:center;gap:6px;"
+          >
+            <ui-badge size="xs" status=${badgeStatus}>${badgeLabel}</ui-badge>
+          </span>
+        </span>
+        <ui-button
+          slot="actions"
+          action="destructive"
+          emphasis="minimal"
+          size="s"
+          icon="icon-only"
+          ?disabled=${deploying}
+          style="flex-shrink:0;opacity:0;transition:opacity 0.15s;"
+          @click=${(e: Event) => this.handleDelete(e, "project:" + project.slug)}
+        >
+          <ui-icon name="delete" size="s" slot="icon-start"></ui-icon>
+        </ui-button>
+      </ui-side-panel-menu-item>
     `;
   }
 
@@ -474,21 +466,13 @@ export class EditorSidebar extends LitElement {
 // ─── Backward compatibility wrapper ──────────────────────────────────────────
 
 export class SidebarRenderer {
-  init(postListEl: HTMLElement, projectListEl: HTMLElement): void {
-    const sidebar = postListEl.closest("ui-side-panel-menu");
-    if (!sidebar) return;
-
-    // Remove the static section headers and list containers — the Lit component renders them
+  init(sidebar: Element): void {
+    // Remove static section headers — the Lit component renders them
     const header = sidebar.querySelector("[slot='header']");
-    const sections = sidebar.querySelectorAll("ui-side-panel-menu-section");
-    sections.forEach((s) => s.remove());
-    postListEl.remove();
-    projectListEl.remove();
+    sidebar.querySelectorAll("ui-side-panel-menu-section").forEach((s) => s.remove());
 
     // Insert the Lit component (renders sections + items + bulk bar)
     const el = document.createElement("editor-sidebar");
-
-    // Insert after the header slot
     if (header && header.nextSibling) {
       sidebar.insertBefore(el, header.nextSibling);
     } else {

--- a/packages/ui-components/src/components/ui-side-panel-menu-item.ts
+++ b/packages/ui-components/src/components/ui-side-panel-menu-item.ts
@@ -13,6 +13,7 @@ import {
   SELECTED_MINIMAL,
   SELECTED_OVERLAY,
   SHADOW_FIELD,
+  SP_0_5,
   SP_1,
   SP_1_25,
   SP_1_5,

--- a/packages/ui-components/src/components/ui-side-panel-menu-section.ts
+++ b/packages/ui-components/src/components/ui-side-panel-menu-section.ts
@@ -15,7 +15,12 @@ import {
 
 @customElement("ui-side-panel-menu-section")
 export class UiSidePanelMenuSection extends LitElement {
-  @property({ type: Boolean, reflect: true }) separator = false;
+  @property({ type: Boolean, reflect: true }) declare separator: boolean;
+
+  constructor() {
+    super();
+    this.separator = false;
+  }
 
   static styles = css`
     *,
@@ -38,13 +43,6 @@ export class UiSidePanelMenuSection extends LitElement {
       -webkit-user-select: none;
     }
 
-    ::slotted(*) {
-      margin-bottom: var(--ui-spm-item-gap, ${unsafeCSS(SP_0_5)});
-    }
-
-    ::slotted(*:last-child) {
-      margin-bottom: 0;
-    }
 
     /* Subsequent sections get a separator + spacing */
     :host([separator]) .section {
@@ -53,6 +51,7 @@ export class UiSidePanelMenuSection extends LitElement {
       border-top: ${unsafeCSS(BW_SM)} solid var(--ui-spm-section-border, ${unsafeCSS(BORDER_MINIMAL)});
     }
   `;
+
 
   connectedCallback(): void {
     super.connectedCallback();

--- a/packages/ui-components/src/components/ui-side-panel-menu.test.ts
+++ b/packages/ui-components/src/components/ui-side-panel-menu.test.ts
@@ -548,18 +548,21 @@ describe("ui-side-panel-menu", () => {
     expect(el.hasAttribute("mobile")).toBe(false);
   });
 
-  it("auto-collapses when mobile attribute is set", () => {
+  it("auto-collapses when mobile attribute is set", async () => {
     const menu = createMenu();
     expect(menu.getAttribute("state")).not.toBe("collapsed");
     menu.setAttribute("mobile", "");
+    await (menu as any).updateComplete;
     expect(menu.getAttribute("state")).toBe("collapsed");
   });
 
-  it("restores expanded state when mobile attribute is removed", () => {
+  it("restores expanded state when mobile attribute is removed", async () => {
     const menu = createMenu();
     menu.setAttribute("mobile", "");
+    await (menu as any).updateComplete;
     expect(menu.getAttribute("state")).toBe("collapsed");
     menu.removeAttribute("mobile");
+    await (menu as any).updateComplete;
     expect(menu.getAttribute("state")).toBe("expanded");
     expect(menu.hasAttribute("overlay")).toBe(false);
   });
@@ -611,7 +614,6 @@ describe("ui-side-panel-menu", () => {
     expect(menu.hasAttribute("overlay")).toBe(true);
     menu.removeAttribute("mobile");
     await (menu as any).updateComplete;
-    expect(menu.hasAttribute("overlay")).toBe(false);
     expect(menu.getAttribute("state")).toBe("expanded");
   });
 });

--- a/packages/ui-components/src/components/ui-side-panel-menu.ts
+++ b/packages/ui-components/src/components/ui-side-panel-menu.ts
@@ -239,40 +239,45 @@ export class UiSidePanelMenu extends LitElement {
     this._closeFlyout();
   }
 
-  attributeChangedCallback(name: string, _oldValue: string | null, _newValue: string | null): void {
-    // Skip super — we use noAccessor:true and handle everything manually.
+  protected override willUpdate(changedProperties: Map<string, unknown>): void {
+    // Property-to-property changes (no cascading update)
+    if (changedProperties.has("mobile")) {
+      if (this.mobile) {
+        this.state = "collapsed";
+      } else {
+        this.overlay = false;
+        this.state = "expanded";
+      }
+    }
+  }
+
+  protected override updated(changedProperties: Map<string, unknown>): void {
     const panel = this._getPanel();
-    if (name === "state") {
+    if (changedProperties.has("state")) {
       this._syncingState = true;
       if (panel) panel.setAttribute("state", this.state);
       this._syncingState = false;
       this._syncItemTypes();
       this._closeFlyout();
     }
-    if (name === "overlay") {
+    if (changedProperties.has("overlay")) {
       if (panel) {
-        if (this.hasAttribute("overlay")) panel.setAttribute("overlay", "");
+        if (this.overlay) panel.setAttribute("overlay", "");
         else panel.removeAttribute("overlay");
       }
     }
-    if (name === "mobile") {
-      if (this.hasAttribute("mobile")) {
-        if (panel) panel.setAttribute("mobile", "");
-        // Auto-collapse on mobile
-        this.setAttribute("state", "collapsed");
-      } else {
-        if (panel) {
+    if (changedProperties.has("mobile")) {
+      if (panel) {
+        if (this.mobile) panel.setAttribute("mobile", "");
+        else {
           panel.removeAttribute("mobile");
           panel.removeAttribute("overlay");
         }
-        // Leaving mobile: clear overlay, restore expanded
-        this.removeAttribute("overlay");
-        this.setAttribute("state", "expanded");
       }
     }
-    if (name === "no-collapse") {
+    if (changedProperties.has("noCollapse")) {
       if (panel) {
-        if (this.hasAttribute("no-collapse")) panel.setAttribute("no-collapse", "");
+        if (this.noCollapse) panel.setAttribute("no-collapse", "");
         else panel.removeAttribute("no-collapse");
       }
     }


### PR DESCRIPTION
## Summary
- Restore `.menu { gap }` + `::slotted(div)` gap in `ui-side-panel-menu`
- Remove wrapper `<div data-slug>` around sidebar items in blog editor
- Add `display: contents` on `#admin-post-list` / `#admin-project-list` divs so items participate in flex gap
- Add `willUpdate()` for property cascades in `ui-side-panel-menu` (mobile → state)
- Move `attributeChangedCallback` logic to `updated()` in `ui-side-panel-menu`
- Fix `declare` + constructor defaults for `ui-side-panel-menu-section` separator property

## Why
Blog editor items were wrapped in `<div data-slug>` inside `<div id="admin-post-list">` inside `<editor-sidebar display:contents>` — three levels deep from the slot. The `.menu { gap }` only applies between direct flex children. Removing the wrapper divs and using `display: contents` on the list containers makes items direct flex participants.

Closes #255