### PR TITLE
fix(blog): replace sidebar click workaround with direct Lit event bindings

### DIFF
--- a/apps/blog/src/pages/editor/editor-page.ts
+++ b/apps/blog/src/pages/editor/editor-page.ts
@@ -180,7 +180,7 @@ export class EditorPage extends LitElement {
     const s = this.store.state;
     return html`
       <div class="admin-layout">
-        <ui-side-panel-menu id="admin-sidebar" style="display:${s.loaded ? "" : "none"}" @select=${this._onSidebarSelect} @toggle=${() => saveUIState()} @click=${this._onSidebarClick}>
+        <ui-side-panel-menu id="admin-sidebar" style="display:${s.loaded ? "" : "none"}" @select=${this._onSidebarSelect} @toggle=${() => saveUIState()} @new-post=${() => this._onNewPost()} @new-project=${() => this._onNewProject()}>
           <span slot="header" style="display:flex;align-items:center;gap:8px;">
             <ui-button action="secondary" emphasis="minimal" size="s" @click=${() => { window.location.href = "/admin"; }}>
               <ui-icon name="chevron_left" size="s" slot="icon-start"></ui-icon>
@@ -600,12 +600,6 @@ export class EditorPage extends LitElement {
     saveUIState();
   }
 
-  private _onSidebarClick(e: Event): void {
-    const target = (e.target as Element).closest?.("ui-button[id]");
-    if (!target) return;
-    if ((target as HTMLElement).id === "admin-new-post") this._onNewPost();
-    if ((target as HTMLElement).id === "admin-new-project") this._onNewProject();
-  }
 
   // ─── Ctrl+S keyboard shortcut (replaces keyboard.ts Ctrl+S handler) ────────
   private _onDocumentKeydown = (e: KeyboardEvent): void => {

--- a/apps/blog/src/pages/editor/sidebar.ts
+++ b/apps/blog/src/pages/editor/sidebar.ts
@@ -58,6 +58,7 @@ export class EditorSidebar extends LitElement {
             size="s"
             icon="icon-only"
             aria-label="New Post"
+            @click=${() => this.dispatchEvent(new CustomEvent('new-post', { bubbles: true, composed: true }))}
             ><ui-icon name="add" size="s" slot="icon-start"></ui-icon
           ></ui-button>
         </span>
@@ -77,6 +78,7 @@ export class EditorSidebar extends LitElement {
             size="s"
             icon="icon-only"
             aria-label="New Project"
+            @click=${() => this.dispatchEvent(new CustomEvent('new-project', { bubbles: true, composed: true }))}
             ><ui-icon name="add" size="s" slot="icon-start"></ui-icon
           ></ui-button>
         </span>


### PR DESCRIPTION
## Summary

Fixes #256 — Lit `@click` bindings fail on elements slotted into `ui-side-panel-menu-section`.

## Root Cause

The entire side-panel family has since been migrated to Lit (ADR-028), but the imperative event delegation workaround was never removed. The original bug — Lit `@click` not firing through double-nested vanilla Shadow DOM slots — no longer applies since all components in the chain are now LitElement.

## Changes

- `sidebar.ts`: Added `@click` handlers on "New Post" and "New Project" buttons that dispatch `new-post` / `new-project` custom events (`bubbles: true, composed: true`)
- `editor-page.ts`: Replaced `@click=${this._onSidebarClick}` event delegation workaround with `@new-post` / `@new-project` listeners. Removed `_onSidebarClick` method.

Net: +3 lines, -7 lines.