### PR TITLE
chore(blog): remove album sub-routes from sitemap

### DIFF
--- a/apps/blog/plugins/sitemap.ts
+++ b/apps/blog/plugins/sitemap.ts
@@ -48,18 +48,6 @@ export function sitemapPlugin(): Plugin {
         console.error("[sitemap] Failed to fetch posts/projects from Turso:", err);
       }
 
-      // Albums query is separate — table may not exist yet
-      try {
-        const albumsResult = await db.execute(
-          "SELECT slug FROM albums WHERE status = 'published' ORDER BY sort_order ASC, created_at DESC",
-        );
-        for (const row of albumsResult.rows) {
-          urls.push({ loc: `${SITE_URL}/photography/${row.slug as string}`, priority: "0.6" });
-        }
-      } catch {
-        // albums table may not exist yet — silently skip
-      }
-
       const today = new Date().toISOString().split("T")[0];
       const xml = [
         '<?xml version="1.0" encoding="UTF-8"?>',


### PR DESCRIPTION
## Summary

Removes `/photography/:album-slug` URLs from sitemap.xml — these routes don't exist in the router and return 404.

## Changes

- `apps/blog/plugins/sitemap.ts` — removed albums query that generated dead `/photography/:slug` URLs