### PR TITLE
feat(blog): add /draft/:slug URLs for sharing unpublished posts

### DIFF
--- a/apps/blog/index.html
+++ b/apps/blog/index.html
@@ -24,6 +24,7 @@
       var t = localStorage.getItem('blog-theme');
       if (t === 'dark') document.documentElement.setAttribute('data-theme', 'heroui-dark');
       else document.documentElement.setAttribute('data-theme', 'heroui');
+      if (localStorage.getItem('blog-muted') === 'true') document.documentElement.setAttribute('data-muted', '');
       var p = location.pathname; if (p === '/' || p === '') document.documentElement.dataset.page = 'home';
     })();
   </script>
@@ -373,6 +374,41 @@
     .post-content ul, .post-content ol { font-size: var(--fd-type-body-01-font-size); line-height: var(--fd-type-body-01-line-height); margin: 0 0 var(--fd-space-2); padding-left: var(--fd-space-3); }
     .post-content li { margin-bottom: var(--fd-space-0-5); }
 
+    /* ── Mute mode: soften all text globally (toggled via data-muted on :root) ── */
+    [data-muted] { --fd-text-primary: var(--fd-color-gray-30, #C1CCD6); }
+    [data-muted] .site-name { color: var(--fd-text-secondary); -webkit-text-stroke-color: var(--fd-text-secondary); }
+    [data-muted] .hero-accent { color: var(--fd-text-secondary); -webkit-text-stroke-color: var(--fd-text-secondary); }
+    [data-muted] .hero-accent .sig-underline path { fill: var(--fd-text-secondary); }
+    [data-muted] .post-content,
+    [data-muted] .post-content h2,
+    [data-muted] .post-content h3,
+    [data-muted] .post-content h4,
+    [data-muted] .post-content p,
+    [data-muted] .post-content li,
+    [data-muted] .post-content blockquote { color: var(--fd-text-secondary); }
+    [data-muted] .post-content a,
+    [data-muted] .post-content ui-link { --ui-link-color: var(--fd-text-tertiary); }
+    [data-muted] .post-card-title { color: var(--fd-text-secondary); }
+    [data-muted] .post-meta { color: var(--fd-text-tertiary); }
+    [data-muted] .post-excerpt { color: var(--fd-text-tertiary); }
+    [data-muted] .display-03 { color: var(--fd-text-secondary); }
+    [data-muted] .heading-02 { color: var(--fd-text-secondary); }
+    [data-muted] .heading-03 { color: var(--fd-text-secondary); }
+    [data-muted] .heading-04 { color: var(--fd-text-secondary); }
+    [data-muted] .heading-05 { color: var(--fd-text-secondary); }
+    [data-muted] .body-01 { color: var(--fd-text-secondary); }
+    [data-muted] .body-02 { color: var(--fd-text-secondary); }
+    [data-muted] .body-03 { color: var(--fd-text-tertiary); }
+    [data-muted] .text-link { color: var(--fd-text-tertiary); }
+    [data-muted] .inline-link { color: var(--fd-text-secondary); }
+    [data-muted] .arrow-link { color: var(--fd-text-secondary); }
+    [data-muted] nav a { color: var(--fd-text-tertiary); }
+    [data-muted] nav a.active { color: var(--fd-text-secondary); }
+    [data-muted] nav a::after { background: var(--fd-text-tertiary); }
+    [data-muted] footer { color: var(--fd-text-tertiary); }
+    [data-muted] ui-alert { opacity: 0.5; }
+    [data-muted] ui-badge { opacity: 0.6; }
+    [data-muted] .project-card-title { color: var(--fd-text-secondary); }
     .post-content pre {
       border: 1px solid var(--fd-border-minimal, #e4e4e7);
       border-radius: var(--fd-radius-sm);
@@ -773,7 +809,10 @@
         <a href="/blog" data-route="blog">Blog</a>
         <a href="/portfolio" data-route="portfolio">Portfolio</a>
         <a href="/about" data-route="about">About</a>
-        <theme-toggle></theme-toggle>
+        <div style="display:inline-flex;align-items:center;gap:2px;">
+          <mute-toggle></mute-toggle>
+          <theme-toggle></theme-toggle>
+        </div>
       </nav>
     </header>
     <main id="content">

--- a/apps/blog/plugins/markdown-posts.ts
+++ b/apps/blog/plugins/markdown-posts.ts
@@ -15,8 +15,10 @@ import anchor from "markdown-it-anchor";
 import { createHighlighter } from "shiki";
 import { fromHighlighter } from "@shikijs/markdown-it";
 
-const VIRTUAL_MODULE_ID = "virtual:posts";
-const RESOLVED_ID = "\0" + VIRTUAL_MODULE_ID;
+const POSTS_VIRTUAL_ID = "virtual:posts";
+const POSTS_RESOLVED_ID = "\0" + POSTS_VIRTUAL_ID;
+const DRAFTS_VIRTUAL_ID = "virtual:drafts";
+const DRAFTS_RESOLVED_ID = "\0" + DRAFTS_VIRTUAL_ID;
 
 // Shiki highlighter (created lazily, cached)
 let mdInstance: MarkdownIt | null = null;
@@ -87,11 +89,11 @@ async function getMd(): Promise<MarkdownIt> {
 }
 
 export function markdownPostsPlugin(): Plugin {
-  async function loadPosts(): Promise<string> {
+  async function loadFromDb(status: "published" | "draft", label: string): Promise<string> {
     const db = getDb();
     try {
       const result = await db.execute(
-        "SELECT slug, title, body_md, excerpt, tags, created_at FROM posts WHERE status = 'published' ORDER BY created_at DESC",
+        `SELECT slug, title, body_md, excerpt, tags, created_at FROM posts WHERE status = '${status}' ORDER BY created_at DESC`,
       );
 
       const md = await getMd();
@@ -131,21 +133,23 @@ export function markdownPostsPlugin(): Plugin {
         };
       });
 
-      console.log(`[markdown-posts] Loaded ${posts.length} published posts from Turso`);
-      return `export const posts = ${JSON.stringify(posts)};`;
+      console.log(`[markdown-posts] Loaded ${posts.length} ${label} posts from Turso`);
+      return `export const ${label === "published" ? "posts" : "drafts"} = ${JSON.stringify(posts)};`;
     } catch (err) {
-      console.error("[markdown-posts] Failed to fetch from Turso:", err);
-      return "export const posts = [];";
+      console.error(`[markdown-posts] Failed to fetch ${label} from Turso:`, err);
+      return `export const ${label === "published" ? "posts" : "drafts"} = [];`;
     }
   }
 
   return {
     name: "markdown-posts",
     resolveId(id) {
-      if (id === VIRTUAL_MODULE_ID) return RESOLVED_ID;
+      if (id === POSTS_VIRTUAL_ID) return POSTS_RESOLVED_ID;
+      if (id === DRAFTS_VIRTUAL_ID) return DRAFTS_RESOLVED_ID;
     },
     async load(id) {
-      if (id === RESOLVED_ID) return loadPosts();
+      if (id === POSTS_RESOLVED_ID) return loadFromDb("published", "published");
+      if (id === DRAFTS_RESOLVED_ID) return loadFromDb("draft", "draft");
     },
   };
 }

--- a/apps/blog/scripts/prerender.ts
+++ b/apps/blog/scripts/prerender.ts
@@ -47,6 +47,7 @@ async function prerender(): Promise<void> {
     const { homeRoute } = await vite.ssrLoadModule("/src/pages/home.ts") as any;
     const { blogRoute } = await vite.ssrLoadModule("/src/pages/blog.ts") as any;
     const { postRoutes } = await vite.ssrLoadModule("/src/pages/post.ts") as any;
+    const { draftRoutes } = await vite.ssrLoadModule("/src/pages/draft.ts") as any;
     const { portfolioRoute } = await vite.ssrLoadModule("/src/pages/portfolio.ts") as any;
     const { projectRoutes } = await vite.ssrLoadModule("/src/pages/project.ts") as any;
     const { resumeRoute } = await vite.ssrLoadModule("/src/pages/resume.ts") as any;
@@ -66,6 +67,7 @@ async function prerender(): Promise<void> {
       photographyRoute,
       mapRoute,
       ...projectRoutes,
+      ...draftRoutes,
       resumeRoute,
       aboutRoute,
     ];

--- a/apps/blog/src/components/mute-toggle.ts
+++ b/apps/blog/src/components/mute-toggle.ts
@@ -1,0 +1,60 @@
+import "@maneki/ui-components/components/ui-button.js";
+
+/**
+ * <mute-toggle> — contrast mute toggle button.
+ * Vanilla Web Component — no Lit dependency.
+ * Uses <ui-button> from the design system internally.
+ * Toggles data-muted attribute on :root, persisted to localStorage.
+ * Shows ◐ when normal, ◑ when muted.
+ */
+class MuteToggle extends HTMLElement {
+  private _muted = false;
+  private _btn?: HTMLElement;
+  private _observer?: MutationObserver;
+
+  connectedCallback() {
+    this._muted = document.documentElement.hasAttribute("data-muted");
+
+    const btn = document.createElement("ui-button");
+    btn.setAttribute("action", "secondary");
+    btn.setAttribute("emphasis", "minimal");
+    btn.setAttribute("size", "s");
+    btn.setAttribute("aria-label", "Toggle muted colors");
+    btn.textContent = this._muted ? "\u25D1" : "\u25D0";
+    btn.style.opacity = this._muted ? "0.7" : "0.4";
+    btn.addEventListener("click", () => this._toggle());
+    this._btn = btn;
+    this.appendChild(btn);
+
+    this._observer = new MutationObserver(() => {
+      this._muted = document.documentElement.hasAttribute("data-muted");
+      this._render();
+    });
+    this._observer.observe(document.documentElement, { attributes: true, attributeFilter: ["data-muted"] });
+  }
+
+  disconnectedCallback() {
+    this._observer?.disconnect();
+  }
+
+  private _toggle() {
+    this._muted = !this._muted;
+    if (this._muted) {
+      document.documentElement.setAttribute("data-muted", "");
+      localStorage.setItem("blog-muted", "true");
+    } else {
+      document.documentElement.removeAttribute("data-muted");
+      localStorage.removeItem("blog-muted");
+    }
+    this._render();
+  }
+
+  private _render() {
+    if (this._btn) {
+      this._btn.textContent = this._muted ? "\u25D1" : "\u25D0";
+      this._btn.style.opacity = this._muted ? "0.7" : "0.4";
+    }
+  }
+}
+
+customElements.define("mute-toggle", MuteToggle);

--- a/apps/blog/src/components/theme-toggle.ts
+++ b/apps/blog/src/components/theme-toggle.ts
@@ -20,7 +20,7 @@ class ThemeToggle extends HTMLElement {
     const btn = document.createElement("ui-button");
     btn.setAttribute("action", "secondary");
     btn.setAttribute("emphasis", "minimal");
-    btn.setAttribute("size", "m");
+    btn.setAttribute("size", "s");
     btn.setAttribute("aria-label", "Toggle dark mode");
     btn.textContent = this._dark ? "\u{1F319}" : "\u{2600}\u{FE0F}";
     btn.addEventListener("click", () => this._toggle());

--- a/apps/blog/src/main.ts
+++ b/apps/blog/src/main.ts
@@ -43,10 +43,16 @@ registerPatternRoute({
   prefix: "project/",
   load: (id) => import("./pages/project.js").then((m) => m.findProjectRoute(id)),
 });
+registerPatternRoute({
+  prefix: "draft/",
+  load: (id) => import("./pages/draft.js").then((m) => m.findDraftRoute(id)),
+});
 
 // ─── Theme Toggle ─────────────────────────────────────────────────────────
 
 import "./components/theme-toggle.js";
+
+import "./components/mute-toggle.js";
 
 // ─── Reading Progress ─────────────────────────────────────────────────────────
 

--- a/apps/blog/src/pages/draft.ts
+++ b/apps/blog/src/pages/draft.ts
@@ -1,0 +1,38 @@
+import { drafts } from "virtual:drafts";
+import type { Route } from "../router.js";
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export const draftRoutes: Route[] = drafts.map((draft) => ({
+  id: `draft/${draft.slug}`,
+  render: () => `
+    <article>
+      <ui-alert status="warning" emphasis="subtle" size="m" class="mb-3">This is an unpublished draft shared for review.</ui-alert>
+      <a href="/blog" class="inline-link body-02 arrow-link"><span class="arrow-left">←</span> <span class="link-text">Back to blog</span></a>
+      <h1 class="heading-02 mt-3">${draft.title}</h1>
+      <div class="post-meta mt-1">${formatDate(draft.date)} · ${draft.readTime}</div>
+      <div class="tags mt-2">
+        ${draft.tags.map((t: string) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
+      </div>
+      <div class="post-content mt-4 reveal">
+        ${draft.content}
+      </div>
+    </article>
+  `,
+  meta: {
+    title: `[Draft] ${draft.title}`,
+    description: draft.excerpt,
+  },
+  showProgress: true,
+}));
+
+/** Lookup a single draft route by ID — used by lazy router. */
+export function findDraftRoute(id: string): Route | undefined {
+  return draftRoutes.find((r) => r.id === id);
+}

--- a/apps/blog/src/virtual-posts.d.ts
+++ b/apps/blog/src/virtual-posts.d.ts
@@ -11,3 +11,8 @@ declare module "virtual:posts" {
   }
   export const posts: Post[];
 }
+
+declare module "virtual:drafts" {
+  import type { Post } from "virtual:posts";
+  export const drafts: Post[];
+}


### PR DESCRIPTION
## Summary

- Extend `markdown-posts` Vite plugin to export `virtual:drafts` (draft posts from Turso)
- Add `src/pages/draft.ts` with draft banner UI and `[Draft]` title prefix
- Register `draft/*` pattern route in `main.ts` for client-side navigation
- Include draft routes in prerender script (excluded from sitemap)

## Details

Draft posts are now prerendered at build time just like published posts, accessible at `/draft/:slug`. They render with a visible "Draft" badge banner so reviewers know it's unpublished. No auth required — share the URL directly.

Drafts are intentionally excluded from the sitemap to avoid search engine indexing.