### PR TITLE
fix(blog): strip duplicate mm suffix from EXIF focal length

### DIFF
--- a/apps/blog/src/components/photo-grid.ts
+++ b/apps/blog/src/components/photo-grid.ts
@@ -139,7 +139,7 @@ class PhotoGrid extends HTMLElement {
       const exif = photo.exif || {};
       const parts: string[] = [];
       if (exif.Make || exif.Model) parts.push(String(exif.Make && exif.Model ? `${exif.Make} ${exif.Model}` : exif.Make || exif.Model));
-      if (exif.FocalLength) parts.push(`${exif.FocalLength}mm`);
+      if (exif.FocalLength) parts.push(`${String(exif.FocalLength).replace(/\s*mm$/i, '')} mm`);
       if (exif.FNumber != null) parts.push(`ƒ/${String(exif.FNumber).replace(/^f\//, "")}`);
 
       if (exif.ExposureTime) parts.push(`${exif.ExposureTime}s`);


### PR DESCRIPTION
## Summary

Fixes #325 — focal length on photography page shows double 'mm' (e.g. '105 mmmm').

## Cause

EXIF `FocalLength` already includes the 'mm' suffix, and the rendering code appended another.

## Fix

Strip trailing 'mm' from the EXIF value before appending ' mm' with proper spacing.