### PR TITLE
fix(blog): fail-fast on all Vite plugins

### DIFF
--- a/apps/blog/plugins/markdown-posts.ts
+++ b/apps/blog/plugins/markdown-posts.ts
@@ -137,7 +137,7 @@ export function markdownPostsPlugin(): Plugin {
       return `export const ${label === "published" ? "posts" : "drafts"} = ${JSON.stringify(posts)};`;
     } catch (err) {
       console.error(`[markdown-posts] Failed to fetch ${label} from Turso:`, err);
-      return `export const ${label === "published" ? "posts" : "drafts"} = [];`;
+      throw err;
     }
   }
 

--- a/apps/blog/plugins/pages.ts
+++ b/apps/blog/plugins/pages.ts
@@ -79,7 +79,7 @@ export function pagesPlugin(): Plugin {
       return `export const pages = ${JSON.stringify(pages)};\nexport function getPage(slug) { return pages.find((p) => p.slug === slug); }`;
     } catch (err) {
       console.error("[pages] Failed to fetch pages from Turso:", err);
-      return EMPTY;
+      throw err;
     }
   }
 

--- a/apps/blog/plugins/photography.ts
+++ b/apps/blog/plugins/photography.ts
@@ -97,7 +97,7 @@ export function photographyPlugin(): Plugin {
       return `export const albums = ${JSON.stringify(albums)};`;
     } catch (err) {
       console.error("[photography] Failed to fetch albums from Turso:", err);
-      return EMPTY_ALBUMS;
+      throw err;
     }
   }
 

--- a/apps/blog/plugins/portfolio-projects.ts
+++ b/apps/blog/plugins/portfolio-projects.ts
@@ -41,7 +41,7 @@ export function portfolioProjectsPlugin(): Plugin {
       return `export const projects = ${JSON.stringify(projects)};\nexport const pinnedProjects = ${JSON.stringify(pinned)};`;
     } catch (err) {
       console.error("[portfolio-projects] Failed to fetch from Turso:", err);
-      return "export const projects = [];\nexport const pinnedProjects = [];";
+      throw err;
     }
   }
 

--- a/apps/blog/plugins/rss-feed.ts
+++ b/apps/blog/plugins/rss-feed.ts
@@ -69,6 +69,7 @@ export function rssFeedPlugin(): Plugin {
         console.log(`[rss-feed] Generated feed.xml with ${items.length} items`);
       } catch (err) {
         console.error("[rss-feed] Failed to generate feed:", err);
+        throw err;
       }
     },
   };

--- a/apps/blog/plugins/sitemap.ts
+++ b/apps/blog/plugins/sitemap.ts
@@ -46,6 +46,7 @@ export function sitemapPlugin(): Plugin {
         }
       } catch (err) {
         console.error("[sitemap] Failed to fetch posts/projects from Turso:", err);
+        throw err;
       }
 
       const today = new Date().toISOString().split("T")[0];


### PR DESCRIPTION
## Summary
- All 6 Vite plugins now `throw` on Turso errors instead of silently returning empty arrays
- Affected: markdown-posts, portfolio-projects, photography (photos + albums), pages, sitemap, rss-feed
- Build will crash with a clear error if any DB query fails, preventing deploys with missing content