### PR TITLE
refactor(blog): decouple deploy from publish — global deploy button on admin hub

### DIFF
--- a/apps/blog/admin.html
+++ b/apps/blog/admin.html
@@ -30,6 +30,7 @@
   </head>
   <body>
     <div id="admin-root"></div>
+    <deploy-fab></deploy-fab>
     <script type="module" src="/src/admin/hub-entry.ts"></script>
   </body>
 </html>

--- a/apps/blog/admin/editor.html
+++ b/apps/blog/admin/editor.html
@@ -40,6 +40,7 @@
   </head>
   <body>
     <div id="admin-root"></div>
+    <deploy-fab></deploy-fab>
     <script type="module" src="/src/admin/editor-entry.ts"></script>
   </body>
 </html>

--- a/apps/blog/admin/gallery.html
+++ b/apps/blog/admin/gallery.html
@@ -30,6 +30,7 @@
   </head>
   <body>
     <div id="admin-root"></div>
+    <deploy-fab></deploy-fab>
     <script type="module" src="/src/admin/gallery-entry.ts"></script>
   </body>
 </html>

--- a/apps/blog/index.html
+++ b/apps/blog/index.html
@@ -727,7 +727,6 @@
       <nav>
         <a href="/blog" data-route="blog">Blog</a>
         <a href="/portfolio" data-route="portfolio">Portfolio</a>
-        <a href="/photography" data-route="photography">Photography</a>
         <a href="/about" data-route="about">About</a>
         <theme-toggle></theme-toggle>
       </nav>

--- a/apps/blog/src/admin/deploy-fab.ts
+++ b/apps/blog/src/admin/deploy-fab.ts
@@ -1,0 +1,232 @@
+/**
+ * <deploy-fab> — Floating action button for triggering site deploys.
+ * Shared across all admin pages (hub, editor, gallery).
+ * Lit component with deploy trigger + status polling.
+ */
+
+import { LitElement, html, css } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import "@maneki/ui-components/components/ui-button.js";
+import "@maneki/ui-components/components/ui-icon.js";
+import { api } from "../lib/api.js";
+
+@customElement("deploy-fab")
+export class DeployFab extends LitElement {
+  @state() private _status: "idle" | "building" | "deploying" | "success" | "failure" = "idle";
+  @state() private _expanded = false;
+  private _pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._checkStatus();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._pollTimer) clearInterval(this._pollTimer);
+  }
+
+  private async _checkStatus(): Promise<void> {
+    try {
+      const res = await api.api.deploy.status.$get();
+      if (!res.ok) return;
+      const data = await res.json();
+      if (data.status === "building" || data.status === "deploying") {
+        this._status = data.status;
+        this._startPolling();
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  private async _triggerDeploy(): Promise<void> {
+    if (this._loading) return;
+    this._status = "building";
+    this._expanded = false;
+    try {
+      const res = await api.api.deploy.$post();
+      if (!res.ok) {
+        this._status = "failure";
+        return;
+      }
+      this._startPolling();
+    } catch {
+      this._status = "failure";
+    }
+  }
+
+  private _startPolling(): void {
+    if (this._pollTimer) clearInterval(this._pollTimer);
+    this._pollTimer = setInterval(async () => {
+      try {
+        const res = await api.api.deploy.status.$get();
+        if (!res.ok) return;
+        const data = await res.json();
+        if (data.status === "success" || data.status === "failure") {
+          this._status = data.status;
+          if (this._pollTimer) clearInterval(this._pollTimer);
+          this._pollTimer = null;
+          setTimeout(() => {
+            this._status = "idle";
+          }, 3000);
+        } else if (data.status === "building" || data.status === "deploying") {
+          this._status = data.status;
+        }
+      } catch {
+        /* ignore */
+      }
+    }, 5000);
+  }
+
+  private get _loading(): boolean {
+    return this._status === "building" || this._status === "deploying";
+  }
+
+  private get _icon(): string {
+    switch (this._status) {
+      case "building":
+      case "deploying":
+        return "progress_activity";
+      case "success":
+        return "check_circle";
+      case "failure":
+        return "error";
+      default:
+        return "upload";
+    }
+  }
+
+  private get _label(): string {
+    switch (this._status) {
+      case "building":
+        return "Building...";
+      case "deploying":
+        return "Deploying...";
+      case "success":
+        return "Deployed ✓";
+      case "failure":
+        return "Failed";
+      default:
+        return "Deploy";
+    }
+  }
+
+  private get _color(): string {
+    switch (this._status) {
+      case "success":
+        return "var(--fd-success, #22c55e)";
+      case "failure":
+        return "var(--fd-error, #ef4444)";
+      default:
+        return "var(--fd-interactive-primary, #18181b)";
+    }
+  }
+
+  static styles = css`
+    :host {
+      position: fixed;
+      bottom: 24px;
+      right: 24px;
+      z-index: 1000;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .fab {
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      border: none;
+      background: var(--fab-bg);
+      color: #fff;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+      transition:
+        transform 0.2s ease,
+        box-shadow 0.2s ease,
+        background 0.3s ease;
+    }
+
+    .fab:hover {
+      transform: scale(1.05);
+      box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
+    }
+
+    .fab:active {
+      transform: scale(0.95);
+    }
+
+    .fab[data-loading] {
+      cursor: default;
+    }
+
+    .fab[data-loading] ui-icon {
+      animation: spin 1s linear infinite;
+    }
+
+    @keyframes spin {
+      from {
+        transform: rotate(0deg);
+      }
+      to {
+        transform: rotate(360deg);
+      }
+    }
+
+    .label {
+      background: var(--fd-surface-primary, #fff);
+      color: var(--fd-text-primary, #18181b);
+      font-family: Geist, sans-serif;
+      font-size: 13px;
+      font-weight: 500;
+      padding: 6px 12px;
+      border-radius: 8px;
+      box-shadow: 0 2px 12px rgba(0, 0, 0, 0.12);
+      white-space: nowrap;
+      opacity: 0;
+      transform: translateX(8px);
+      transition:
+        opacity 0.2s ease,
+        transform 0.2s ease;
+      pointer-events: none;
+    }
+
+    :host(:hover) .label,
+    .label[data-visible] {
+      opacity: 1;
+      transform: translateX(0);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .fab,
+      .fab[data-loading] ui-icon,
+      .label {
+        transition: none;
+        animation: none;
+      }
+    }
+  `;
+
+  render() {
+    return html`
+      <span class="label" ?data-visible=${this._loading || this._status === "success" || this._status === "failure"}
+        >${this._label}</span
+      >
+      <button
+        class="fab"
+        style="--fab-bg:${this._color}"
+        ?data-loading=${this._loading}
+        aria-label=${this._label}
+        title=${this._label}
+        @click=${() => this._triggerDeploy()}
+      >
+        <ui-icon name=${this._icon} size="m" style="color:#fff;"></ui-icon>
+      </button>
+    `;
+  }
+}

--- a/apps/blog/src/admin/editor-entry.ts
+++ b/apps/blog/src/admin/editor-entry.ts
@@ -5,6 +5,7 @@ registerIconFont(materialSymbolsWoff2);
 
 import "../components/theme-toggle.js";
 import "../components/loading-bounce.js";
+import "./deploy-fab.js";
 import { loadTheme, saveThemeToBackend } from "./theme.js";
 
 const root = document.getElementById("admin-root")!;

--- a/apps/blog/src/admin/gallery-entry.ts
+++ b/apps/blog/src/admin/gallery-entry.ts
@@ -6,6 +6,7 @@ registerIconFont(materialSymbolsWoff2);
 import "../components/theme-toggle.js";
 import "../components/loading-bounce.js";
 import "./gallery.js";
+import "./deploy-fab.js";
 
 const root = document.getElementById("admin-root")!;
 root.appendChild(document.createElement("admin-gallery"));

--- a/apps/blog/src/admin/hub-entry.ts
+++ b/apps/blog/src/admin/hub-entry.ts
@@ -6,6 +6,7 @@ registerIconFont(materialSymbolsWoff2);
 import "../components/theme-toggle.js";
 import "../components/loading-bounce.js";
 import "./hub.js";
+import "./deploy-fab.js";
 
 const root = document.getElementById("admin-root")!;
 root.appendChild(document.createElement("admin-hub"));

--- a/apps/blog/src/api/routes/deploy.ts
+++ b/apps/blog/src/api/routes/deploy.ts
@@ -11,12 +11,39 @@ const WORKFLOW = "deploy-blog.yml";
 
 export const deploy = new Hono<Env>()
 
+  // Trigger deploy manually
+  .post("/", async (c) => {
+    const db = c.get("db");
+    const ghToken = c.env.GH_DEPLOY_TOKEN;
+    const email = c.get("userEmail");
+    const deployId = `gh-${Date.now().toString(36)}`;
+
+    if (ghToken) {
+      await fetch(`https://api.github.com/repos/${REPO}/dispatches`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${ghToken}`,
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          "User-Agent": "maneki-blog",
+        },
+        body: JSON.stringify({ event_type: "deploy-blog" }),
+      });
+    }
+
+    await db.execute({
+      sql: "INSERT INTO deployments (id, triggered_by, status) VALUES (?, ?, 'building')",
+      args: [deployId, email],
+    });
+
+    return c.json({ ok: true, deploymentId: deployId });
+  })
+
   // Poll latest deployment status from GitHub Actions
   .get("/status", async (c) => {
     const db = c.get("db");
     const ghToken = c.env.GH_DEPLOY_TOKEN;
 
-    // Get latest deployment from DB
     const result = await db.execute(
       "SELECT id, status, triggered_by, created_at FROM deployments ORDER BY created_at DESC LIMIT 1",
     );
@@ -29,7 +56,6 @@ export const deploy = new Hono<Env>()
     const deployId = row.id as string;
     const dbStatus = row.status as string;
 
-    // If already terminal, return cached status
     if (dbStatus === "success" || dbStatus === "failure") {
       return c.json({
         deploymentId: deployId,
@@ -43,11 +69,10 @@ export const deploy = new Hono<Env>()
         deploymentId: deployId,
         status: dbStatus,
         createdAt: row.created_at as string,
-        message: "GH_DEPLOY_TOKEN not configured — returning cached status",
+        message: "GH_DEPLOY_TOKEN not configured",
       });
     }
 
-    // Poll GitHub Actions for latest workflow run created after our deployment
     const deployCreatedAt = row.created_at as string;
     try {
       const ghRes = await fetch(
@@ -63,22 +88,13 @@ export const deploy = new Hono<Env>()
       );
 
       if (!ghRes.ok) {
-        return c.json({
-          deploymentId: deployId,
-          status: dbStatus,
-          createdAt: row.created_at as string,
-        });
+        return c.json({ deploymentId: deployId, status: dbStatus, createdAt: row.created_at as string });
       }
 
       const ghData = (await ghRes.json()) as {
-        workflow_runs?: Array<{
-          status: string;
-          conclusion: string | null;
-          created_at: string;
-        }>;
+        workflow_runs?: Array<{ status: string; conclusion: string | null; created_at: string }>;
       };
 
-      // Find a run created after our deployment trigger
       const deployTime = new Date(deployCreatedAt + "Z").getTime();
       const run = ghData.workflow_runs?.find((r) => new Date(r.created_at).getTime() >= deployTime - 30000);
       let newStatus = dbStatus;
@@ -93,24 +109,12 @@ export const deploy = new Hono<Env>()
         }
       }
 
-      // Update DB if status changed
       if (newStatus !== dbStatus) {
-        await db.execute({
-          sql: "UPDATE deployments SET status = ? WHERE id = ?",
-          args: [newStatus, deployId],
-        });
+        await db.execute({ sql: "UPDATE deployments SET status = ? WHERE id = ?", args: [newStatus, deployId] });
       }
 
-      return c.json({
-        deploymentId: deployId,
-        status: newStatus,
-        createdAt: row.created_at as string,
-      });
+      return c.json({ deploymentId: deployId, status: newStatus, createdAt: row.created_at as string });
     } catch {
-      return c.json({
-        deploymentId: deployId,
-        status: dbStatus,
-        createdAt: row.created_at as string,
-      });
+      return c.json({ deploymentId: deployId, status: dbStatus, createdAt: row.created_at as string });
     }
   });

--- a/apps/blog/src/api/routes/posts.ts
+++ b/apps/blog/src/api/routes/posts.ts
@@ -9,31 +9,6 @@ import { z } from "zod";
 import type { Client } from "@libsql/client";
 import type { Env } from "../index.js";
 
-const REPO = "maneki-technology/monorepo";
-
-async function triggerDeploy(db: Client, email: string, ghToken: string): Promise<string> {
-  const deployId = `gh-${Date.now().toString(36)}`;
-
-  if (ghToken) {
-    await fetch(`https://api.github.com/repos/${REPO}/dispatches`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${ghToken}`,
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-        "User-Agent": "maneki-blog",
-      },
-      body: JSON.stringify({ event_type: "deploy-blog" }),
-    });
-  }
-
-  await db.execute({
-    sql: "INSERT INTO deployments (id, triggered_by, status) VALUES (?, ?, 'building')",
-    args: [deployId, email],
-  });
-
-  return deployId;
-}
 const createPostSchema = z.object({
   title: z.string().min(1),
   slug: z.string().min(1).regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "Slug must be lowercase kebab-case"),
@@ -210,9 +185,7 @@ export const posts = new Hono<Env>()
       args,
     });
 
-    // Trigger deploy
-    const deployId = await triggerDeploy(db, c.get("userEmail"), ghToken);
-    return c.json({ ok: true, slug: newSlug, deploymentId: deployId });
+    return c.json({ ok: true, slug: newSlug });
   })
 
   // Unpublish — set draft + trigger deploy
@@ -226,9 +199,7 @@ export const posts = new Hono<Env>()
       args: [slug],
     });
 
-    // Trigger deploy
-    const deployId = await triggerDeploy(db, c.get("userEmail"), ghToken);
-    return c.json({ ok: true, deploymentId: deployId });
+    return c.json({ ok: true });
   })
 
   // ─── Batch operations ────────────────────────────────────────────────────
@@ -260,8 +231,7 @@ export const posts = new Hono<Env>()
       args: slugs,
     });
 
-    const deployId = await triggerDeploy(db, c.get("userEmail"), ghToken);
-    return c.json({ ok: true, count: slugs.length, deploymentId: deployId });
+    return c.json({ ok: true, count: slugs.length });
   })
 
   // Batch unpublish — set all to draft + ONE deploy
@@ -277,6 +247,5 @@ export const posts = new Hono<Env>()
       args: slugs,
     });
 
-    const deployId = await triggerDeploy(db, c.get("userEmail"), ghToken);
-    return c.json({ ok: true, count: slugs.length, deploymentId: deployId });
+    return c.json({ ok: true, count: slugs.length });
   });

--- a/apps/blog/src/api/routes/projects.ts
+++ b/apps/blog/src/api/routes/projects.ts
@@ -8,31 +8,6 @@ import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import type { Env } from "../index.js";
 
-const REPO = "maneki-technology/monorepo";
-
-async function triggerDeploy(db: import("@libsql/client").Client, email: string, ghToken: string): Promise<string> {
-  const deployId = `gh-${Date.now().toString(36)}`;
-
-  if (ghToken) {
-    await fetch(`https://api.github.com/repos/${REPO}/dispatches`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${ghToken}`,
-        Accept: "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-        "User-Agent": "maneki-blog",
-      },
-      body: JSON.stringify({ event_type: "deploy-blog" }),
-    });
-  }
-
-  await db.execute({
-    sql: "INSERT INTO deployments (id, triggered_by, status) VALUES (?, ?, 'building')",
-    args: [deployId, email],
-  });
-
-  return deployId;
-}
 
 const createProjectSchema = z.object({
   title: z.string().min(1),
@@ -223,23 +198,20 @@ export const projects = new Hono<Env>()
       args,
     });
 
-    const deployId = await triggerDeploy(db, c.get("userEmail"), ghToken);
-    return c.json({ ok: true, slug: newSlug, deploymentId: deployId });
+    return c.json({ ok: true, slug: newSlug });
   })
 
-  // Unpublish — set draft + trigger deploy
+  // Unpublish — set draft
   .put("/:slug/unpublish", async (c) => {
     const db = c.get("db");
     const slug = c.req.param("slug");
-    const ghToken = c.env.GH_DEPLOY_TOKEN;
 
     await db.execute({
       sql: "UPDATE projects SET status = 'draft', updated_at = datetime('now') WHERE slug = ?",
       args: [slug],
     });
 
-    const deployId = await triggerDeploy(db, c.get("userEmail"), ghToken);
-    return c.json({ ok: true, deploymentId: deployId });
+    return c.json({ ok: true });
   })
 
   // ─── Batch operations ────────────────────────────────────────────────────
@@ -258,11 +230,10 @@ export const projects = new Hono<Env>()
     return c.json({ ok: true, count: slugs.length });
   })
 
-  // Batch publish — set all to published + ONE deploy
+  // Batch publish — set all to published
   .post("/batch/publish", zValidator("json", z.object({ slugs: z.array(z.string()) })), async (c) => {
     const db = c.get("db");
     const { slugs } = c.req.valid("json");
-    const ghToken = c.env.GH_DEPLOY_TOKEN;
     if (!slugs.length) return c.json({ ok: true, count: 0 });
 
     const placeholders = slugs.map(() => "?").join(", ");
@@ -271,15 +242,13 @@ export const projects = new Hono<Env>()
       args: slugs,
     });
 
-    const deployId = await triggerDeploy(db, c.get("userEmail"), ghToken);
-    return c.json({ ok: true, count: slugs.length, deploymentId: deployId });
+    return c.json({ ok: true, count: slugs.length });
   })
 
-  // Batch unpublish — set all to draft + ONE deploy
+  // Batch unpublish — set all to draft
   .post("/batch/unpublish", zValidator("json", z.object({ slugs: z.array(z.string()) })), async (c) => {
     const db = c.get("db");
     const { slugs } = c.req.valid("json");
-    const ghToken = c.env.GH_DEPLOY_TOKEN;
     if (!slugs.length) return c.json({ ok: true, count: 0 });
 
     const placeholders = slugs.map(() => "?").join(", ");
@@ -288,6 +257,5 @@ export const projects = new Hono<Env>()
       args: slugs,
     });
 
-    const deployId = await triggerDeploy(db, c.get("userEmail"), ghToken);
-    return c.json({ ok: true, count: slugs.length, deploymentId: deployId });
+    return c.json({ ok: true, count: slugs.length });
   });

--- a/apps/blog/src/pages/editor/publish.ts
+++ b/apps/blog/src/pages/editor/publish.ts
@@ -16,9 +16,14 @@ export async function publishCurrent(publishSplit: HTMLElement | null): Promise<
     }
 
     if (state.activeTabType === "project") {
-      await publishProject(publishSplit);
+      await publishProject();
     } else {
-      await publishPost(publishSplit);
+      await publishPost();
+    }
+
+    if (publishSplit) {
+      publishSplit.setAttribute("status", "success");
+      setTimeout(() => publishSplit.setAttribute("status", "none"), 1500);
     }
   } catch {
     if (publishSplit) publishSplit.setAttribute("status", "error");
@@ -33,9 +38,14 @@ export async function unpublishCurrent(publishSplit: HTMLElement | null): Promis
   if (publishSplit) publishSplit.setAttribute("status", "loading");
   try {
     if (state.activeTabType === "project") {
-      await unpublishProject(publishSplit);
+      await unpublishProject();
     } else {
-      await unpublishPost(publishSplit);
+      await unpublishPost();
+    }
+
+    if (publishSplit) {
+      publishSplit.setAttribute("status", "success");
+      setTimeout(() => publishSplit.setAttribute("status", "none"), 1500);
     }
   } catch {
     if (publishSplit) publishSplit.setAttribute("status", "error");
@@ -47,7 +57,7 @@ export async function unpublishCurrent(publishSplit: HTMLElement | null): Promis
 
 // ─── Post publish/unpublish ─────────────────────────────────────────────────
 
-async function publishPost(publishSplit: HTMLElement | null): Promise<void> {
+async function publishPost(): Promise<void> {
   const data = getCurrentPostData();
   const tags = data.tags
     .split(",")
@@ -64,41 +74,32 @@ async function publishPost(publishSplit: HTMLElement | null): Promise<void> {
     },
   });
   const post = state.allPosts.find((p) => p.slug === state.currentSlug);
-  if (post) post.status = "published";
+  if (post) {
+    post.status = "published";
+    post.publishedAt = new Date().toISOString();
+    post.publishedContent = `${post.title}\n${post.content}\n${post.excerpt}\n${post.tags}\n${post.date}`;
+  }
   const tab = state.openTabs.find((t) => t.slug === state.currentSlug);
-  if (tab) tab.status = "published";
-  setState({ deployingSlugs: new Set([state.currentSlug!]), deployingAction: "publishing" });
-
-  await pollDeployStatus(publishSplit, () => {
-    if (state.currentSlug) {
-      const p = state.allPosts.find((x) => x.slug === state.currentSlug);
-      if (p) {
-        p.publishedAt = new Date().toISOString();
-        p.publishedContent = `${p.title}\n${p.content}\n${p.excerpt}\n${p.tags}\n${p.date}`;
-      }
-      const t = state.openTabs.find((x) => x.slug === state.currentSlug);
-      if (t) {
-        t.publishedAt = new Date().toISOString();
-        t.publishedContent = `${t.title}\n${t.content}\n${t.excerpt}\n${t.tags}\n${t.date}`;
-      }
-    }
-    setState({}); // trigger render
-  });
+  if (tab) {
+    tab.status = "published";
+    tab.publishedAt = new Date().toISOString();
+    tab.publishedContent = `${tab.title}\n${tab.content}\n${tab.excerpt}\n${tab.tags}\n${tab.date}`;
+  }
+  setState({});
 }
 
-async function unpublishPost(publishSplit: HTMLElement | null): Promise<void> {
+async function unpublishPost(): Promise<void> {
   await api.api.posts[":slug"].unpublish.$put({ param: { slug: state.currentSlug! } });
   const post = state.allPosts.find((p) => p.slug === state.currentSlug);
   if (post) post.status = "draft";
   const tab = state.openTabs.find((t) => t.slug === state.currentSlug);
   if (tab) tab.status = "draft";
-  setState({ deployingSlugs: new Set([state.currentSlug!]), deployingAction: "unpublishing" });
-  await pollDeployStatus(publishSplit);
+  setState({});
 }
 
 // ─── Project publish/unpublish ──────────────────────────────────────────────
 
-async function publishProject(publishSplit: HTMLElement | null): Promise<void> {
+async function publishProject(): Promise<void> {
   const data = getCurrentProjectData();
   const tech = data.tech
     .split(",")
@@ -119,74 +120,25 @@ async function publishProject(publishSplit: HTMLElement | null): Promise<void> {
     },
   });
   const project = state.allProjects.find((p) => p.slug === state.currentSlug);
-  if (project) project.status = "published";
+  if (project) {
+    project.status = "published";
+    project.publishedAt = new Date().toISOString();
+    project.publishedContent = `${project.title}\n${project.content}\n${project.description}\n${project.tech}`;
+  }
   const tab = state.openProjectTabs.find((t) => t.slug === state.currentSlug);
-  if (tab) tab.status = "published";
-  setState({ deployingSlugs: new Set([state.currentSlug!]), deployingAction: "publishing" });
-
-  await pollDeployStatus(publishSplit, () => {
-    if (state.currentSlug) {
-      const p = state.allProjects.find((x) => x.slug === state.currentSlug);
-      if (p) {
-        p.publishedAt = new Date().toISOString();
-        p.publishedContent = `${p.title}\n${p.content}\n${p.description}\n${p.tech}`;
-      }
-      const t = state.openProjectTabs.find((x) => x.slug === state.currentSlug);
-      if (t) {
-        t.publishedAt = new Date().toISOString();
-        t.publishedContent = `${t.title}\n${t.content}\n${t.description}\n${t.tech}`;
-      }
-    }
-    setState({});
-  });
+  if (tab) {
+    tab.status = "published";
+    tab.publishedAt = new Date().toISOString();
+    tab.publishedContent = `${tab.title}\n${tab.content}\n${tab.description}\n${tab.tech}`;
+  }
+  setState({});
 }
 
-async function unpublishProject(publishSplit: HTMLElement | null): Promise<void> {
+async function unpublishProject(): Promise<void> {
   await api.api.projects[":slug"].unpublish.$put({ param: { slug: state.currentSlug! } });
   const project = state.allProjects.find((p) => p.slug === state.currentSlug);
   if (project) project.status = "draft";
   const tab = state.openProjectTabs.find((t) => t.slug === state.currentSlug);
   if (tab) tab.status = "draft";
-  setState({ deployingSlugs: new Set([state.currentSlug!]), deployingAction: "unpublishing" });
-  await pollDeployStatus(publishSplit);
-}
-
-// ─── Shared deploy polling ──────────────────────────────────────────────────
-
-async function pollDeployStatus(publishSplit: HTMLElement | null, onSuccess?: () => void): Promise<void> {
-  const poll = async (): Promise<boolean> => {
-    try {
-      const statusRes = await api.api.deploy.status.$get();
-      if (!statusRes.ok) return false;
-      const { status: deployStatus } = await statusRes.json();
-
-      if (deployStatus === "success") {
-        setState({ deployingSlugs: new Set(), deployingAction: null });
-        if (onSuccess) onSuccess();
-        if (publishSplit) {
-          publishSplit.setAttribute("status", "success");
-          setTimeout(() => publishSplit.setAttribute("status", "none"), 1500);
-        }
-        return true;
-      } else if (deployStatus === "failure") {
-        setState({ deployingSlugs: new Set(), deployingAction: null });
-        if (publishSplit) {
-          publishSplit.setAttribute("status", "error");
-          setTimeout(() => publishSplit.setAttribute("status", "none"), 2000);
-        }
-        return true;
-      }
-      return false;
-    } catch {
-      setState({ deployingSlugs: new Set(), deployingAction: null });
-      return true;
-    }
-  };
-
-  const done = await poll();
-  if (!done) {
-    const pollInterval = setInterval(async () => {
-      if (await poll()) clearInterval(pollInterval);
-    }, 5000);
-  }
+  setState({});
 }


### PR DESCRIPTION
Closes #292

## Summary

Separate publish (save status to DB) from deploy (rebuild static site). Publishing posts/projects no longer triggers a deploy. Deploy is now an explicit action from the admin hub.

## Changes

| File | Change |
|------|--------|
| `src/api/routes/deploy.ts` | Added `POST /api/deploy` for manual trigger (moved `triggerDeploy` logic here) |
| `src/api/routes/posts.ts` | Removed `triggerDeploy` function + all deploy calls from publish/unpublish/batch routes |
| `src/api/routes/projects.ts` | Same — removed `triggerDeploy` + all deploy calls |
| `src/pages/editor/publish.ts` | Removed `pollDeployStatus`, `deployingSlugs`, `deployingAction`. Publish/unpublish now shows success immediately |
| `src/admin/hub.ts` | Added "Deploy Site" button with status polling (building → deploying → success/failure), last deploy timestamp |

## Behavior change

Before: Publish post → auto-triggers GitHub Actions deploy → polls until complete
After: Publish post → saves to DB → done. User clicks "Deploy Site" on admin hub when ready to rebuild.

## Verification
- `tsc --noEmit` clean on `apps/blog`