### PR TITLE
feat(blog): editable about page — DB schema, API, Vite plugin

### DIFF
--- a/apps/blog/plugins/pages.ts
+++ b/apps/blog/plugins/pages.ts
@@ -1,0 +1,102 @@
+/**
+ * Vite plugin that fetches published pages from Turso,
+ * renders markdown content to HTML, and exposes them as a virtual module.
+ *
+ * Usage:
+ *   import { pages, getPage } from "virtual:pages";
+ *
+ * Requires TURSO_URL + TURSO_AUTH_TOKEN env vars at build time.
+ * Falls back to empty array if DB is unavailable (dev without DB).
+ */
+
+import { type Plugin } from "vite";
+import { createClient } from "@libsql/client";
+import MarkdownIt from "markdown-it";
+
+const VIRTUAL_MODULE_ID = "virtual:pages";
+const RESOLVED_ID = "\0" + VIRTUAL_MODULE_ID;
+
+const EMPTY = "export const pages = [];\nexport function getPage(_slug) { return undefined; }";
+
+function createMd(): MarkdownIt {
+  const md = new MarkdownIt({ html: true, linkify: true, typographer: true });
+
+  // <a> → <ui-link>
+  const defaultLinkOpen =
+    md.renderer.rules.link_open ||
+    function (tokens, idx, options, _env, self) {
+      return self.renderToken(tokens, idx, options);
+    };
+
+  md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
+    const token = tokens[idx];
+    const href = token.attrGet("href") ?? "";
+    const isExternal = /^https?:\/\//.test(href);
+    token.tag = "ui-link";
+    if (isExternal) {
+      token.attrSet("external", "");
+      token.attrSet("target", "_blank");
+      token.attrSet("rel", "noopener");
+    }
+    return defaultLinkOpen(tokens, idx, options, env, self);
+  };
+
+  md.renderer.rules.link_close = function () {
+    return "</ui-link>";
+  };
+
+  // <img> → <ui-image>
+  md.renderer.rules.image = function (tokens, idx) {
+    const token = tokens[idx];
+    const src = token.attrGet("src") ?? "";
+    const alt = token.content ?? "";
+    return `<ui-image src="${src}" alt="${alt}"></ui-image>`;
+  };
+
+  return md;
+}
+
+export function pagesPlugin(): Plugin {
+  async function loadPages(): Promise<string> {
+    const url = process.env.TURSO_URL;
+    const authToken = process.env.TURSO_AUTH_TOKEN;
+
+    if (!url) {
+      console.warn("[pages] TURSO_URL not set — returning empty pages");
+      return EMPTY;
+    }
+
+    try {
+      const db = createClient({ url, authToken: authToken || undefined });
+      const result = await db.execute(
+        "SELECT slug, title, content, meta, updated_at FROM pages WHERE status = 'published' ORDER BY updated_at DESC",
+      );
+
+      const md = createMd();
+
+      const pages = result.rows.map((row) => ({
+        slug: row.slug as string,
+        title: row.title as string,
+        content: md.render(row.content as string),
+        meta: JSON.parse((row.meta as string) || "{}"),
+        updatedAt: row.updated_at as string,
+      }));
+
+      console.log(`[pages] Loaded ${pages.length} published pages from Turso`);
+      return `export const pages = ${JSON.stringify(pages)};\nexport function getPage(slug) { return pages.find((p) => p.slug === slug); }`;
+    } catch (err) {
+      console.error("[pages] Failed to fetch pages from Turso:", err);
+      return EMPTY;
+    }
+  }
+
+  return {
+    name: "pages",
+    resolveId(id) {
+      if (id === VIRTUAL_MODULE_ID) return RESOLVED_ID;
+    },
+    async load(id) {
+      if (id === RESOLVED_ID) return loadPages();
+    },
+  };
+}

--- a/apps/blog/scripts/seed-about.ts
+++ b/apps/blog/scripts/seed-about.ts
@@ -1,0 +1,80 @@
+/**
+ * Seed the about page into the pages table.
+ * Usage: TURSO_URL=... TURSO_AUTH_TOKEN=... npx tsx scripts/seed-about.ts
+ */
+
+import { createClient } from "@libsql/client";
+
+const url = process.env.TURSO_URL;
+const authToken = process.env.TURSO_AUTH_TOKEN;
+
+if (!url) {
+  console.error("Missing TURSO_URL env var");
+  process.exit(1);
+}
+
+const db = createClient({ url, authToken: authToken || undefined });
+
+const aboutContent = `Senior Software Engineer with 14+ years of hands-on experience across the full stack. Polyglot engineer specializing in distributed systems, micro-frontend architecture, and fine-grained authorization. Comfortable owning systems end-to-end — from API design and data modeling to CI/CD pipelines and observability.
+
+Currently at Xendit, building mission-critical authorization services and leading frontend development for cross-border financial products across Southeast Asia.
+
+## What I work with
+
+Go, TypeScript, Java, Python, React, Web Components, Kafka, PostgreSQL, Redis, OpenFGA, Docker/K8s
+
+## Areas of focus
+
+Distributed Systems, Micro-Frontends, Event-Driven Architecture, DDD, Fine-Grained Authorization, Design Systems, API Design
+
+## Outside of work
+
+Amateur photographer — mostly street, travel, and landscapes. You can see some of my shots on the [photography page](/photography).
+
+## Get in touch
+
+Find me on [GitHub](https://github.com/kiennt23) and [LinkedIn](https://linkedin.com/in/kiennt23), or drop me an email at [kien@maneki.tech](mailto:kien@maneki.tech).`;
+
+const meta = JSON.stringify({
+  skills: [
+    "Go",
+    "TypeScript",
+    "Java",
+    "Python",
+    "React",
+    "Web Components",
+    "Kafka",
+    "PostgreSQL",
+    "Redis",
+    "OpenFGA",
+    "Docker/K8s",
+  ],
+  focusAreas: [
+    "Distributed Systems",
+    "Micro-Frontends",
+    "Event-Driven Architecture",
+    "DDD",
+    "Fine-Grained Authorization",
+    "Design Systems",
+    "API Design",
+  ],
+  social: {
+    github: "https://github.com/kiennt23",
+    linkedin: "https://linkedin.com/in/kiennt23",
+    email: "kien@maneki.tech",
+  },
+});
+
+await db.execute({
+  sql: `INSERT INTO pages (slug, title, content, meta, status, updated_at)
+        VALUES (?, ?, ?, ?, 'published', datetime('now'))
+        ON CONFLICT (slug) DO UPDATE SET
+          title = excluded.title,
+          content = excluded.content,
+          meta = excluded.meta,
+          status = excluded.status,
+          updated_at = excluded.updated_at`,
+  args: ["about", "About", aboutContent, meta],
+});
+
+console.log("✓ Seeded about page.");

--- a/apps/blog/src/api/db/schema.ts
+++ b/apps/blog/src/api/db/schema.ts
@@ -115,4 +115,17 @@ CREATE TABLE IF NOT EXISTS photo_tags (
 
 CREATE INDEX IF NOT EXISTS idx_photo_tags_photo ON photo_tags(photo_id);
 CREATE INDEX IF NOT EXISTS idx_photo_tags_tag ON photo_tags(tag_id);
+
+CREATE TABLE IF NOT EXISTS pages (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug TEXT UNIQUE NOT NULL,
+  title TEXT NOT NULL DEFAULT '',
+  content TEXT NOT NULL DEFAULT '',
+  meta TEXT NOT NULL DEFAULT '{}',
+  status TEXT NOT NULL DEFAULT 'published' CHECK (status IN ('draft', 'published', 'deleted')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_pages_slug ON pages(slug);
+CREATE INDEX IF NOT EXISTS idx_pages_status ON pages(status);
 `;

--- a/apps/blog/src/api/index.ts
+++ b/apps/blog/src/api/index.ts
@@ -16,6 +16,7 @@ import { projects } from "./routes/projects.js";
 import { photos } from "./routes/photos.js";
 import { albums } from "./routes/albums.js";
 import { tags } from "./routes/tags.js";
+import { pages } from "./routes/pages.js";
 
 /** Env bindings available in CF Pages Functions. */
 export type Env = {
@@ -53,7 +54,8 @@ const app = new Hono<Env>()
   .route("/projects", projects)
   .route("/photos", photos)
   .route("/albums", albums)
-  .route("/tags", tags);
+  .route("/tags", tags)
+  .route("/pages", pages);
 
 export type AppType = typeof app;
 export default app;

--- a/apps/blog/src/api/routes/pages.ts
+++ b/apps/blog/src/api/routes/pages.ts
@@ -1,0 +1,143 @@
+/**
+ * Pages CRUD routes.
+ * Generic static pages (about, etc.) stored in Turso.
+ * All routes are protected by CF Access auth middleware (applied at app level).
+ */
+
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import type { Env } from "../index.js";
+
+const createPageSchema = z.object({
+  slug: z
+    .string()
+    .min(1)
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "Slug must be lowercase kebab-case"),
+  title: z.string().default(""),
+  content: z.string().default(""),
+  meta: z.record(z.string(), z.unknown()).default({}),
+  status: z.enum(["draft", "published"]).default("published"),
+});
+
+const updatePageSchema = z.object({
+  title: z.string().optional(),
+  content: z.string().optional(),
+  meta: z.record(z.string(), z.unknown()).optional(),
+  status: z.enum(["draft", "published"]).optional(),
+});
+
+export const pages = new Hono<Env>()
+  // List all pages
+  .get("/", async (c) => {
+    const status = c.req.query("status");
+    const db = c.get("db");
+
+    const sql = status
+      ? "SELECT * FROM pages WHERE status = ? ORDER BY updated_at DESC"
+      : "SELECT * FROM pages WHERE status != 'deleted' ORDER BY updated_at DESC";
+    const args = status ? [status] : [];
+
+    const result = await db.execute({ sql, args });
+    const rows = result.rows.map((r) => ({
+      ...r,
+      meta: JSON.parse((r.meta as string) || "{}"),
+    }));
+    return c.json({ pages: rows });
+  })
+
+  // Get single page by slug
+  .get("/:slug", async (c) => {
+    const db = c.get("db");
+    const result = await db.execute({
+      sql: "SELECT * FROM pages WHERE slug = ?",
+      args: [c.req.param("slug")],
+    });
+    if (!result.rows.length) {
+      return c.json({ error: "not found" }, 404);
+    }
+    const page = {
+      ...result.rows[0],
+      meta: JSON.parse((result.rows[0].meta as string) || "{}"),
+    };
+    return c.json({ page });
+  })
+
+  // Create page
+  .post("/", zValidator("json", createPageSchema), async (c) => {
+    const { slug, title, content, meta, status } = c.req.valid("json");
+    const db = c.get("db");
+
+    await db.execute({
+      sql: `INSERT INTO pages (slug, title, content, meta, status, updated_at)
+            VALUES (?, ?, ?, ?, ?, datetime('now'))`,
+      args: [slug, title, content, JSON.stringify(meta), status],
+    });
+    const result = await db.execute({
+      sql: "SELECT * FROM pages WHERE slug = ?",
+      args: [slug],
+    });
+    const page = {
+      ...result.rows[0],
+      meta: JSON.parse((result.rows[0].meta as string) || "{}"),
+    };
+    return c.json({ ok: true, slug, page }, 201);
+  })
+
+  // Update page by slug
+  .put("/:slug", zValidator("json", updatePageSchema), async (c) => {
+    const slug = c.req.param("slug");
+    const updates = c.req.valid("json");
+    const db = c.get("db");
+
+    const setClauses: string[] = [];
+    const args: (string | number | null)[] = [];
+
+    if (updates.title !== undefined) {
+      setClauses.push("title = ?");
+      args.push(updates.title);
+    }
+    if (updates.content !== undefined) {
+      setClauses.push("content = ?");
+      args.push(updates.content);
+    }
+    if (updates.meta !== undefined) {
+      setClauses.push("meta = ?");
+      args.push(JSON.stringify(updates.meta));
+    }
+    if (updates.status !== undefined) {
+      setClauses.push("status = ?");
+      args.push(updates.status);
+    }
+
+    if (setClauses.length === 0) {
+      return c.json({ error: "no fields to update" }, 400);
+    }
+
+    setClauses.push("updated_at = datetime('now')");
+    args.push(slug);
+
+    await db.execute({
+      sql: `UPDATE pages SET ${setClauses.join(", ")} WHERE slug = ?`,
+      args,
+    });
+    const result = await db.execute({
+      sql: "SELECT * FROM pages WHERE slug = ?",
+      args: [slug],
+    });
+    const page = {
+      ...result.rows[0],
+      meta: JSON.parse((result.rows[0].meta as string) || "{}"),
+    };
+    return c.json({ ok: true, page });
+  })
+
+  // Soft delete page by slug
+  .delete("/:slug", async (c) => {
+    const db = c.get("db");
+    await db.execute({
+      sql: "UPDATE pages SET status = 'deleted', updated_at = datetime('now') WHERE slug = ?",
+      args: [c.req.param("slug")],
+    });
+    return c.json({ ok: true });
+  });

--- a/apps/blog/src/pages/about.ts
+++ b/apps/blog/src/pages/about.ts
@@ -1,35 +1,53 @@
+import { getPage } from "virtual:pages";
 import type { Route } from "../router.js";
+
+function renderBadges(items: string[]): string {
+  return `<div class="row gap-1" style="flex-wrap:wrap;">${items.map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}</div>`;
+}
+
+function renderAboutPage(): string {
+  const page = getPage("about");
+
+  if (!page) {
+    return `
+      <h1 class="heading-02 mb-4">About</h1>
+      <div class="post-content reveal">
+        <p>About page coming soon.</p>
+      </div>`;
+  }
+
+  const meta = page.meta as {
+    skills?: string[];
+    focusAreas?: string[];
+    social?: { github?: string; linkedin?: string; email?: string };
+  };
+
+  // Rendered markdown HTML from the plugin — contains prose + headings.
+  // Enhance "What I work with" and "Areas of focus" sections with badge rows
+  // by replacing the plain-text comma lists that follow those headings.
+  let html = page.content;
+
+  if (meta.skills?.length) {
+    html = html.replace(/(<h2>What I work with<\/h2>\s*)<p>[^<]+<\/p>/, `$1${renderBadges(meta.skills)}`);
+  }
+
+  if (meta.focusAreas?.length) {
+    html = html.replace(/(<h2>Areas of focus<\/h2>\s*)<p>[^<]+<\/p>/, `$1${renderBadges(meta.focusAreas)}`);
+  }
+
+  return `
+    <h1 class="heading-02 mb-4">${page.title || "About"}</h1>
+    <div class="post-content reveal">
+      ${html}
+    </div>`;
+}
 
 export const aboutRoute: Route = {
   id: "about",
-  meta: { title: "About", description: "Senior Software Engineer with 14+ years of experience across the full stack. Polyglot engineer specializing in distributed systems, micro-frontend architecture, and fine-grained authorization." },
-  render: () => `
-    <h1 class="heading-02 mb-4">About</h1>
-
-    <div class="post-content reveal">
-      <p>Senior Software Engineer with 14+ years of hands-on experience across the full stack. Polyglot engineer specializing in distributed systems, micro-frontend architecture, and fine-grained authorization. Comfortable owning systems end-to-end — from API design and data modeling to CI/CD pipelines and observability.</p>
-
-      <p>Currently at Xendit, building mission-critical authorization services and leading frontend development for cross-border financial products across Southeast Asia.</p>
-
-      <h2>What I work with</h2>
-      <div class="row gap-1" style="flex-wrap:wrap;">
-        ${["Go", "TypeScript", "Java", "Python", "React", "Web Components", "Kafka", "PostgreSQL", "Redis", "OpenFGA", "Docker/K8s"].map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
-      </div>
-
-      <h2>Areas of focus</h2>
-      <div class="row gap-1" style="flex-wrap:wrap;">
-        ${["Distributed Systems", "Micro-Frontends", "Event-Driven Architecture", "DDD", "Fine-Grained Authorization", "Design Systems", "API Design"].map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
-      </div>
-
-      <h2>Outside of work</h2>
-      <p>Amateur photographer — mostly street, travel, and landscapes. You can see some of my shots on the <ui-link href="/photography">photography page</ui-link>.</p>
-
-      <h2>Get in touch</h2>
-      <p>
-        Find me on <ui-link href="https://github.com/kiennt23" external>GitHub</ui-link>
-        and <ui-link href="https://linkedin.com/in/kiennt23" external>LinkedIn</ui-link>,
-        or drop me an email at <ui-link href="mailto:kien@maneki.tech">kien@maneki.tech</ui-link>.
-      </p>
-    </div>
-  `,
+  meta: {
+    title: "About",
+    description:
+      "Senior Software Engineer with 14+ years of experience across the full stack. Polyglot engineer specializing in distributed systems, micro-frontend architecture, and fine-grained authorization.",
+  },
+  render: renderAboutPage,
 };

--- a/apps/blog/src/virtual-pages.d.ts
+++ b/apps/blog/src/virtual-pages.d.ts
@@ -1,0 +1,11 @@
+declare module "virtual:pages" {
+  export interface VirtualPage {
+    slug: string;
+    title: string;
+    content: string;
+    meta: Record<string, unknown>;
+    updatedAt: string;
+  }
+  export const pages: VirtualPage[];
+  export function getPage(slug: string): VirtualPage | undefined;
+}

--- a/apps/blog/vite.config.ts
+++ b/apps/blog/vite.config.ts
@@ -7,6 +7,7 @@ import { autoUiComponentsPlugin } from "./plugins/auto-ui-components.js";
 import { sitemapPlugin } from "./plugins/sitemap.js";
 import { rssFeedPlugin } from "./plugins/rss-feed.js";
 import { injectTokensPlugin } from "./plugins/inject-tokens.js";
+import { pagesPlugin } from "./plugins/pages.js";
 import { devAliases } from "../../shared/vite-dev-aliases.js";
 import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
@@ -50,6 +51,7 @@ export default defineConfig(({ command }) => ({
     autoUiComponentsPlugin(),
     sitemapPlugin(),
     rssFeedPlugin(),
+    pagesPlugin(),
     VitePWA({
       registerType: "autoUpdate",
       manifest: false,


### PR DESCRIPTION
Closes #247

## Summary

About page content stored in Turso DB via a generic `pages` table. Public `/about` page renders from `virtual:pages` build-time data.

## Changes

| File | Change |
|------|--------|
| `src/api/db/schema.ts` | Added `pages` table (slug, title, content, meta JSON, status) |
| `src/api/routes/pages.ts` | CRUD API — list, get by slug, create, update, soft delete |
| `src/api/index.ts` | Mount pages routes |
| `plugins/pages.ts` | Vite plugin — `virtual:pages` fetches pages at build time |
| `src/virtual-pages.d.ts` | Type declarations for virtual module |
| `src/pages/about.ts` | Rewritten to render from `virtual:pages` dynamically |
| `scripts/seed-about.ts` | Seed script for current about page content |
| `vite.config.ts` | Register pages plugin |

## Generic pages table
Reusable for any static page (about, contact, etc.) — not just about.

## Verification
- `tsc --noEmit` clean on `apps/blog`