### PR TITLE
fix(blog): strip f/ prefix from EXIF FNumber before display

### DIFF
--- a/apps/blog/src/admin/gallery.ts
+++ b/apps/blog/src/admin/gallery.ts
@@ -1395,7 +1395,7 @@ export class AdminGallery extends LitElement {
                     ${exif.Make ? html`<div class="exif-row"><span class="exif-key">Camera</span><span class="exif-val">${exif.Make}${exif.Model ? ` ${exif.Model}` : ""}</span></div>` : nothing}
                     ${exif.LensModel ? html`<div class="exif-row"><span class="exif-key">Lens</span><span class="exif-val">${exif.LensModel}</span></div>` : nothing}
                     ${exif.FocalLength ? html`<div class="exif-row"><span class="exif-key">Focal Length</span><span class="exif-val">${exif.FocalLength}mm</span></div>` : nothing}
-                    ${exif.FNumber ? html`<div class="exif-row"><span class="exif-key">Aperture</span><span class="exif-val">${String(exif.FNumber).startsWith("f/") ? exif.FNumber : `f/${exif.FNumber}`}</span></div>` : nothing}
+                    ${exif.FNumber ? html`<div class="exif-row"><span class="exif-key">Aperture</span><span class="exif-val">ƒ/${String(exif.FNumber).replace(/^f\//, "")}</span></div>` : nothing}
                     ${exif.ExposureTime ? html`<div class="exif-row"><span class="exif-key">Shutter</span><span class="exif-val">${exif.ExposureTime}s</span></div>` : nothing}
                     ${exif.ISO ? html`<div class="exif-row"><span class="exif-key">ISO</span><span class="exif-val">${exif.ISO}</span></div>` : nothing}
                     ${exif.DateTimeOriginal ? html`<div class="exif-row"><span class="exif-key">Date Taken</span><span class="exif-val">${exif.DateTimeOriginal}</span></div>` : nothing}

--- a/apps/blog/src/components/photo-grid.ts
+++ b/apps/blog/src/components/photo-grid.ts
@@ -150,7 +150,8 @@ class PhotoGrid extends HTMLElement {
       const parts: string[] = [];
       if (exif.Make || exif.Model) parts.push(String(exif.Make && exif.Model ? `${exif.Make} ${exif.Model}` : exif.Make || exif.Model));
       if (exif.FocalLength) parts.push(`${exif.FocalLength}mm`);
-      if (exif.FNumber != null) parts.push(`ƒ/${exif.FNumber}`);
+      if (exif.FNumber != null) parts.push(`ƒ/${String(exif.FNumber).replace(/^f\//, "")}`);
+
       if (exif.ExposureTime) parts.push(`${exif.ExposureTime}s`);
       if (exif.ISO) parts.push(`ISO ${exif.ISO}`);
 

--- a/apps/blog/src/components/photo-lightbox.ts
+++ b/apps/blog/src/components/photo-lightbox.ts
@@ -323,7 +323,7 @@ class PhotoLightbox extends HTMLElement {
       ["Camera", exif.Make && exif.Model ? `${exif.Make} ${exif.Model}` : exif.Make || exif.Model],
       ["Lens", exif.LensModel],
       ["Focal Length", exif.FocalLength],
-      ["Aperture", exif.FNumber != null ? `ƒ/${exif.FNumber}` : null],
+      ["Aperture", exif.FNumber != null ? `ƒ/${String(exif.FNumber).replace(/^f\//, "")}` : null],
       ["Shutter Speed", exif.ExposureTime],
       ["ISO", exif.ISO],
     ];


### PR DESCRIPTION
## Summary
- EXIF aperture was displaying as `ƒ/f/2.8` instead of `ƒ/2.8` because `exif.FNumber` already contains the `f/` prefix from exif-reader
- Strip `f/` prefix before prepending `ƒ/` in all three display locations
- Admin gallery also switched from `f/` to `ƒ/` for consistent typography

Closes #311