### PR TITLE
fix(charts): build order — vite build before tsc to preserve d.ts files

### DIFF
--- a/packages/charts/moon.yml
+++ b/packages/charts/moon.yml
@@ -4,7 +4,7 @@ language: 'typescript'
 
 tasks:
   build:
-    script: 'tsc && vite build'
+    script: 'vite build && tsc --emitDeclarationOnly'
     inputs:
       - 'src/**/*'
       - 'tsconfig.json'

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build && tsc --emitDeclarationOnly",
     "preview": "vite preview",
     "test": "vitest --run",
     "test:watch": "vitest"


### PR DESCRIPTION
Closes #317

## Summary
Same issue as grid-layout had — `tsc && vite build` means Vite's `emptyOutDir` wipes the `.d.ts` files that tsc generated. Reversed to `vite build && tsc --emitDeclarationOnly`.

## Changes
- `packages/charts/package.json` — build script order
- `packages/charts/moon.yml` — same