### PR TITLE
feat(blog): lightbox photos fill max viewport

### DIFF
--- a/apps/blog/src/components/photo-lightbox.ts
+++ b/apps/blog/src/components/photo-lightbox.ts
@@ -37,13 +37,13 @@ styles.replaceSync(/*css*/ `
     display: flex;
     align-items: center;
     justify-content: center;
-    max-width: 90vw;
-    max-height: 85vh;
+    max-width: 96vw;
+    max-height: 96vh;
   }
 
   .image-wrapper img {
-    max-width: 90vw;
-    max-height: 85vh;
+    max-width: 96vw;
+    max-height: 96vh;
     object-fit: contain;
     opacity: 1;
     transition: opacity 0.2s ease;


### PR DESCRIPTION
## Summary
- Changed lightbox image constraints from 90vw/85vh to 96vw/96vh so photos fill nearly the entire viewport while still respecting aspect ratio via `object-fit: contain`