### PR TITLE
fix(blog): polaroid stack broken with portrait photos

### DIFF
--- a/apps/blog/index.html
+++ b/apps/blog/index.html
@@ -454,7 +454,7 @@
       margin-left: -210px;
       margin-top: -230px;
       background: #fff;
-      padding: 10px 10px 36px;
+      padding: 10px;
       border-radius: 2px;
       box-shadow: 0 2px 12px rgba(0,0,0,0.15);
       transform-origin: center center;
@@ -467,8 +467,10 @@
     .polaroid img {
       display: block;
       width: 100%;
-      height: auto;
+      height: 280px;
+      object-fit: contain;
       border-radius: 1px;
+      background: #fff;
     }
 
     .polaroid-stack:hover .polaroid {
@@ -480,12 +482,14 @@
 
     @media (max-width: 768px) {
       .polaroid-stack { height: 400px; }
-      .polaroid { width: 280px; margin-left: -140px; margin-top: -160px; padding: 8px 8px 28px; }
+      .polaroid { width: 280px; margin-left: -140px; margin-top: -160px; padding: 8px; }
+      .polaroid img { height: 180px; }
     }
 
     @media (max-width: 480px) {
       .polaroid-stack { height: 340px; }
-      .polaroid { width: 240px; margin-left: -120px; margin-top: -140px; padding: 6px 6px 24px; }
+      .polaroid { width: 240px; margin-left: -120px; margin-top: -140px; padding: 6px; }
+      .polaroid img { height: 150px; }
     }
 
     @media (prefers-reduced-motion: reduce) {

--- a/apps/blog/src/pages/home.ts
+++ b/apps/blog/src/pages/home.ts
@@ -37,7 +37,7 @@ export const homeRoute: Route = {
             const dx = (i - (count - 1) / 2) * defaultSpacing;
             const dy = [8, -14, 10, -8, 12][i] || 0;
             return `
-            <div class="polaroid" data-photo-index="${i}" style="--rot:${angles[i]}deg;--ox:${dx}px;--oy:${dy}px;--fan-x:${fanX}px;">
+            <div class="polaroid${p.height > p.width ? ' portrait' : ''}" data-photo-index="${i}" style="--rot:${angles[i]}deg;--ox:${dx}px;--oy:${dy}px;--fan-x:${fanX}px;">
               <img src="${p.url}" alt="${p.title || ''}"
                    width="${p.width}" height="${p.height}"
                    loading="lazy" decoding="async">


### PR DESCRIPTION
## Summary

Portrait (vertical) photos in the polaroid stack on the homepage break the layout — they render much taller than landscape photos, causing the stack to overflow.

## Fix

Letterbox approach — fixed height frame with `object-fit: contain` and white background. Portrait photos fit inside the polaroid frame with white padding on the sides, like a real photo in a frame. Landscape photos fill the width naturally.

- Desktop: 280px image height
- Tablet: 180px
- Mobile: 150px