### PR TITLE
feat(blog): generic editable pages system

### DIFF
--- a/apps/blog/plugins/pages.ts
+++ b/apps/blog/plugins/pages.ts
@@ -1,0 +1,102 @@
+/**
+ * Vite plugin that fetches published pages from Turso,
+ * renders markdown content to HTML, and exposes them as a virtual module.
+ *
+ * Usage:
+ *   import { pages, getPage } from "virtual:pages";
+ *
+ * Requires TURSO_URL + TURSO_AUTH_TOKEN env vars at build time.
+ * Falls back to empty array if DB is unavailable (dev without DB).
+ */
+
+import { type Plugin } from "vite";
+import { createClient } from "@libsql/client";
+import MarkdownIt from "markdown-it";
+
+const VIRTUAL_MODULE_ID = "virtual:pages";
+const RESOLVED_ID = "\0" + VIRTUAL_MODULE_ID;
+
+const EMPTY = "export const pages = [];\nexport function getPage(_slug) { return undefined; }";
+
+function createMd(): MarkdownIt {
+  const md = new MarkdownIt({ html: true, linkify: true, typographer: true });
+
+  // <a> → <ui-link>
+  const defaultLinkOpen =
+    md.renderer.rules.link_open ||
+    function (tokens, idx, options, _env, self) {
+      return self.renderToken(tokens, idx, options);
+    };
+
+  md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
+    const token = tokens[idx];
+    const href = token.attrGet("href") ?? "";
+    const isExternal = /^https?:\/\//.test(href);
+    token.tag = "ui-link";
+    if (isExternal) {
+      token.attrSet("external", "");
+      token.attrSet("target", "_blank");
+      token.attrSet("rel", "noopener");
+    }
+    return defaultLinkOpen(tokens, idx, options, env, self);
+  };
+
+  md.renderer.rules.link_close = function () {
+    return "</ui-link>";
+  };
+
+  // <img> → <ui-image>
+  md.renderer.rules.image = function (tokens, idx) {
+    const token = tokens[idx];
+    const src = token.attrGet("src") ?? "";
+    const alt = token.content ?? "";
+    return `<ui-image src="${src}" alt="${alt}"></ui-image>`;
+  };
+
+  return md;
+}
+
+export function pagesPlugin(): Plugin {
+  async function loadPages(): Promise<string> {
+    const url = process.env.TURSO_URL;
+    const authToken = process.env.TURSO_AUTH_TOKEN;
+
+    if (!url) {
+      console.warn("[pages] TURSO_URL not set — returning empty pages");
+      return EMPTY;
+    }
+
+    try {
+      const db = createClient({ url, authToken: authToken || undefined });
+      const result = await db.execute(
+        "SELECT slug, title, content, description, updated_at FROM pages WHERE status = 'published' ORDER BY updated_at DESC",
+      );
+
+      const md = createMd();
+
+      const pages = result.rows.map((row) => ({
+        slug: row.slug as string,
+        title: row.title as string,
+        content: md.render(row.content as string),
+        description: row.description as string,
+        updatedAt: row.updated_at as string,
+      }));
+
+      console.log(`[pages] Loaded ${pages.length} published pages from Turso`);
+      return `export const pages = ${JSON.stringify(pages)};\nexport function getPage(slug) { return pages.find((p) => p.slug === slug); }`;
+    } catch (err) {
+      console.error("[pages] Failed to fetch pages from Turso:", err);
+      return EMPTY;
+    }
+  }
+
+  return {
+    name: "pages",
+    resolveId(id) {
+      if (id === VIRTUAL_MODULE_ID) return RESOLVED_ID;
+    },
+    async load(id) {
+      if (id === RESOLVED_ID) return loadPages();
+    },
+  };
+}

--- a/apps/blog/scripts/migrate.ts
+++ b/apps/blog/scripts/migrate.ts
@@ -82,6 +82,23 @@ for (const table of ["photos", "albums"]) {
   } catch { console.log(`${table}.longitude already exists.`); }
 }
 
+// Create pages table if missing
+await db.executeMultiple(`
+  CREATE TABLE IF NOT EXISTS pages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug TEXT UNIQUE NOT NULL,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL DEFAULT '',
+    description TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'published', 'deleted')),
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  );
+  CREATE INDEX IF NOT EXISTS idx_pages_status ON pages(status);
+  CREATE INDEX IF NOT EXISTS idx_pages_slug ON pages(slug);
+`);
+console.log("Pages table ready.");
+
 // Add published_snapshot column to posts and projects if missing
 for (const table of ["posts", "projects"]) {
   try {

--- a/apps/blog/scripts/seed-about.ts
+++ b/apps/blog/scripts/seed-about.ts
@@ -1,0 +1,72 @@
+/**
+ * Seed about page content into Turso.
+ * Usage: TURSO_URL=... TURSO_AUTH_TOKEN=... npx tsx scripts/seed-about.ts
+ */
+
+import { createClient } from "@libsql/client";
+
+const url = process.env.TURSO_URL;
+const authToken = process.env.TURSO_AUTH_TOKEN;
+
+if (!url) {
+  console.error("Missing TURSO_URL env var");
+  process.exit(1);
+}
+
+const db = createClient({ url, authToken: authToken || undefined });
+
+const title = "About";
+const description =
+  "Senior Software Engineer with 14+ years of experience across the full stack. Polyglot engineer specializing in distributed systems, micro-frontend architecture, and fine-grained authorization.";
+
+const content = `Senior Software Engineer with 14+ years of hands-on experience across the full stack. Polyglot engineer specializing in distributed systems, micro-frontend architecture, and fine-grained authorization. Comfortable owning systems end-to-end — from API design and data modeling to CI/CD pipelines and observability.
+
+Currently at Xendit, building mission-critical authorization services and leading frontend development for cross-border financial products across Southeast Asia.
+
+## What I work with
+
+<div class="row gap-1" style="flex-wrap:wrap;">
+<ui-badge size="s" emphasis="subtle">Go</ui-badge>
+<ui-badge size="s" emphasis="subtle">TypeScript</ui-badge>
+<ui-badge size="s" emphasis="subtle">Java</ui-badge>
+<ui-badge size="s" emphasis="subtle">Python</ui-badge>
+<ui-badge size="s" emphasis="subtle">React</ui-badge>
+<ui-badge size="s" emphasis="subtle">Web Components</ui-badge>
+<ui-badge size="s" emphasis="subtle">Kafka</ui-badge>
+<ui-badge size="s" emphasis="subtle">PostgreSQL</ui-badge>
+<ui-badge size="s" emphasis="subtle">Redis</ui-badge>
+<ui-badge size="s" emphasis="subtle">OpenFGA</ui-badge>
+<ui-badge size="s" emphasis="subtle">Docker/K8s</ui-badge>
+</div>
+
+## Areas of focus
+
+<div class="row gap-1" style="flex-wrap:wrap;">
+<ui-badge size="s" emphasis="subtle">Distributed Systems</ui-badge>
+<ui-badge size="s" emphasis="subtle">Micro-Frontends</ui-badge>
+<ui-badge size="s" emphasis="subtle">Event-Driven Architecture</ui-badge>
+<ui-badge size="s" emphasis="subtle">DDD</ui-badge>
+<ui-badge size="s" emphasis="subtle">Fine-Grained Authorization</ui-badge>
+<ui-badge size="s" emphasis="subtle">Design Systems</ui-badge>
+<ui-badge size="s" emphasis="subtle">API Design</ui-badge>
+</div>
+
+## Outside of work
+
+Amateur photographer — mostly street, travel, and landscapes. You can see some of my shots on the [photography page](/photography).
+
+## Get in touch
+
+Find me on [GitHub](https://github.com/kiennt23) and [LinkedIn](https://linkedin.com/in/kiennt23), or drop me an email at [kien@maneki.tech](mailto:kien@maneki.tech).
+`;
+
+console.log("Seeding about page...");
+
+await db.execute({ sql: "DELETE FROM pages WHERE slug = ?", args: ["about"] });
+await db.execute({
+  sql: `INSERT INTO pages (slug, title, content, description, status, updated_at)
+        VALUES (?, ?, ?, ?, 'published', datetime('now'))`,
+  args: ["about", title, content, description],
+});
+
+console.log("Done — about page seeded.");

--- a/apps/blog/scripts/seed-resume.ts
+++ b/apps/blog/scripts/seed-resume.ts
@@ -1,0 +1,232 @@
+/**
+ * Seed resume content as a markdown page into Turso.
+ * Usage: TURSO_URL=... TURSO_AUTH_TOKEN=... npx tsx scripts/seed-resume.ts
+ */
+
+import { createClient } from "@libsql/client";
+
+const url = process.env.TURSO_URL;
+const authToken = process.env.TURSO_AUTH_TOKEN;
+
+if (!url) {
+  console.error("Missing TURSO_URL env var");
+  process.exit(1);
+}
+
+const db = createClient({ url, authToken: authToken || undefined });
+
+const title = "Kien Nguyen Trung";
+const description = "Senior Software Engineer with 14+ years of experience. Go, TypeScript, Java, Python. Distributed systems, micro-frontends, fine-grained authorization.";
+
+const content = `<p class="body-01 text-secondary">Senior Software Engineer</p>
+
+<div class="row gap-2 mt-1" style="flex-wrap:wrap;">
+<ui-link href="mailto:kien@maneki.tech" size="s">kien@maneki.tech</ui-link>
+<ui-link href="https://github.com/kiennt23" size="s" external>GitHub</ui-link>
+<ui-link href="https://linkedin.com/in/kiennt23" size="s" external>LinkedIn</ui-link>
+</div>
+
+Senior Software Engineer with 14+ years of hands-on experience across the full stack. Polyglot engineer (Go, TypeScript, Java, Python) specializing in distributed systems, micro-frontend architecture, and fine-grained authorization.
+
+## Skills
+
+<div class="stack gap-2 reveal">
+<div>
+<p class="heading-05 mb-1">System Design</p>
+<div class="row gap-1" style="flex-wrap:wrap;">
+<ui-badge size="s" emphasis="subtle">Microservices</ui-badge>
+<ui-badge size="s" emphasis="subtle">Event-Driven Architecture</ui-badge>
+<ui-badge size="s" emphasis="subtle">DDD</ui-badge>
+<ui-badge size="s" emphasis="subtle">Fine-Grained Authorization (OpenFGA)</ui-badge>
+<ui-badge size="s" emphasis="subtle">API Design (REST, GraphQL)</ui-badge>
+</div>
+</div>
+<div>
+<p class="heading-05 mb-1">Frontend Architecture</p>
+<div class="row gap-1" style="flex-wrap:wrap;">
+<ui-badge size="s" emphasis="subtle">React</ui-badge>
+<ui-badge size="s" emphasis="subtle">Web Components (Lit)</ui-badge>
+<ui-badge size="s" emphasis="subtle">Micro-Frontends (Module Federation)</ui-badge>
+<ui-badge size="s" emphasis="subtle">Atomic State Management</ui-badge>
+<ui-badge size="s" emphasis="subtle">Component-Driven Development</ui-badge>
+<ui-badge size="s" emphasis="subtle">Multi-Brand White-Labeling</ui-badge>
+</div>
+</div>
+<div>
+<p class="heading-05 mb-1">Distributed Systems</p>
+<div class="row gap-1" style="flex-wrap:wrap;">
+<ui-badge size="s" emphasis="subtle">Kafka</ui-badge>
+<ui-badge size="s" emphasis="subtle">Redis</ui-badge>
+<ui-badge size="s" emphasis="subtle">Elasticsearch</ui-badge>
+<ui-badge size="s" emphasis="subtle">PostgreSQL</ui-badge>
+<ui-badge size="s" emphasis="subtle">SQL & NoSQL</ui-badge>
+</div>
+</div>
+<div>
+<p class="heading-05 mb-1">Languages</p>
+<div class="row gap-1" style="flex-wrap:wrap;">
+<ui-badge size="s" emphasis="subtle">Go</ui-badge>
+<ui-badge size="s" emphasis="subtle">TypeScript</ui-badge>
+<ui-badge size="s" emphasis="subtle">Java</ui-badge>
+<ui-badge size="s" emphasis="subtle">Python</ui-badge>
+</div>
+</div>
+</div>
+
+## Experience
+
+### Xendit Pte Ltd — Senior Software Engineer
+
+<p class="body-02 text-secondary">March 2021 – Present</p>
+<p class="body-02 text-secondary mb-2">Southeast Asian fintech providing payment infrastructure across Indonesia, the Philippines, Hong Kong, Mexico, and beyond.</p>
+
+#### Auth Platform <span class="body-02 text-secondary">| Engineer | Team of 2</span>
+
+Designed and built a mission-critical fine-grained authorization service using OpenFGA — a single point of dependency for all product APIs and the merchant dashboard. Handles dynamic permission overrides across 5 product types and 140+ currency pairs with P99 latency under 40ms.
+
+- Architected an FGA system using OpenFGA to replace legacy Postgres-based permission checks, supporting real-time blocklist/whitelist overrides across 5 financial products and 140+ currency pairs
+- Implemented smart override resolution that checks default permissions before writing, reducing write operations by ~40%
+- Parallelized all FGA read paths achieving P99 <40ms across 11 concurrent FGA calls in the hot path of every API request
+- Designed a modular FGA model with source/destination/pair-level granularity, enabling country-office-level currency restrictions without downtime
+
+<div class="row gap-1 mb-3" style="flex-wrap:wrap;">
+<ui-badge size="s" emphasis="subtle">Go 1.24</ui-badge>
+<ui-badge size="s" emphasis="subtle">Echo v4</ui-badge>
+<ui-badge size="s" emphasis="subtle">OpenFGA</ui-badge>
+<ui-badge size="s" emphasis="subtle">PostgreSQL</ui-badge>
+<ui-badge size="s" emphasis="subtle">Redis</ui-badge>
+<ui-badge size="s" emphasis="subtle">Kafka</ui-badge>
+</div>
+
+#### Regional Dashboard <span class="body-02 text-secondary">| Frontend Lead | Team of 6</span>
+
+Led frontend development for Xendit's global expansion, shipping 5 cross-border products in under 6 months — Xendit's highest-margin product line.
+
+- Delivered cross-border payments, balance conversion, cross-border payouts, withdrawals, and FX management — 5 products in <6 months
+- Modernized the frontend tech stack through the strangler pattern — no major rewrites, zero downtime
+- Built a scalable authorization layer ensuring compliance with local and global regulatory requirements across new markets
+- Optimized frontend performance, reducing initial load time by ~30%
+
+<div class="row gap-1 mb-3" style="flex-wrap:wrap;">
+<ui-badge size="s" emphasis="subtle">React 18</ui-badge>
+<ui-badge size="s" emphasis="subtle">TypeScript</ui-badge>
+<ui-badge size="s" emphasis="subtle">Module Federation</ui-badge>
+<ui-badge size="s" emphasis="subtle">React Compiler</ui-badge>
+<ui-badge size="s" emphasis="subtle">Jotai</ui-badge>
+<ui-badge size="s" emphasis="subtle">Radix UI</ui-badge>
+</div>
+
+#### Transaction Monitoring System <span class="body-02 text-secondary">| Senior Software Engineer | Team of 6</span>
+
+Built a compliance-driven transaction monitoring platform from the ground up.
+
+- Developed a rule management UI for risk and compliance teams
+- Built the core rule engine to evaluate transactions in real-time and generate alerts
+- Integrated a third-party case management system for investigation workflows
+- Designed ETL pipelines to consolidate transaction data from multiple upstream sources
+
+<div class="row gap-1 mb-3" style="flex-wrap:wrap;">
+<ui-badge size="s" emphasis="subtle">React 18</ui-badge>
+<ui-badge size="s" emphasis="subtle">TypeScript</ui-badge>
+<ui-badge size="s" emphasis="subtle">Go</ui-badge>
+<ui-badge size="s" emphasis="subtle">Kafka</ui-badge>
+</div>
+
+#### Merchant Dashboard <span class="body-02 text-secondary">| Senior Software Engineer | Team of 5</span>
+
+Maintained and evolved a Module Federation monorepo hosting 14 micro-frontends, 3 BFF gateways, and 3 shared libraries serving multi-brand fintech dashboards.
+
+- Developed a TUI launcher for local development handling submodule management across 21 git submodules
+- Supported multi-brand white-labeling across 4 fintech brands with shared infrastructure
+- Leading migration of the authentication layer to SuperTokens
+
+<div class="row gap-1 mb-3" style="flex-wrap:wrap;">
+<ui-badge size="s" emphasis="subtle">React 18</ui-badge>
+<ui-badge size="s" emphasis="subtle">Module Federation</ui-badge>
+<ui-badge size="s" emphasis="subtle">Redux</ui-badge>
+<ui-badge size="s" emphasis="subtle">Jotai</ui-badge>
+<ui-badge size="s" emphasis="subtle">Node.js/Express</ui-badge>
+<ui-badge size="s" emphasis="subtle">Nx</ui-badge>
+<ui-badge size="s" emphasis="subtle">Vite</ui-badge>
+</div>
+
+### Hearti Lab Pte Ltd — Product Developer Lead
+
+<p class="body-02 text-secondary">October 2019 – February 2021</p>
+
+#### CYBERhythm <span class="body-02 text-secondary">| Lead | Team of 6</span>
+
+Led development of a multi-cloud cybersecurity platform for SMEs, providing unified security monitoring across AWS, Azure, GCP, and Alibaba Cloud.
+
+- Led a cross-functional team from architecture through delivery
+- Designed and built the CI/CD pipeline on Azure DevOps with Docker/AKS
+- Integrated 4 cloud providers, open threat intelligence feeds, and a payment gateway
+- Built ETL pipelines with Airflow to consolidate security events into a unified dashboard
+
+<div class="row gap-1 mb-3" style="flex-wrap:wrap;">
+<ui-badge size="s" emphasis="subtle">Django</ui-badge>
+<ui-badge size="s" emphasis="subtle">React/Redux</ui-badge>
+<ui-badge size="s" emphasis="subtle">Spring Cloud</ui-badge>
+<ui-badge size="s" emphasis="subtle">Airflow</ui-badge>
+<ui-badge size="s" emphasis="subtle">PostgreSQL</ui-badge>
+<ui-badge size="s" emphasis="subtle">Elasticsearch</ui-badge>
+<ui-badge size="s" emphasis="subtle">Docker/AKS</ui-badge>
+</div>
+
+### Helius Technologies — Senior Application Developer
+
+<p class="body-02 text-secondary">May 2018 – October 2019</p>
+
+#### DBS Digimarkets
+
+Built an FX trading platform for DBS enabling traders to request quotes and book deals, with data-driven analytics.
+
+- Designed and developed the platform end-to-end, from Polymer/LitElement frontend to Spring Cloud backend with GraphQL APIs
+- Built a business rule engine service using OpenL Tablets
+
+<div class="row gap-1 mb-3" style="flex-wrap:wrap;">
+<ui-badge size="s" emphasis="subtle">Polymer/LitElement</ui-badge>
+<ui-badge size="s" emphasis="subtle">Spring Cloud</ui-badge>
+<ui-badge size="s" emphasis="subtle">GraphQL</ui-badge>
+<ui-badge size="s" emphasis="subtle">Kafka</ui-badge>
+<ui-badge size="s" emphasis="subtle">Elasticsearch</ui-badge>
+<ui-badge size="s" emphasis="subtle">Docker/OpenShift</ui-badge>
+</div>
+
+### FPT Software Limited — Software Engineer
+
+<p class="body-02 text-secondary">June 2014 – May 2018</p>
+
+Built retail and configuration systems for Starhub (AngularJS, Spring Boot, Neo4j) and a high-availability program guide web service for DirecTV/AT&T (Java/Spring Boot, Couchbase, Elasticsearch).
+
+### VietSoftware International — Software Engineer
+
+<p class="body-02 text-secondary">May 2012 – June 2014</p>
+
+Built an enterprise service bus for Alliance Bernstein (UK) and a foreign exchange management system for BIDV bank.
+
+## Education
+
+<div class="reveal">
+
+**Bachelor of Engineering, Information Technology**
+
+<p class="body-02 text-secondary">Post and Telecommunication Institute of Technology, Hanoi</p>
+
+</div>
+
+## Training
+
+Essential DDD — Paul Rayner
+`;
+
+console.log("Seeding resume page...");
+
+await db.execute({ sql: "DELETE FROM pages WHERE slug = ?", args: ["resume"] });
+await db.execute({
+  sql: `INSERT INTO pages (slug, title, content, description, status, updated_at)
+        VALUES (?, ?, ?, ?, 'published', datetime('now'))`,
+  args: ["resume", title, content, description],
+});
+
+console.log("Done — resume page seeded.");

--- a/apps/blog/src/api/db/schema.ts
+++ b/apps/blog/src/api/db/schema.ts
@@ -115,4 +115,18 @@ CREATE TABLE IF NOT EXISTS photo_tags (
 
 CREATE INDEX IF NOT EXISTS idx_photo_tags_photo ON photo_tags(photo_id);
 CREATE INDEX IF NOT EXISTS idx_photo_tags_tag ON photo_tags(tag_id);
+
+CREATE TABLE IF NOT EXISTS pages (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug TEXT UNIQUE NOT NULL,
+  title TEXT NOT NULL,
+  content TEXT NOT NULL DEFAULT '',
+  description TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'published', 'deleted')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_pages_status ON pages(status);
+CREATE INDEX IF NOT EXISTS idx_pages_slug ON pages(slug);
 `;

--- a/apps/blog/src/api/index.ts
+++ b/apps/blog/src/api/index.ts
@@ -16,6 +16,7 @@ import { projects } from "./routes/projects.js";
 import { photos } from "./routes/photos.js";
 import { albums } from "./routes/albums.js";
 import { tags } from "./routes/tags.js";
+import { pages } from "./routes/pages.js";
 
 /** Env bindings available in CF Pages Functions. */
 export type Env = {
@@ -53,7 +54,8 @@ const app = new Hono<Env>()
   .route("/projects", projects)
   .route("/photos", photos)
   .route("/albums", albums)
-  .route("/tags", tags);
+  .route("/tags", tags)
+  .route("/pages", pages);
 
 export type AppType = typeof app;
 export default app;

--- a/apps/blog/src/api/routes/pages.ts
+++ b/apps/blog/src/api/routes/pages.ts
@@ -1,0 +1,126 @@
+/**
+ * Pages CRUD routes — generic editable pages (about, resume, home, etc.).
+ * All routes are protected by CF Access auth middleware (applied at app level).
+ */
+
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import type { Env } from "../index.js";
+
+const createPageSchema = z.object({
+  slug: z
+    .string()
+    .min(1)
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/, "Slug must be lowercase kebab-case"),
+  title: z.string().min(1),
+  content: z.string().default(""),
+  description: z.string().default(""),
+  status: z.enum(["draft", "published"]).default("draft"),
+});
+
+const updatePageSchema = z.object({
+  title: z.string().min(1).optional(),
+  content: z.string().optional(),
+  description: z.string().optional(),
+  status: z.enum(["draft", "published"]).optional(),
+});
+
+export const pages = new Hono<Env>()
+  // List all pages
+  .get("/", async (c) => {
+    const status = c.req.query("status");
+    const db = c.get("db");
+
+    const sql = status
+      ? "SELECT * FROM pages WHERE status = ? ORDER BY updated_at DESC"
+      : "SELECT * FROM pages WHERE status != 'deleted' ORDER BY updated_at DESC";
+    const args = status ? [status] : [];
+
+    const result = await db.execute({ sql, args });
+    return c.json({ pages: result.rows });
+  })
+
+  // Get single page by slug
+  .get("/:slug", async (c) => {
+    const db = c.get("db");
+    const result = await db.execute({
+      sql: "SELECT * FROM pages WHERE slug = ?",
+      args: [c.req.param("slug")],
+    });
+    if (!result.rows.length) {
+      return c.json({ error: "not found" }, 404);
+    }
+    return c.json({ page: result.rows[0] });
+  })
+
+  // Create page
+  .post("/", zValidator("json", createPageSchema), async (c) => {
+    const data = c.req.valid("json");
+    const db = c.get("db");
+
+    await db.execute({
+      sql: `INSERT INTO pages (slug, title, content, description, status, updated_at)
+            VALUES (?, ?, ?, ?, ?, datetime('now'))`,
+      args: [data.slug, data.title, data.content, data.description, data.status],
+    });
+    const result = await db.execute({
+      sql: "SELECT * FROM pages WHERE slug = ?",
+      args: [data.slug],
+    });
+    return c.json({ ok: true, page: result.rows[0] }, 201);
+  })
+
+  // Update page by slug
+  .put("/:slug", zValidator("json", updatePageSchema), async (c) => {
+    const slug = c.req.param("slug");
+    const updates = c.req.valid("json");
+    const db = c.get("db");
+
+    const setClauses: string[] = [];
+    const args: (string | number | null)[] = [];
+
+    if (updates.title !== undefined) {
+      setClauses.push("title = ?");
+      args.push(updates.title);
+    }
+    if (updates.content !== undefined) {
+      setClauses.push("content = ?");
+      args.push(updates.content);
+    }
+    if (updates.description !== undefined) {
+      setClauses.push("description = ?");
+      args.push(updates.description);
+    }
+    if (updates.status !== undefined) {
+      setClauses.push("status = ?");
+      args.push(updates.status);
+    }
+
+    if (setClauses.length === 0) {
+      return c.json({ error: "no fields to update" }, 400);
+    }
+
+    setClauses.push("updated_at = datetime('now')");
+    args.push(slug);
+
+    await db.execute({
+      sql: `UPDATE pages SET ${setClauses.join(", ")} WHERE slug = ?`,
+      args,
+    });
+    const result = await db.execute({
+      sql: "SELECT * FROM pages WHERE slug = ?",
+      args: [slug],
+    });
+    return c.json({ ok: true, page: result.rows[0] });
+  })
+
+  // Soft delete page by slug
+  .delete("/:slug", async (c) => {
+    const db = c.get("db");
+    await db.execute({
+      sql: "UPDATE pages SET status = 'deleted', updated_at = datetime('now') WHERE slug = ?",
+      args: [c.req.param("slug")],
+    });
+    return c.json({ ok: true });
+  });

--- a/apps/blog/src/pages/about.ts
+++ b/apps/blog/src/pages/about.ts
@@ -1,35 +1,30 @@
+import { getPage } from "virtual:pages";
 import type { Route } from "../router.js";
+
+function renderAboutPage(): string {
+  const page = getPage("about");
+
+  if (!page) {
+    return `
+      <h1 class="heading-02 mb-4">About</h1>
+      <div class="post-content reveal">
+        <p>About page coming soon.</p>
+      </div>`;
+  }
+
+  return `
+    <h1 class="heading-02 mb-4">${page.title || "About"}</h1>
+    <div class="post-content reveal">
+      ${page.content}
+    </div>`;
+}
 
 export const aboutRoute: Route = {
   id: "about",
-  meta: { title: "About", description: "Senior Software Engineer with 14+ years of experience across the full stack. Polyglot engineer specializing in distributed systems, micro-frontend architecture, and fine-grained authorization." },
-  render: () => `
-    <h1 class="heading-02 mb-4">About</h1>
-
-    <div class="post-content reveal">
-      <p>Senior Software Engineer with 14+ years of hands-on experience across the full stack. Polyglot engineer specializing in distributed systems, micro-frontend architecture, and fine-grained authorization. Comfortable owning systems end-to-end — from API design and data modeling to CI/CD pipelines and observability.</p>
-
-      <p>Currently at Xendit, building mission-critical authorization services and leading frontend development for cross-border financial products across Southeast Asia.</p>
-
-      <h2>What I work with</h2>
-      <div class="row gap-1" style="flex-wrap:wrap;">
-        ${["Go", "TypeScript", "Java", "Python", "React", "Web Components", "Kafka", "PostgreSQL", "Redis", "OpenFGA", "Docker/K8s"].map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
-      </div>
-
-      <h2>Areas of focus</h2>
-      <div class="row gap-1" style="flex-wrap:wrap;">
-        ${["Distributed Systems", "Micro-Frontends", "Event-Driven Architecture", "DDD", "Fine-Grained Authorization", "Design Systems", "API Design"].map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
-      </div>
-
-      <h2>Outside of work</h2>
-      <p>Amateur photographer — mostly street, travel, and landscapes. You can see some of my shots on the <ui-link href="/photography">photography page</ui-link>.</p>
-
-      <h2>Get in touch</h2>
-      <p>
-        Find me on <ui-link href="https://github.com/kiennt23" external>GitHub</ui-link>
-        and <ui-link href="https://linkedin.com/in/kiennt23" external>LinkedIn</ui-link>,
-        or drop me an email at <ui-link href="mailto:kien@maneki.tech">kien@maneki.tech</ui-link>.
-      </p>
-    </div>
-  `,
+  meta: {
+    title: "About",
+    description:
+      "Senior Software Engineer with 14+ years of experience across the full stack. Polyglot engineer specializing in distributed systems, micro-frontend architecture, and fine-grained authorization.",
+  },
+  render: renderAboutPage,
 };

--- a/apps/blog/src/pages/resume.ts
+++ b/apps/blog/src/pages/resume.ts
@@ -1,147 +1,31 @@
+import { getPage } from "virtual:pages";
 import type { Route } from "../router.js";
+
+function renderResumePage(): string {
+  const page = getPage("resume");
+
+  if (!page) {
+    return `
+      <h1 class="heading-02 mb-4">Resume</h1>
+      <div class="post-content reveal">
+        <p>Resume coming soon.</p>
+      </div>`;
+  }
+
+  return `
+    <h1 class="heading-02 mb-2">${page.title || "Resume"}</h1>
+    <div class="post-content mt-4">
+      ${page.content}
+    </div>`;
+}
 
 export const resumeRoute: Route = {
   id: "resume",
-  meta: { title: "Resume", description: "Senior Software Engineer with 14+ years of experience. Go, TypeScript, Java, Python. Distributed systems, micro-frontends, fine-grained authorization." },
+  meta: {
+    title: "Resume",
+    description:
+      "Senior Software Engineer with 14+ years of experience. Go, TypeScript, Java, Python. Distributed systems, micro-frontends, fine-grained authorization.",
+  },
   showProgress: true,
-  render: () => `
-    <h1 class="heading-02 mb-2">Kien Nguyen Trung</h1>
-    <p class="body-01 text-secondary">Senior Software Engineer</p>
-    <div class="row gap-2 mt-1" style="flex-wrap:wrap;">
-      <ui-link href="mailto:kien@maneki.tech" size="s">kien@maneki.tech</ui-link>
-      <ui-link href="https://github.com/kiennt23" size="s" external>GitHub</ui-link>
-      <ui-link href="https://linkedin.com/in/kiennt23" size="s" external>LinkedIn</ui-link>
-    </div>
-
-    <div class="post-content mt-4">
-      <p>Senior Software Engineer with 14+ years of hands-on experience across the full stack. Polyglot engineer (Go, TypeScript, Java, Python) specializing in distributed systems, micro-frontend architecture, and fine-grained authorization.</p>
-
-      <h2>Skills</h2>
-      <div class="stack gap-2 reveal">
-        <div>
-          <p class="heading-05 mb-1">System Design</p>
-          <div class="row gap-1" style="flex-wrap:wrap;">
-            ${["Microservices", "Event-Driven Architecture", "DDD", "Fine-Grained Authorization (OpenFGA)", "API Design (REST, GraphQL)"].map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
-          </div>
-        </div>
-        <div>
-          <p class="heading-05 mb-1">Frontend Architecture</p>
-          <div class="row gap-1" style="flex-wrap:wrap;">
-            ${["React", "Web Components (Lit)", "Micro-Frontends (Module Federation)", "Atomic State Management", "Component-Driven Development", "Multi-Brand White-Labeling"].map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
-          </div>
-        </div>
-        <div>
-          <p class="heading-05 mb-1">Distributed Systems</p>
-          <div class="row gap-1" style="flex-wrap:wrap;">
-            ${["Kafka", "Redis", "Elasticsearch", "PostgreSQL", "SQL & NoSQL"].map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
-          </div>
-        </div>
-        <div>
-          <p class="heading-05 mb-1">Languages</p>
-          <div class="row gap-1" style="flex-wrap:wrap;">
-            ${["Go", "TypeScript", "Java", "Python"].map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
-          </div>
-        </div>
-      </div>
-
-      <h2>Experience</h2>
-
-      <h3>Xendit Pte Ltd \u2014 Senior Software Engineer</h3>
-      <p class="body-02 text-secondary">March 2021 \u2013 Present</p>
-      <p class="body-02 text-secondary mb-2">Southeast Asian fintech providing payment infrastructure across Indonesia, the Philippines, Hong Kong, Mexico, and beyond.</p>
-
-      <h4>Auth Platform <span class="body-02 text-secondary">| Engineer | Team of 2</span></h4>
-      <p>Designed and built a mission-critical fine-grained authorization service using OpenFGA \u2014 a single point of dependency for all product APIs and the merchant dashboard. Handles dynamic permission overrides across 5 product types and 140+ currency pairs with P99 latency under 40ms.</p>
-      <ul>
-        <li>Architected an FGA system using OpenFGA to replace legacy Postgres-based permission checks, supporting real-time blocklist/whitelist overrides across 5 financial products and 140+ currency pairs</li>
-        <li>Implemented smart override resolution that checks default permissions before writing, reducing write operations by ~40%</li>
-        <li>Parallelized all FGA read paths achieving P99 &lt;40ms across 11 concurrent FGA calls in the hot path of every API request</li>
-        <li>Designed a modular FGA model with source/destination/pair-level granularity, enabling country-office-level currency restrictions without downtime</li>
-      </ul>
-      <div class="row gap-1 mb-3" style="flex-wrap:wrap;">
-        ${["Go 1.24", "Echo v4", "OpenFGA", "PostgreSQL", "Redis", "Kafka"].map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
-      </div>
-
-      <h4>Regional Dashboard <span class="body-02 text-secondary">| Frontend Lead | Team of 6</span></h4>
-      <p>Led frontend development for Xendit's global expansion, shipping 5 cross-border products in under 6 months \u2014 Xendit's highest-margin product line.</p>
-      <ul>
-        <li>Delivered cross-border payments, balance conversion, cross-border payouts, withdrawals, and FX management \u2014 5 products in &lt;6 months</li>
-        <li>Modernized the frontend tech stack through the strangler pattern \u2014 no major rewrites, zero downtime</li>
-        <li>Built a scalable authorization layer ensuring compliance with local and global regulatory requirements across new markets</li>
-        <li>Optimized frontend performance, reducing initial load time by ~30%</li>
-      </ul>
-      <div class="row gap-1 mb-3" style="flex-wrap:wrap;">
-        ${["React 18", "TypeScript", "Module Federation", "React Compiler", "Jotai", "Radix UI"].map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
-      </div>
-
-      <h4>Transaction Monitoring System <span class="body-02 text-secondary">| Senior Software Engineer | Team of 6</span></h4>
-      <p>Built a compliance-driven transaction monitoring platform from the ground up.</p>
-      <ul>
-        <li>Developed a rule management UI for risk and compliance teams</li>
-        <li>Built the core rule engine to evaluate transactions in real-time and generate alerts</li>
-        <li>Integrated a third-party case management system for investigation workflows</li>
-        <li>Designed ETL pipelines to consolidate transaction data from multiple upstream sources</li>
-      </ul>
-      <div class="row gap-1 mb-3" style="flex-wrap:wrap;">
-        ${["React 18", "TypeScript", "Go", "Kafka"].map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
-      </div>
-
-      <h4>Merchant Dashboard <span class="body-02 text-secondary">| Senior Software Engineer | Team of 5</span></h4>
-      <p>Maintained and evolved a Module Federation monorepo hosting 14 micro-frontends, 3 BFF gateways, and 3 shared libraries serving multi-brand fintech dashboards.</p>
-      <ul>
-        <li>Developed a TUI launcher for local development handling submodule management across 21 git submodules</li>
-        <li>Supported multi-brand white-labeling across 4 fintech brands with shared infrastructure</li>
-        <li>Leading migration of the authentication layer to SuperTokens</li>
-      </ul>
-      <div class="row gap-1 mb-3" style="flex-wrap:wrap;">
-        ${["React 18", "Module Federation", "Redux", "Jotai", "Node.js/Express", "Nx", "Vite"].map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
-      </div>
-
-      <h3>Hearti Lab Pte Ltd \u2014 Product Developer Lead</h3>
-      <p class="body-02 text-secondary">October 2019 \u2013 February 2021</p>
-
-      <h4>CYBERhythm <span class="body-02 text-secondary">| Lead | Team of 6</span></h4>
-      <p>Led development of a multi-cloud cybersecurity platform for SMEs, providing unified security monitoring across AWS, Azure, GCP, and Alibaba Cloud.</p>
-      <ul>
-        <li>Led a cross-functional team from architecture through delivery</li>
-        <li>Designed and built the CI/CD pipeline on Azure DevOps with Docker/AKS</li>
-        <li>Integrated 4 cloud providers, open threat intelligence feeds, and a payment gateway</li>
-        <li>Built ETL pipelines with Airflow to consolidate security events into a unified dashboard</li>
-      </ul>
-      <div class="row gap-1 mb-3" style="flex-wrap:wrap;">
-        ${["Django", "React/Redux", "Spring Cloud", "Airflow", "PostgreSQL", "Elasticsearch", "Docker/AKS"].map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
-      </div>
-
-      <h3>Helius Technologies \u2014 Senior Application Developer</h3>
-      <p class="body-02 text-secondary">May 2018 \u2013 October 2019</p>
-
-      <h4>DBS Digimarkets</h4>
-      <p>Built an FX trading platform for DBS enabling traders to request quotes and book deals, with data-driven analytics.</p>
-      <ul>
-        <li>Designed and developed the platform end-to-end, from Polymer/LitElement frontend to Spring Cloud backend with GraphQL APIs</li>
-        <li>Built a business rule engine service using OpenL Tablets</li>
-      </ul>
-      <div class="row gap-1 mb-3" style="flex-wrap:wrap;">
-        ${["Polymer/LitElement", "Spring Cloud", "GraphQL", "Kafka", "Elasticsearch", "Docker/OpenShift"].map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
-      </div>
-
-      <h3>FPT Software Limited \u2014 Software Engineer</h3>
-      <p class="body-02 text-secondary">June 2014 \u2013 May 2018</p>
-      <p>Built retail and configuration systems for Starhub (AngularJS, Spring Boot, Neo4j) and a high-availability program guide web service for DirecTV/AT&T (Java/Spring Boot, Couchbase, Elasticsearch).</p>
-
-      <h3>VietSoftware International \u2014 Software Engineer</h3>
-      <p class="body-02 text-secondary">May 2012 \u2013 June 2014</p>
-      <p>Built an enterprise service bus for Alliance Bernstein (UK) and a foreign exchange management system for BIDV bank.</p>
-
-      <h2>Education</h2>
-      <div class="reveal">
-      <p><strong>Bachelor of Engineering, Information Technology</strong></p>
-      <p class="body-02 text-secondary">Post and Telecommunication Institute of Technology, Hanoi</p>
-      </div>
-
-
-      <h2>Training</h2>
-      <p>Essential DDD \u2014 Paul Rayner</p>
-    </div>
-  `,
+  render: renderResumePage,
 };

--- a/apps/blog/src/virtual-pages.d.ts
+++ b/apps/blog/src/virtual-pages.d.ts
@@ -1,0 +1,11 @@
+declare module "virtual:pages" {
+  export interface VirtualPage {
+    slug: string;
+    title: string;
+    content: string;
+    description: string;
+    updatedAt: string;
+  }
+  export const pages: VirtualPage[];
+  export function getPage(slug: string): VirtualPage | undefined;
+}

--- a/apps/blog/vite.config.ts
+++ b/apps/blog/vite.config.ts
@@ -6,6 +6,7 @@ import { photographyPlugin } from "./plugins/photography.js";
 import { autoUiComponentsPlugin } from "./plugins/auto-ui-components.js";
 import { sitemapPlugin } from "./plugins/sitemap.js";
 import { rssFeedPlugin } from "./plugins/rss-feed.js";
+import { pagesPlugin } from "./plugins/pages.js";
 import { injectTokensPlugin } from "./plugins/inject-tokens.js";
 import { devAliases } from "../../shared/vite-dev-aliases.js";
 import { readFileSync, existsSync } from "node:fs";
@@ -50,6 +51,7 @@ export default defineConfig(({ command }) => ({
     autoUiComponentsPlugin(),
     sitemapPlugin(),
     rssFeedPlugin(),
+    pagesPlugin(),
     VitePWA({
       registerType: "autoUpdate",
       manifest: false,


### PR DESCRIPTION
Closes #246, #247

## Summary
- Add generic `pages` table for editable content pages (about, resume, homepage, etc.)
- Pages API routes (CRUD), Vite plugin (`virtual:pages`), markdown → HTML rendering
- Rewrite `about.ts` and `resume.ts` to use `virtual:pages` — thin wrappers that call `getPage(slug)`
- All page-specific content (badges, links, layout) lives in the markdown itself — no `meta` field hacks
- Seed scripts for about + resume content

## Changes

| File | Change |
|------|--------|
| `schema.ts` | Add `pages` table (slug, title, content, description, status) |
| `routes/pages.ts` | Generic CRUD for pages |
| `api/index.ts` | Mount `/api/pages` route |
| `plugins/pages.ts` | Vite plugin: fetch from Turso, render markdown, expose `virtual:pages` |
| `virtual-pages.d.ts` | Type declarations for virtual module |
| `vite.config.ts` | Register pages plugin |
| `pages/about.ts` | Rewritten to use `getPage("about")` |
| `pages/resume.ts` | Rewritten to use `getPage("resume")` |
| `scripts/seed-about.ts` | Seed about page content |
| `scripts/seed-resume.ts` | Seed resume page content |
| `scripts/migrate.ts` | Create pages table migration |

## Setup
1. Run `npm run migrate` to create the pages table
2. Run `npx tsx scripts/seed-about.ts` and `npx tsx scripts/seed-resume.ts` to populate content