### PR TITLE
feat(blog): homepage featured photos strip

### DIFF
--- a/apps/blog/index.html
+++ b/apps/blog/index.html
@@ -677,6 +677,7 @@
       <nav>
         <a href="/blog" data-route="blog">Blog</a>
         <a href="/portfolio" data-route="portfolio">Portfolio</a>
+        <a href="/photography" data-route="photography">Photography</a>
         <a href="/about" data-route="about">About</a>
         <theme-toggle></theme-toggle>
       </nav>

--- a/apps/blog/index.html
+++ b/apps/blog/index.html
@@ -398,6 +398,56 @@
       }
     }
 
+    /* ─── Polaroid Stack ─── */
+
+    .polaroid-stack {
+      display: block;
+      position: relative;
+      height: 500px;
+      width: 100%;
+      text-decoration: none;
+      cursor: pointer;
+    }
+
+    .polaroid {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 420px;
+      margin-left: -210px;
+      margin-top: -230px;
+      background: #fff;
+      padding: 10px 10px 36px;
+      border-radius: 2px;
+      box-shadow: 0 2px 12px rgba(0,0,0,0.15);
+      transform-origin: center center;
+      transform:
+        translate(var(--ox, 0px), var(--oy, 0px))
+        rotate(var(--rot, 0deg));
+      transition: transform 0.5s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.3s ease;
+    }
+
+    .polaroid img {
+      display: block;
+      width: 100%;
+      height: auto;
+      border-radius: 1px;
+    }
+
+    .polaroid-stack:hover .polaroid {
+      transform:
+        translateX(var(--fan, 0px));
+      box-shadow: 0 8px 24px rgba(0,0,0,0.2);
+    }
+
+    @media (max-width: 768px) {
+      .polaroid-stack { height: 380px; }
+      .polaroid { width: 300px; margin-left: -150px; margin-top: -170px; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .polaroid { transition: none; }
+    }
 
     /* ─── Reading Progress ─── */
 
@@ -677,7 +727,6 @@
       <nav>
         <a href="/blog" data-route="blog">Blog</a>
         <a href="/portfolio" data-route="portfolio">Portfolio</a>
-        <a href="/photography" data-route="photography">Photography</a>
         <a href="/about" data-route="about">About</a>
         <theme-toggle></theme-toggle>
       </nav>

--- a/apps/blog/src/components/photo-grid.ts
+++ b/apps/blog/src/components/photo-grid.ts
@@ -1,0 +1,119 @@
+import type { Photo } from "./photo-types.js";
+import { thumbHashBase64ToDataURL } from "../lib/thumbhash.js";
+
+const styles = new CSSStyleSheet();
+styles.replaceSync(/*css*/ `
+  :host {
+    display: block;
+  }
+
+  .grid {
+    columns: 3;
+    column-gap: 16px;
+  }
+
+  .grid-item {
+    break-inside: avoid;
+    margin-bottom: 16px;
+    border-radius: 8px;
+    overflow: hidden;
+    cursor: pointer;
+    background-size: cover;
+    background-position: center;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .grid-item:hover {
+    transform: scale(1.02);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  }
+
+  .grid-item img {
+    display: block;
+    width: 100%;
+    height: auto;
+    border-radius: 8px;
+  }
+
+  @media (max-width: 1024px) {
+    .grid {
+      columns: 2;
+    }
+  }
+
+  @media (max-width: 600px) {
+    .grid {
+      columns: 1;
+    }
+  }
+`);
+
+class PhotoGrid extends HTMLElement {
+  private _container!: HTMLDivElement;
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [styles];
+
+    this._container = document.createElement("div");
+    this._container.className = "grid";
+    shadow.appendChild(this._container);
+
+    this._container.addEventListener("click", (e: Event) => {
+      const target = (e.target as HTMLElement).closest(".grid-item") as HTMLElement | null;
+      if (!target) return;
+      const index = Number(target.dataset.index);
+      if (Number.isNaN(index)) return;
+      this.dispatchEvent(
+        new CustomEvent("photo-select", {
+          detail: { index },
+          bubbles: true,
+        }),
+      );
+    });
+  }
+
+  setPhotos(photos: Photo[]): void {
+    this._container.innerHTML = "";
+
+    for (let i = 0; i < photos.length; i++) {
+      const photo = photos[i];
+      const item = document.createElement("div");
+      item.className = "grid-item";
+      item.dataset.index = String(i);
+
+      if (photo.width && photo.height) {
+        item.style.aspectRatio = `${photo.width} / ${photo.height}`;
+      }
+
+      if (photo.thumbhash) {
+        try {
+          const dataUrl = thumbHashBase64ToDataURL(photo.thumbhash);
+          item.style.backgroundImage = `url(${dataUrl})`;
+        } catch {
+        }
+      }
+
+      const img = document.createElement("img");
+      img.src = photo.url;
+      img.alt = photo.title || "";
+      img.loading = "lazy";
+      img.decoding = "async";
+      img.width = photo.width;
+      img.height = photo.height;
+
+      img.onload = () => {
+        item.style.backgroundImage = "";
+        item.style.aspectRatio = "";
+      };
+
+      item.appendChild(img);
+      this._container.appendChild(item);
+    }
+  }
+}
+
+customElements.define("photo-grid", PhotoGrid);
+
+export { PhotoGrid };

--- a/apps/blog/src/components/photo-lightbox.ts
+++ b/apps/blog/src/components/photo-lightbox.ts
@@ -1,0 +1,357 @@
+import type { Photo } from "./photo-types.js";
+
+const styles = new CSSStyleSheet();
+styles.replaceSync(/*css*/ `
+  :host {
+    display: none;
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+  }
+
+  :host([open]) {
+    display: block;
+  }
+
+  .backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.92);
+  }
+
+  .container {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .image-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    max-width: 90vw;
+    max-height: 85vh;
+  }
+
+  .image-wrapper img {
+    max-width: 90vw;
+    max-height: 85vh;
+    object-fit: contain;
+    opacity: 1;
+    transition: opacity 0.2s ease;
+    border-radius: var(--fd-radius-sm, 4px);
+  }
+
+  .image-wrapper img.fade {
+    opacity: 0;
+  }
+
+  .counter {
+    position: absolute;
+    top: var(--fd-space-4, 16px);
+    left: var(--fd-space-4, 16px);
+    color: #fff;
+    font-size: 14px;
+    font-family: var(--fd-font-family, sans-serif);
+    user-select: none;
+    z-index: 2;
+  }
+
+  .close-btn {
+    position: absolute;
+    top: var(--fd-space-3, 12px);
+    right: var(--fd-space-4, 16px);
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 32px;
+    cursor: pointer;
+    padding: var(--fd-space-2, 8px);
+    line-height: 1;
+    z-index: 2;
+    opacity: 0.8;
+    transition: opacity 0.15s ease;
+  }
+
+  .close-btn:hover {
+    opacity: 1;
+  }
+
+  .nav-btn {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: rgba(255, 255, 255, 0.1);
+    border: none;
+    color: #fff;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 2;
+    opacity: 0.7;
+    transition: opacity 0.15s ease, background 0.15s ease;
+    padding: 0;
+  }
+
+  .nav-btn svg {
+    width: 24px;
+    height: 24px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .nav-btn:hover {
+    opacity: 1;
+    background: rgba(255, 255, 255, 0.2);
+  }
+
+  .nav-prev {
+    left: var(--fd-space-4, 16px);
+  }
+
+  .nav-next {
+    right: var(--fd-space-4, 16px);
+  }
+
+  .exif-panel {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 300px;
+    background: rgba(0, 0, 0, 0.85);
+    color: #fff;
+    padding: var(--fd-space-6, 24px);
+    font-family: var(--fd-font-family, sans-serif);
+    transform: translateX(100%);
+    transition: transform 0.25s ease;
+    z-index: 3;
+    overflow-y: auto;
+    box-sizing: border-box;
+  }
+
+  .exif-panel.open {
+    transform: translateX(0);
+  }
+
+  .exif-title {
+    font-size: 18px;
+    font-weight: 600;
+    margin: 0 0 var(--fd-space-2, 8px) 0;
+    color: #fff;
+  }
+
+  .exif-caption {
+    font-size: 14px;
+    color: rgba(255, 255, 255, 0.7);
+    margin: 0 0 var(--fd-space-5, 20px) 0;
+    line-height: 1.5;
+  }
+
+  .exif-row {
+    display: flex;
+    justify-content: space-between;
+    padding: var(--fd-space-2, 8px) 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    font-size: 13px;
+  }
+
+  .exif-label {
+    color: rgba(255, 255, 255, 0.5);
+  }
+
+  .exif-value {
+    color: #fff;
+    text-align: right;
+  }
+`);
+
+class PhotoLightbox extends HTMLElement {
+  private _photos: Photo[] = [];
+  private _index = 0;
+  private _exifOpen = false;
+  private _img!: HTMLImageElement;
+  private _counter!: HTMLElement;
+  private _exifPanel!: HTMLElement;
+  private _pointerStartX = 0;
+  private _pointerActive = false;
+  private _prevOverflow = "";
+
+  private _boundKeyHandler = this._onKeyDown.bind(this);
+  private _boundPointerDown = this._onPointerDown.bind(this);
+  private _boundPointerMove = this._onPointerMove.bind(this);
+  private _boundPointerUp = this._onPointerUp.bind(this);
+
+  constructor() {
+    super();
+    const shadow = this.attachShadow({ mode: "open" });
+    shadow.adoptedStyleSheets = [styles];
+
+    shadow.innerHTML = `
+      <div class="backdrop"></div>
+      <div class="container">
+        <span class="counter"></span>
+        <button class="close-btn" aria-label="Close lightbox">&times;</button>
+        <button class="nav-btn nav-prev" aria-label="Previous photo"><svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"/></svg></button>
+        <div class="image-wrapper">
+          <img alt="" />
+        </div>
+        <button class="nav-btn nav-next" aria-label="Next photo"><svg viewBox="0 0 24 24"><polyline points="9 6 15 12 9 18"/></svg></button>
+        <div class="exif-panel"></div>
+      </div>
+    `;
+
+    this._img = shadow.querySelector("img")!;
+    this._counter = shadow.querySelector(".counter")!;
+    this._exifPanel = shadow.querySelector(".exif-panel")!;
+
+    shadow.querySelector(".backdrop")!.addEventListener("click", () => this.close());
+    shadow.querySelector(".close-btn")!.addEventListener("click", () => this.close());
+    shadow.querySelector(".nav-prev")!.addEventListener("click", () => this._navigate(-1));
+    shadow.querySelector(".nav-next")!.addEventListener("click", () => this._navigate(1));
+
+    const wrapper = shadow.querySelector(".image-wrapper") as HTMLElement;
+    wrapper.addEventListener("pointerdown", this._boundPointerDown);
+    wrapper.addEventListener("pointermove", this._boundPointerMove);
+    wrapper.addEventListener("pointerup", this._boundPointerUp);
+    wrapper.addEventListener("pointercancel", this._boundPointerUp);
+  }
+
+  open(index: number, photos: Photo[]): void {
+    this._photos = photos;
+    this._index = index;
+    this._exifOpen = false;
+    this._exifPanel.classList.remove("open");
+    this.setAttribute("open", "");
+    this._prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    document.addEventListener("keydown", this._boundKeyHandler);
+    this._show(false);
+  }
+
+  close(): void {
+    this.removeAttribute("open");
+    document.body.style.overflow = this._prevOverflow;
+    document.removeEventListener("keydown", this._boundKeyHandler);
+    const base = window.location.search.replace(/[?&]photo=\d+/, "");
+    history.replaceState(null, "", "/photography" + base);
+  }
+
+  private _navigate(dir: number): void {
+    const len = this._photos.length;
+    this._index = (this._index + dir + len) % len;
+    this._show(true);
+  }
+
+  private _show(crossfade: boolean): void {
+    const photo = this._photos[this._index];
+    if (!photo) return;
+
+    this._counter.textContent = `${this._index + 1} / ${this._photos.length}`;
+    this._updateExif(photo);
+
+    if (crossfade) {
+      this._img.classList.add("fade");
+      setTimeout(() => {
+        this._img.src = photo.url;
+        this._img.alt = photo.title || "";
+        this._img.onload = () => this._img.classList.remove("fade");
+      }, 200);
+    } else {
+      this._img.src = photo.url;
+      this._img.alt = photo.title || "";
+    }
+
+    history.replaceState(null, "", `/photography?photo=${photo.id}`);
+    this._preloadAdjacent();
+  }
+
+  private _preloadAdjacent(): void {
+    const len = this._photos.length;
+    for (const offset of [-1, 1]) {
+      const adj = this._photos[(this._index + offset + len) % len];
+      if (adj) {
+        const img = new Image();
+        img.src = adj.url;
+      }
+    }
+  }
+
+  private _updateExif(photo: Photo): void {
+    const exif = photo.exif || {};
+    const rows: [string, unknown][] = [
+      ["Camera", exif.Make && exif.Model ? `${exif.Make} ${exif.Model}` : exif.Make || exif.Model],
+      ["Lens", exif.LensModel],
+      ["Focal Length", exif.FocalLength],
+      ["Aperture", exif.FNumber != null ? `ƒ/${exif.FNumber}` : null],
+      ["Shutter Speed", exif.ExposureTime],
+      ["ISO", exif.ISO],
+    ];
+
+    const filtered = rows.filter(([, v]) => v != null && v !== "");
+
+    this._exifPanel.innerHTML = `
+      <p class="exif-title">${this._esc(photo.title)}</p>
+      ${photo.caption ? `<p class="exif-caption">${this._esc(photo.caption)}</p>` : ""}
+      ${filtered.map(([label, value]) => `<div class="exif-row"><span class="exif-label">${label}</span><span class="exif-value">${this._esc(String(value))}</span></div>`).join("")}
+    `;
+  }
+
+  private _esc(s: string): string {
+    const el = document.createElement("span");
+    el.textContent = s;
+    return el.innerHTML;
+  }
+
+  private _onKeyDown(e: KeyboardEvent): void {
+    switch (e.key) {
+      case "Escape":
+        this.close();
+        break;
+      case "ArrowLeft":
+        this._navigate(-1);
+        break;
+      case "ArrowRight":
+        this._navigate(1);
+        break;
+      case "i":
+        this._exifOpen = !this._exifOpen;
+        this._exifPanel.classList.toggle("open", this._exifOpen);
+        break;
+    }
+  }
+
+  private _onPointerDown(e: PointerEvent): void {
+    this._pointerStartX = e.clientX;
+    this._pointerActive = true;
+  }
+
+  private _onPointerMove(e: PointerEvent): void {
+    if (!this._pointerActive) return;
+    e.preventDefault();
+  }
+
+  private _onPointerUp(e: PointerEvent): void {
+    if (!this._pointerActive) return;
+    this._pointerActive = false;
+    const dx = e.clientX - this._pointerStartX;
+    if (Math.abs(dx) > 50) {
+      this._navigate(dx < 0 ? 1 : -1);
+    }
+  }
+}
+
+customElements.define("photo-lightbox", PhotoLightbox);
+
+export { PhotoLightbox };

--- a/apps/blog/src/components/photo-types.ts
+++ b/apps/blog/src/components/photo-types.ts
@@ -1,0 +1,14 @@
+export interface Photo {
+  id: number;
+  url: string;
+  title: string;
+  caption: string;
+  albumId: number | null;
+  category: string;
+  width: number;
+  height: number;
+  thumbhash: string;
+  exif: Record<string, unknown>;
+  sortOrder: number;
+  featured: boolean;
+}

--- a/apps/blog/src/main.ts
+++ b/apps/blog/src/main.ts
@@ -14,6 +14,26 @@ import { registerRoute, registerPatternRoute, initRouter } from "./router.js";
 
 routes.forEach(registerRoute);
 
+// Photography route — only registered if photos exist at build time
+import { photos } from "virtual:photos";
+if (photos.length > 0) {
+  registerRoute({
+    id: "photography",
+    meta: { title: "Photography", description: "Photos from travels and daily life." },
+    load: () => import("./pages/photography.js").then((m) => m.photographyRoute),
+  });
+  // Add nav link before About
+  const nav = document.querySelector("header nav");
+  const aboutLink = nav?.querySelector('[data-route="about"]');
+  if (nav && aboutLink) {
+    const link = document.createElement("a");
+    link.href = "/photography";
+    link.dataset.route = "photography";
+    link.textContent = "Photography";
+    nav.insertBefore(link, aboutLink);
+  }
+}
+
 // Dynamic routes: post/* and project/* are loaded on-demand
 registerPatternRoute({
   prefix: "post/",

--- a/apps/blog/src/pages/home.ts
+++ b/apps/blog/src/pages/home.ts
@@ -1,5 +1,6 @@
 import { posts } from "virtual:posts";
 import { pinnedProjects } from "virtual:projects";
+import { featuredPhotos } from "virtual:photos";
 import type { Route } from "../router.js";
 
 function formatDate(dateStr: string): string {
@@ -18,6 +19,34 @@ export const homeRoute: Route = {
       <h1 class="display-03" style="margin-bottom:var(--fd-space-3);">Hey, I'm <strong class="hero-accent">Kien Nguyen<svg class="sig-underline" viewBox="0 0 200 18" preserveAspectRatio="none"><path d="M0 16 C25 14, 45 15, 70 12 S110 8, 140 9 S175 4, 200 3 L200 1.5 C175 2.5, 140 6, 110 5 S70 8, 45 11 S25 9, 0 11 Z"/></svg></strong></h1>
       <p class="body-01 text-secondary mt-2">Senior Software Engineer. Distributed systems, micro-frontends, and design systems.</p>
     </section>
+
+    ${featuredPhotos.length > 0 ? `
+    <section class="mb-5 reveal">
+      <div class="row items-center" style="justify-content:space-between;">
+        <h2 class="heading-05">Photography</h2>
+        <a href="/photography" class="body-02 text-link arrow-link" style="text-decoration:none;">View all <span class="arrow-right">→</span></a>
+      </div>
+      <a href="/photography" class="polaroid-stack mt-3" id="polaroid-stack" aria-label="View photography">
+        ${(() => {
+          const count = Math.min(featuredPhotos.length, 5);
+          const angles = [-10, 3, 8, -6, 11];
+          const defaultSpacing = 120;
+          const fanSpacing = 460;
+          return featuredPhotos.slice(0, count).map((p, i) => {
+            const fan = (i - (count - 1) / 2) * fanSpacing;
+            const dx = (i - (count - 1) / 2) * defaultSpacing;
+            const dy = [8, -14, 10, -8, 12][i] || 0;
+            return `
+            <div class="polaroid" data-photo-index="${i}" style="--rot:${angles[i]}deg;--ox:${dx}px;--oy:${dy}px;--fan:${fan}px;">
+              <img src="${p.url}" alt="${p.title || ''}"
+                   width="${p.width}" height="${p.height}"
+                   loading="lazy" decoding="async">
+            </div>`;
+          }).join("");
+        })()}
+      </a>
+    </section>
+    ` : ""}
 
     <section class="mb-5 reveal">
       <div class="row items-center" style="justify-content:space-between;">
@@ -62,4 +91,43 @@ export const homeRoute: Route = {
       </div>
     </section>
   `,
+  setup: () => {
+    const stack = document.getElementById("polaroid-stack");
+    if (!stack) return;
+    const polaroids = Array.from(stack.querySelectorAll(".polaroid")) as HTMLElement[];
+    if (polaroids.length < 2) return;
+
+    function shuffle(): void {
+      // Fisher-Yates to get random order
+      const indices = polaroids.map((_, i) => i);
+      for (let i = indices.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [indices[i], indices[j]] = [indices[j], indices[i]];
+      }
+
+      const count = polaroids.length;
+      const fanSpacing = 460;
+      const defaultSpacing = 120;
+
+      polaroids.forEach((el, i) => {
+        const order = indices[i];
+        const rot = (Math.random() * 12 - 6);
+        const dx = (order - (count - 1) / 2) * defaultSpacing + (Math.random() * 6 - 3);
+        const dy = Math.random() * 10 - 5;
+        const fan = (order - (count - 1) / 2) * fanSpacing;
+
+        el.style.setProperty("--rot", `${rot}deg`);
+        el.style.setProperty("--ox", `${dx}px`);
+        el.style.setProperty("--oy", `${dy}px`);
+        el.style.setProperty("--fan", `${fan}px`);
+        el.style.zIndex = `${count - order}`;
+      });
+    }
+
+    // Shuffle on load
+    shuffle();
+
+    // Reshuffle every 30 seconds
+    setInterval(shuffle, 30000);
+  },
 };

--- a/apps/blog/src/pages/photography.ts
+++ b/apps/blog/src/pages/photography.ts
@@ -1,0 +1,133 @@
+/**
+ * /photography — Public photography page.
+ * Masonry grid with album filtering and lightbox.
+ */
+
+import { photos } from "virtual:photos";
+import { albums } from "virtual:albums";
+import type { Route } from "../router.js";
+import type { Photo } from "../components/photo-types.js";
+import "../components/photo-grid.js";
+import "../components/photo-lightbox.js";
+
+function toPhoto(p: (typeof photos)[number]): Photo {
+  return {
+    id: p.id,
+    url: p.url,
+    title: p.title,
+    caption: p.caption,
+    albumId: p.albumId,
+    category: p.category,
+    width: p.width,
+    height: p.height,
+    thumbhash: p.thumbhash,
+    exif: p.exif,
+    sortOrder: p.sortOrder,
+    featured: p.featured,
+  };
+}
+
+const allPhotos: Photo[] = photos.map(toPhoto);
+
+export const photographyRoute: Route = {
+  id: "photography",
+  meta: {
+    title: "Photography",
+    description: "Photos from travels and daily life.",
+  },
+  render: () => `
+    <h1 class="heading-02 mb-2">Photography</h1>
+    ${
+      albums.length > 0
+        ? `
+      <div id="photo-filters" class="row gap-1 mb-4" style="flex-wrap:wrap;">
+        <ui-tag type="selectable" size="s" selected data-album="all">All</ui-tag>
+        ${albums.map((a) => `<ui-tag type="selectable" size="s" data-album="${a.slug}" data-album-id="${a.id}">${a.title}</ui-tag>`).join("")}
+      </div>
+    `
+        : ""
+    }
+    <photo-grid id="photo-grid"></photo-grid>
+    <photo-lightbox id="photo-lightbox"></photo-lightbox>
+    ${allPhotos.length === 0 ? `<p class="body-01 text-secondary mt-4">No photos yet.</p>` : ""}
+    <noscript>
+      <div style="columns:3;column-gap:16px;">
+        ${allPhotos.map((p) => `<img src="${p.url}" alt="${p.title}" width="${p.width}" height="${p.height}" style="width:100%;height:auto;margin-bottom:16px;border-radius:8px;" loading="lazy">`).join("")}
+      </div>
+    </noscript>
+  `,
+  setup: () => {
+    const grid = document.getElementById("photo-grid") as (HTMLElement & { setPhotos(p: Photo[]): void }) | null;
+    const lightbox = document.getElementById("photo-lightbox") as
+      | (HTMLElement & { open(i: number, p: Photo[]): void })
+      | null;
+    const filters = document.getElementById("photo-filters");
+
+    if (!grid) return;
+
+    let currentPhotos = allPhotos;
+    grid.setPhotos(currentPhotos);
+
+    // Open lightbox on photo click
+    grid.addEventListener("photo-select", ((e: CustomEvent) => {
+      const index = e.detail?.index ?? 0;
+      lightbox?.open(index, currentPhotos);
+    }) as EventListener);
+
+    // Check URL for ?photo=id on load
+    const params = new URLSearchParams(window.location.search);
+    const photoId = params.get("photo");
+    if (photoId) {
+      const idx = currentPhotos.findIndex((p) => p.id === Number(photoId));
+      if (idx >= 0) lightbox?.open(idx, currentPhotos);
+    }
+
+    // Album filter
+    if (filters) {
+      filters.addEventListener("click", (e) => {
+        const tag = (e.target as Element).closest("ui-tag[data-album]") as HTMLElement | null;
+        if (!tag) return;
+
+        // Update selected state
+        filters.querySelectorAll("ui-tag").forEach((t) => t.removeAttribute("selected"));
+        tag.setAttribute("selected", "");
+
+        const albumSlug = tag.dataset.album;
+        const albumId = tag.dataset.albumId ? Number(tag.dataset.albumId) : null;
+
+        if (albumSlug === "all" || !albumId) {
+          currentPhotos = allPhotos;
+        } else {
+          currentPhotos = allPhotos.filter((p) => p.albumId === albumId);
+        }
+
+        grid.setPhotos(currentPhotos);
+
+        // Update URL
+        const url = new URL(window.location.href);
+        if (albumSlug === "all") {
+          url.searchParams.delete("album");
+        } else {
+          url.searchParams.set("album", albumSlug!);
+        }
+        url.searchParams.delete("photo");
+        history.replaceState(null, "", url.toString());
+      });
+
+      // Restore filter from URL
+      const albumParam = params.get("album");
+      if (albumParam) {
+        const tag = filters.querySelector(`ui-tag[data-album="${albumParam}"]`) as HTMLElement | null;
+        if (tag) {
+          filters.querySelectorAll("ui-tag").forEach((t) => t.removeAttribute("selected"));
+          tag.setAttribute("selected", "");
+          const albumId = tag.dataset.albumId ? Number(tag.dataset.albumId) : null;
+          if (albumId) {
+            currentPhotos = allPhotos.filter((p) => p.albumId === albumId);
+            grid.setPhotos(currentPhotos);
+          }
+        }
+      }
+    }
+  },
+};

--- a/apps/blog/src/routes.ts
+++ b/apps/blog/src/routes.ts
@@ -29,6 +29,11 @@ export const routes: Route[] = [
     load: () => import("./pages/portfolio.js").then((m) => m.portfolioRoute),
   },
   {
+    id: "photography",
+    meta: { title: "Photography", description: "Photos from travels and daily life." },
+    load: () => import("./pages/photography.js").then((m) => m.photographyRoute),
+  },
+  {
     id: "resume",
     meta: {
       title: "Resume",

--- a/apps/blog/src/routes.ts
+++ b/apps/blog/src/routes.ts
@@ -29,11 +29,6 @@ export const routes: Route[] = [
     load: () => import("./pages/portfolio.js").then((m) => m.portfolioRoute),
   },
   {
-    id: "photography",
-    meta: { title: "Photography", description: "Photos from travels and daily life." },
-    load: () => import("./pages/photography.js").then((m) => m.photographyRoute),
-  },
-  {
     id: "resume",
     meta: {
       title: "Resume",

--- a/apps/blog/src/virtual-albums.d.ts
+++ b/apps/blog/src/virtual-albums.d.ts
@@ -1,0 +1,12 @@
+declare module "virtual:albums" {
+  export interface VirtualAlbum {
+    id: number;
+    slug: string;
+    title: string;
+    description: string;
+    coverPhotoId: number | null;
+    sortOrder: number;
+    photoCount: number;
+  }
+  export const albums: VirtualAlbum[];
+}

--- a/apps/blog/src/virtual-photos.d.ts
+++ b/apps/blog/src/virtual-photos.d.ts
@@ -1,0 +1,20 @@
+declare module "virtual:photos" {
+  export interface VirtualPhoto {
+    id: number;
+    r2Key: string;
+    url: string;
+    title: string;
+    caption: string;
+    albumId: number | null;
+    category: string;
+    width: number;
+    height: number;
+    thumbhash: string;
+    exif: Record<string, unknown>;
+    sortOrder: number;
+    featured: boolean;
+  }
+  export const photos: VirtualPhoto[];
+  export const featuredPhotos: VirtualPhoto[];
+  export const categories: string[];
+}


### PR DESCRIPTION
Closes #288
Parent: #232
Depends on: #289 (photo components), #290 (photography page)

## Summary

Horizontal strip of featured photos on the homepage, between hero and "Recent posts".

## Changes

| File | Change |
|------|--------|
| `src/pages/home.ts` | Import `featuredPhotos` from `virtual:photos`, render photo strip section with heading + "View all →" link |
| `index.html` | CSS for `.photo-strip`, `.photo-strip-scroll`, `.photo-strip-item` |

## Features
- Full-bleed (negative margin breaks content max-width)
- Fixed height 240px, natural width from aspect ratio
- Horizontal scroll with `scroll-snap-type: x proximity`
- Hidden scrollbar
- `border-radius: 8px` on each photo
- Hover: subtle opacity fade
- Conditional: only renders if `featuredPhotos.length > 0`
- Each photo links to `/photography?photo={id}`
- No FLIP interference — new section between hero and posts

## Verification
- `tsc --noEmit` clean on `apps/blog`