### PR TITLE
fix(blog): atomic slug rename for draft posts

### DIFF
--- a/apps/blog/src/api/routes/posts.ts
+++ b/apps/blog/src/api/routes/posts.ts
@@ -26,6 +26,7 @@ const updatePostSchema = z.object({
   tags: z.array(z.string()).optional(),
   status: z.enum(["draft", "published"]).optional(),
   date: z.string().optional(),
+  new_slug: z.string().min(1).regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "Slug must be lowercase kebab-case").optional(),
 });
 
 export const posts = new Hono<Env>()
@@ -120,6 +121,13 @@ export const posts = new Hono<Env>()
       setClauses.push("created_at = ?");
       args.push(updates.date);
     }
+    // Atomic slug rename — single UPDATE instead of DELETE + CREATE
+    let newSlug = slug;
+    if (updates.new_slug !== undefined && updates.new_slug !== slug) {
+      setClauses.push("slug = ?");
+      args.push(updates.new_slug);
+      newSlug = updates.new_slug;
+    }
 
     if (setClauses.length === 0) {
       return c.json({ error: "no fields to update" }, 400);
@@ -134,13 +142,13 @@ export const posts = new Hono<Env>()
     });
     const result = await db.execute({
       sql: "SELECT * FROM posts WHERE slug = ?",
-      args: [slug],
+      args: [newSlug],
     });
     const post = {
       ...result.rows[0],
       tags: JSON.parse((result.rows[0].tags as string) || "[]"),
     };
-    return c.json({ ok: true, post });
+    return c.json({ ok: true, slug: newSlug, post });
   })
 
   // Soft delete post by slug

--- a/apps/blog/src/pages/editor/api.ts
+++ b/apps/blog/src/pages/editor/api.ts
@@ -54,21 +54,22 @@ export async function savePost(post: Post): Promise<{ slug: string; saved: Post 
     });
 
     if (post.persisted) {
-      // Draft with changed title → delete old slug, create with new slug
-      if (post.status === "draft" && newSlug !== slug) {
-        await api.api.posts[":slug"].$delete({ param: { slug } });
-        const res = await api.api.posts.$post({
-          json: { title: post.title || "Untitled", slug: newSlug, body_md: post.content, excerpt: post.excerpt, tags, status: post.status as "draft" | "published", date: post.date },
-        });
-        const data = await res.json() as { post: Record<string, unknown> };
-        return { slug: newSlug, saved: mapPost(data.post) };
-      }
+      // Use PUT with new_slug for atomic rename (no DELETE + CREATE)
       const res = await api.api.posts[":slug"].$put({
         param: { slug },
-        json: { title: post.title || "Untitled", body_md: post.content, excerpt: post.excerpt, tags, status: post.status as "draft" | "published", date: post.date },
+        json: {
+          title: post.title || "Untitled",
+          body_md: post.content,
+          excerpt: post.excerpt,
+          tags,
+          status: post.status as "draft" | "published",
+          date: post.date,
+          ...(newSlug !== slug ? { new_slug: newSlug } : {}),
+        },
       });
-      const data = await res.json() as { post: Record<string, unknown> };
-      return { slug, saved: mapPost(data.post) };
+      const data = await res.json() as { post: Record<string, unknown>; slug?: string };
+      const savedSlug = (data.slug as string) || slug;
+      return { slug: savedSlug, saved: mapPost(data.post) };
     }
 
     const res = await api.api.posts.$post({


### PR DESCRIPTION
Closes #266

## Problem

When saving a draft post whose title changed, the editor did DELETE + CREATE — non-atomic. If DELETE succeeds but CREATE fails, the post is lost.

## Fix

- Added `new_slug` field to `updatePostSchema` in `PUT /api/posts/:slug`
- Backend renames slug atomically in a single SQL UPDATE
- Frontend uses `PUT` with `new_slug` instead of `DELETE` + `POST`

## Changes

| File | Change |
|------|--------|
| `src/api/routes/posts.ts` | Added `new_slug` to update schema, `SET slug = ?` in UPDATE, return `newSlug` |
| `src/pages/editor/api.ts` | Replaced DELETE+CREATE with single PUT containing `new_slug` |

## Verification
- `tsc --noEmit` clean on `apps/blog`