### PR TITLE
feat(blog): full-width photography grid with responsive columns

### DIFF
--- a/apps/blog/index.html
+++ b/apps/blog/index.html
@@ -121,7 +121,8 @@
       color: var(--fd-text-primary, #27272a);
       text-decoration: none;
       -webkit-text-stroke: 1.5px currentColor;
-      transition: opacity 200ms ease;
+      transition: opacity 200ms ease, transform 0.4s ease;
+      transform-origin: left center;
     }
 
     :root[data-page="home"] .site-name {
@@ -183,7 +184,20 @@
     body.wide-layout header,
     body.wide-layout main,
     body.wide-layout footer {
-      max-width: 1200px;
+      max-width: 100vw;
+      padding-inline: 24px;
+    }
+
+    @media (min-width: 1024px) {
+      body.wide-layout .site-name {
+        transform: scale(1.5625);
+      }
+      body.wide-layout nav {
+        gap: var(--fd-space-4);
+      }
+      body.wide-layout nav a {
+        font-size: 16px;
+      }
     }
 
     /* ─── Footer ─── */

--- a/apps/blog/src/components/photo-grid.ts
+++ b/apps/blog/src/components/photo-grid.ts
@@ -9,26 +9,24 @@ styles.replaceSync(/*css*/ `
   }
 
   .grid {
-    columns: 3;
-    column-gap: 16px;
+    display: flex;
+    gap: 16px;
+    align-items: flex-start;
+  }
+
+  .grid-column {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    min-width: 0;
   }
 
   .grid-item {
-    break-inside: avoid;
-    margin-bottom: 16px;
     border-radius: 8px;
     overflow: hidden;
     cursor: pointer;
     position: relative;
-    background-size: cover;
-    background-position: center;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-  }
-    break-inside: avoid;
-    margin-bottom: 16px;
-    border-radius: 8px;
-    overflow: hidden;
-    cursor: pointer;
     background-size: cover;
     background-position: center;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -73,18 +71,13 @@ styles.replaceSync(/*css*/ `
   .grid-item-info span { white-space: nowrap; }
 
   .grid-item-title { font-size: 13px; font-weight: 600; width: 100%; white-space: normal; }
-
-  @media (max-width: 1024px) {
-    .grid { columns: 2; }
-  }
-
-  @media (max-width: 600px) {
-    .grid { columns: 1; }
-  }
 `);
 
 class PhotoGrid extends HTMLElement {
   private _container!: HTMLDivElement;
+  private _photos: Photo[] = [];
+  private _resizeObserver: ResizeObserver | null = null;
+  private _lastColCount = 0;
 
   constructor() {
     super();
@@ -109,8 +102,50 @@ class PhotoGrid extends HTMLElement {
     });
   }
 
+  connectedCallback(): void {
+    this._resizeObserver = new ResizeObserver(() => {
+      const cols = this._getColumnCount();
+      if (cols !== this._lastColCount) this._layout();
+    });
+    this._resizeObserver.observe(this);
+  }
+
+  disconnectedCallback(): void {
+    this._resizeObserver?.disconnect();
+    this._resizeObserver = null;
+  }
+
+  private _getColumnCount(): number {
+    const w = this.clientWidth;
+    if (w >= 2200) return 6;
+    if (w >= 1400) return 5;
+    if (w >= 1024) return 4;
+    if (w >= 640) return 3;
+    return 2;
+  }
+
   setPhotos(photos: Photo[]): void {
+    this._photos = photos;
+    this._layout();
+  }
+
+  private _layout(): void {
+    const photos = this._photos;
     this._container.innerHTML = "";
+    if (photos.length === 0) return;
+
+    const colCount = this._getColumnCount();
+    this._lastColCount = colCount;
+    const columns: HTMLDivElement[] = [];
+    const heights: number[] = [];
+
+    for (let c = 0; c < colCount; c++) {
+      const col = document.createElement("div");
+      col.className = "grid-column";
+      columns.push(col);
+      heights.push(0);
+      this._container.appendChild(col);
+    }
 
     for (let i = 0; i < photos.length; i++) {
       const photo = photos[i];
@@ -141,7 +176,6 @@ class PhotoGrid extends HTMLElement {
       if (exif.Make || exif.Model) parts.push(String(exif.Make && exif.Model ? `${exif.Make} ${exif.Model}` : exif.Make || exif.Model));
       if (exif.FocalLength) parts.push(`${String(exif.FocalLength).replace(/\s*mm$/i, '')} mm`);
       if (exif.FNumber != null) parts.push(`ƒ/${String(exif.FNumber).replace(/^f\//, "")}`);
-
       if (exif.ExposureTime) parts.push(`${exif.ExposureTime}s`);
       if (exif.ISO) parts.push(`ISO ${exif.ISO}`);
 
@@ -154,7 +188,13 @@ class PhotoGrid extends HTMLElement {
         item.appendChild(info);
       }
 
-      this._container.appendChild(item);
+      // Place in shortest column
+      let shortest = 0;
+      for (let c = 1; c < colCount; c++) {
+        if (heights[c] < heights[shortest]) shortest = c;
+      }
+      columns[shortest].appendChild(item);
+      heights[shortest] += photo.height && photo.width ? photo.height / photo.width : 1;
     }
   }
 }

--- a/apps/blog/src/router.ts
+++ b/apps/blog/src/router.ts
@@ -241,7 +241,11 @@ export async function renderRoute(): Promise<void> {
         forwardClone.style.fontSize = getComputedStyle(heroEl).fontSize;
         heroEl.style.visibility = "hidden";
         // Start FLIP immediately — clone flies while page blurs out underneath
-        flipSignature(forwardClone, forwardSourceRect, siteName, "forward");
+        flipSignature(forwardClone, forwardSourceRect, siteName, "forward", () => {
+          if (routeId === "photography") {
+            setTimeout(() => document.body.classList.add("wide-layout"), 50);
+          }
+        });
       }
     }
 
@@ -253,10 +257,13 @@ export async function renderRoute(): Promise<void> {
 
     // Toggle wide layout — delay when FLIP is active to avoid moving the target
     const hasFlip = isLeavingHome || isGoingHome;
-    if (hasFlip) {
-      setTimeout(() => document.body.classList.toggle("wide-layout", routeId === "photography"), 450);
-    } else {
+    if (!hasFlip) {
       document.body.classList.toggle("wide-layout", routeId === "photography");
+    } else if (!isLeavingHome) {
+      // Going home — remove wide-layout after FLIP finishes
+      setTimeout(() => {
+        document.body.classList.remove("wide-layout");
+      }, 400);
     }
     // Re-trigger enter animation
     content.style.animation = "none";


### PR DESCRIPTION
## Summary

Photography page now uses full-width edge-to-edge masonry grid with responsive column count and larger header.

## Changes

### `apps/blog/src/components/photo-grid.ts`
- Switched from CSS `columns` to JS-based masonry with flex columns
- Photos distributed into shortest-column-first for balanced heights
- Responsive column count via ResizeObserver (based on component width):
  - `< 640px`: 2 columns
  - `640px+`: 3 columns
  - `1024px+`: 4 columns
  - `1400px+`: 5 columns
  - `2200px+`: 6 columns
- Only re-layouts when column count changes
- Fixed duplicate CSS block

### `apps/blog/index.html`
- `body.wide-layout` sets `max-width: 100vw` with `24px` padding
- Site-name scales to 1.5625x (32px → 50px visual) via GPU-accelerated `transform: scale()`
- Nav links bumped to 16px with wider gaps on 1024px+

### `apps/blog/src/router.ts`
- FLIP `onComplete` callback adds `wide-layout` class with 50ms delay for scale animation
- Going home: removes `wide-layout` after 400ms FLIP duration

Related: #337 (polish site-name animation)