### PR TITLE
fix(blog): photography page mobile padding and single column

### DIFF
--- a/apps/blog/index.html
+++ b/apps/blog/index.html
@@ -185,9 +185,16 @@
     body.wide-layout main,
     body.wide-layout footer {
       max-width: 100vw;
-      padding-inline: 24px;
     }
 
+
+    @media (min-width: 1400px) {
+      body.wide-layout header,
+      body.wide-layout main,
+      body.wide-layout footer {
+        padding-inline: 24px;
+      }
+    }
     @media (min-width: 1024px) {
       body.wide-layout .site-name {
         transform: scale(1.5625);

--- a/apps/blog/src/components/photo-grid.ts
+++ b/apps/blog/src/components/photo-grid.ts
@@ -121,7 +121,7 @@ class PhotoGrid extends HTMLElement {
     if (w >= 1400) return 5;
     if (w >= 1024) return 4;
     if (w >= 640) return 3;
-    return 2;
+    return 1;
   }
 
   setPhotos(photos: Photo[]): void {


### PR DESCRIPTION
## Summary

Fixes photography page layout on mobile/small screens and aligns padding with content.

## Changes

- **Single column on mobile** (`< 640px`) instead of 2 columns — photos get full width
- **Consistent padding on small/medium screens** — same as other pages
- **24px padding on large screens** (`1400px+`) — when the grid is truly wider than the text column