### PR TITLE
refactor(blog): convert project-preview to Lit component using grid-layout

### DIFF
--- a/.github/workflows/deploy-blog.yml
+++ b/.github/workflows/deploy-blog.yml
@@ -7,6 +7,7 @@ on:
       - 'apps/blog/**'
       - 'packages/ui-components/**'
       - 'packages/foundation/**'
+      - 'packages/grid-layout/**'
       - '.github/workflows/deploy-blog.yml'
   pull_request:
     branches: [main]
@@ -14,6 +15,7 @@ on:
       - 'apps/blog/**'
       - 'packages/ui-components/**'
       - 'packages/foundation/**'
+      - 'packages/grid-layout/**'
       - '.github/workflows/deploy-blog.yml'
   repository_dispatch:
     types: [deploy-blog]
@@ -41,6 +43,10 @@ jobs:
       - name: Build ui-components
         run: npm run build
         working-directory: packages/ui-components
+
+      - name: Build grid-layout
+        run: npm run build
+        working-directory: packages/grid-layout
 
       - name: Build blog
         run: npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
       - 'packages/foundation/**'
       - 'packages/ui-components/**'
       - 'packages/charts/**'
+      - 'packages/grid-layout/**'
       - 'apps/blog/**'
       - 'apps/catalog/**'
       - '.github/workflows/test.yml'
@@ -18,6 +19,7 @@ on:
       - 'packages/foundation/**'
       - 'packages/ui-components/**'
       - 'packages/charts/**'
+      - 'packages/grid-layout/**'
       - 'apps/blog/**'
       - 'apps/catalog/**'
       - '.github/workflows/test.yml'
@@ -52,6 +54,10 @@ jobs:
       - name: Test ui-components
         run: npx vitest --run
         working-directory: packages/ui-components
+
+      - name: Build grid-layout
+        run: npm run build
+        working-directory: packages/grid-layout
 
       - name: Type check blog
         run: npx tsc --noEmit

--- a/apps/blog/moon.yml
+++ b/apps/blog/moon.yml
@@ -5,6 +5,7 @@ language: 'typescript'
 dependsOn:
   - 'foundation'
   - 'ui-components'
+  - 'grid-layout'
 
 tasks:
   dev:

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -16,6 +16,7 @@
     "@hono/zod-validator": "^0.7.6",
     "@libsql/client": "^0.17.2",
     "@maneki/foundation": "*",
+    "@maneki/grid-layout": "*",
     "@maneki/ui-components": "*",
     "exifreader": "^4.38.1",
     "hono": "^4.12.9",

--- a/apps/blog/src/pages/editor/editor-page.ts
+++ b/apps/blog/src/pages/editor/editor-page.ts
@@ -12,7 +12,7 @@ import "./gallery.js";
 import { setupContextMenu } from "./context-menu.js";
 import { setupScrollSync } from "./scroll-sync.js";
 import { setupUndoStack } from "./undo.js";
-import { openPortfolioLayout, setProjectPreviewRoot } from "./project-preview.js";
+import "./project-preview.js";
 import { publishCurrent, unpublishCurrent } from "./publish.js";
 import "./delete-modal.js";
 import { setSidebarRoot } from "./sidebar.js";
@@ -58,6 +58,7 @@ export class EditorPage extends LitElement {
   private _sidebarRef: Ref<HTMLElement> = createRef();
   private _textareaWrapRef: Ref<HTMLElement> = createRef();
   private _previewWrapRef: Ref<HTMLElement> = createRef();
+  private _projectPreviewRef: Ref<HTMLElement & { show(): void; hide(): void }> = createRef();
 
   // ─── Post form fields (reactive) ─────────────────────────────────────────
   @litState() postTitle = "";
@@ -288,7 +289,7 @@ export class EditorPage extends LitElement {
               </ui-button-group>
               <span style="flex:1"></span>
               <ui-button id="admin-preview-btn" action="secondary" emphasis="subtle" size="s" @click=${this._openFullscreenPreview}>Preview</ui-button>
-              <ui-button id="admin-portfolio-btn" action="secondary" emphasis="subtle" size="s" style="display:${s.activeTabType === "project" ? "" : "none"}" @click=${openPortfolioLayout}>Portfolio</ui-button>
+              <ui-button id="admin-portfolio-btn" action="secondary" emphasis="subtle" size="s" style="display:${s.activeTabType === "project" ? "" : "none"}" @click=${() => this._projectPreviewRef.value?.show()}>Portfolio</ui-button>
               <ui-button id="admin-save-btn" action="primary" size="s" status=${this._saveStatus} ?disabled=${s.deployingSlugs.size > 0} @click=${() => this._onSave()}>Save</ui-button>
               <ui-dropdown-split id="admin-publish-split" action="primary" size="s" label="Publish" status=${this._publishStatus} ?disabled=${s.deployingSlugs.size > 0} @action=${this._onPublishAction}>
                 <ui-dropdown-item id="admin-unpublish-btn" value="unpublish" @select=${this._onUnpublish}>Unpublish</ui-dropdown-item>
@@ -315,6 +316,7 @@ export class EditorPage extends LitElement {
             </div>
           <editor-gallery ${ref(this._galleryRef)} .onSelect=${(url: string, name: string) => { const ta = this._textareaRef.value; if (ta) insertAtCursor(ta, `![${name}](${url})`); }}></editor-gallery>
           <editor-delete-modal ${ref(this._deleteModalRef)}></editor-delete-modal>
+          <editor-project-preview ${ref(this._projectPreviewRef)}></editor-project-preview>
           </div>
         </div>
       </div>
@@ -329,7 +331,7 @@ export class EditorPage extends LitElement {
     // Set root references for modules that need them
     setEditorPage(this);
     setSidebarRoot(root);
-    setProjectPreviewRoot(root);
+
 
     const textarea = this._textareaRef.value!;
 

--- a/apps/blog/src/pages/editor/project-preview.ts
+++ b/apps/blog/src/pages/editor/project-preview.ts
@@ -1,174 +1,319 @@
 /**
- * Fullscreen portfolio layout preview with drag-to-reorder + pin toggle.
- * Opened via a separate "Portfolio" button in the toolbar.
+ * <editor-project-preview> — Fullscreen portfolio layout preview.
+ * Uses @maneki/grid-layout for drag-to-reorder project cards.
  */
 
-import { state, setState } from "./state.js";
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { createRef, ref, type Ref } from "lit/directives/ref.js";
+import { repeat } from "lit/directives/repeat.js";
+import { state as editorState, setState } from "./state.js";
 import { api } from "../../lib/api.js";
 import type { Project } from "./types.js";
+import type { Layout, LayoutItem, GridConfig, ResizeConfig } from "@maneki/grid-layout";
+
+import "@maneki/grid-layout";
 import "@maneki/ui-components/components/ui-card.js";
+import "@maneki/ui-components/components/ui-badge.js";
+import "@maneki/ui-components/components/ui-image.js";
+import "@maneki/ui-components/components/ui-button.js";
+import "@maneki/ui-components/components/ui-scrollbar.js";
 
-let overlay: HTMLElement | null = null;
-let _projectPreviewRoot: ParentNode | null = null;
+const COLS = 3;
 
-export function setProjectPreviewRoot(root: ParentNode): void {
-  _projectPreviewRoot = root;
-}
+@customElement("editor-project-preview")
+export class EditorProjectPreview extends LitElement {
+  @state() declare _open: boolean;
+  @state() declare _projects: Project[];
+  private _layout: Layout = [];
 
-function createOverlay(): HTMLElement {
-  const el = document.createElement("div");
-  el.id = "admin-project-preview-overlay";
-  el.className = "admin-preview-overlay";
-  el.style.display = "none";
-
-  el.innerHTML = `
-    <div class="admin-preview-overlay-header">
-      <span class="heading-05">Portfolio Layout</span>
-      <ui-button id="project-preview-close" action="secondary" emphasis="subtle" size="s">Close</ui-button>
-    </div>
-    <ui-scrollbar emphasis="minimal">
-      <div class="admin-preview-overlay-content">
-        <div id="project-preview-grid" style="max-width:900px;margin:0 auto;padding:48px 24px;"></div>
-      </div>
-    </ui-scrollbar>
-  `;
-
-  const closeBtn = el.querySelector("#project-preview-close");
-  if (closeBtn)
-    (closeBtn as HTMLElement).onclick = () => {
-      el.style.display = "none";
-    };
-
-  el.addEventListener("keydown", (e) => {
-    if (e.key === "Escape") el.style.display = "none";
-  });
-
-  return el;
-}
-
-function renderProjectCards(): void {
-  if (!overlay) return;
-  const container = overlay.querySelector("#project-preview-grid") as HTMLElement | null;
-  if (!container) return;
-
-  const published = state.allProjects.filter((p) => p.status !== "deleted");
-  container.innerHTML = "";
-
-  const grid = document.createElement("div");
-  grid.className = "project-preview-sortable";
-
-  for (const project of published) {
-    const card = document.createElement("ui-card") as HTMLElement;
-    card.setAttribute("bordered", "");
-    card.setAttribute("data-slug", project.slug);
-    card.setAttribute("draggable", "true");
-    card.style.cursor = "grab";
-
-    card.innerHTML = `
-      <div class="project-preview-card-header">
-        <span class="heading-05">${project.title || "Untitled"}</span>
-        <span class="pin-toggle" role="button" tabindex="0" aria-label="Pin to homepage" style="cursor:pointer;font-size:16px;opacity:${project.pinned ? "1" : "0.3"};transition:opacity 0.15s;">\uD83D\uDCCC</span>
-      </div>
-      ${project.image ? `<ui-image slot="image" src="${project.image}" alt="${project.title}" style="width:100%;height:100px;--ui-image-fit:cover;--ui-image-bg:var(--fd-surface-secondary);"></ui-image>` : ""}
-      <p class="body-02 text-secondary">${project.description}</p>
-      <div class="tags mt-1">
-        ${project.tech
-          .split(",")
-          .map((t: string) => t.trim())
-          .filter(Boolean)
-          .map((t: string) => `<ui-badge size="xs" emphasis="subtle">${t}</ui-badge>`)
-          .join("")}
-      </div>
-      <div class="project-preview-card-status">
-        <ui-badge size="xs" status="${project.status === "published" ? "success" : "warning"}">${project.status}</ui-badge>
-      </div>
-    `;
-
-    // Pin toggle
-    const pinBtn = card.querySelector(".pin-toggle") as HTMLElement;
-    if (pinBtn) {
-      pinBtn.onclick = async (e) => {
-        e.stopPropagation();
-        const newPinned = !project.pinned;
-        project.pinned = newPinned;
-        pinBtn.style.opacity = newPinned ? "1" : "0.3";
-        try {
-          await api.api.projects[":slug"].$put({
-            param: { slug: project.slug },
-            json: { pinned: newPinned },
-          });
-        } catch {
-          /* ignore */
-        }
-        setState({});
-      };
+  private _gridRef: Ref<
+    HTMLElement & {
+      layout: Layout;
+      gridConfig: GridConfig;
+      resizeConfig: ResizeConfig;
     }
+  > = createRef();
 
-    // Drag events
-    card.addEventListener("dragstart", (e) => {
-      card.classList.add("dragging");
-      e.dataTransfer!.effectAllowed = "move";
-      e.dataTransfer!.setData("text/plain", project.slug);
-    });
-
-    card.addEventListener("dragend", () => {
-      card.classList.remove("dragging");
-    });
-
-    card.addEventListener("dragover", (e) => {
-      e.preventDefault();
-      e.dataTransfer!.dropEffect = "move";
-      const dragging = grid.querySelector(".dragging");
-      if (dragging && dragging !== card) {
-        const rect = card.getBoundingClientRect();
-        const midY = rect.top + rect.height / 2;
-        if (e.clientY < midY) {
-          grid.insertBefore(dragging, card);
-        } else {
-          grid.insertBefore(dragging, card.nextSibling);
-        }
-      }
-    });
-
-    grid.appendChild(card);
+  constructor() {
+    super();
+    this._open = false;
+    this._projects = [];
   }
 
-  // Save order on drop
-  grid.addEventListener("drop", async (e) => {
-    e.preventDefault();
-    const cards = grid.querySelectorAll("ui-card[data-slug]");
-    const slugs: string[] = [];
-    cards.forEach((c) => slugs.push(c.getAttribute("data-slug")!));
+  private _cachedGridConfig: GridConfig = {
+    cols: COLS,
+    rowHeight: 420,
+    margin: [16, 16] as [number, number],
+    containerPadding: [0, 0] as [number, number],
+    maxRows: Infinity,
+  };
 
-    const reordered: Project[] = [];
-    for (const slug of slugs) {
-      const p = state.allProjects.find((proj) => proj.slug === slug);
-      if (p) {
-        p.sortOrder = reordered.length;
-        reordered.push(p);
-      }
+  private _cachedResizeConfig: ResizeConfig = { enabled: false, handles: [] };
+
+  static styles = css`
+    :host {
+      display: contents;
     }
-    for (const p of state.allProjects) {
-      if (!reordered.includes(p)) reordered.push(p);
+
+    .overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      z-index: 200;
+      display: flex;
+      flex-direction: column;
+      background: var(--fd-surface-primary, #fff);
     }
-    setState({ allProjects: reordered });
+
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 12px 24px;
+      border-bottom: 1px solid var(--fd-border-minimal, #e4e4e7);
+    }
+
+    .heading-05 {
+      font-size: 16px;
+      line-height: 24px;
+      font-weight: 500;
+    }
+
+    .grid-wrap {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 48px 24px;
+      width: 100%;
+      box-sizing: border-box;
+    }
+
+    grid-layout {
+      display: block;
+      width: 100%;
+      --grid-item-transition-duration: 0.15s;
+      --grid-placeholder-bg: var(--fd-surface-secondary, #f4f4f5);
+      --grid-placeholder-border: 2px dashed var(--fd-border-moderate, #a1a1aa);
+      --grid-placeholder-radius: var(--fd-radius-sm, 4px);
+    }
+
+    .card-wrap {
+      position: relative;
+      height: 100%;
+      cursor: grab;
+      padding: 2px;
+      box-sizing: border-box;
+    }
+
+    .card-wrap:active {
+      cursor: grabbing;
+    }
+
+    .card-wrap ui-card {
+      pointer-events: none;
+      height: 100%;
+    }
+
+
+    .card-body {
+      padding: 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+
+    .card-title {
+      font-size: 16px;
+      font-weight: 500;
+      line-height: 24px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      min-width: 0;
+    }
+
+    .pin-toggle {
+      pointer-events: auto;
+      position: absolute;
+      top: 22px;
+      right: 22px;
+      z-index: 2;
+      cursor: pointer;
+      font-size: 14px;
+      transition: opacity 0.15s;
+      background: none;
+      border: none;
+      padding: 2px;
+    }
+
+    .description {
+      font-size: 14px;
+      line-height: 20px;
+      color: var(--fd-text-secondary, #52525b);
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      margin: 0;
+    }
+
+    .tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+    }
+
+    .status {
+      margin-top: auto;
+    }
+  `;
+
+  show(): void {
+    this._projects = editorState.allProjects.filter((p) => p.status !== "deleted");
+    this._layout = this._buildLayout();
+    this._open = true;
+  }
+
+  hide(): void {
+    this._open = false;
+  }
+
+  private _buildLayout(): Layout {
+    return this._projects.map((p, i) => ({
+      i: p.slug,
+      x: i % COLS,
+      y: Math.floor(i / COLS),
+      w: 1,
+      h: 1,
+    }));
+  }
+
+
+  private async _onLayoutChange(e: CustomEvent<{ layout: Layout }>): Promise<void> {
+    const layout = e.detail.layout;
+    // Sort by row (y) then column (x) to derive visual order
+    const sorted = [...layout].sort((a, b) => a.y - b.y || a.x - b.x);
+    const slugs = sorted.map((item: LayoutItem) => item.i);
+
+    // Reorder internal array in-place — do NOT reassign _projects to avoid Lit re-render
+    // Grid-layout already shows the correct positions
+    const orderMap = new Map(slugs.map((s, i) => [s, i]));
+    this._projects.sort((a, b) => (orderMap.get(a.slug) ?? 0) - (orderMap.get(b.slug) ?? 0));
+    this._projects.forEach((p, i) => { p.sortOrder = i; });
+
+    // Sync cached layout so future re-renders don't reset
+    this._layout = layout.map(item => ({ ...item }));
+
+    // Update global state
+    const updated = [...this._projects];
+    for (const p of editorState.allProjects) {
+      if (!updated.find((u) => u.slug === p.slug)) updated.push(p);
+    }
+    setState({ allProjects: updated });
 
     try {
       await api.api.projects.reorder.$put({ json: { slugs } });
     } catch {
       /* ignore */
     }
-  });
+  }
 
-  container.appendChild(grid);
+  private async _togglePin(project: Project, e: Event): Promise<void> {
+    const newPinned = !project.pinned;
+    project.pinned = newPinned;
+    // Update opacity directly — don't trigger Lit re-render
+    const btn = e.currentTarget as HTMLElement;
+    btn.style.opacity = newPinned ? "1" : "0.3";
+    try {
+      await api.api.projects[":slug"].$put({
+        param: { slug: project.slug },
+        json: { pinned: newPinned },
+      });
+    } catch {
+      /* ignore */
+    }
+    setState({});
+  }
+
+  private _onKeydown(e: KeyboardEvent): void {
+    if (e.key === "Escape") this.hide();
+  }
+
+  protected render(): unknown {
+    if (!this._open) return nothing;
+
+    return html`
+      <div class="overlay" @keydown=${this._onKeydown} tabindex="-1">
+        <div class="header">
+          <span class="heading-05">Portfolio Layout</span>
+          <ui-button action="secondary" emphasis="subtle" size="s" @click=${this.hide}>Close</ui-button>
+        </div>
+        <ui-scrollbar emphasis="minimal">
+          <div class="grid-wrap">
+            <grid-layout
+              ${ref(this._gridRef)}
+              .layout=${this._layout}
+              .gridConfig=${this._cachedGridConfig}
+              .resizeConfig=${this._cachedResizeConfig}
+              .compactType=${"horizontal" as const}
+              @layout-change=${this._onLayoutChange}
+            >
+              ${repeat(this._projects, (p) => p.slug, (project) => html`
+                  <grid-item item-id=${project.slug} w="1" h="1">
+                    <div class="card-wrap">
+                      <button
+                        class="pin-toggle"
+                        aria-label="Pin to homepage"
+                        style="opacity:${project.pinned ? "1" : "0.3"}"
+                        @pointerdown=${(e: Event) => e.stopPropagation()}
+                        @click=${(e: Event) => {
+                          e.stopPropagation();
+                          this._togglePin(project, e);
+                        }}
+                      >
+                        📌
+                      </button>
+                      <ui-card size="m" bordered>
+                        ${project.image
+                          ? html`<ui-image
+                              src=${project.image}
+                              alt=${project.title}
+                              slot="image"
+                              style="width:100%;height:180px;--ui-image-fit:cover;"
+                            ></ui-image>`
+                          : nothing}
+                        <div class="card-body">
+                          <span class="card-title">${project.title || "Untitled"}</span>
+                          <p class="description">${project.description}</p>
+                          <div class="tags">
+                            ${project.tech
+                              .split(",")
+                              .map((t: string) => t.trim())
+                              .filter(Boolean)
+                              .map((t: string) => html`<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`)}
+                          </div>
+                          <div class="status">
+                            <ui-badge size="s" status=${project.status === "published" ? "success" : "warning"}>${project.status}</ui-badge>
+                          </div>
+                        </div>
+                      </ui-card>
+                    </div>
+                  </grid-item>
+                `,
+              )}
+            </grid-layout>
+          </div>
+        </ui-scrollbar>
+      </div>
+    `;
+  }
 }
 
-export function openPortfolioLayout(): void {
-  const root = _projectPreviewRoot;
-  if (!overlay) {
-    overlay = createOverlay();
-    root?.querySelector(".admin-main")?.appendChild(overlay);
+declare global {
+  interface HTMLElementTagNameMap {
+    "editor-project-preview": EditorProjectPreview;
   }
-  overlay.style.display = "flex";
-  renderProjectCards();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@hono/zod-validator": "^0.7.6",
         "@libsql/client": "^0.17.2",
         "@maneki/foundation": "*",
+        "@maneki/grid-layout": "*",
         "@maneki/ui-components": "*",
         "exifreader": "^4.38.1",
         "hono": "^4.12.9",

--- a/packages/grid-layout/moon.yml
+++ b/packages/grid-layout/moon.yml
@@ -4,7 +4,7 @@ language: 'typescript'
 
 tasks:
   build:
-    script: 'tsc && vite build'
+    script: 'vite build && tsc --emitDeclarationOnly'
     inputs:
       - 'src/**/*'
       - 'tsconfig.json'

--- a/packages/grid-layout/package.json
+++ b/packages/grid-layout/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build && tsc --emitDeclarationOnly",
     "preview": "vite preview",
     "test": "vitest --run",
     "test:watch": "vitest",

--- a/packages/grid-layout/src/components/grid-layout.ts
+++ b/packages/grid-layout/src/components/grid-layout.ts
@@ -431,9 +431,14 @@ export class GridLayoutElement extends HTMLElement {
     const target = e.target;
     if (!(target instanceof HTMLElement)) return;
 
-    // Find the grid-item
-    const gridItem = target.closest?.("grid-item") as GridItemElement | null
-      ?? (target.getRootNode() as ShadowRoot).host as GridItemElement | null;
+    // Find the grid-item — walk composedPath to cross shadow DOM boundaries
+    let gridItem: GridItemElement | null = null;
+    for (const el of e.composedPath()) {
+      if (el instanceof GridItemElement) {
+        gridItem = el;
+        break;
+      }
+    }
 
     if (!gridItem || !(gridItem instanceof GridItemElement)) return;
     if (!gridItem.itemId) return;
@@ -515,9 +520,9 @@ export class GridLayoutElement extends HTMLElement {
       oldItem: { ...item },
     };
     this._dragThresholdMet = false;
-    document.addEventListener("pointermove", this._onPointerMove);
-    document.addEventListener("pointerup", this._onPointerUp);
-    (e.target as HTMLElement)?.setPointerCapture?.(e.pointerId);
+    this.addEventListener("pointermove", this._onPointerMove);
+    this.addEventListener("pointerup", this._onPointerUp);
+    this.setPointerCapture(e.pointerId);
   }
 
   private onDrag(e: PointerEvent): void {
@@ -586,8 +591,9 @@ export class GridLayoutElement extends HTMLElement {
     this._dragState = null;
     this._dragThresholdMet = false;
     this.clearSessionCaches();
-    document.removeEventListener("pointermove", this._onPointerMove);
-    document.removeEventListener("pointerup", this._onPointerUp);
+    this.removeEventListener("pointermove", this._onPointerMove);
+    this.removeEventListener("pointerup", this._onPointerUp);
+    this.releasePointerCapture(e.pointerId);
   }
 
   // --- Resize ---
@@ -613,8 +619,8 @@ export class GridLayoutElement extends HTMLElement {
     gridItem.toggleAttribute("resizing", true);
     this.toggleAttribute("interacting", true);
     this.emitResizeEvent("resize-start", this._resizeState.oldItem, this._resizeState.oldItem, e, gridItem);
-    document.addEventListener("pointermove", this._onPointerMove);
-    document.addEventListener("pointerup", this._onPointerUp);
+    this.addEventListener("pointermove", this._onPointerMove);
+    this.addEventListener("pointerup", this._onPointerUp);
     e.preventDefault();
     e.stopPropagation();
   }
@@ -684,8 +690,8 @@ export class GridLayoutElement extends HTMLElement {
     this.updatePositions();
     this._resizeState = null;
     this.clearSessionCaches();
-    document.removeEventListener("pointermove", this._onPointerMove);
-    document.removeEventListener("pointerup", this._onPointerUp);
+    this.removeEventListener("pointermove", this._onPointerMove);
+    this.removeEventListener("pointerup", this._onPointerUp);
   }
 
   private clearSessionCaches(): void {


### PR DESCRIPTION
Closes #281

## Summary

Rewrite `project-preview.ts` from 174 lines of imperative DOM to `<editor-project-preview>` LitElement. Dogfoods `@maneki/grid-layout` for drag-to-reorder.

## Changes

| File | Change |
|------|--------|
| `project-preview.ts` | Rewritten as LitElement with `@state()`, `<grid-layout>` for reorder, declarative template |
| `editor-page.ts` | Render `<editor-project-preview>` in template, ref + `show()`, removed old imports |

## Features
- `<grid-layout>` with 3 columns for drag-to-reorder
- `layout-change` event derives visual order (sorted by y→x)
- Pin toggle via `@click`
- Escape to close
- `show()`/`hide()` public API

## Verification
- `tsc --noEmit` clean on `apps/blog`