### PR TITLE
refactor(blog): migrate loading-bounce to Lit

### DIFF
--- a/apps/blog/src/components/loading-bounce.ts
+++ b/apps/blog/src/components/loading-bounce.ts
@@ -1,50 +1,50 @@
 /**
  * <loading-bounce> — Bouncy favicon loading indicator.
- * Vanilla Web Component (no Lit) — works in both admin Lit pages and light DOM editor.
+ * Lit component — works in both admin Lit pages and public pages.
  */
 
-const STYLES = /* css */ `
-  :host {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex: 1;
-    padding: 48px 24px;
-    min-height: 200px;
-  }
+import { LitElement, html, css } from "lit";
+import { customElement } from "lit/decorators.js";
 
-  .icon {
-    width: var(--loading-bounce-size, 80px);
-    height: var(--loading-bounce-size, 80px);
-    animation: bounce 1s ease-in-out infinite;
-    border-radius: 50%;
-  }
+@customElement("loading-bounce")
+export class LoadingBounce extends LitElement {
+  static styles = css`
+    :host {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex: 1;
+      padding: 48px 24px;
+      min-height: 200px;
+    }
 
-  @keyframes bounce {
-    0%, 100% { transform: translateY(0) scale(1); opacity: 0.7; }
-    50% { transform: translateY(-12px) scale(1.1); opacity: 1; }
-  }
+    .icon {
+      width: var(--loading-bounce-size, 80px);
+      height: var(--loading-bounce-size, 80px);
+      animation: bounce 1s ease-in-out infinite;
+      border-radius: 50%;
+    }
 
-  @media (prefers-reduced-motion: reduce) {
-    .icon { animation-duration: 0.01ms !important; }
-  }
-`;
+    @keyframes bounce {
+      0%,
+      100% {
+        transform: translateY(0) scale(1);
+        opacity: 0.7;
+      }
+      50% {
+        transform: translateY(-12px) scale(1.1);
+        opacity: 1;
+      }
+    }
 
-const sheet = new CSSStyleSheet();
-sheet.replaceSync(STYLES);
+    @media (prefers-reduced-motion: reduce) {
+      .icon {
+        animation-duration: 0.01ms !important;
+      }
+    }
+  `;
 
-export class LoadingBounce extends HTMLElement {
-  constructor() {
-    super();
-    const shadow = this.attachShadow({ mode: "open" });
-    shadow.adoptedStyleSheets = [sheet];
-
-    const img = document.createElement("img");
-    img.className = "icon";
-    img.src = "/favicon.png";
-    img.alt = "Loading";
-    shadow.appendChild(img);
+  protected render(): unknown {
+    return html`<img class="icon" src="/favicon.png" alt="Loading" />`;
   }
 }
-
-customElements.define("loading-bounce", LoadingBounce);


### PR DESCRIPTION
Closes #230

## Summary

Convert `<loading-bounce>` from vanilla Web Component to LitElement. Same visual behavior, same custom element registration — just idiomatic Lit now.

## Changes

| Before | After |
|--------|-------|
| `HTMLElement` + `attachShadow` + `CSSStyleSheet` + imperative DOM | `LitElement` + `static styles` + `render()` |

One file changed: `apps/blog/src/components/loading-bounce.ts`

## Verification
- `tsc --noEmit` clean