### PR TITLE
feat(blog): photography page tagline + neutral filter tag colors

### DIFF
--- a/apps/blog/index.html
+++ b/apps/blog/index.html
@@ -195,6 +195,12 @@
         padding-inline: 24px;
       }
     }
+
+    /* Override tag selected color to match blog aesthetic */
+    ui-tag[type="selectable"][state="selected"] {
+      --ui-tag-bg: var(--fd-text-primary);
+      --ui-tag-color: var(--fd-surface-primary);
+    }
     @media (min-width: 1024px) {
       body.wide-layout .site-name {
         transform: scale(1.5625);

--- a/apps/blog/src/pages/photography.ts
+++ b/apps/blog/src/pages/photography.ts
@@ -36,7 +36,8 @@ export const photographyRoute: Route = {
     description: "Photos from travels and daily life.",
   },
   render: () => `
-    <h1 class="heading-02 mb-2">Photography</h1>
+    <h1 class="heading-02 mb-1">Photography</h1>
+    <p class="body-02 text-secondary mb-3">Moments to remember.</p>
     ${
       allTags.length > 0
         ? `


### PR DESCRIPTION
## Summary

Adds personality to the photography page and makes filter tags match the blog's neutral aesthetic.

## Changes

- **Tagline**: "Moments to remember." under the Photography heading
- **Filter tag selected color**: overrides the default blue with `--fd-text-primary` bg + `--fd-surface-primary` text — dark on light, light on dark. Matches the blog's minimal style.

### Files changed
- `apps/blog/src/pages/photography.ts` — tagline
- `apps/blog/index.html` — `ui-tag[type="selectable"][state="selected"]` CSS override