### PR TITLE
fix(blog): resolve undo stack conflict with native browser undo

### DIFF
--- a/apps/blog/src/pages/editor/undo.ts
+++ b/apps/blog/src/pages/editor/undo.ts
@@ -29,7 +29,9 @@ function capture(): UndoEntry | null {
 function restore(entry: UndoEntry): void {
   if (!textareaRef) return;
   programmatic = true;
-  textareaRef.value = entry.value;
+  // Use setRangeText to replace entire content — avoids polluting the browser's
+  // native undo stack (textarea.value = ... resets it and causes state jumps)
+  textareaRef.setRangeText(entry.value, 0, textareaRef.value.length, "preserve");
   textareaRef.setSelectionRange(entry.selectionStart, entry.selectionEnd);
   textareaRef.dispatchEvent(new Event("input", { bubbles: true }));
   programmatic = false;
@@ -46,8 +48,6 @@ export function pushUndo(): void {
   undoStack.push(entry);
   if (undoStack.length > MAX_HISTORY) undoStack.shift();
   redoStack = [];
-  programmatic = true;
-  requestAnimationFrame(() => { programmatic = false; });
 }
 
 export function undo(): void {


### PR DESCRIPTION
Closes #272

## Summary
- Fix `restore()` in `undo.ts` to use `setRangeText()` instead of `textarea.value = ...`, which was polluting the browser's native undo stack and causing state jumps on Cmd-Z
- Remove stale `programmatic` flag manipulation in `pushUndo()` that was no longer needed

## Changes

| File | Change |
|------|--------|
| `undo.ts` | `restore()` uses `setRangeText(value, 0, length, "preserve")` instead of direct `.value` assignment; removed `programmatic` flag toggle in `pushUndo()` |

## Verification
- `tsc --noEmit` clean on `apps/blog`