### PR TITLE
refactor(blog): replace setAttribute('status') pattern with reactive @state()

### DIFF
--- a/apps/blog/src/pages/editor/api.ts
+++ b/apps/blog/src/pages/editor/api.ts
@@ -241,10 +241,9 @@ export function getCurrentPostData(): Omit<
   return _editorPage!.getPostData();
 }
 
-export async function saveCurrent(_forceApi = false, statusEl?: HTMLElement | null): Promise<boolean> {
-  if (state.saving) return false;
+export async function saveCurrent(_forceApi = false): Promise<"success" | "error"> {
+  if (state.saving) return "error";
   setState({ saving: true });
-  if (statusEl) statusEl.setAttribute("status", "loading");
   try {
     const currentPost = state.allPosts.find((p) => p.slug === state.currentSlug);
     const data = getCurrentPostData();
@@ -271,17 +270,9 @@ export async function saveCurrent(_forceApi = false, statusEl?: HTMLElement | nu
       setState({ allPosts: newAllPosts, openTabs: newOpenTabs, currentSlug: slug });
       _editorPage?.loadPost(saved);
       saveUIState();
-      if (statusEl) {
-        statusEl.setAttribute("status", "success");
-        setTimeout(() => statusEl.setAttribute("status", "none"), 1500);
-      }
-      return true;
+      return "success";
     }
-    if (statusEl) {
-      statusEl.setAttribute("status", "error");
-      setTimeout(() => statusEl.setAttribute("status", "none"), 2000);
-    }
-    return false;
+    return "error";
   } finally {
     setState({ saving: false });
   }
@@ -341,10 +332,9 @@ export function getCurrentProjectData(): Omit<
   return _editorPage!.getProjectData();
 }
 
-export async function saveCurrentProject(_forceApi = false, statusEl?: HTMLElement | null): Promise<boolean> {
-  if (state.saving) return false;
+export async function saveCurrentProject(_forceApi = false): Promise<"success" | "error"> {
+  if (state.saving) return "error";
   setState({ saving: true });
-  if (statusEl) statusEl.setAttribute("status", "loading");
   try {
     const currentProject = state.allProjects.find((p) => p.slug === state.currentSlug);
     const data = getCurrentProjectData();
@@ -371,17 +361,9 @@ export async function saveCurrentProject(_forceApi = false, statusEl?: HTMLEleme
       setState({ allProjects: newAllProjects, openProjectTabs: newOpenProjectTabs, currentSlug: slug });
       _editorPage?.loadProject(saved);
       saveUIState();
-      if (statusEl) {
-        statusEl.setAttribute("status", "success");
-        setTimeout(() => statusEl.setAttribute("status", "none"), 1500);
-      }
-      return true;
+      return "success";
     }
-    if (statusEl) {
-      statusEl.setAttribute("status", "error");
-      setTimeout(() => statusEl.setAttribute("status", "none"), 2000);
-    }
-    return false;
+    return "error";
   } finally {
     setState({ saving: false });
   }

--- a/apps/blog/src/pages/editor/editor-page.ts
+++ b/apps/blog/src/pages/editor/editor-page.ts
@@ -49,8 +49,7 @@ export class EditorPage extends LitElement {
 
   // ─── Element refs ──────────────────────────────────────────────────────────
   private _textareaRef: Ref<HTMLTextAreaElement> = createRef();
-  private _saveBtnRef: Ref<HTMLElement> = createRef();
-  private _publishSplitRef: Ref<HTMLElement> = createRef();
+
   private _galleryRef: Ref<HTMLElement & { show(cb?: (url: string, name: string) => void): void; hide(): void; toggle(): void }> = createRef();
   private _deleteModalRef: Ref<HTMLElement & { show(): void }> = createRef();
   private _previewRef: Ref<HTMLElement> = createRef();
@@ -75,6 +74,10 @@ export class EditorPage extends LitElement {
   @litState() projectRepo = "";
   @litState() projectImage = "";
   @litState() projectPinned = false;
+
+  // ─── Button status (reactive) ──────────────────────────────────────────
+  @litState() private _saveStatus = "none";
+  @litState() private _publishStatus = "none";
 
   static styles = css`
     .admin-layout { display: flex; height: 100vh; overflow: hidden; }
@@ -286,8 +289,8 @@ export class EditorPage extends LitElement {
               <span style="flex:1"></span>
               <ui-button id="admin-preview-btn" action="secondary" emphasis="subtle" size="s" @click=${this._openFullscreenPreview}>Preview</ui-button>
               <ui-button id="admin-portfolio-btn" action="secondary" emphasis="subtle" size="s" style="display:${s.activeTabType === "project" ? "" : "none"}" @click=${openPortfolioLayout}>Portfolio</ui-button>
-              <ui-button id="admin-save-btn" ${ref(this._saveBtnRef)} action="primary" size="s" ?disabled=${s.deployingSlugs.size > 0} @click=${() => this._onSave()}>Save</ui-button>
-              <ui-dropdown-split id="admin-publish-split" ${ref(this._publishSplitRef)} action="primary" size="s" label="Publish" ?disabled=${s.deployingSlugs.size > 0} @action=${this._onPublishAction}>
+              <ui-button id="admin-save-btn" action="primary" size="s" status=${this._saveStatus} ?disabled=${s.deployingSlugs.size > 0} @click=${() => this._onSave()}>Save</ui-button>
+              <ui-dropdown-split id="admin-publish-split" action="primary" size="s" label="Publish" status=${this._publishStatus} ?disabled=${s.deployingSlugs.size > 0} @action=${this._onPublishAction}>
                 <ui-dropdown-item id="admin-unpublish-btn" value="unpublish" @select=${this._onUnpublish}>Unpublish</ui-dropdown-item>
                 <ui-dropdown-item id="admin-export-btn" value="export" @select=${this._onExport}>Export .md</ui-dropdown-item>
               </ui-dropdown-split>
@@ -329,8 +332,6 @@ export class EditorPage extends LitElement {
     setProjectPreviewRoot(root);
 
     const textarea = this._textareaRef.value!;
-    const publishSplit = this._publishSplitRef.value ?? null;
-
 
     // Plugins
     setupContextMenu(textarea);
@@ -608,12 +609,7 @@ export class EditorPage extends LitElement {
   private _onDocumentKeydown = (e: KeyboardEvent): void => {
     if ((e.metaKey || e.ctrlKey) && e.key === "s") {
       e.preventDefault();
-      const saveBtn = this._saveBtnRef.value ?? null;
-      if (state.activeTabType === "project") {
-        saveCurrentProject(true, saveBtn);
-      } else {
-        saveCurrent(true, saveBtn);
-      }
+      this._onSave();
     }
   };
 
@@ -684,13 +680,17 @@ export class EditorPage extends LitElement {
 
   // ─── Publish/unpublish/export (replaces setupPublish) ─────────────────────
   private async _onPublishAction(): Promise<void> {
-    const el = this._publishSplitRef.value ?? null;
-    await publishCurrent(el);
+    this._publishStatus = "loading";
+    const result = await publishCurrent();
+    this._publishStatus = result;
+    setTimeout(() => { this._publishStatus = "none"; }, result === "success" ? 1500 : 2000);
   }
 
   private async _onUnpublish(): Promise<void> {
-    const el = this._publishSplitRef.value ?? null;
-    await unpublishCurrent(el);
+    this._publishStatus = "loading";
+    const result = await unpublishCurrent();
+    this._publishStatus = result;
+    setTimeout(() => { this._publishStatus = "none"; }, result === "success" ? 1500 : 2000);
   }
   private _onExport(): void {
     exportAsMarkdown();
@@ -769,11 +769,10 @@ export class EditorPage extends LitElement {
     setState({});
     if (this._autoSaveTimer) clearTimeout(this._autoSaveTimer);
     this._autoSaveTimer = setTimeout(() => {
-      const saveBtn = this._saveBtnRef.value ?? null;
       if (state.activeTabType === "project") {
-        if (state.currentSlug) saveCurrentProject(false, saveBtn);
+        if (state.currentSlug) this._doSave(false);
       } else {
-        if (state.currentSlug || this.postContent.trim()) saveCurrent(false, saveBtn);
+        if (state.currentSlug || this.postContent.trim()) this._doSave(false);
       }
     }, 2000);
   }
@@ -902,12 +901,16 @@ export class EditorPage extends LitElement {
         }, 100);
       });
     }
-    const saveBtn = this._saveBtnRef.value ?? null;
-    if (state.activeTabType === "project") {
-      saveCurrentProject(true, saveBtn);
-    } else {
-      saveCurrent(true, saveBtn);
-    }
+    this._doSave(true);
+  }
+
+  private async _doSave(forceApi: boolean): Promise<void> {
+    this._saveStatus = "loading";
+    const result = state.activeTabType === "project"
+      ? await saveCurrentProject(forceApi)
+      : await saveCurrent(forceApi);
+    this._saveStatus = result;
+    setTimeout(() => { this._saveStatus = "none"; }, result === "success" ? 1500 : 2000);
   }
 
   // ─── Project image helpers ───────────────────────────────────────────────────

--- a/apps/blog/src/pages/editor/publish.ts
+++ b/apps/blog/src/pages/editor/publish.ts
@@ -4,15 +4,10 @@ import { getCurrentPostData, getCurrentProjectData } from "./api.js";
 
 // ─── Public API (called by editor-page event handlers) ───────────────────────
 
-export async function publishCurrent(publishSplit: HTMLElement | null): Promise<void> {
-  if (publishSplit) publishSplit.setAttribute("status", "loading");
+export async function publishCurrent(): Promise<"success" | "error"> {
   try {
     if (!state.currentSlug) {
-      if (publishSplit) publishSplit.setAttribute("status", "error");
-      setTimeout(() => {
-        if (publishSplit) publishSplit.setAttribute("status", "none");
-      }, 2000);
-      return;
+      return "error";
     }
 
     if (state.activeTabType === "project") {
@@ -21,21 +16,14 @@ export async function publishCurrent(publishSplit: HTMLElement | null): Promise<
       await publishPost();
     }
 
-    if (publishSplit) {
-      publishSplit.setAttribute("status", "success");
-      setTimeout(() => publishSplit.setAttribute("status", "none"), 1500);
-    }
+    return "success";
   } catch {
-    if (publishSplit) publishSplit.setAttribute("status", "error");
-    setTimeout(() => {
-      if (publishSplit) publishSplit.setAttribute("status", "none");
-    }, 2000);
+    return "error";
   }
 }
 
-export async function unpublishCurrent(publishSplit: HTMLElement | null): Promise<void> {
-  if (!state.currentSlug) return;
-  if (publishSplit) publishSplit.setAttribute("status", "loading");
+export async function unpublishCurrent(): Promise<"success" | "error"> {
+  if (!state.currentSlug) return "error";
   try {
     if (state.activeTabType === "project") {
       await unpublishProject();
@@ -43,15 +31,9 @@ export async function unpublishCurrent(publishSplit: HTMLElement | null): Promis
       await unpublishPost();
     }
 
-    if (publishSplit) {
-      publishSplit.setAttribute("status", "success");
-      setTimeout(() => publishSplit.setAttribute("status", "none"), 1500);
-    }
+    return "success";
   } catch {
-    if (publishSplit) publishSplit.setAttribute("status", "error");
-    setTimeout(() => {
-      if (publishSplit) publishSplit.setAttribute("status", "none");
-    }, 2000);
+    return "error";
   }
 }
 

--- a/apps/blog/src/pages/editor/sidebar.ts
+++ b/apps/blog/src/pages/editor/sidebar.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, nothing } from "lit";
-import { customElement } from "lit/decorators.js";
+import { customElement, state as litState } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
 import { api } from "../../lib/api.js";
 import { state, setState, hasUnpublishedChanges } from "./state.js";
@@ -31,6 +31,11 @@ function ensureSidebarStyles(): void {
 @customElement("editor-sidebar")
 export class EditorSidebar extends LitElement {
   private store = new EditorStoreController(this);
+
+  // ─── Bulk action status (reactive) ─────────────────────────────────────────
+  @litState() private _bulkDeleteStatus = "none";
+  @litState() private _bulkPublishStatus = "none";
+  @litState() private _bulkUnpublishStatus = "none";
 
   createRenderRoot(): this {
     this.style.display = "contents";
@@ -244,6 +249,7 @@ export class EditorSidebar extends LitElement {
               size="s"
               icon="icon-only"
               aria-label="Delete selected"
+              status=${this._bulkDeleteStatus}
               @click=${() => this.handleBulkDelete(isProject)}
             >
               <ui-icon
@@ -259,6 +265,7 @@ export class EditorSidebar extends LitElement {
               size="s"
               icon="icon-only"
               aria-label="Publish selected"
+              status=${this._bulkPublishStatus}
               @click=${() => this.handleBulkPublish(isProject)}
             >
               <ui-icon
@@ -274,6 +281,7 @@ export class EditorSidebar extends LitElement {
               size="s"
               icon="icon-only"
               aria-label="Unpublish selected"
+              status=${this._bulkUnpublishStatus}
               @click=${() => this.handleBulkUnpublish(isProject)}
             >
               <ui-icon name="download" size="s" slot="icon-start"></ui-icon>
@@ -334,8 +342,7 @@ export class EditorSidebar extends LitElement {
 
   private async handleBulkDelete(isProject: boolean): Promise<void> {
     const slugs = [...state.selectedSlugs];
-    const btn = this.querySelector("#admin-bulk-actions ui-button[aria-label='Delete selected']") as HTMLElement | null;
-    if (btn) btn.setAttribute("status", "loading");
+    this._bulkDeleteStatus = "loading";
     try {
       if (isProject) {
         await api.api.projects.batch.delete.$post({ json: { slugs } });
@@ -359,19 +366,14 @@ export class EditorSidebar extends LitElement {
         });
       }
     } catch {
-      if (btn) {
-        btn.setAttribute("status", "error");
-        setTimeout(() => btn.setAttribute("status", "none"), 2000);
-      }
+      this._bulkDeleteStatus = "error";
+      setTimeout(() => { this._bulkDeleteStatus = "none"; }, 2000);
     }
   }
 
   private async handleBulkPublish(isProject: boolean): Promise<void> {
     const slugs = [...state.selectedSlugs];
-    const btn = this.querySelector(
-      "#admin-bulk-actions ui-button[aria-label='Publish selected']",
-    ) as HTMLElement | null;
-    if (btn) btn.setAttribute("status", "loading");
+    this._bulkPublishStatus = "loading";
     try {
       if (isProject) {
         await api.api.projects.batch.publish.$post({ json: { slugs } });
@@ -393,19 +395,14 @@ export class EditorSidebar extends LitElement {
       setState({ selectedSlugs: new Set(), deployingSlugs: new Set(slugs), deployingAction: "publishing" });
       this.pollDeployStatus();
     } catch {
-      if (btn) {
-        btn.setAttribute("status", "error");
-        setTimeout(() => btn.setAttribute("status", "none"), 2000);
-      }
+      this._bulkPublishStatus = "error";
+      setTimeout(() => { this._bulkPublishStatus = "none"; }, 2000);
     }
   }
 
   private async handleBulkUnpublish(isProject: boolean): Promise<void> {
     const slugs = [...state.selectedSlugs];
-    const btn = this.querySelector(
-      "#admin-bulk-actions ui-button[aria-label='Unpublish selected']",
-    ) as HTMLElement | null;
-    if (btn) btn.setAttribute("status", "loading");
+    this._bulkUnpublishStatus = "loading";
     try {
       if (isProject) {
         await api.api.projects.batch.unpublish.$post({ json: { slugs } });
@@ -421,10 +418,8 @@ export class EditorSidebar extends LitElement {
       setState({ selectedSlugs: new Set(), deployingSlugs: new Set(slugs), deployingAction: "unpublishing" });
       this.pollDeployStatus();
     } catch {
-      if (btn) {
-        btn.setAttribute("status", "error");
-        setTimeout(() => btn.setAttribute("status", "none"), 2000);
-      }
+      this._bulkUnpublishStatus = "error";
+      setTimeout(() => { this._bulkUnpublishStatus = "none"; }, 2000);
     }
   }
 


### PR DESCRIPTION
Closes #278

## Summary

Replace 31 imperative `setAttribute("status", ...)` calls with reactive `@state()` properties bound in Lit templates.

## Changes

| File | Change |
|------|--------|
| `editor-page.ts` | +`_saveStatus`, `_publishStatus` @state, bound to template, `_doSave()` helper |
| `api.ts` | `saveCurrent()`/`saveCurrentProject()` return `"success"\|"error"` instead of mutating DOM |
| `publish.ts` | `publishCurrent()`/`unpublishCurrent()` return status instead of accepting DOM element |
| `sidebar.ts` | +`_bulkDeleteStatus`, `_bulkPublishStatus`, `_bulkUnpublishStatus` @state, bound to bulk buttons |

## Verification
- `tsc --noEmit` clean on `apps/blog`
- 4 files changed, 64 insertions, 102 deletions (net -38 lines)