### PR TITLE
feat(ui-components): add placeholder attribute to ui-image

### DIFF
--- a/apps/catalog/src/pages/image.ts
+++ b/apps/catalog/src/pages/image.ts
@@ -18,19 +18,22 @@ registerPage("image", {
     <h3>Object Fit</h3>
     <div id="object-fit-demo" class="variant-row gap-24"></div>
 
-    <h3>Placeholder</h3>
+    <h3>Placeholder (blur-up)</h3>
     <div class="variant-row gap-24">
       <div class="flex-1">
         <p class="mono-label">No src (default bg)</p>
         <ui-image ratio="16:9"></ui-image>
       </div>
       <div class="flex-1">
-        <p class="mono-label">Custom placeholder</p>
+        <p class="mono-label">Custom fallback slot</p>
         <ui-image ratio="16:9">
           <div style="display:flex;align-items:center;justify-content:center;height:100%;color:#5b7282;font-size:14px">No image available</div>
         </ui-image>
       </div>
     </div>
+
+    <h3>Placeholder with data URL</h3>
+    <div id="placeholder-demo" class="variant-row gap-24"></div>
 
     <h3>In Card</h3>
     <div class="w-320">
@@ -68,14 +71,50 @@ registerPage("image", {
   `,
   setup: () => {
     const png = createLandscapePng();
+
+    // Object fit demo
     const container = document.getElementById("object-fit-demo");
-    if (!container) return;
-    container.innerHTML = "";
-    for (const f of ["cover", "contain", "fill", "none"]) {
-      const col = document.createElement("div");
-      col.className = "flex-1";
-      col.innerHTML = `<p class="mono-label">${f}</p><ui-image ratio="1:1" fit="${f}" src="${png}" alt="landscape"></ui-image>`;
-      container.appendChild(col);
+    if (container) {
+      container.innerHTML = "";
+      for (const f of ["cover", "contain", "fill", "none"]) {
+        const col = document.createElement("div");
+        col.className = "flex-1";
+        col.innerHTML = `<p class="mono-label">${f}</p><ui-image ratio="1:1" fit="${f}" src="${png}" alt="landscape"></ui-image>`;
+        container.appendChild(col);
+      }
+    }
+
+    // Placeholder blur-up demo — generate a tiny blurred placeholder from canvas
+    const phDemo = document.getElementById("placeholder-demo");
+    if (phDemo) {
+      const c = document.createElement("canvas");
+      c.width = 4; c.height = 2;
+      const ctx = c.getContext("2d")!;
+      ctx.fillStyle = "#87CEEB"; ctx.fillRect(0, 0, 4, 2);
+      ctx.fillStyle = "#228B22"; ctx.fillRect(0, 1, 4, 1);
+      const placeholder = c.toDataURL("image/png");
+
+      // With placeholder + real image (shows blur then crossfade)
+      const col1 = document.createElement("div");
+      col1.className = "flex-1";
+      col1.innerHTML = `<p class="mono-label">placeholder + src (blur-up)</p><ui-image ratio="16:9" placeholder="${placeholder}" src="${png}" alt="landscape"></ui-image>`;
+      phDemo.appendChild(col1);
+
+      // With placeholder only (no src — stays blurred)
+      const col2 = document.createElement("div");
+      col2.className = "flex-1";
+      col2.innerHTML = `<p class="mono-label">placeholder only (no src)</p><ui-image ratio="16:9" placeholder="${placeholder}"></ui-image>`;
+      phDemo.appendChild(col2);
+
+      // Delayed load — shows placeholder then fades in after 1s
+      const col3 = document.createElement("div");
+      col3.className = "flex-1";
+      col3.innerHTML = `<p class="mono-label">delayed load (1s)</p><ui-image id="delayed-placeholder" ratio="16:9" placeholder="${placeholder}"></ui-image>`;
+      phDemo.appendChild(col3);
+      setTimeout(() => {
+        const delayed = document.getElementById("delayed-placeholder");
+        if (delayed) delayed.setAttribute("src", png);
+      }, 1000);
     }
   },
 });

--- a/packages/ui-components/src/components/ui-image.ts
+++ b/packages/ui-components/src/components/ui-image.ts
@@ -32,6 +32,8 @@ const STYLES = /* css */ `
     width: 100%;
     overflow: hidden;
     background-color: var(--ui-image-bg, ${SURFACE_SECONDARY});
+    background-size: cover;
+    background-position: center;
   }
 
   .container.has-ratio {
@@ -47,6 +49,21 @@ const STYLES = /* css */ `
     width: 100%;
     height: 100%;
     object-fit: var(--ui-image-fit, cover);
+  }
+
+  :host([placeholder]) img {
+    opacity: 0;
+    transition: opacity 0.3s ease;
+  }
+
+  :host([placeholder]) img.loaded {
+    opacity: 1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    :host([placeholder]) img {
+      transition: none;
+    }
   }
 
   .container.has-ratio img {
@@ -97,7 +114,7 @@ const sheet = new CSSStyleSheet();
 sheet.replaceSync(STYLES);
 
 export class UiImage extends HTMLElement {
-  static readonly observedAttributes = ["src", "alt", "ratio", "fit"];
+  static readonly observedAttributes = ["src", "alt", "ratio", "fit", "placeholder"];
 
   private _container: HTMLDivElement;
   private _img: HTMLImageElement;
@@ -117,6 +134,8 @@ export class UiImage extends HTMLElement {
     // img
     const img = document.createElement("img");
     img.alt = "";
+    img.addEventListener("load", () => this._onImgLoad());
+    img.addEventListener("error", () => this._onImgError());
     container.appendChild(img);
 
     // fallback slot
@@ -186,6 +205,14 @@ export class UiImage extends HTMLElement {
     this.setAttribute("fit", v);
   }
 
+  get placeholder(): string {
+    return this.getAttribute("placeholder") ?? "";
+  }
+  set placeholder(v: string) {
+    if (v) this.setAttribute("placeholder", v);
+    else this.removeAttribute("placeholder");
+  }
+
   // ── Lifecycle ────────────────────────────────────────────────────────────
 
   attributeChangedCallback(name: string, _old: string | null, _new: string | null): void {
@@ -202,6 +229,9 @@ export class UiImage extends HTMLElement {
       case "fit":
         this._syncFit();
         break;
+      case "placeholder":
+        this._syncPlaceholder();
+        break;
     }
   }
 
@@ -210,11 +240,13 @@ export class UiImage extends HTMLElement {
   private _syncSrc(): void {
     const src = this.src;
     if (src) {
+      this._img.classList.remove("loaded");
       this._img.src = src;
       this._img.style.display = "";
     } else {
       this._img.removeAttribute("src");
       this._img.style.display = "none";
+      this._img.classList.remove("loaded");
     }
   }
 
@@ -233,6 +265,24 @@ export class UiImage extends HTMLElement {
   private _syncFit(): void {
     const fit = this.fit;
     this._container.style.setProperty("--ui-image-fit", fit);
+  }
+
+  private _syncPlaceholder(): void {
+    const ph = this.placeholder;
+    if (ph) {
+      this._container.style.backgroundImage = `url(${ph})`;
+    } else {
+      this._container.style.backgroundImage = "";
+      this._img.classList.add("loaded");
+    }
+  }
+
+  private _onImgLoad(): void {
+    this._img.classList.add("loaded");
+  }
+
+  private _onImgError(): void {
+    this._container.style.backgroundImage = "";
   }
 
   private _syncCaption(caption: HTMLDivElement, slot: HTMLSlotElement): void {


### PR DESCRIPTION
Closes #309

## Summary
Add a `placeholder` attribute to `<ui-image>` that shows a blurred placeholder (data URL) while the main image loads, with a 0.3s crossfade on load.

## API
```html
<ui-image src="photo.jpg" placeholder="data:image/png;base64,..."></ui-image>
```

## Behavior
1. Placeholder shown as `background-image` on the container
2. `<img>` starts at `opacity: 0`, fades to `1` on load (0.3s ease)
3. On error, placeholder is cleared
4. When `src` changes, resets to placeholder state
5. Without `placeholder`, behaves exactly as before (no transition)
6. Respects `prefers-reduced-motion`

## Notes
- Consumers handle thumbhash decoding — `ui-image` accepts any data URL
- No new dependencies
- All 3632 existing tests pass