### PR TITLE
feat(blog): separate editor and photography images with R2 key prefixes

### DIFF
--- a/apps/blog/src/admin/gallery.ts
+++ b/apps/blog/src/admin/gallery.ts
@@ -541,7 +541,7 @@ export class AdminGallery extends LitElement {
       const formData = new FormData();
       formData.append("file", optimized);
       try {
-        const res = await fetch("/api/images", { method: "POST", body: formData, credentials: "same-origin" });
+        const res = await fetch("/api/images?prefix=photos", { method: "POST", body: formData, credentials: "same-origin" });
         if (!res.ok) continue;
         const data = (await res.json()) as { url: string; name: string; r2_key?: string };
         const meta = this._uploadMeta[i] ?? { title: file.name.replace(/\.[^.]+$/, ""), caption: "" };

--- a/apps/blog/src/api/routes/images.ts
+++ b/apps/blog/src/api/routes/images.ts
@@ -1,9 +1,10 @@
 /**
  * Image upload routes — store images in Cloudflare R2.
- * POST   /images       → upload image, returns URL
- * GET    /images       → list all images
- * GET    /images/:name → serve image
- * DELETE /images/:name → delete image
+ * Editor images use "editor/" prefix, photography photos use "photos/" prefix.
+ * POST   /images       → upload image (prefix via ?prefix=editor|photos, default: editor)
+ * GET    /images       → list editor images only
+ * GET    /images/:prefix/:name → serve image
+ * DELETE /images/:prefix/:name → delete image
  */
 
 import { Hono } from "hono";
@@ -16,6 +17,8 @@ const ALLOWED_TYPES = new Set([
   "image/webp",
   "image/svg+xml",
 ]);
+
+const VALID_PREFIXES = new Set(["editor", "photos"]);
 
 export const images = new Hono<Env>()
   // Upload image
@@ -32,9 +35,14 @@ export const images = new Hono<Env>()
       return c.json({ error: `unsupported type: ${file.type}` }, 400);
     }
 
-    // Generate unique filename: timestamp-originalname
-    const name = `${Date.now().toString(36)}-${file.name.replace(/[^\w.-]/g, "_")}`;
-    await bucket.put(name, await file.arrayBuffer(), {
+    const prefix = (c.req.query("prefix") || "editor") as string;
+    if (!VALID_PREFIXES.has(prefix)) {
+      return c.json({ error: `invalid prefix: ${prefix}` }, 400);
+    }
+
+    const filename = `${Date.now().toString(36)}-${file.name.replace(/[^\w.-]/g, "_")}`;
+    const key = `${prefix}/${filename}`;
+    await bucket.put(key, await file.arrayBuffer(), {
       httpMetadata: { contentType: file.type },
       customMetadata: {
         originalName: file.name,
@@ -43,14 +51,14 @@ export const images = new Hono<Env>()
     });
 
     const baseUrl = c.env.IMAGES_BASE_URL || "/api/images";
-    const url = `${baseUrl}/${name}`;
-    return c.json({ ok: true, name, url, r2_key: name }, 201);
+    const url = `${baseUrl}/${key}`;
+    return c.json({ ok: true, name: key, url, r2_key: key }, 201);
   })
 
-  // List all images
+  // List editor images only
   .get("/", async (c) => {
     const bucket = c.env.IMAGES_BUCKET;
-    const listed = await bucket.list({ limit: 500 });
+    const listed = await bucket.list({ prefix: "editor/", limit: 500 });
 
     const baseUrl = c.env.IMAGES_BASE_URL || "/api/images";
     const items = listed.objects.map((obj) => ({
@@ -64,7 +72,25 @@ export const images = new Hono<Env>()
     return c.json({ images: items });
   })
 
-  // Serve image
+  // Serve image (supports prefixed keys: /images/editor/foo.jpg or /images/photos/foo.jpg)
+  .get("/:prefix/:name", async (c) => {
+    const bucket = c.env.IMAGES_BUCKET;
+    const key = `${c.req.param("prefix")}/${c.req.param("name")}`;
+    const object = await bucket.get(key);
+
+    if (!object) {
+      return c.json({ error: "not found" }, 404);
+    }
+
+    const headers = new Headers();
+    headers.set("Content-Type", object.httpMetadata?.contentType ?? "application/octet-stream");
+    headers.set("Cache-Control", "public, max-age=31536000, immutable");
+    headers.set("ETag", object.httpEtag);
+
+    return new Response(object.body, { headers });
+  })
+
+  // Serve legacy unprefixed images (backward compat)
   .get("/:name", async (c) => {
     const bucket = c.env.IMAGES_BUCKET;
     const name = c.req.param("name");
@@ -82,7 +108,15 @@ export const images = new Hono<Env>()
     return new Response(object.body, { headers });
   })
 
-  // Delete image
+  // Delete image (prefixed)
+  .delete("/:prefix/:name", async (c) => {
+    const bucket = c.env.IMAGES_BUCKET;
+    const key = `${c.req.param("prefix")}/${c.req.param("name")}`;
+    await bucket.delete(key);
+    return c.json({ ok: true });
+  })
+
+  // Delete legacy unprefixed image (backward compat)
   .delete("/:name", async (c) => {
     const bucket = c.env.IMAGES_BUCKET;
     const name = c.req.param("name");


### PR DESCRIPTION
## Summary

Fixes #332 — editor gallery side sheet shows photography photos, risking accidental deletion.

## Approach

R2 key prefixes partition images by source:
- `editor/` — images uploaded from the blog editor (for post content)
- `photos/` — images uploaded from the admin gallery (photography page)

## Changes

### `apps/blog/src/api/routes/images.ts`
- **POST** accepts `?prefix=editor|photos` query param (default: `editor`)
- **GET /images** lists only `editor/` prefix (editor gallery sees only its own images)
- **GET /images/:prefix/:name** serves prefixed images
- **GET /images/:name** backward compat for legacy unprefixed keys
- **DELETE** same pattern — prefixed + legacy fallback

### `apps/blog/src/admin/gallery.ts`
- Upload uses `?prefix=photos` so photography images get the `photos/` prefix

### Backward compatibility
- Legacy unprefixed keys still served and deletable via `/:name` routes
- Existing images continue to work — no migration required
- New uploads are automatically prefixed