### PR TITLE
feat(blog): add published_snapshot for change detection and recovery

### DIFF
--- a/apps/blog/scripts/migrate.ts
+++ b/apps/blog/scripts/migrate.ts
@@ -82,6 +82,21 @@ for (const table of ["photos", "albums"]) {
   } catch { console.log(`${table}.longitude already exists.`); }
 }
 
+// Add published_snapshot column to posts and projects if missing
+for (const table of ["posts", "projects"]) {
+  try {
+    await db.execute(`ALTER TABLE ${table} ADD COLUMN published_snapshot TEXT`);
+    console.log(`Added published_snapshot column to ${table}.`);
+    // Backfill existing published rows
+    if (table === "posts") {
+      await db.execute(`UPDATE posts SET published_snapshot = json_object('title', title, 'body_md', body_md, 'excerpt', excerpt, 'tags', tags, 'date', created_at) WHERE status = 'published' AND published_snapshot IS NULL`);
+    } else {
+      await db.execute(`UPDATE projects SET published_snapshot = json_object('title', title, 'body_md', body_md, 'description', description, 'tech', tech) WHERE status = 'published' AND published_snapshot IS NULL`);
+    }
+    console.log(`Backfilled published_snapshot for ${table}.`);
+  } catch { console.log(`${table}.published_snapshot already exists.`); }
+}
+
 // Create any missing tables
 await db.executeMultiple(SCHEMA);
 console.log("Done.");

--- a/apps/blog/src/api/db/schema.ts
+++ b/apps/blog/src/api/db/schema.ts
@@ -11,7 +11,8 @@ CREATE TABLE IF NOT EXISTS posts (
   status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'published', 'deleted')),
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at TEXT NOT NULL DEFAULT (datetime('now')),
-  published_at TEXT
+  published_at TEXT,
+  published_snapshot TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_posts_status ON posts(status);
@@ -47,7 +48,8 @@ CREATE TABLE IF NOT EXISTS projects (
   status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'published', 'deleted')),
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at TEXT NOT NULL DEFAULT (datetime('now')),
-  published_at TEXT
+  published_at TEXT,
+  published_snapshot TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status);

--- a/apps/blog/src/api/routes/posts.ts
+++ b/apps/blog/src/api/routes/posts.ts
@@ -193,6 +193,14 @@ export const posts = new Hono<Env>()
       args,
     });
 
+    // Save published snapshot for change detection
+    const snapResult = await db.execute({ sql: "SELECT title, body_md, excerpt, tags, created_at FROM posts WHERE slug = ?", args: [newSlug] });
+    if (snapResult.rows.length) {
+      const r = snapResult.rows[0];
+      const snapshot = JSON.stringify({ title: r.title, body_md: r.body_md, excerpt: r.excerpt, tags: r.tags, date: r.created_at });
+      await db.execute({ sql: "UPDATE posts SET published_snapshot = ? WHERE slug = ?", args: [snapshot, newSlug] });
+    }
+
     return c.json({ ok: true, slug: newSlug });
   })
 
@@ -203,7 +211,7 @@ export const posts = new Hono<Env>()
     const ghToken = c.env.GH_DEPLOY_TOKEN;
 
     await db.execute({
-      sql: "UPDATE posts SET status = 'draft', updated_at = datetime('now') WHERE slug = ?",
+      sql: "UPDATE posts SET status = 'draft', updated_at = datetime('now'), published_snapshot = NULL WHERE slug = ?",
       args: [slug],
     });
 

--- a/apps/blog/src/api/routes/projects.ts
+++ b/apps/blog/src/api/routes/projects.ts
@@ -198,6 +198,14 @@ export const projects = new Hono<Env>()
       args,
     });
 
+    // Save published snapshot for change detection
+    const snapResult = await db.execute({ sql: "SELECT title, body_md, description, tech FROM projects WHERE slug = ?", args: [newSlug] });
+    if (snapResult.rows.length) {
+      const r = snapResult.rows[0];
+      const snapshot = JSON.stringify({ title: r.title, body_md: r.body_md, description: r.description, tech: r.tech });
+      await db.execute({ sql: "UPDATE projects SET published_snapshot = ? WHERE slug = ?", args: [snapshot, newSlug] });
+    }
+
     return c.json({ ok: true, slug: newSlug });
   })
 
@@ -207,7 +215,7 @@ export const projects = new Hono<Env>()
     const slug = c.req.param("slug");
 
     await db.execute({
-      sql: "UPDATE projects SET status = 'draft', updated_at = datetime('now') WHERE slug = ?",
+      sql: "UPDATE projects SET status = 'draft', updated_at = datetime('now'), published_snapshot = NULL WHERE slug = ?",
       args: [slug],
     });
 

--- a/apps/blog/src/pages/editor/api.ts
+++ b/apps/blog/src/pages/editor/api.ts
@@ -21,10 +21,7 @@ export async function fetchPosts(): Promise<Post[]> {
       updatedAt: p.updated_at as string,
       publishedAt: (p.published_at as string) ?? null,
       persisted: true,
-      publishedContent:
-        p.status === "published"
-          ? `${p.title}\n${p.body_md}\n${p.excerpt}\n${(p.tags as string[]).join(", ")}\n${(p.created_at as string).split("T")[0]}`
-          : null,
+      publishedSnapshot: p.published_snapshot ? JSON.stringify({ type: "post", ...JSON.parse(p.published_snapshot as string) }) : null,
     }));
   } catch {
     return [];
@@ -48,9 +45,7 @@ export async function savePost(post: Post): Promise<{ slug: string; saved: Post 
       updatedAt: (p.updated_at as string) || new Date().toISOString(),
       publishedAt: (p.published_at as string) || null,
       persisted: true,
-      publishedContent: p.status === "published"
-        ? `${p.title}\n${p.body_md}\n${p.excerpt}\n${Array.isArray(p.tags) ? (p.tags as string[]).join(", ") : ""}\n${((p.created_at as string) || "").split("T")[0]}`
-        : null,
+      publishedSnapshot: p.published_snapshot ? JSON.stringify({ type: "post", ...JSON.parse(p.published_snapshot as string) }) : null,
     });
 
     if (post.persisted) {
@@ -110,10 +105,7 @@ export async function fetchProjects(): Promise<Project[]> {
       updatedAt: p.updated_at as string,
       publishedAt: (p.published_at as string) ?? null,
       persisted: true,
-      publishedContent:
-        p.status === "published"
-          ? `${p.title}\n${p.body_md}\n${p.description}\n${(p.tech as string[]).join(", ")}`
-          : null,
+      publishedSnapshot: p.published_snapshot ? JSON.stringify({ type: "project", ...JSON.parse(p.published_snapshot as string) }) : null,
     }));
   } catch {
     return [];
@@ -140,9 +132,7 @@ export async function saveProject(project: Project): Promise<{ slug: string; sav
       updatedAt: (p.updated_at as string) || new Date().toISOString(),
       publishedAt: (p.published_at as string) || null,
       persisted: true,
-      publishedContent: p.status === "published"
-        ? `${p.title}\n${p.body_md}\n${p.description}\n${Array.isArray(p.tech) ? (p.tech as string[]).join(", ") : ""}`
-        : null,
+      publishedSnapshot: p.published_snapshot ? JSON.stringify({ type: "project", ...JSON.parse(p.published_snapshot as string) }) : null,
     });
 
     if (project.persisted) {
@@ -237,7 +227,7 @@ export function setEditorPage(page: EditorPage): void {
 
 export function getCurrentPostData(): Omit<
   Post,
-  "slug" | "updatedAt" | "publishedAt" | "persisted" | "publishedContent"
+  "slug" | "updatedAt" | "publishedAt" | "persisted" | "publishedSnapshot"
 > {
   return _editorPage!.getPostData();
 }
@@ -254,7 +244,7 @@ export async function saveCurrent(_forceApi = false): Promise<"success" | "error
       updatedAt: new Date().toISOString(),
       publishedAt: currentPost?.publishedAt ?? null,
       persisted: currentPost?.persisted ?? false,
-      publishedContent: currentPost?.publishedContent ?? null,
+      publishedSnapshot: currentPost?.publishedSnapshot ?? null,
     };
 
     const result = await savePost(post);
@@ -333,7 +323,7 @@ export function exportAsMarkdown(): void {
 
 export function getCurrentProjectData(): Omit<
   Project,
-  "slug" | "updatedAt" | "publishedAt" | "persisted" | "publishedContent"
+  "slug" | "updatedAt" | "publishedAt" | "persisted" | "publishedSnapshot"
 > {
   return _editorPage!.getProjectData();
 }
@@ -350,7 +340,7 @@ export async function saveCurrentProject(_forceApi = false): Promise<"success" |
       updatedAt: new Date().toISOString(),
       publishedAt: currentProject?.publishedAt ?? null,
       persisted: currentProject?.persisted ?? false,
-      publishedContent: currentProject?.publishedContent ?? null,
+      publishedSnapshot: currentProject?.publishedSnapshot ?? null,
     };
 
     const result = await saveProject(project);

--- a/apps/blog/src/pages/editor/editor-page.ts
+++ b/apps/blog/src/pages/editor/editor-page.ts
@@ -797,7 +797,7 @@ export class EditorPage extends LitElement {
     renderPreview(this.shadowRoot!, this._previewRef.value);
   }
 
-  getPostData(): Omit<Post, "slug" | "updatedAt" | "publishedAt" | "persisted" | "publishedContent"> {
+  getPostData(): Omit<Post, "slug" | "updatedAt" | "publishedAt" | "persisted" | "publishedSnapshot"> {
     return {
       title: this.postTitle,
       date: this.postDate,
@@ -829,7 +829,7 @@ export class EditorPage extends LitElement {
     renderPreview(this.shadowRoot!, this._previewRef.value);
   }
 
-  getProjectData(): Omit<Project, "slug" | "updatedAt" | "publishedAt" | "persisted" | "publishedContent"> {
+  getProjectData(): Omit<Project, "slug" | "updatedAt" | "publishedAt" | "persisted" | "publishedSnapshot"> {
     return {
       title: this.projectTitle,
       description: this.projectDescription,
@@ -869,7 +869,7 @@ export class EditorPage extends LitElement {
       updatedAt: new Date().toISOString(),
       publishedAt: null,
       persisted: false,
-      publishedContent: null,
+      publishedSnapshot: null,
     };
     setState({ allPosts: [post, ...state.allPosts], openTabs: [...state.openTabs, post] });
     loadPostIntoEditor(post);
@@ -892,7 +892,7 @@ export class EditorPage extends LitElement {
       updatedAt: new Date().toISOString(),
       publishedAt: null,
       persisted: false,
-      publishedContent: null,
+      publishedSnapshot: null,
     };
     setState({ allProjects: [project, ...state.allProjects], openProjectTabs: [...state.openProjectTabs, project] });
     loadProjectIntoEditor(project);

--- a/apps/blog/src/pages/editor/publish.ts
+++ b/apps/blog/src/pages/editor/publish.ts
@@ -59,13 +59,13 @@ async function publishPost(): Promise<void> {
   if (post) {
     post.status = "published";
     post.publishedAt = new Date().toISOString();
-    post.publishedContent = `${post.title}\n${post.content}\n${post.excerpt}\n${post.tags}\n${post.date}`;
+    post.publishedSnapshot = JSON.stringify({ type: "post", title: post.title, body_md: post.content, excerpt: post.excerpt, tags: post.tags, date: post.date });
   }
   const tab = state.openTabs.find((t) => t.slug === state.currentSlug);
   if (tab) {
     tab.status = "published";
     tab.publishedAt = new Date().toISOString();
-    tab.publishedContent = `${tab.title}\n${tab.content}\n${tab.excerpt}\n${tab.tags}\n${tab.date}`;
+    tab.publishedSnapshot = JSON.stringify({ type: "post", title: tab.title, body_md: tab.content, excerpt: tab.excerpt, tags: tab.tags, date: tab.date });
   }
   setState({});
 }
@@ -73,9 +73,9 @@ async function publishPost(): Promise<void> {
 async function unpublishPost(): Promise<void> {
   await api.api.posts[":slug"].unpublish.$put({ param: { slug: state.currentSlug! } });
   const post = state.allPosts.find((p) => p.slug === state.currentSlug);
-  if (post) post.status = "draft";
+  if (post) { post.status = "draft"; post.publishedSnapshot = null; }
   const tab = state.openTabs.find((t) => t.slug === state.currentSlug);
-  if (tab) tab.status = "draft";
+  if (tab) { tab.status = "draft"; tab.publishedSnapshot = null; }
   setState({});
 }
 
@@ -105,13 +105,13 @@ async function publishProject(): Promise<void> {
   if (project) {
     project.status = "published";
     project.publishedAt = new Date().toISOString();
-    project.publishedContent = `${project.title}\n${project.content}\n${project.description}\n${project.tech}`;
+    project.publishedSnapshot = JSON.stringify({ type: "project", title: project.title, body_md: project.content, description: project.description, tech: project.tech });
   }
   const tab = state.openProjectTabs.find((t) => t.slug === state.currentSlug);
   if (tab) {
     tab.status = "published";
     tab.publishedAt = new Date().toISOString();
-    tab.publishedContent = `${tab.title}\n${tab.content}\n${tab.description}\n${tab.tech}`;
+    tab.publishedSnapshot = JSON.stringify({ type: "project", title: tab.title, body_md: tab.content, description: tab.description, tech: tab.tech });
   }
   setState({});
 }
@@ -119,8 +119,8 @@ async function publishProject(): Promise<void> {
 async function unpublishProject(): Promise<void> {
   await api.api.projects[":slug"].unpublish.$put({ param: { slug: state.currentSlug! } });
   const project = state.allProjects.find((p) => p.slug === state.currentSlug);
-  if (project) project.status = "draft";
+  if (project) { project.status = "draft"; project.publishedSnapshot = null; }
   const tab = state.openProjectTabs.find((t) => t.slug === state.currentSlug);
-  if (tab) tab.status = "draft";
+  if (tab) { tab.status = "draft"; tab.publishedSnapshot = null; }
   setState({});
 }

--- a/apps/blog/src/pages/editor/state.ts
+++ b/apps/blog/src/pages/editor/state.ts
@@ -1,4 +1,4 @@
-import type { Post, Project } from "./types.js";
+import type { Post, Project, PostSnapshot, ProjectSnapshot } from "./types.js";
 
 export interface EditorState {
   allPosts: Post[];
@@ -78,6 +78,25 @@ export function setState(partial: Partial<EditorState>): void {
 
 export function hasUnpublishedChanges(item: Post | Project): boolean {
   if (item.status !== "published") return false;
-  if (!item.publishedAt) return false;
-  return item.updatedAt > item.publishedAt;
+  if (!item.publishedSnapshot) return false;
+  try {
+    const snap = JSON.parse(item.publishedSnapshot) as PostSnapshot | ProjectSnapshot;
+    // DB stores tags/tech as JSON arrays; client uses comma-separated strings
+    const norm = (v: string): string => {
+      try { const arr = JSON.parse(v); return Array.isArray(arr) ? arr.join(", ") : v; } catch { return v; }
+    };
+    if (snap.type === "post") {
+      const post = item as Post;
+      return snap.title !== post.title || snap.body_md !== post.content || snap.excerpt !== post.excerpt
+        || norm(snap.tags) !== post.tags || snap.date.split("T")[0] !== post.date;
+    }
+    if (snap.type === "project") {
+      const project = item as Project;
+      return snap.title !== project.title || snap.body_md !== project.content
+        || snap.description !== project.description || norm(snap.tech) !== project.tech;
+    }
+    return false;
+  } catch {
+    return false;
+  }
 }

--- a/apps/blog/src/pages/editor/tabbar.ts
+++ b/apps/blog/src/pages/editor/tabbar.ts
@@ -147,7 +147,7 @@ export class EditorTabbar extends LitElement {
       updatedAt: new Date().toISOString(),
       publishedAt: null,
       persisted: false,
-      publishedContent: null,
+      publishedSnapshot: null,
     };
     setState({ allPosts: [post, ...state.allPosts], openTabs: [...state.openTabs, post] });
     loadPostIntoEditor(post);

--- a/apps/blog/src/pages/editor/types.ts
+++ b/apps/blog/src/pages/editor/types.ts
@@ -9,8 +9,8 @@ export interface Post {
   updatedAt: string;
   publishedAt: string | null;
   persisted: boolean;
-  /** Snapshot of content at last publish — used to detect unpublished changes */
-  publishedContent: string | null;
+  /** JSON snapshot of content at last publish — used to detect unpublished changes */
+  publishedSnapshot: string | null;
 }
 
 export interface Project {
@@ -28,7 +28,24 @@ export interface Project {
   updatedAt: string;
   publishedAt: string | null;
   persisted: boolean;
-  publishedContent: string | null;
+  publishedSnapshot: string | null;
+}
+
+export interface PostSnapshot {
+  type: "post";
+  title: string;
+  body_md: string;
+  excerpt: string;
+  tags: string;
+  date: string;
+}
+
+export interface ProjectSnapshot {
+  type: "project";
+  title: string;
+  body_md: string;
+  description: string;
+  tech: string;
 }
 
 export interface EditorUIState {


### PR DESCRIPTION
## Summary
- Add `published_snapshot` TEXT column to posts and projects tables to store a JSON snapshot of content at publish time
- Enables reliable unpublished-changes detection that survives page refresh (replaces timestamp-based comparison)
- Foundation for future "revert to published" feature

## Changes

| File | Change |
|------|--------|
| `schema.ts` | Add `published_snapshot TEXT` to posts + projects |
| `routes/posts.ts` | Save snapshot on publish, clear on unpublish |
| `routes/projects.ts` | Save snapshot on publish, clear on unpublish |
| `types.ts` | Rename `publishedContent` → `publishedSnapshot` |
| `api.ts` | Read `published_snapshot` from API response |
| `publish.ts` | Store JSON snapshot client-side on publish/unpublish |
| `state.ts` | `hasUnpublishedChanges()` compares current fields against parsed snapshot |
| `migrate.ts` | Add column + backfill existing published rows |

## Migration
Run `npm run migrate` to add the column and backfill existing published posts/projects.