### PR TITLE
refactor(blog): Phase 2 — upload + publish migration

### DIFF
--- a/apps/blog/src/pages/editor/editor-page.ts
+++ b/apps/blog/src/pages/editor/editor-page.ts
@@ -4,16 +4,16 @@ import { createRef, ref, type Ref } from "lit/directives/ref.js";
 import type { Post, Project } from "./types.js";
 import { state, setState, hasUnpublishedChanges } from "./state.js";
 import { api } from "../../lib/api.js";
-import { fetchPosts, fetchProjects, loadUIState, setEditorPage, saveUIState, saveCurrent, saveCurrentProject, loadPostIntoEditor, loadProjectIntoEditor } from "./api.js";
+import { fetchPosts, fetchProjects, loadUIState, setEditorPage, saveUIState, saveCurrent, saveCurrentProject, loadPostIntoEditor, loadProjectIntoEditor, exportAsMarkdown } from "./api.js";
 import { renderPreview, triggerPreview } from "./preview.js";
 import { wrapSelection, insertAtCursor } from "./toolbar.js";
-import { setupImageUpload } from "./upload.js";
+import { uploadFile } from "./upload.js";
 import { initGallery, toggleGallery, openGalleryForPick } from "./gallery.js";
 import { setupContextMenu } from "./context-menu.js";
 import { setupScrollSync } from "./scroll-sync.js";
 import { setupUndoStack } from "./undo.js";
 import { openPortfolioLayout, setProjectPreviewRoot } from "./project-preview.js";
-import { setupPublish } from "./publish.js";
+import { publishCurrent, unpublishCurrent } from "./publish.js";
 import { setupDeleteModal } from "./delete-modal.js";
 import { setupFullscreenPreview } from "./fullscreen-preview.js";
 import { SidebarRenderer, setSidebarRoot } from "./sidebar.js";
@@ -297,14 +297,14 @@ export class EditorPage extends LitElement {
               <ui-button id="admin-preview-btn" action="secondary" emphasis="subtle" size="s">Preview</ui-button>
               <ui-button id="admin-portfolio-btn" action="secondary" emphasis="subtle" size="s" style="display:${s.activeTabType === "project" ? "" : "none"}" @click=${openPortfolioLayout}>Portfolio</ui-button>
               <ui-button id="admin-save-btn" ${ref(this._saveBtnRef)} action="primary" size="s" ?disabled=${s.deployingSlugs.size > 0} @click=${() => this._onSave()}>Save</ui-button>
-              <ui-dropdown-split id="admin-publish-split" ${ref(this._publishSplitRef)} action="primary" size="s" label="Publish" ?disabled=${s.deployingSlugs.size > 0}>
-                <ui-dropdown-item id="admin-unpublish-btn" value="unpublish">Unpublish</ui-dropdown-item>
-                <ui-dropdown-item id="admin-export-btn" value="export">Export .md</ui-dropdown-item>
+              <ui-dropdown-split id="admin-publish-split" ${ref(this._publishSplitRef)} action="primary" size="s" label="Publish" ?disabled=${s.deployingSlugs.size > 0} @action=${this._onPublishAction}>
+                <ui-dropdown-item id="admin-unpublish-btn" value="unpublish" @select=${this._onUnpublish}>Unpublish</ui-dropdown-item>
+                <ui-dropdown-item id="admin-export-btn" value="export" @select=${this._onExport}>Export .md</ui-dropdown-item>
               </ui-dropdown-split>
             </ui-toolbar>
             <div class="admin-split">
               <ui-scrollbar emphasis="minimal" class="admin-textarea-wrap">
-                <textarea id="admin-content" ${ref(this._textareaRef)} placeholder="Write your post in Markdown..." spellcheck="false" .value=${this.postContent} @input=${this._onContentInput} @keydown=${this._onTextareaKeydown}></textarea>
+                <textarea id="admin-content" ${ref(this._textareaRef)} placeholder="Write your post in Markdown..." spellcheck="false" .value=${this.postContent} @input=${this._onContentInput} @keydown=${this._onTextareaKeydown} @dragover=${this._onTextareaDragover} @dragleave=${this._onTextareaDragleave} @drop=${this._onTextareaDrop} @paste=${this._onTextareaPaste}></textarea>
                 <div class="admin-textarea-spacer"></div>
               </ui-scrollbar>
               <ui-scrollbar emphasis="minimal"><div id="admin-preview" class="admin-preview"></div></ui-scrollbar>
@@ -351,8 +351,7 @@ export class EditorPage extends LitElement {
     });
 
 
-    // Plugins (toolbar action handled by @click on <ui-toolbar>, keyboard absorbed into editor-page)
-    setupImageUpload(textarea, root);
+    // Plugins
     initGallery((url, name) => insertAtCursor(textarea, `![${name}](${url})`), root);
     setupContextMenu(textarea);
     setupUndoStack(textarea);
@@ -363,7 +362,6 @@ export class EditorPage extends LitElement {
     if (textareaWrap && previewWrap) setupScrollSync(textareaWrap, previewWrap);
 
     setupFullscreenPreview(textarea, root);
-    setupPublish(publishSplit, textarea, root);
     setupDeleteModal(root);
 
     // Project tech tags
@@ -549,7 +547,7 @@ export class EditorPage extends LitElement {
       case "link": wrapSelection(ta, "[", "](url)"); break;
       case "code": wrapSelection(ta, "`", "`"); break;
       case "codeblock": wrapSelection(ta, "\n```ts\n", "\n```\n"); break;
-      case "image": insertAtCursor(ta, "![alt](/images/)"); break;
+      case "image": this._openImageFilePicker(); break;
       case "ul": wrapSelection(ta, "\n- ", "\n"); break;
       case "ol": wrapSelection(ta, "\n1. ", "\n"); break;
       case "quote": wrapSelection(ta, "\n> ", "\n"); break;
@@ -587,6 +585,75 @@ export class EditorPage extends LitElement {
   disconnectedCallback(): void {
     super.disconnectedCallback();
     document.removeEventListener("keydown", this._onDocumentKeydown);
+  }
+  // ─── Image upload via file picker (replaces upload.ts toolbar button handler) ─
+  private _openImageFilePicker(): void {
+    const ta = this._textareaRef.value;
+    if (!ta) return;
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = "image/*";
+    input.multiple = true;
+    input.addEventListener("change", () => {
+      if (!input.files) return;
+      for (const file of input.files) {
+        uploadFile(file, ta);
+      }
+    });
+    input.click();
+  }
+
+  // ─── Textarea drag/drop/paste for image upload (replaces setupImageUpload) ──
+  private _onTextareaDragover(e: Event): void {
+    e.preventDefault();
+    (e.target as HTMLTextAreaElement).classList.add("drag-over");
+  }
+
+  private _onTextareaDragleave(e: Event): void {
+    (e.target as HTMLTextAreaElement).classList.remove("drag-over");
+  }
+
+  private _onTextareaDrop(e: Event): void {
+    const de = e as DragEvent;
+    de.preventDefault();
+    (de.target as HTMLTextAreaElement).classList.remove("drag-over");
+    const ta = this._textareaRef.value;
+    if (!ta) return;
+    const files = de.dataTransfer?.files;
+    if (!files) return;
+    for (const file of files) {
+      if (file.type.startsWith("image/")) uploadFile(file, ta);
+    }
+  }
+
+  private _onTextareaPaste(e: Event): void {
+    const ce = e as ClipboardEvent;
+    const items = ce.clipboardData?.items;
+    if (!items) return;
+    const ta = this._textareaRef.value;
+    if (!ta) return;
+    for (const item of items) {
+      if (item.type.startsWith("image/")) {
+        ce.preventDefault();
+        const file = item.getAsFile();
+        if (file) uploadFile(file, ta);
+        return;
+      }
+    }
+  }
+
+  // ─── Publish/unpublish/export (replaces setupPublish) ─────────────────────
+  private async _onPublishAction(): Promise<void> {
+    const el = this._publishSplitRef.value ?? null;
+    await publishCurrent(el);
+  }
+
+  private async _onUnpublish(): Promise<void> {
+    const el = this._publishSplitRef.value ?? null;
+    await unpublishCurrent(el);
+  }
+  private _onExport(): void {
+    exportAsMarkdown();
   }
 
   private _onTagKeydown(e: Event): void {

--- a/apps/blog/src/pages/editor/publish.ts
+++ b/apps/blog/src/pages/editor/publish.ts
@@ -2,58 +2,48 @@ import { api } from "../../lib/api.js";
 import { state, setState } from "./state.js";
 import { getCurrentPostData, getCurrentProjectData } from "./api.js";
 
-export function setupPublish(publishSplit: HTMLElement | null, _textarea: HTMLTextAreaElement, root: ParentNode): void {
-  // Publish (split button left action) — save, publish (triggers deploy), poll
-  publishSplit?.addEventListener("action", async () => {
-    if (publishSplit) publishSplit.setAttribute("status", "loading");
-    try {
-      if (!state.currentSlug) {
-        if (publishSplit) publishSplit.setAttribute("status", "error");
-        setTimeout(() => {
-          if (publishSplit) publishSplit.setAttribute("status", "none");
-        }, 2000);
-        return;
-      }
+// ─── Public API (called by editor-page event handlers) ───────────────────────
 
-      if (state.activeTabType === "project") {
-        await publishProject(publishSplit);
-      } else {
-        await publishPost(publishSplit);
-      }
-    } catch {
+export async function publishCurrent(publishSplit: HTMLElement | null): Promise<void> {
+  if (publishSplit) publishSplit.setAttribute("status", "loading");
+  try {
+    if (!state.currentSlug) {
       if (publishSplit) publishSplit.setAttribute("status", "error");
       setTimeout(() => {
         if (publishSplit) publishSplit.setAttribute("status", "none");
       }, 2000);
+      return;
     }
-  });
 
-  // Unpublish (dropdown item) — unpublish + poll deploy status
-  const unpublishBtn = root.querySelector("#admin-unpublish-btn") as HTMLElement | null;
-  unpublishBtn?.addEventListener("select", async () => {
-    if (!state.currentSlug) return;
-    if (publishSplit) publishSplit.setAttribute("status", "loading");
-    try {
-      if (state.activeTabType === "project") {
-        await unpublishProject(publishSplit);
-      } else {
-        await unpublishPost(publishSplit);
-      }
-    } catch {
-      if (publishSplit) publishSplit.setAttribute("status", "error");
-      setTimeout(() => {
-        if (publishSplit) publishSplit.setAttribute("status", "none");
-      }, 2000);
+    if (state.activeTabType === "project") {
+      await publishProject(publishSplit);
+    } else {
+      await publishPost(publishSplit);
     }
-  });
-
-  // Export (split button dropdown item)
-  const exportBtn = root.querySelector("#admin-export-btn") as HTMLElement | null;
-  exportBtn?.addEventListener("select", exportAsMarkdown);
+  } catch {
+    if (publishSplit) publishSplit.setAttribute("status", "error");
+    setTimeout(() => {
+      if (publishSplit) publishSplit.setAttribute("status", "none");
+    }, 2000);
+  }
 }
 
-// Re-export from api.js to keep the import local
-import { exportAsMarkdown } from "./api.js";
+export async function unpublishCurrent(publishSplit: HTMLElement | null): Promise<void> {
+  if (!state.currentSlug) return;
+  if (publishSplit) publishSplit.setAttribute("status", "loading");
+  try {
+    if (state.activeTabType === "project") {
+      await unpublishProject(publishSplit);
+    } else {
+      await unpublishPost(publishSplit);
+    }
+  } catch {
+    if (publishSplit) publishSplit.setAttribute("status", "error");
+    setTimeout(() => {
+      if (publishSplit) publishSplit.setAttribute("status", "none");
+    }, 2000);
+  }
+}
 
 // ─── Post publish/unpublish ─────────────────────────────────────────────────
 

--- a/apps/blog/src/pages/editor/upload.ts
+++ b/apps/blog/src/pages/editor/upload.ts
@@ -1,6 +1,5 @@
 /**
- * Image upload helpers — drag & drop, paste, toolbar button.
- * Uploads to POST /api/images, inserts markdown at cursor.
+ * Image upload helper — optimizes and uploads to POST /api/images, inserts markdown at cursor.
  */
 
 import { insertAtCursor } from "./toolbar.js";
@@ -79,62 +78,5 @@ export async function uploadFile(file: File, textarea: HTMLTextAreaElement): Pro
   } catch {
     textarea.value = textarea.value.replace(placeholder, "![Upload failed]()");
     textarea.dispatchEvent(new Event("input", { bubbles: true }));
-  }
-}
-
-export function setupImageUpload(textarea: HTMLTextAreaElement, root: ParentNode): void {
-  // Drag & drop
-  textarea.addEventListener("dragover", (e) => {
-    e.preventDefault();
-    textarea.classList.add("drag-over");
-  });
-
-  textarea.addEventListener("dragleave", () => {
-    textarea.classList.remove("drag-over");
-  });
-
-  textarea.addEventListener("drop", (e) => {
-    e.preventDefault();
-    textarea.classList.remove("drag-over");
-    const files = e.dataTransfer?.files;
-    if (!files) return;
-    for (const file of files) {
-      if (file.type.startsWith("image/")) {
-        uploadFile(file, textarea);
-      }
-    }
-  });
-
-  // Paste from clipboard
-  textarea.addEventListener("paste", (e) => {
-    const items = e.clipboardData?.items;
-    if (!items) return;
-    for (const item of items) {
-      if (item.type.startsWith("image/")) {
-        e.preventDefault();
-        const file = item.getAsFile();
-        if (file) uploadFile(file, textarea);
-        return;
-      }
-    }
-  });
-
-  // Toolbar image button — open file picker
-  const imageBtn = root.querySelector("[data-action='image']") as HTMLElement;
-  if (imageBtn) {
-    imageBtn.onclick = (e) => {
-      e.stopImmediatePropagation(); // prevent toolbar handler
-      const input = document.createElement("input");
-      input.type = "file";
-      input.accept = "image/*";
-      input.multiple = true;
-      input.addEventListener("change", () => {
-        if (!input.files) return;
-        for (const file of input.files) {
-          uploadFile(file, textarea);
-        }
-      });
-      input.click();
-    };
   }
 }


### PR DESCRIPTION
Closes #265
Parent: #260
Depends on: #267 (Phase 1)

## Summary

- Migrate upload drag/drop/paste from `setupImageUpload()` to declarative template bindings on textarea
- Migrate publish/unpublish/export from `setupPublish()` to declarative `@action`/`@select` bindings on dropdown-split
- Image toolbar button now opens file picker via `_openImageFilePicker()` instead of overriding onclick

## Changes

| File | Change |
|------|--------|
| `editor-page.ts` | +`@dragover`/`@dragleave`/`@drop`/`@paste` on textarea, +`@action` on publish split, +`@select` on unpublish/export items, +`_openImageFilePicker`, +`_onPublishAction`/`_onUnpublish`/`_onExport` |
| `publish.ts` | Removed `setupPublish()`, exported `publishCurrent(el)` / `unpublishCurrent(el)` |
| `upload.ts` | Removed `setupImageUpload()`, kept `uploadFile()` as pure utility export |

## querySelector calls eliminated
~4: publish's `#admin-unpublish-btn` and `#admin-export-btn`, upload's `[data-action='image']`, editor-page's `setupPublish`/`setupImageUpload` calls removed from firstUpdated

## Verification
- `tsc --noEmit` clean on `apps/blog`