### PR TITLE
fix(blog): photography filter — use categories, fix uncheck behavior

### DIFF
--- a/apps/blog/index.html
+++ b/apps/blog/index.html
@@ -112,6 +112,7 @@
       width: 100%;
       margin: 0 auto;
       padding: var(--fd-space-3) var(--fd-space-3) 0;
+      transition: max-width 0.4s ease;
     }
 
     .site-name {
@@ -176,6 +177,13 @@
       width: 100%;
       margin: 0 auto;
       padding: var(--fd-space-6) var(--fd-space-3);
+      transition: max-width 0.4s ease;
+    }
+
+    body.wide-layout header,
+    body.wide-layout main,
+    body.wide-layout footer {
+      max-width: 1200px;
     }
 
     /* ─── Footer ─── */
@@ -188,6 +196,7 @@
       border-top: 1px solid var(--fd-border-minimal, #e4e4e7);
       font-size: 12px;
       color: var(--fd-text-secondary, #52525b);
+      transition: max-width 0.4s ease;
       display: flex;
       justify-content: space-between;
       align-items: center;

--- a/apps/blog/plugins/photography.ts
+++ b/apps/blog/plugins/photography.ts
@@ -19,7 +19,7 @@ const PHOTOS_RESOLVED_ID = "\0" + PHOTOS_MODULE_ID;
 const ALBUMS_MODULE_ID = "virtual:albums";
 const ALBUMS_RESOLVED_ID = "\0" + ALBUMS_MODULE_ID;
 
-const EMPTY_PHOTOS = "export const photos = [];\nexport const featuredPhotos = [];\nexport const categories = [];";
+const EMPTY_PHOTOS = "export const photos = [];\nexport const featuredPhotos = [];\nexport const tags = [];";
 const EMPTY_ALBUMS = "export const albums = [];";
 
 export function photographyPlugin(): Plugin {
@@ -38,6 +38,17 @@ export function photographyPlugin(): Plugin {
         "SELECT id, r2_key, url, title, caption, album_id, category, width, height, thumbhash, exif_json, sort_order, featured FROM photos WHERE status = 'published' ORDER BY sort_order ASC, created_at DESC",
       );
 
+      // Fetch tags per photo
+      const tagResult = await db.execute(
+        "SELECT pt.photo_id, t.name FROM photo_tags pt JOIN tags t ON t.id = pt.tag_id",
+      );
+      const photoTags = new Map<number, string[]>();
+      for (const row of tagResult.rows) {
+        const pid = row.photo_id as number;
+        if (!photoTags.has(pid)) photoTags.set(pid, []);
+        photoTags.get(pid)!.push(row.name as string);
+      }
+
       const photos = result.rows.map((row) => ({
         id: row.id as number,
         r2Key: row.r2_key as string,
@@ -46,6 +57,7 @@ export function photographyPlugin(): Plugin {
         caption: row.caption as string,
         albumId: (row.album_id as number) ?? null,
         category: row.category as string,
+        tags: [...new Set(photoTags.get(row.id as number) ?? [])],
         width: row.width as number,
         height: row.height as number,
         thumbhash: row.thumbhash as string,
@@ -55,13 +67,13 @@ export function photographyPlugin(): Plugin {
       }));
 
       const featured = photos.filter((p) => p.featured);
-      const categorySet = new Set(photos.map((p) => p.category).filter(Boolean));
-      const categories = [...categorySet].sort();
+      const tagSet = new Set(photos.flatMap((p) => p.tags));
+      const tags = [...tagSet].sort();
 
       console.log(
-        `[photography] Loaded ${photos.length} published photos (${featured.length} featured, ${categories.length} categories)`,
+        `[photography] Loaded ${photos.length} published photos (${featured.length} featured, ${tags.length} tags)`,
       );
-      return `export const photos = ${JSON.stringify(photos)};\nexport const featuredPhotos = ${JSON.stringify(featured)};\nexport const categories = ${JSON.stringify(categories)};`;
+      return `export const photos = ${JSON.stringify(photos)};\nexport const featuredPhotos = ${JSON.stringify(featured)};\nexport const tags = ${JSON.stringify(tags)};`;
     } catch (err) {
       console.error("[photography] Failed to fetch photos from Turso:", err);
       return EMPTY_PHOTOS;

--- a/apps/blog/scripts/prerender.ts
+++ b/apps/blog/scripts/prerender.ts
@@ -138,6 +138,11 @@ async function prerender(): Promise<void> {
           );
       }
 
+      // Add wide-layout class for photography page
+      if (route.id === "photography") {
+        page = page.replace("<body", '<body class="wide-layout"');
+      }
+
       // Write flat files: dist/blog.html (not dist/blog/index.html)
       // Cloudflare Pages serves blog.html for /blog without trailing slash redirect
       if (route.id === "home") {

--- a/apps/blog/src/components/photo-lightbox.ts
+++ b/apps/blog/src/components/photo-lightbox.ts
@@ -3,14 +3,18 @@ import type { Photo } from "./photo-types.js";
 const styles = new CSSStyleSheet();
 styles.replaceSync(/*css*/ `
   :host {
-    display: none;
+    display: block;
     position: fixed;
     inset: 0;
     z-index: 9999;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.25s ease, visibility 0.25s ease;
   }
 
   :host([open]) {
-    display: block;
+    opacity: 1;
+    visibility: visible;
   }
 
   .backdrop {

--- a/apps/blog/src/components/photo-types.ts
+++ b/apps/blog/src/components/photo-types.ts
@@ -5,6 +5,7 @@ export interface Photo {
   caption: string;
   albumId: number | null;
   category: string;
+  tags: string[];
   width: number;
   height: number;
   thumbhash: string;

--- a/apps/blog/src/pages/photography.ts
+++ b/apps/blog/src/pages/photography.ts
@@ -1,10 +1,9 @@
 /**
  * /photography — Public photography page.
- * Masonry grid with album filtering and lightbox.
+ * Masonry grid with tag filtering and lightbox.
  */
 
-import { photos } from "virtual:photos";
-import { albums } from "virtual:albums";
+import { photos, tags as allTags } from "virtual:photos";
 import type { Route } from "../router.js";
 import type { Photo } from "../components/photo-types.js";
 import "../components/photo-grid.js";
@@ -18,6 +17,7 @@ function toPhoto(p: (typeof photos)[number]): Photo {
     caption: p.caption,
     albumId: p.albumId,
     category: p.category,
+    tags: p.tags,
     width: p.width,
     height: p.height,
     thumbhash: p.thumbhash,
@@ -38,11 +38,11 @@ export const photographyRoute: Route = {
   render: () => `
     <h1 class="heading-02 mb-2">Photography</h1>
     ${
-      albums.length > 0
+      allTags.length > 0
         ? `
       <div id="photo-filters" class="row gap-1 mb-4" style="flex-wrap:wrap;">
-        <ui-tag type="selectable" size="s" selected data-album="all">All</ui-tag>
-        ${albums.map((a) => `<ui-tag type="selectable" size="s" data-album="${a.slug}" data-album-id="${a.id}">${a.title}</ui-tag>`).join("")}
+        <ui-tag type="selectable" size="s" data-tag="all" state="selected">All</ui-tag>
+        ${allTags.map((t) => `<ui-tag type="selectable" size="s" data-tag="${t}">${t}</ui-tag>`).join("")}
       </div>
     `
         : ""
@@ -64,9 +64,10 @@ export const photographyRoute: Route = {
     const filters = document.getElementById("photo-filters");
 
     if (!grid) return;
+    const gridEl = grid;
 
     let currentPhotos = allPhotos;
-    grid.setPhotos(currentPhotos);
+    gridEl.setPhotos(currentPhotos);
 
     // Open lightbox on photo click
     grid.addEventListener("photo-select", ((e: CustomEvent) => {
@@ -82,51 +83,64 @@ export const photographyRoute: Route = {
       if (idx >= 0) lightbox?.open(idx, currentPhotos);
     }
 
-    // Album filter
+    // Tag filter
     if (filters) {
-      filters.addEventListener("click", (e) => {
-        const tag = (e.target as Element).closest("ui-tag[data-album]") as HTMLElement | null;
-        if (!tag) return;
+      const selectedTags = new Set<string>();
 
-        // Update selected state
-        filters.querySelectorAll("ui-tag").forEach((t) => t.removeAttribute("selected"));
-        tag.setAttribute("selected", "");
-
-        const albumSlug = tag.dataset.album;
-        const albumId = tag.dataset.albumId ? Number(tag.dataset.albumId) : null;
-
-        if (albumSlug === "all" || !albumId) {
+      function applyFilter(): void {
+        if (selectedTags.size === 0) {
           currentPhotos = allPhotos;
         } else {
-          currentPhotos = allPhotos.filter((p) => p.albumId === albumId);
+          currentPhotos = allPhotos.filter((p) => p.tags.some((t) => selectedTags.has(t)));
         }
+        gridEl.setPhotos(currentPhotos);
 
-        grid.setPhotos(currentPhotos);
+        // Sync "All" tag visual state
+        const allTag = filters!.querySelector('ui-tag[data-tag="all"]') as HTMLElement | null;
+        if (allTag) allTag.setAttribute("state", selectedTags.size === 0 ? "selected" : "enabled");
 
         // Update URL
         const url = new URL(window.location.href);
-        if (albumSlug === "all") {
-          url.searchParams.delete("album");
-        } else {
-          url.searchParams.set("album", albumSlug!);
-        }
+        url.searchParams.delete("tag");
         url.searchParams.delete("photo");
+        for (const t of selectedTags) url.searchParams.append("tag", t);
         history.replaceState(null, "", url.toString());
-      });
+      }
 
-      // Restore filter from URL
-      const albumParam = params.get("album");
-      if (albumParam) {
-        const tag = filters.querySelector(`ui-tag[data-album="${albumParam}"]`) as HTMLElement | null;
-        if (tag) {
-          filters.querySelectorAll("ui-tag").forEach((t) => t.removeAttribute("selected"));
-          tag.setAttribute("selected", "");
-          const albumId = tag.dataset.albumId ? Number(tag.dataset.albumId) : null;
-          if (albumId) {
-            currentPhotos = allPhotos.filter((p) => p.albumId === albumId);
-            grid.setPhotos(currentPhotos);
+      filters.addEventListener("change", ((e: CustomEvent) => {
+        const tag = (e.target as HTMLElement).closest("ui-tag[data-tag]") as HTMLElement | null;
+        if (!tag) return;
+        const tagName = tag.dataset.tag!;
+        const isSelected = e.detail?.selected;
+
+        if (tagName === "all") {
+          // "All" clicked — clear all other selections
+          selectedTags.clear();
+          filters!.querySelectorAll('ui-tag:not([data-tag="all"])').forEach((t) => t.setAttribute("state", "enabled"));
+          // Force "All" to stay selected
+          tag.setAttribute("state", "selected");
+        } else {
+          if (isSelected) {
+            selectedTags.add(tagName);
+          } else {
+            selectedTags.delete(tagName);
           }
         }
+
+        applyFilter();
+      }) as EventListener);
+
+      // Restore filter from URL
+      const tagParams = params.getAll("tag");
+      if (tagParams.length > 0) {
+        for (const t of tagParams) {
+          const tagEl = filters.querySelector(`ui-tag[data-tag="${t}"]`) as HTMLElement | null;
+          if (tagEl) {
+            selectedTags.add(t);
+            tagEl.setAttribute("state", "selected");
+          }
+        }
+        applyFilter();
       }
     }
   },

--- a/apps/blog/src/router.ts
+++ b/apps/blog/src/router.ts
@@ -250,6 +250,14 @@ export async function renderRoute(): Promise<void> {
     await new Promise((r) => setTimeout(r, 150));
     content.innerHTML = route.render!();
     content.classList.remove("page-exit");
+
+    // Toggle wide layout — delay when FLIP is active to avoid moving the target
+    const hasFlip = isLeavingHome || isGoingHome;
+    if (hasFlip) {
+      setTimeout(() => document.body.classList.toggle("wide-layout", routeId === "photography"), 450);
+    } else {
+      document.body.classList.toggle("wide-layout", routeId === "photography");
+    }
     // Re-trigger enter animation
     content.style.animation = "none";
     content.offsetHeight; // force reflow
@@ -298,6 +306,7 @@ function updateMeta(routeId: string, route: Route | undefined): void {
 
   // Toggle page identifier for conditional styling (e.g., hide site-name on home)
   document.documentElement.dataset.page = routeId === "home" ? "home" : "";
+
 
 
   // Update active nav link with directional underline

--- a/apps/blog/src/virtual-photos.d.ts
+++ b/apps/blog/src/virtual-photos.d.ts
@@ -7,6 +7,7 @@ declare module "virtual:photos" {
     caption: string;
     albumId: number | null;
     category: string;
+    tags: string[];
     width: number;
     height: number;
     thumbhash: string;
@@ -16,5 +17,5 @@ declare module "virtual:photos" {
   }
   export const photos: VirtualPhoto[];
   export const featuredPhotos: VirtualPhoto[];
-  export const categories: string[];
+  export const tags: string[];
 }


### PR DESCRIPTION
## Summary

Fixes #330 — photography page filter tags can't be unchecked, and filters use albums instead of tags.

## Changes

### Tag-based filtering
- **Switched from album-based to tag-based filtering**: queries `tags` + `photo_tags` many-to-many tables. Each photo carries `tags: string[]` (deduplicated).
- **Multi-tag selection**: toggle individual tags independently, filter shows photos matching ANY selected tag. URL supports multiple `?tag=` params via `getAll`/`append`.
- **"All" tag** (selected by default) resets all selections. Works with `ui-tag`'s built-in `state` attribute and `change` event.

### Lightbox animation
- **Added fade-in/out** on open/close: `opacity` + `visibility` transition (0.25s ease).

### Wider layout
- **Photography page uses 1200px max-width** via `body.wide-layout` class on header/main/footer.
- **Smooth width transition** (0.4s ease) with FLIP-aware timing — width change delayed 450ms when FLIP signature animation is active (home ↔ other pages), immediate otherwise.
- **Prerender** adds `wide-layout` class to `<body>` for `/photography` to avoid flash on direct load.

### Files changed
- `apps/blog/plugins/photography.ts` — query photo_tags, export `tags`, deduplicate per-photo tags
- `apps/blog/src/components/photo-types.ts` — added `tags: string[]`
- `apps/blog/src/virtual-photos.d.ts` — added `tags` to VirtualPhoto + module export
- `apps/blog/src/pages/photography.ts` — multi-tag filter with `change` event, "All" tag, URL params
- `apps/blog/src/components/photo-lightbox.ts` — fade animation on open/close
- `apps/blog/index.html` — `body.wide-layout` rules + max-width transition
- `apps/blog/src/router.ts` — toggle `wide-layout` class with FLIP-aware delay
- `apps/blog/scripts/prerender.ts` — add `wide-layout` class for photography prerender