### PR TITLE
refactor(blog): break up gallery.ts god component into smaller Lit components

### DIFF
--- a/apps/blog/src/admin/gallery-album-modal.ts
+++ b/apps/blog/src/admin/gallery-album-modal.ts
@@ -1,0 +1,174 @@
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, state, property } from "lit/decorators.js";
+import "../components/map-picker.js";
+import { api } from "../lib/api.js";
+import type { Album } from "./gallery-types.js";
+import { slugify } from "./gallery-utils.js";
+import "@maneki/ui-components/components/ui-button.js";
+import "@maneki/ui-components/components/ui-input.js";
+import "@maneki/ui-components/components/ui-label.js";
+import "@maneki/ui-components/components/ui-textarea.js";
+import "@maneki/ui-components/components/ui-select.js";
+import "@maneki/ui-components/components/ui-dropdown-item.js";
+import "@maneki/ui-components/components/ui-modal.js";
+import "@maneki/ui-components/components/ui-alert.js";
+
+@customElement("gallery-album-modal")
+export class GalleryAlbumModal extends LitElement {
+  @property({ type: Object }) album: Album | null = null;
+  @property({ type: Array }) albums: Album[] = [];
+
+  @state() private _editingAlbum: Album | null = null;
+  @state() private _savingAction: "none" | "saving" | "deleting" = "none";
+  @state() private _saveError = "";
+
+  static styles = css`
+    .modal-form { display: flex; flex-direction: column; gap: 12px; }
+    .modal-actions-right { display: flex; gap: 8px; }
+  `;
+
+  willUpdate(changed: Map<string, unknown>) {
+    if (changed.has("album") && this.album) {
+      this._editingAlbum = { ...this.album };
+      this._saveError = "";
+      this._savingAction = "none";
+    }
+    if (changed.has("album") && !this.album) {
+      this._editingAlbum = null;
+    }
+  }
+
+  render() {
+    if (!this._editingAlbum) return html`<ui-modal size="m" dismissible></ui-modal>`;
+    const a = this._editingAlbum;
+    const isNew = a.id === 0;
+    return html`
+      <ui-modal class="album-edit-modal" size="m" open dismissible @close=${() => { this.dispatchEvent(new CustomEvent("close")); this._saveError = ""; }}>
+        <span>${isNew ? "New Album" : "Edit Album"}</span>
+        <div slot="body" class="modal-form">
+          ${this._saveError ? html`<ui-alert status="error" size="s" dismissible @dismiss=${() => { this._saveError = ""; }}>${this._saveError}</ui-alert>` : nothing}
+          <ui-input
+            size="m"
+            .value=${a.title}
+            @input=${(e: Event) => {
+              const title = (e.target as HTMLInputElement).value;
+              const updates: Partial<Album> = { title };
+              if (isNew) updates.slug = slugify(title);
+              this._editingAlbum = { ...a, ...updates };
+            }}
+          ><ui-label slot="label" size="m">Title</ui-label></ui-input>
+          <ui-input
+            size="m"
+            .value=${a.slug}
+            @input=${(e: Event) => { this._editingAlbum = { ...a, slug: (e.target as HTMLInputElement).value }; }}
+          ><ui-label slot="label" size="m">Slug</ui-label></ui-input>
+          <ui-textarea
+            size="m"
+            rows="2"
+            .value=${a.description}
+            @input=${(e: Event) => { this._editingAlbum = { ...a, description: (e.target as HTMLTextAreaElement).value }; }}
+          ><ui-label slot="label" size="m">Description</ui-label></ui-textarea>
+          <div>
+            <ui-label size="m">Location</ui-label>
+            <map-picker
+              .location=${a.location || ""}
+              .latitude=${a.latitude ?? null}
+              .longitude=${a.longitude ?? null}
+              @location-picked=${(e: CustomEvent) => {
+                const d = e.detail as { location: string; latitude: number | null; longitude: number | null };
+                this._editingAlbum = { ...a, location: d.location, latitude: d.latitude, longitude: d.longitude };
+              }}
+            ></map-picker>
+          </div>
+          <ui-select
+            size="m"
+            .value=${a.status}
+            @change=${(e: Event) => { this._editingAlbum = { ...a, status: (e.target as HTMLElement & { value: string }).value }; }}
+          >
+            <ui-label slot="label" size="m">Status</ui-label>
+            <ui-dropdown-item value="draft">Draft</ui-dropdown-item>
+            <ui-dropdown-item value="published">Published</ui-dropdown-item>
+          </ui-select>
+        </div>
+        ${isNew ? html`<div slot="footer-start"></div>` : html`<ui-button slot="footer-start" action="destructive" emphasis="minimal" size="s" status=${this._savingAction === "deleting" ? "loading" : "none"} ?disabled=${this._savingAction === "saving"} @click=${() => this._deleteAlbum(a.slug)}>Delete</ui-button>`}
+        <div slot="footer-end" class="modal-actions-right">
+          <ui-button action="secondary" emphasis="subtle" size="s" ?disabled=${this._savingAction !== "none"} @click=${() => { this._closeModal(); }}>Cancel</ui-button>
+          <ui-button action="primary" size="s" status=${this._savingAction === "saving" ? "loading" : "none"} ?disabled=${this._savingAction === "deleting"} @click=${this._saveAlbum}>${isNew ? "Create" : "Save"}</ui-button>
+        </div>
+      </ui-modal>
+    `;
+  }
+
+  private _closeModal() {
+    (this.shadowRoot!.querySelector('.album-edit-modal') as HTMLElement & { close(): void })?.close();
+  }
+
+  private async _saveAlbum() {
+    const a = this._editingAlbum;
+    if (!a) return;
+    this._savingAction = "saving";
+    this._saveError = "";
+    try {
+      if (a.id === 0) {
+        let slug = a.slug || slugify(a.title);
+        let res = await api.api.albums.$post({
+          json: {
+            title: a.title, slug, description: a.description, status: a.status as "draft" | "published",
+            location: a.location, latitude: a.latitude ?? null, longitude: a.longitude ?? null,
+          },
+        });
+        // Auto-resolve slug conflict by appending suffix
+        if (!res.ok && res.status === 409) {
+          for (let i = 2; i <= 10; i++) {
+            slug = `${slugify(a.title)}-${i}`;
+            res = await api.api.albums.$post({
+              json: {
+                title: a.title, slug, description: a.description, status: a.status as "draft" | "published",
+                location: a.location, latitude: a.latitude ?? null, longitude: a.longitude ?? null,
+              },
+            });
+            if (res.ok || res.status !== 409) break;
+          }
+        }
+        if (!res.ok) {
+          this._saveError = "Could not create album. Please try a different name.";
+          return;
+        }
+      } else {
+        const original = this.albums.find((x) => x.id === a.id);
+        if (!original) return;
+        const res = await api.api.albums[":slug"].$put({
+          param: { slug: original.slug },
+          json: {
+            title: a.title,
+            slug: a.slug,
+            description: a.description,
+            status: a.status as "draft" | "published",
+            location: a.location,
+            latitude: a.latitude ?? null,
+            longitude: a.longitude ?? null,
+          },
+        });
+        if (!res.ok) {
+          this._saveError = "Could not update album. Please try again.";
+          return;
+        }
+      }
+      this._closeModal();
+      this.dispatchEvent(new CustomEvent("album-saved"));
+    } finally {
+      this._savingAction = "none";
+    }
+  }
+
+  private async _deleteAlbum(slug: string) {
+    this._savingAction = "deleting";
+    try {
+      await api.api.albums[":slug"].$delete({ param: { slug } });
+      this._closeModal();
+      this.dispatchEvent(new CustomEvent("album-deleted", { detail: { slug } }));
+    } finally {
+      this._savingAction = "none";
+    }
+  }
+}

--- a/apps/blog/src/admin/gallery-photo-modal.ts
+++ b/apps/blog/src/admin/gallery-photo-modal.ts
@@ -1,0 +1,446 @@
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, state, property } from "lit/decorators.js";
+import "../components/map-picker.js";
+import { api } from "../lib/api.js";
+import type { Photo, Album, Tag } from "./gallery-types.js";
+import { optimizeImage, generateThumbnail } from "./gallery-utils.js";
+import "@maneki/ui-components/components/ui-button.js";
+import "@maneki/ui-components/components/ui-icon.js";
+import "@maneki/ui-components/components/ui-badge.js";
+import "@maneki/ui-components/components/ui-input.js";
+import "@maneki/ui-components/components/ui-label.js";
+import "@maneki/ui-components/components/ui-textarea.js";
+import "@maneki/ui-components/components/ui-select.js";
+import "@maneki/ui-components/components/ui-dropdown-item.js";
+import "@maneki/ui-components/components/ui-modal.js";
+import "@maneki/ui-components/components/ui-checkbox-item.js";
+import "@maneki/ui-components/components/ui-tag.js";
+import "@maneki/ui-components/components/ui-alert.js";
+import "@maneki/ui-components/components/ui-image.js";
+
+@customElement("gallery-photo-modal")
+export class GalleryPhotoModal extends LitElement {
+  @property({ type: Object }) photo: Photo | null = null;
+  @property({ type: Object }) viewPhoto: Photo | null = null;
+  @property({ type: Array }) albums: Album[] = [];
+  @property({ type: Array }) tags: Tag[] = [];
+
+  @state() private _editingPhoto: Photo | null = null;
+  @state() private _editingPhotoTagIds: number[] = [];
+  @state() private _savingAction: "none" | "saving" | "deleting" = "none";
+  @state() private _saveError = "";
+  @state() private _reuploadingPhotoId: number | null = null;
+  @state() private _reuploadedPhotoId: number | null = null;
+  @state() private _regeneratingThumbs = false;
+  @state() private _creatingTag = false;
+  @state() private _newTagName = "";
+
+  static styles = css`
+    .photo-detail { display: flex; gap: 24px; }
+    .photo-detail-preview { flex: 1; min-width: 0; }
+    .photo-detail-preview ui-image { width: 100%; border-radius: 8px; display: block; }
+    .photo-detail-info { width: 280px; flex-shrink: 0; display: flex; flex-direction: column; gap: 12px; overflow-y: auto; }
+    .modal-form { display: flex; flex-direction: column; gap: 12px; }
+    .field-row { display: flex; gap: 12px; }
+    .field-row > * { flex: 1; min-width: 0; }
+    .toggle-row { display: flex; align-items: center; gap: 8px; }
+    .modal-actions-right { display: flex; gap: 8px; }
+    .tag-section { margin-top: 12px; }
+    .tag-section ui-label { display: block; margin-bottom: 6px; }
+    .tag-list { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+    .new-tag-inline { display: inline-flex; }
+    .new-tag-inline ui-input { width: 120px; }
+    .detail-label { font-size: 11px; font-weight: 500; color: var(--fd-text-secondary, #71717a); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 2px; }
+    .detail-value { font-size: 14px; }
+    .detail-row { display: flex; gap: 16px; }
+    .detail-row .detail-section { flex: 1; }
+    .detail-tags { display: flex; flex-wrap: wrap; gap: 4px; }
+    .detail-exif { display: flex; flex-direction: column; gap: 4px; font-size: 13px; }
+    .exif-row { display: flex; justify-content: space-between; padding: 3px 0; border-bottom: 1px solid var(--fd-border-minimal, #e4e4e7); }
+    .exif-key { color: var(--fd-text-secondary, #71717a); }
+    .exif-val { font-weight: 500; }
+  `;
+
+  willUpdate(changed: Map<string, unknown>) {
+    if (changed.has("photo") && this.photo) {
+      this._editingPhoto = { ...this.photo };
+      this._editingPhotoTagIds = (this.photo as Photo & { tags?: Array<{ id: number }> }).tags?.map((t) => t.id) ?? [];
+      this._saveError = "";
+      this._savingAction = "none";
+    }
+    if (changed.has("photo") && !this.photo) {
+      this._editingPhoto = null;
+    }
+  }
+
+  render() {
+    return html`
+      ${this._renderEditModal()}
+      ${this._renderDetailModal()}
+    `;
+  }
+
+  private _renderDetailModal() {
+    if (!this.viewPhoto) return html`<ui-modal size="l" style="--ui-modal-width: 900px" dismissible></ui-modal>`;
+    const p = this.viewPhoto;
+    const albumName = this.albums.find((a) => a.id === p.album_id)?.title ?? "None";
+    const tags = (p as Photo & { tags?: Array<{ id: number; name: string }> }).tags ?? [];
+
+    return html`
+      <ui-modal size="l" style="--ui-modal-width: 900px" open dismissible @close=${() => { this.dispatchEvent(new CustomEvent("close-detail")); }}>
+        <span>${p.title || "Photo Details"}</span>
+        <div slot="body" class="photo-detail">
+          <div class="photo-detail-preview">
+            <ui-image src=${p.url} alt=${p.title || "Photo"} style="width:100%;border-radius:8px;"></ui-image>
+          </div>
+          <div class="photo-detail-info">
+            <div class="detail-section">
+              <div class="detail-label">Title</div>
+              <div class="detail-value">${p.title || "\u2014"}</div>
+            </div>
+            <div class="detail-section">
+              <div class="detail-label">Caption</div>
+              <div class="detail-value">${p.caption || "\u2014"}</div>
+            </div>
+            <div class="detail-row">
+              <div class="detail-section">
+                <div class="detail-label">Album</div>
+                <div class="detail-value">${albumName}</div>
+              </div>
+              <div class="detail-section">
+                <div class="detail-label">Category</div>
+                <div class="detail-value">${p.category || "\u2014"}</div>
+              </div>
+            </div>
+            <div class="detail-row">
+              <div class="detail-section">
+                <div class="detail-label">Status</div>
+                <div class="detail-value"><ui-badge size="xs" status=${p.status === "published" ? "success" : "warning"}>${p.status}</ui-badge></div>
+              </div>
+              <div class="detail-section">
+                <div class="detail-label">Featured</div>
+                <div class="detail-value">${p.featured ? "Yes" : "No"}</div>
+              </div>
+            </div>
+            ${tags.length > 0 ? html`
+              <div class="detail-section">
+                <div class="detail-label">Tags</div>
+                <div class="detail-value detail-tags">${tags.map((t) => html`<ui-tag size="xs" emphasis="subtle">${t.name}</ui-tag>`)}</div>
+              </div>
+            ` : nothing}
+            ${p.location ? html`
+              <div class="detail-section">
+                <div class="detail-label">Location</div>
+                <div class="detail-value">
+                  <a href=${p.latitude != null
+                    ? `https://www.google.com/maps?q=${p.latitude},${p.longitude}`
+                    : `https://www.google.com/maps?q=${encodeURIComponent(p.location)}`}
+                    target="_blank" rel="noopener" style="color:var(--fd-text-link);text-decoration:none">${p.location}</a>
+                </div>
+                </div>
+              </div>
+            ` : nothing}
+            <div class="detail-row">
+              <div class="detail-section">
+                <div class="detail-label">Dimensions</div>
+                <div class="detail-value">${p.width && p.height ? `${p.width} \u00d7 ${p.height}` : "\u2014"}</div>
+              </div>
+              <div class="detail-section">
+                <div class="detail-label">Created</div>
+                <div class="detail-value">${p.created_at ? new Date(p.created_at).toLocaleDateString() : "\u2014"}</div>
+              </div>
+            </div>
+            ${(() => {
+              const exif = typeof p.exif_json === "string" ? JSON.parse(p.exif_json || "{}") : (p.exif_json || {});
+              return Object.keys(exif).length > 0 ? html`
+                <div class="detail-section">
+                  <div class="detail-label">Camera Info</div>
+                  <div class="detail-exif">
+                    ${exif.Make ? html`<div class="exif-row"><span class="exif-key">Camera</span><span class="exif-val">${exif.Make}${exif.Model ? ` ${exif.Model}` : ""}</span></div>` : nothing}
+                    ${exif.LensModel ? html`<div class="exif-row"><span class="exif-key">Lens</span><span class="exif-val">${exif.LensModel}</span></div>` : nothing}
+                    ${exif.FocalLength ? html`<div class="exif-row"><span class="exif-key">Focal Length</span><span class="exif-val">${exif.FocalLength}mm</span></div>` : nothing}
+                    ${exif.FNumber ? html`<div class="exif-row"><span class="exif-key">Aperture</span><span class="exif-val">\u0192/${String(exif.FNumber).replace(/^f\//, "")}</span></div>` : nothing}
+                    ${exif.ExposureTime ? html`<div class="exif-row"><span class="exif-key">Shutter</span><span class="exif-val">${exif.ExposureTime}s</span></div>` : nothing}
+                    ${exif.ISO ? html`<div class="exif-row"><span class="exif-key">ISO</span><span class="exif-val">${exif.ISO}</span></div>` : nothing}
+                    ${exif.DateTimeOriginal ? html`<div class="exif-row"><span class="exif-key">Date Taken</span><span class="exif-val">${exif.DateTimeOriginal}</span></div>` : nothing}
+                  </div>
+                </div>
+              ` : nothing;
+            })()}
+          </div>
+        </div>
+        <div slot="footer-end">
+          <ui-button action="primary" size="s" @click=${() => {
+            this.dispatchEvent(new CustomEvent("edit-from-detail", { detail: { photo: this.viewPhoto } }));
+          }}>Edit</ui-button>
+        </div>
+      </ui-modal>
+    `;
+  }
+
+  private _renderEditModal() {
+    const p = this._editingPhoto;
+    if (!p) return html`<ui-modal size="m" dismissible></ui-modal>`;
+    return html`
+      <ui-modal class="photo-edit-modal" size="l" style="--ui-modal-width: 900px" open dismissible @close=${() => { this.dispatchEvent(new CustomEvent("close")); }}>
+        <span>Edit Photo</span>
+        <div slot="body" class="photo-detail">
+          ${this._saveError ? html`<ui-alert status="error" size="s" dismissible @dismiss=${() => { this._saveError = ""; }} style="margin-bottom:12px">${this._saveError}</ui-alert>` : nothing}
+          <div class="photo-detail-preview">
+            <ui-image src=${p.url} alt=${p.title || "Photo"} style="width:100%;border-radius:8px;"></ui-image>
+          </div>
+          <div class="photo-detail-info modal-form" style="width:340px;">
+          <ui-input
+            size="m"
+            .value=${p.title}
+            @input=${(e: Event) => { this._editingPhoto = { ...p, title: (e.target as HTMLInputElement).value }; }}
+          ><ui-label slot="label" size="m">Title</ui-label></ui-input>
+          <ui-textarea
+            size="m"
+            rows="2"
+            .value=${p.caption}
+            @input=${(e: Event) => { this._editingPhoto = { ...p, caption: (e.target as HTMLTextAreaElement).value }; }}
+          ><ui-label slot="label" size="m">Caption</ui-label></ui-textarea>
+          <ui-select
+            size="m"
+            .value=${String(p.album_id ?? "")}
+            @change=${(e: Event) => {
+              const v = (e.target as HTMLElement & { value: string }).value;
+              this._editingPhoto = { ...p, album_id: v ? Number(v) : null };
+            }}
+          >
+            <ui-label slot="label" size="m">Album</ui-label>
+            <ui-dropdown-item value="">None</ui-dropdown-item>
+            ${this.albums.map((a) => html`<ui-dropdown-item value=${String(a.id)} ?selected=${p.album_id === a.id}>${a.title}</ui-dropdown-item>`)}
+          </ui-select>
+          <ui-input
+            size="m"
+            .value=${p.category}
+            @input=${(e: Event) => { this._editingPhoto = { ...p, category: (e.target as HTMLInputElement).value }; }}
+          ><ui-label slot="label" size="m">Category</ui-label></ui-input>
+          <div style="display:flex;flex-direction:column;gap:4px;">
+            <ui-label size="m">Location</ui-label>
+            <map-picker
+              .location=${p.location || ""}
+              .latitude=${p.latitude ?? null}
+              .longitude=${p.longitude ?? null}
+              @location-picked=${(e: CustomEvent) => {
+                const d = e.detail as { location: string; latitude: number | null; longitude: number | null };
+                this._editingPhoto = { ...p, location: d.location, latitude: d.latitude, longitude: d.longitude };
+              }}
+            ></map-picker>
+          </div>
+          <div class="field-row">
+            <ui-select
+              size="m"
+              .value=${p.status}
+              @change=${(e: Event) => { this._editingPhoto = { ...p, status: (e.target as HTMLElement & { value: string }).value }; }}
+            >
+              <ui-label slot="label" size="m">Status</ui-label>
+              <ui-dropdown-item value="draft">Draft</ui-dropdown-item>
+              <ui-dropdown-item value="published">Published</ui-dropdown-item>
+            </ui-select>
+          </div>
+          <div class="toggle-row">
+            <ui-checkbox-item
+              size="m"
+              label-position="right"
+              ?checked=${!!p.featured}
+              @change=${(e: Event) => { this._editingPhoto = { ...p, featured: (e.target as HTMLInputElement).checked ? 1 : 0 }; }}
+            ><ui-label slot="label" size="m">Featured</ui-label></ui-checkbox-item>
+          </div>
+          <div style="display:flex;gap:8px;align-items:center;">
+            <ui-button action="secondary" emphasis="subtle" size="s" ?disabled=${this._reuploadingPhotoId === p.id} status=${this._reuploadingPhotoId === p.id ? "loading" : this._reuploadedPhotoId === p.id ? "success" : "none"} @click=${() => this._reuploadPhoto(p)}>
+              <ui-icon name="upload" size="s" slot="icon-start"></ui-icon>
+              ${this._reuploadingPhotoId === p.id ? "Uploading..." : this._reuploadedPhotoId === p.id ? "Done" : "Reupload"}
+            </ui-button>
+            <ui-button action="secondary" emphasis="minimal" size="s" ?disabled=${this._regeneratingThumbs} status=${this._regeneratingThumbs ? "loading" : "none"} @click=${() => this._regenerateSingleThumbnail(p)}>
+              Regen Thumb
+            </ui-button>
+          </div>
+          ${p.thumbnail_url ? html`<span style="font-size:11px;color:var(--fd-text-secondary);">${p.thumbnail_url.split('/').pop()}</span>` : nothing}
+        <div class="tag-section">
+          <ui-label size="m">Tags</ui-label>
+          <div class="tag-list">
+            ${this.tags.map((t) => html`
+              <ui-tag
+                size="s"
+                emphasis=${this._editingPhotoTagIds.includes(t.id) ? "subtle" : "minimal"}
+                @click=${() => {
+                  this._editingPhotoTagIds = this._editingPhotoTagIds.includes(t.id)
+                    ? this._editingPhotoTagIds.filter((id) => id !== t.id)
+                    : [...this._editingPhotoTagIds, t.id];
+                }}
+              >${t.name}</ui-tag>
+            `)}
+            ${this._creatingTag ? html`
+              <div class="new-tag-inline">
+                <ui-input
+                  size="s"
+                  .value=${this._newTagName}
+                  placeholder="Tag name"
+                  @input=${(e: Event) => { this._newTagName = (e.target as HTMLInputElement).value; }}
+                  @keydown=${(e: KeyboardEvent) => {
+                    if (e.key === "Enter") this._createQuickTag();
+                    if (e.key === "Escape") { this._creatingTag = false; this._newTagName = ""; }
+                  }}
+                ></ui-input>
+              </div>
+            ` : html`
+              <ui-tag
+                size="s"
+                type="basic"
+                emphasis="minimal"
+                @click=${() => { this._creatingTag = true; }}
+              >+ New</ui-tag>
+            `}
+          </div>
+        </div>
+        </div>
+        </div>
+        <ui-button slot="footer-start" action="destructive" emphasis="minimal" size="s" status=${this._savingAction === "deleting" ? "loading" : "none"} ?disabled=${this._savingAction === "saving"} @click=${() => this._deletePhoto(p.id)}>Delete</ui-button>
+        <div slot="footer-end" class="modal-actions-right">
+          <ui-button action="secondary" emphasis="subtle" size="s" ?disabled=${this._savingAction !== "none"} @click=${() => { this._closeEditModal(); }}>Cancel</ui-button>
+          <ui-button action="primary" size="s" status=${this._savingAction === "saving" ? "loading" : "none"} ?disabled=${this._savingAction === "deleting"} @click=${this._savePhoto}>Save</ui-button>
+        </div>
+      </ui-modal>
+    `;
+  }
+
+  private _closeEditModal() {
+    (this.shadowRoot!.querySelector('.photo-edit-modal') as HTMLElement & { close(): void })?.close();
+  }
+
+  private async _savePhoto() {
+    const p = this._editingPhoto;
+    if (!p) return;
+    this._savingAction = "saving";
+    try {
+      await api.api.photos[":id"].$put({
+        param: { id: String(p.id) },
+        json: {
+          title: p.title,
+          caption: p.caption,
+          album_id: p.album_id,
+          category: p.category,
+          featured: !!p.featured,
+          status: p.status as "draft" | "published",
+          tag_ids: this._editingPhotoTagIds,
+          location: p.location,
+          latitude: p.latitude ?? null,
+          longitude: p.longitude ?? null,
+        },
+      });
+      this._closeEditModal();
+      this.dispatchEvent(new CustomEvent("photo-saved"));
+    } catch {
+      this._saveError = "Failed to save photo. Please try again.";
+    } finally {
+      this._savingAction = "none";
+    }
+  }
+
+  private async _deletePhoto(id: number) {
+    this._savingAction = "deleting";
+    try {
+      await api.api.photos[":id"].$delete({ param: { id: String(id) } });
+      this._closeEditModal();
+      this.dispatchEvent(new CustomEvent("photo-deleted"));
+    } catch {
+      this._saveError = "Failed to delete photo.";
+    } finally {
+      this._savingAction = "none";
+    }
+  }
+
+  private async _reuploadPhoto(photo: Photo) {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = "image/*";
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file) return;
+
+      this._reuploadingPhotoId = photo.id;
+      try {
+        const optimized = await optimizeImage(file);
+        const thumb = await generateThumbnail(file);
+
+        const dims = await new Promise<{ width: number; height: number }>((resolve) => {
+          const img = new Image();
+          img.onload = () => resolve({ width: img.naturalWidth, height: img.naturalHeight });
+          img.onerror = () => resolve({ width: 0, height: 0 });
+          img.src = URL.createObjectURL(optimized);
+        });
+
+        const formData = new FormData();
+        formData.append("file", optimized);
+        formData.append("thumbnail", thumb);
+        formData.append("width", String(dims.width));
+        formData.append("height", String(dims.height));
+
+        const res = await fetch(`/api/photos/${photo.id}/reupload`, {
+          method: "POST",
+          body: formData,
+          credentials: "same-origin",
+        });
+        if (res.ok) {
+          const data = (await res.json()) as { url: string; thumbnail_url: string; r2_key: string };
+          if (this._editingPhoto?.id === photo.id) {
+            this._editingPhoto = { ...this._editingPhoto, url: data.url, thumbnail_url: data.thumbnail_url, r2_key: data.r2_key, width: dims.width, height: dims.height, thumbhash: "" };
+          }
+          this._reuploadedPhotoId = photo.id;
+          setTimeout(() => { this._reuploadedPhotoId = null; }, 2000);
+          this.dispatchEvent(new CustomEvent("photo-saved"));
+        }
+      } finally {
+        this._reuploadingPhotoId = null;
+      }
+    };
+    input.click();
+  }
+
+  private async _regenerateSingleThumbnail(photo: Photo) {
+    this._regeneratingThumbs = true;
+    try {
+      const res = await fetch(photo.url);
+      if (!res.ok) return;
+      const blob = await res.blob();
+      const file = new File([blob], `photo-${photo.id}.jpg`, { type: blob.type });
+      const thumb = await generateThumbnail(file);
+      const thumbForm = new FormData();
+      thumbForm.append("file", thumb);
+      const uploadRes = await fetch("/api/images?prefix=thumb", { method: "POST", body: thumbForm, credentials: "same-origin" });
+      if (!uploadRes.ok) return;
+      const uploadData = (await uploadRes.json()) as { url: string };
+      await api.api.photos[":id"].$put({
+        param: { id: String(photo.id) },
+        json: { thumbnail_url: uploadData.url },
+      });
+      if (this._editingPhoto?.id === photo.id) {
+        this._editingPhoto = { ...this._editingPhoto, thumbnail_url: uploadData.url };
+      }
+      this.dispatchEvent(new CustomEvent("photo-saved"));
+    } finally {
+      this._regeneratingThumbs = false;
+    }
+  }
+
+  private async _createQuickTag() {
+    if (!this._newTagName.trim()) return;
+    try {
+      const res = await api.api.tags.$post({
+        json: { name: this._newTagName.trim() },
+      });
+      if (res.ok) {
+        const data = await res.json() as { ok: boolean; id: number };
+        this._editingPhotoTagIds = [...this._editingPhotoTagIds, data.id];
+        this._creatingTag = false;
+        this._newTagName = "";
+        this.dispatchEvent(new CustomEvent("tags-changed"));
+      }
+    } catch {
+      this._saveError = "Failed to create tag";
+    }
+  }
+}

--- a/apps/blog/src/admin/gallery-types.ts
+++ b/apps/blog/src/admin/gallery-types.ts
@@ -1,0 +1,42 @@
+export interface Photo {
+  id: number;
+  r2_key: string;
+  url: string;
+  title: string;
+  caption: string;
+  album_id: number | null;
+  category: string;
+  width: number;
+  height: number;
+  thumbhash: string;
+  thumbnail_url: string;
+  exif_json: string;
+  location: string;
+  latitude: number | null;
+  longitude: number | null;
+  sort_order: number;
+  featured: number;
+  status: string;
+  created_at: string;
+}
+
+export interface Album {
+  id: number;
+  slug: string;
+  title: string;
+  description: string;
+  location: string;
+  latitude: number | null;
+  longitude: number | null;
+  cover_photo_id: number | null;
+  sort_order: number;
+  status: string;
+  created_at: string;
+  photo_count?: number;
+}
+
+export interface Tag {
+  id: number;
+  name: string;
+  slug: string;
+}

--- a/apps/blog/src/admin/gallery-upload-wizard.ts
+++ b/apps/blog/src/admin/gallery-upload-wizard.ts
@@ -1,0 +1,564 @@
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, state, property } from "lit/decorators.js";
+import ExifReader from "exifreader";
+import { generateThumbHash } from "../lib/thumbhash.js";
+import "../components/map-picker.js";
+import { api } from "../lib/api.js";
+import type { Photo, Album, Tag } from "./gallery-types.js";
+import { optimizeImage, generateThumbnail, slugify } from "./gallery-utils.js";
+import "@maneki/ui-components/components/ui-button.js";
+import "@maneki/ui-components/components/ui-icon.js";
+import "@maneki/ui-components/components/ui-input.js";
+import "@maneki/ui-components/components/ui-label.js";
+import "@maneki/ui-components/components/ui-select.js";
+import "@maneki/ui-components/components/ui-dropdown-item.js";
+import "@maneki/ui-components/components/ui-modal.js";
+import "@maneki/ui-components/components/ui-checkbox-item.js";
+import "@maneki/ui-components/components/ui-dropzone.js";
+import "@maneki/ui-components/components/ui-tag.js";
+import "@maneki/ui-components/components/ui-wizard.js";
+import "@maneki/ui-components/components/ui-step-group.js";
+import "@maneki/ui-components/components/ui-step-item.js";
+import "@maneki/ui-components/components/ui-alert.js";
+
+@customElement("gallery-upload-wizard")
+export class GalleryUploadWizard extends LitElement {
+  @property({ type: Boolean }) open = false;
+  @property({ type: Array }) albums: Album[] = [];
+  @property({ type: Array }) tags: Tag[] = [];
+
+  @state() private _uploading = false;
+  @state() private _wizardStep = 1;
+  @state() private _wizardError = "";
+  @state() private _uploadFiles: File[] = [];
+  @state() private _uploadMeta: Array<{ title: string; caption: string }> = [];
+  @state() private _batchAlbumId: number | null = null;
+  @state() private _batchCategory = "";
+  @state() private _batchStatus = "draft";
+  @state() private _batchFeatured = false;
+  @state() private _batchLocation = "";
+  @state() private _batchLatitude: number | null = null;
+  @state() private _batchLongitude: number | null = null;
+  @state() private _creatingAlbum = false;
+  @state() private _newAlbumTitle = "";
+  @state() private _batchTagIds: number[] = [];
+  @state() private _creatingTag = false;
+  @state() private _newTagName = "";
+  private _blobUrlCache = new Map<File, string>();
+
+  static styles = css`
+    .wizard-step { padding: 16px; min-height: 200px; }
+    .wizard-step-scroll { max-height: 400px; overflow-y: auto; }
+    .batch-fields { display: flex; flex-direction: column; gap: 12px; margin-bottom: 16px; }
+    .file-list-edit { display: flex; flex-direction: column; gap: 12px; }
+    .file-edit-row { display: flex; gap: 12px; align-items: start; }
+    .file-edit-row .file-thumb { width: 64px; height: 64px; object-fit: cover; border-radius: 6px; flex-shrink: 0; background: var(--fd-surface-secondary, #f4f4f5); }
+    .file-edit-row .file-fields { flex: 1; display: flex; flex-direction: column; gap: 8px; }
+    .summary-section { margin-bottom: 16px; }
+    .summary-label { font-size: 12px; color: var(--fd-text-secondary); margin-bottom: 4px; }
+    .summary-value { font-size: 14px; }
+    .summary-files { display: flex; flex-direction: column; gap: 4px; }
+    .summary-file { font-size: 13px; padding: 6px 8px; background: var(--fd-surface-secondary); border-radius: 4px; }
+    .file-count { font-size: 13px; color: var(--fd-text-secondary); margin-top: 8px; }
+    .selected-files-preview { margin-top: 12px; }
+    .selected-files-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; font-size: 13px; color: var(--fd-text-secondary); }
+    .selected-files-thumbs { display: flex; flex-wrap: wrap; gap: 8px; }
+    .selected-file-chip { display: flex; align-items: center; gap: 6px; padding: 4px 8px; background: var(--fd-surface-secondary, #f4f4f5); border-radius: 6px; font-size: 12px; }
+    .selected-file-img { width: 32px; height: 32px; object-fit: cover; border-radius: 4px; }
+    .selected-file-name { max-width: 100px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .selected-file-chip ui-icon { cursor: pointer; opacity: 0.5; }
+    .selected-file-chip ui-icon:hover { opacity: 1; }
+    .album-grid-step { display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: 12px; padding: 16px; }
+    .album-grid-step .album-card { display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 16px; border: 2px solid var(--fd-border-minimal, #e4e4e7); border-radius: 8px; cursor: pointer; text-align: center; transition: border-color 0.15s ease, background 0.15s ease; min-height: 100px; overflow: visible; box-shadow: none; }
+    .album-grid-step .album-card:hover { border-color: var(--fd-border-moderate, #a1a1aa); background: var(--fd-surface-secondary, #f4f4f5); box-shadow: none; }
+    .album-grid-step .album-card.selected { border-color: var(--fd-border-focus, #186ade); background: var(--fd-surface-secondary, #f4f4f5); }
+    .album-grid-step .album-card-title { font-size: 14px; font-weight: 500; margin-top: 8px; }
+    .album-grid-step .album-card-count { font-size: 12px; color: var(--fd-text-secondary, #71717a); }
+    .album-grid-step .album-card-new { border-style: dashed; color: var(--fd-text-secondary, #71717a); }
+    .album-grid-step .album-card-new:hover { color: var(--fd-text-primary, #27272a); }
+    .album-grid-step .album-card-editing { cursor: default; gap: 8px; padding: 12px; }
+    .album-grid-step .album-card-editing:hover { background: transparent; }
+    .album-grid-step .album-card-actions { display: flex; gap: 6px; }
+    .field-row { display: flex; gap: 12px; }
+    .field-row > * { flex: 1; min-width: 0; }
+    .toggle-row { display: flex; align-items: center; gap: 8px; }
+    .tag-section { margin-top: 12px; }
+    .tag-section ui-label { display: block; margin-bottom: 6px; }
+    .tag-list { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
+    .new-tag-inline { display: inline-flex; }
+    .new-tag-inline ui-input { width: 120px; }
+  `;
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._revokeBlobUrls();
+  }
+
+  render() {
+    return html`
+      <ui-modal size="l" style="--ui-modal-width: 800px" ?open=${this.open} dismissible @close=${this._onClose}>
+        <span>Upload Photos</span>
+        <div slot="body">
+          ${this._wizardError ? html`<ui-alert status="error" size="s" dismissible @dismiss=${() => { this._wizardError = ""; }} style="margin-bottom:12px">${this._wizardError}</ui-alert>` : nothing}
+          <ui-wizard
+            headless
+            layout="horizontal"
+            current-step=${this._wizardStep}
+            status=${this._uploading ? "loading" : "none"}
+            @wizard-next=${(e: Event) => {
+              if (this._wizardStep === 1 && this._uploadFiles.length === 0) {
+                e.preventDefault();
+                return;
+              }
+              this._wizardStep = this._wizardStep + 1;
+            }}
+            @wizard-previous=${() => { this._wizardStep = this._wizardStep - 1; }}
+            @wizard-finish=${() => { this._executeUpload(); }}
+            @wizard-step-change=${(e: CustomEvent) => { this._wizardStep = (e as CustomEvent<{ step: number }>).detail.step; }}
+          >
+            <ui-step-group slot="steps">
+              <ui-step-item label="Select Files"></ui-step-item>
+              <ui-step-item label="Choose Album"></ui-step-item>
+              <ui-step-item label="Edit Details"></ui-step-item>
+              <ui-step-item label="Confirm"></ui-step-item>
+            </ui-step-group>
+            ${this._wizardStep === 1 ? this._renderStep1() : nothing}
+            ${this._wizardStep === 2 ? this._renderStep2() : nothing}
+            ${this._wizardStep === 3 ? this._renderStep3() : nothing}
+            ${this._wizardStep === 4 ? this._renderStep4() : nothing}
+          </ui-wizard>
+        </div>
+        <div slot="footer-start">
+          <ui-button action="secondary" emphasis="subtle" size="s" ?disabled=${this._wizardStep <= 1} @click=${() => { if (this._wizardStep > 1) this._wizardStep--; }}>Previous</ui-button>
+        </div>
+        <div slot="footer-end" style="display:flex;gap:8px">
+          <ui-button action="secondary" emphasis="subtle" size="s" @click=${this._onClose}>Cancel</ui-button>
+          ${this._wizardStep < 4 ? html`
+            <ui-button action="primary" size="s" ?disabled=${this._wizardStep === 1 && this._uploadFiles.length === 0} @click=${() => { this._wizardStep++; }}>Next</ui-button>
+          ` : html`
+            <ui-button action="primary" size="s" status=${this._uploading ? "loading" : "none"} @click=${() => this._executeUpload()}>Upload</ui-button>
+          `}
+        </div>
+      </ui-modal>
+    `;
+  }
+
+  private _onClose() {
+    this._resetUploadWizard();
+    this.dispatchEvent(new CustomEvent("close"));
+  }
+
+  private _renderStep1() {
+    return html`
+      <div class="wizard-step">
+        <ui-dropzone
+          accept="image/*"
+          multiple
+          size="m"
+          hint="PNG, JPG, WebP — optimized to WebP on upload"
+          @change=${(e: CustomEvent) => {
+            const files = (e as CustomEvent<{ files: FileList }>).detail.files;
+            if (files?.length) this._onFilesSelected([...this._uploadFiles, ...Array.from(files)]);
+          }}
+          @drop-files=${(e: CustomEvent) => {
+            const files = (e as CustomEvent<{ files: File[] }>).detail.files;
+            if (files?.length) this._onFilesSelected([...this._uploadFiles, ...files]);
+          }}
+        >
+          <ui-label slot="label" size="m">Photos</ui-label>
+        </ui-dropzone>
+        ${this._uploadFiles.length > 0 ? html`
+          <div class="selected-files-preview">
+            <div class="selected-files-header">
+              <span>${this._uploadFiles.length} file(s) selected</span>
+              <ui-button action="secondary" emphasis="minimal" size="s" @click=${() => { this._revokeBlobUrls(); this._uploadFiles = []; this._uploadMeta = []; }}>Clear all</ui-button>
+            </div>
+            <div class="selected-files-thumbs">
+              ${this._uploadFiles.map((f, i) => html`
+                <div class="selected-file-chip">
+                  <img class="selected-file-img" src=${this._getBlobUrl(f)} alt=${f.name} />
+                  <span class="selected-file-name">${f.name}</span>
+                  <ui-icon name="close" size="xs" @click=${() => {
+                    this._uploadFiles = this._uploadFiles.filter((_, idx) => idx !== i);
+                    this._uploadMeta = this._uploadMeta.filter((_, idx) => idx !== i);
+                  }}></ui-icon>
+                </div>
+              `)}
+            </div>
+          </div>
+        ` : nothing}
+      </div>
+    `;
+  }
+
+  private _renderStep2() {
+    return html`
+      <div class="wizard-step wizard-step-scroll">
+        <div class="album-grid-step">
+          ${this.albums.map((a) => html`
+            <div
+              class="album-card ${this._batchAlbumId === a.id ? "selected" : ""}"
+              @click=${() => { this._batchAlbumId = this._batchAlbumId === a.id ? null : a.id; }}
+            >
+              <ui-icon name="photo_album" size="m"></ui-icon>
+              <span class="album-card-title">${a.title}</span>
+              <span class="album-card-count">${a.photo_count ?? 0} photos</span>
+            </div>
+          `)}
+          ${this._creatingAlbum ? html`
+            <div class="album-card album-card-new album-card-editing">
+              <ui-input
+                size="s"
+                .value=${this._newAlbumTitle}
+                placeholder="Album name"
+                @input=${(e: Event) => { this._newAlbumTitle = (e.target as HTMLInputElement).value; }}
+                @keydown=${(e: KeyboardEvent) => { if (e.key === "Enter") this._createQuickAlbum(); if (e.key === "Escape") { this._creatingAlbum = false; this._newAlbumTitle = ""; } }}
+              ></ui-input>
+              <div class="album-card-actions">
+                <ui-button action="primary" size="s" @click=${this._createQuickAlbum}>Create</ui-button>
+                <ui-button action="secondary" emphasis="subtle" size="s" @click=${() => { this._creatingAlbum = false; this._newAlbumTitle = ""; }}>Cancel</ui-button>
+              </div>
+            </div>
+          ` : html`
+            <div class="album-card album-card-new" @click=${() => { this._creatingAlbum = true; }}>
+              <ui-icon name="add" size="m"></ui-icon>
+              <span class="album-card-title">New Album</span>
+            </div>
+          `}
+      </div>
+    `;
+  }
+
+  private _renderStep3() {
+    return html`
+      <div class="wizard-step wizard-step-scroll">
+        <div class="batch-fields">
+          <ui-input
+            size="m"
+            .value=${this._batchCategory}
+            @input=${(e: Event) => { this._batchCategory = (e.target as HTMLInputElement).value; }}
+          ><ui-label slot="label" size="m">Category</ui-label></ui-input>
+          <div>
+            <ui-label size="m">Location</ui-label>
+            <map-picker
+              .location=${this._batchLocation}
+              .latitude=${this._batchLatitude}
+              .longitude=${this._batchLongitude}
+              @location-picked=${(e: CustomEvent) => {
+                const d = e.detail as { location: string; latitude: number | null; longitude: number | null };
+                this._batchLocation = d.location;
+                this._batchLatitude = d.latitude;
+                this._batchLongitude = d.longitude;
+              }}
+            ></map-picker>
+          </div>
+          <div class="field-row">
+            <ui-select
+              size="m"
+              .value=${this._batchStatus}
+              @change=${(e: Event) => { this._batchStatus = (e.target as HTMLElement & { value: string }).value; }}
+            >
+              <ui-label slot="label" size="m">Status</ui-label>
+              <ui-dropdown-item value="draft">Draft</ui-dropdown-item>
+              <ui-dropdown-item value="published">Published</ui-dropdown-item>
+            </ui-select>
+          </div>
+          <div class="toggle-row">
+            <ui-checkbox-item
+              size="m"
+              label-position="right"
+              ?checked=${this._batchFeatured}
+              @change=${(e: Event) => { this._batchFeatured = (e.target as HTMLInputElement).checked; }}
+            ><ui-label slot="label" size="m">Featured</ui-label></ui-checkbox-item>
+          </div>
+        <div class="tag-section">
+          <ui-label size="m">Tags</ui-label>
+          <div class="tag-list">
+            ${this.tags.map((t) => html`
+              <ui-tag
+                size="s"
+                emphasis=${this._batchTagIds.includes(t.id) ? "subtle" : "minimal"}
+                @click=${() => {
+                  this._batchTagIds = this._batchTagIds.includes(t.id)
+                    ? this._batchTagIds.filter((id) => id !== t.id)
+                    : [...this._batchTagIds, t.id];
+                }}
+              >${t.name}</ui-tag>
+            `)}
+            ${this._creatingTag ? html`
+              <div class="new-tag-inline">
+                <ui-input
+                  size="s"
+                  .value=${this._newTagName}
+                  placeholder="Tag name"
+                  @input=${(e: Event) => { this._newTagName = (e.target as HTMLInputElement).value; }}
+                  @keydown=${(e: KeyboardEvent) => {
+                    if (e.key === "Enter") this._createQuickTag();
+                    if (e.key === "Escape") { this._creatingTag = false; this._newTagName = ""; }
+                  }}
+                ></ui-input>
+              </div>
+            ` : html`
+              <ui-tag
+                size="s"
+                type="basic"
+                emphasis="minimal"
+                @click=${() => { this._creatingTag = true; }}
+              >+ New</ui-tag>
+            `}
+          </div>
+        </div>
+        </div>
+        <div class="file-list-edit">
+          ${this._uploadMeta.map((m, i) => html`
+            <div class="file-edit-row">
+              <img class="file-thumb" src=${this._getBlobUrl(this._uploadFiles[i])} alt=${m.title} />
+              <div class="file-fields">
+                <ui-input
+                  size="s"
+                  .value=${m.title}
+                  @input=${(e: Event) => {
+                    const updated = [...this._uploadMeta];
+                    updated[i] = { ...updated[i], title: (e.target as HTMLInputElement).value };
+                    this._uploadMeta = updated;
+                  }}
+                ><ui-label slot="label" size="s">Title</ui-label></ui-input>
+                <ui-input
+                  size="s"
+                  .value=${m.caption}
+                  @input=${(e: Event) => {
+                    const updated = [...this._uploadMeta];
+                    updated[i] = { ...updated[i], caption: (e.target as HTMLInputElement).value };
+                    this._uploadMeta = updated;
+                  }}
+                ><ui-label slot="label" size="s">Caption</ui-label></ui-input>
+              </div>
+            </div>
+          `)}
+        </div>
+      </div>
+    `;
+  }
+
+  private _renderStep4() {
+    const albumName = this._batchAlbumId ? this.albums.find((a) => a.id === this._batchAlbumId)?.title ?? "—" : "None";
+    return html`
+      <div class="wizard-step wizard-step-scroll">
+        <div class="summary-section">
+          <div class="summary-label">Files</div>
+          <div class="summary-value">${this._uploadFiles.length} photo(s)</div>
+        </div>
+        <div class="summary-section">
+          <div class="summary-label">Album</div>
+          <div class="summary-value">${albumName}</div>
+        </div>
+        <div class="summary-section">
+          <div class="summary-label">Category</div>
+          <div class="summary-value">${this._batchCategory || "—"}</div>
+        </div>
+        <div class="summary-section">
+          <div class="summary-label">Location</div>
+          <div class="summary-value">${this._batchLocation || "None"}${this._batchLatitude != null ? ` (${this._batchLatitude.toFixed(4)}, ${this._batchLongitude!.toFixed(4)})` : ""}</div>
+        </div>
+        <div class="summary-section">
+          <div class="summary-label">Status</div>
+          <div class="summary-value">${this._batchStatus}</div>
+        </div>
+        <div class="summary-section">
+          <div class="summary-label">Featured</div>
+          <div class="summary-value">${this._batchFeatured ? "Yes" : "No"}</div>
+        </div>
+        <div class="summary-section">
+          <div class="summary-label">Tags</div>
+          <div class="summary-value">${this._batchTagIds.length > 0 ? this.tags.filter((t) => this._batchTagIds.includes(t.id)).map((t) => t.name).join(", ") : "None"}</div>
+        </div>
+        <div class="summary-section">
+          <div class="summary-label">Files</div>
+          <div class="summary-files">
+            ${this._uploadMeta.map((m, i) => html`
+              <div class="summary-file">${m.title}${m.caption ? ` — ${m.caption}` : ""}${this._uploadFiles[i] ? ` (${(this._uploadFiles[i].size / 1024).toFixed(0)} KB)` : ""}</div>
+            `)}
+          </div>
+        </div>
+        ${this._uploading ? html`<div class="file-count">Uploading…</div>` : nothing}
+      </div>
+    `;
+  }
+
+  private _onFilesSelected(files: File[]) {
+    this._uploadFiles = files;
+    this._uploadMeta = files.map((f) => ({
+      title: f.name.replace(/\.[^.]+$/, ""),
+      caption: "",
+    }));
+  }
+
+  private async _createQuickAlbum() {
+    if (!this._newAlbumTitle.trim()) return;
+    try {
+      const res = await api.api.albums.$post({
+        json: {
+          title: this._newAlbumTitle.trim(),
+          slug: slugify(this._newAlbumTitle.trim()),
+          description: "",
+          status: "draft",
+          location: "",
+          latitude: null,
+          longitude: null,
+        },
+      });
+      if (res.ok) {
+        await this._refetchAlbums();
+        const newAlbum = this.albums.find((a) => a.slug === slugify(this._newAlbumTitle.trim()));
+        if (newAlbum) this._batchAlbumId = newAlbum.id;
+        this._creatingAlbum = false;
+        this._newAlbumTitle = "";
+      }
+    } catch { this._wizardError = "Failed to create album"; }
+  }
+
+  private async _refetchAlbums() {
+    try {
+      const res = await api.api.albums.$get();
+      if (!res.ok) return;
+      const data = await res.json();
+      this.albums = data.albums as unknown as Album[];
+    } catch { this._dispatchWarning("Failed to refresh albums"); }
+  }
+
+  private async _createQuickTag() {
+    if (!this._newTagName.trim()) return;
+    try {
+      const res = await api.api.tags.$post({
+        json: { name: this._newTagName.trim() },
+      });
+      if (res.ok) {
+        const data = await res.json() as { ok: boolean; id: number };
+        this._batchTagIds = [...this._batchTagIds, data.id];
+        this._creatingTag = false;
+        this._newTagName = "";
+        this.dispatchEvent(new CustomEvent("tags-changed"));
+      }
+    } catch { this._wizardError = "Failed to create tag"; }
+  }
+
+  private async _executeUpload() {
+    this._uploading = true;
+    for (let i = 0; i < this._uploadFiles.length; i++) {
+      const file = this._uploadFiles[i];
+      if (!file.type.startsWith("image/")) continue;
+
+      let exif: Record<string, unknown> = {};
+      let width = 0;
+      let height = 0;
+      try {
+        const buffer = await file.arrayBuffer();
+        const tags = ExifReader.load(buffer, { expanded: true });
+        if (tags.exif) {
+          if (tags.exif.Make) exif.Make = tags.exif.Make.description;
+          if (tags.exif.Model) exif.Model = tags.exif.Model.description;
+          if (tags.exif.LensModel) exif.LensModel = tags.exif.LensModel.description;
+          if (tags.exif.FocalLength) exif.FocalLength = tags.exif.FocalLength.description;
+          if (tags.exif.FNumber) exif.FNumber = tags.exif.FNumber.description;
+          if (tags.exif.ExposureTime) exif.ExposureTime = tags.exif.ExposureTime.description;
+          if (tags.exif.ISOSpeedRatings) exif.ISO = tags.exif.ISOSpeedRatings.description;
+          if (tags.exif.DateTimeOriginal) exif.DateTimeOriginal = tags.exif.DateTimeOriginal.description;
+        }
+        if (tags.file) {
+          if (tags.file["Image Width"]) width = Number(tags.file["Image Width"].value);
+          if (tags.file["Image Height"]) height = Number(tags.file["Image Height"].value);
+        }
+      } catch { this._dispatchWarning("Could not read EXIF data — metadata will be missing"); }
+
+      let thumbhash = "";
+      try { thumbhash = await generateThumbHash(file); } catch { this._dispatchWarning("Thumbhash generation failed — no blur placeholder"); }
+
+      const optimized = await optimizeImage(file);
+
+      const formData = new FormData();
+      formData.append("file", optimized);
+      try {
+        const res = await fetch("/api/images?prefix=photos", { method: "POST", body: formData, credentials: "same-origin" });
+        if (!res.ok) continue;
+        const data = (await res.json()) as { url: string; name: string; r2_key?: string };
+
+        let thumbnailUrl = "";
+        try {
+          const thumb = await generateThumbnail(file);
+          const thumbForm = new FormData();
+          thumbForm.append("file", thumb);
+          const thumbRes = await fetch("/api/images?prefix=thumb", { method: "POST", body: thumbForm, credentials: "same-origin" });
+          if (thumbRes.ok) {
+            const thumbData = (await thumbRes.json()) as { url: string };
+            thumbnailUrl = thumbData.url;
+          }
+        } catch { this._dispatchWarning("Thumbnail generation failed — uploading without thumbnail"); }
+
+        const meta = this._uploadMeta[i] ?? { title: file.name.replace(/\.[^.]+$/, ""), caption: "" };
+        await api.api.photos.$post({
+          json: {
+            r2_key: data.r2_key || data.name,
+            url: data.url,
+            thumbnail_url: thumbnailUrl,
+            title: meta.title,
+            caption: meta.caption,
+            album_id: this._batchAlbumId,
+            category: this._batchCategory,
+            location: this._batchLocation,
+            latitude: this._batchLatitude,
+            longitude: this._batchLongitude,
+            width,
+            height,
+            exif_json: JSON.stringify(exif),
+            status: this._batchStatus as "draft" | "published",
+            featured: this._batchFeatured,
+            thumbhash,
+            tag_ids: this._batchTagIds,
+          },
+        });
+      } catch { this._wizardError = `Failed to upload ${file.name}`; }
+    }
+    this._uploading = false;
+    this._resetUploadWizard();
+    this.dispatchEvent(new CustomEvent("upload-complete"));
+  }
+
+  private _dispatchWarning(message: string) {
+    this.dispatchEvent(new CustomEvent("show-warning", { bubbles: true, composed: true, detail: { message } }));
+  }
+  private _resetUploadWizard() {
+    this._wizardError = "";
+    this._wizardStep = 1;
+    this._revokeBlobUrls();
+    this._uploadFiles = [];
+    this._uploadMeta = [];
+    this._batchAlbumId = null;
+    this._batchCategory = "";
+    this._batchStatus = "draft";
+    this._batchFeatured = false;
+    this._creatingAlbum = false;
+    this._newAlbumTitle = "";
+    this._batchTagIds = [];
+    this._batchLocation = "";
+    this._batchLatitude = null;
+    this._batchLongitude = null;
+    this._creatingTag = false;
+    this._newTagName = "";
+  }
+
+  private _getBlobUrl(file: File): string {
+    let url = this._blobUrlCache.get(file);
+    if (!url) {
+      url = URL.createObjectURL(file);
+      this._blobUrlCache.set(file, url);
+    }
+    return url;
+  }
+
+  private _revokeBlobUrls() {
+    for (const url of this._blobUrlCache.values()) {
+      URL.revokeObjectURL(url);
+    }
+    this._blobUrlCache.clear();
+  }
+}

--- a/apps/blog/src/admin/gallery-utils.ts
+++ b/apps/blog/src/admin/gallery-utils.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared utility functions for gallery components.
+ */
+
+export const MAX_WIDTH = 2400;
+export const THUMB_WIDTH = 800;
+export const QUALITY = 0.92;
+
+export async function optimizeImage(file: File): Promise<File> {
+  if (file.type === "image/svg+xml") return file;
+  if (file.size < 100 * 1024) return file;
+
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      let { width, height } = img;
+      if (width <= MAX_WIDTH) {
+        resolve(file);
+        return;
+      }
+      height = Math.round(height * (MAX_WIDTH / width));
+      width = MAX_WIDTH;
+      const canvas = document.createElement("canvas");
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext("2d")!;
+      ctx.imageSmoothingQuality = "high";
+      ctx.drawImage(img, 0, 0, width, height);
+      canvas.toBlob(
+        (blob) => {
+          if (blob) {
+            resolve(new File([blob], file.name, { type: file.type }));
+          } else {
+            resolve(file);
+          }
+        },
+        file.type,
+        QUALITY,
+      );
+    };
+    img.onerror = () => resolve(file);
+    img.src = URL.createObjectURL(file);
+  });
+}
+
+export async function generateThumbnail(file: File): Promise<File> {
+  if (file.type === "image/svg+xml") return file;
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      let { width, height } = img;
+      if (width <= THUMB_WIDTH) {
+        resolve(file);
+        return;
+      }
+      height = Math.round(height * (THUMB_WIDTH / width));
+      width = THUMB_WIDTH;
+      const canvas = document.createElement("canvas");
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext("2d")!;
+      ctx.imageSmoothingQuality = "high";
+      ctx.drawImage(img, 0, 0, width, height);
+      canvas.toBlob(
+        (blob) => {
+          if (blob) {
+            resolve(new File([blob], file.name.replace(/\.[^.]+$/, ".webp"), { type: "image/webp" }));
+          } else {
+            resolve(file);
+          }
+        },
+        "image/webp",
+        0.8,
+      );
+    };
+    img.onerror = () => resolve(file);
+    img.src = URL.createObjectURL(file);
+  });
+}
+
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}

--- a/apps/blog/src/admin/gallery.ts
+++ b/apps/blog/src/admin/gallery.ts
@@ -1,199 +1,48 @@
 import { LitElement, html, css, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
-import ExifReader from "exifreader";
-import { generateThumbHash, thumbHashBase64ToDataURL } from "../lib/thumbhash.js";
+import { thumbHashBase64ToDataURL } from "../lib/thumbhash.js";
 import "../components/theme-toggle.js";
 import "../components/loading-bounce.js";
-import "../components/map-picker.js";
-import { loadAdminState, saveThemeToBackend, getGalleryTab, setGalleryTab } from "./theme.js";
+import { loadAdminState, saveThemeToBackend, setGalleryTab } from "./theme.js";
 import { api } from "../lib/api.js";
+import type { Photo, Album, Tag } from "./gallery-types.js";
+import { generateThumbnail } from "./gallery-utils.js";
+import "./gallery-upload-wizard.js";
+import "./gallery-photo-modal.js";
+import "./gallery-album-modal.js";
 import "@maneki/ui-components/components/ui-button.js";
 import "@maneki/ui-components/components/ui-icon.js";
 import "@maneki/ui-components/components/ui-badge.js";
 import "@maneki/ui-components/components/ui-input.js";
-import "@maneki/ui-components/components/ui-label.js";
-import "@maneki/ui-components/components/ui-textarea.js";
-import "@maneki/ui-components/components/ui-select.js";
-import "@maneki/ui-components/components/ui-dropdown-item.js";
 import "@maneki/ui-components/components/ui-modal.js";
 import "@maneki/ui-components/components/ui-tab-group.js";
 import "@maneki/ui-components/components/ui-tab-item.js";
-import "@maneki/ui-components/components/ui-checkbox-item.js";
-import "@maneki/ui-components/components/ui-dropzone.js";
-import "@maneki/ui-components/components/ui-tag.js";
-import "@maneki/ui-components/components/ui-wizard.js";
-import "@maneki/ui-components/components/ui-step-group.js";
-import "@maneki/ui-components/components/ui-step-item.js";
 import "@maneki/ui-components/components/ui-alert.js";
 import "@maneki/ui-components/components/ui-image.js";
 import "@maneki/ui-components/components/ui-card.js";
-
-interface Photo {
-  id: number;
-  r2_key: string;
-  url: string;
-  title: string;
-  caption: string;
-  album_id: number | null;
-  category: string;
-  width: number;
-  height: number;
-  thumbhash: string;
-  thumbnail_url: string;
-  exif_json: string;
-  location: string;
-  latitude: number | null;
-  longitude: number | null;
-  sort_order: number;
-  featured: number;
-  status: string;
-  created_at: string;
-}
-
-interface Album {
-  id: number;
-  slug: string;
-  title: string;
-  description: string;
-  location: string;
-  latitude: number | null;
-  longitude: number | null;
-  cover_photo_id: number | null;
-  sort_order: number;
-  status: string;
-  created_at: string;
-  photo_count?: number;
-}
-
-const MAX_WIDTH = 2400;
-const THUMB_WIDTH = 800;
-const QUALITY = 0.92;
-
-async function optimizeImage(file: File): Promise<File> {
-  // Skip optimization for photography — preserve original quality
-  // Only resize if wider than MAX_WIDTH, keep original format
-  if (file.type === "image/svg+xml") return file;
-  if (file.size < 100 * 1024) return file;
-
-  return new Promise((resolve) => {
-    const img = new Image();
-    img.onload = () => {
-      let { width, height } = img;
-      if (width <= MAX_WIDTH) {
-        // No resize needed — return original file as-is
-        resolve(file);
-        return;
-      }
-      height = Math.round(height * (MAX_WIDTH / width));
-      width = MAX_WIDTH;
-      const canvas = document.createElement("canvas");
-      canvas.width = width;
-      canvas.height = height;
-      const ctx = canvas.getContext("2d")!;
-      ctx.imageSmoothingQuality = "high";
-      ctx.drawImage(img, 0, 0, width, height);
-      canvas.toBlob(
-        (blob) => {
-          if (blob) {
-            resolve(new File([blob], file.name, { type: file.type }));
-          } else {
-            resolve(file);
-          }
-        },
-        file.type,
-        QUALITY,
-      );
-    };
-    img.onerror = () => resolve(file);
-    img.src = URL.createObjectURL(file);
-  });
-}
-
-async function generateThumbnail(file: File): Promise<File> {
-  if (file.type === "image/svg+xml") return file;
-  return new Promise((resolve) => {
-    const img = new Image();
-    img.onload = () => {
-      let { width, height } = img;
-      if (width <= THUMB_WIDTH) {
-        resolve(file);
-        return;
-      }
-      height = Math.round(height * (THUMB_WIDTH / width));
-      width = THUMB_WIDTH;
-      const canvas = document.createElement("canvas");
-      canvas.width = width;
-      canvas.height = height;
-      const ctx = canvas.getContext("2d")!;
-      ctx.imageSmoothingQuality = "high";
-      ctx.drawImage(img, 0, 0, width, height);
-      canvas.toBlob(
-        (blob) => {
-          if (blob) {
-            resolve(new File([blob], file.name.replace(/\.[^.]+$/, ".webp"), { type: "image/webp" }));
-          } else {
-            resolve(file);
-          }
-        },
-        "image/webp",
-        0.8,
-      );
-    };
-    img.onerror = () => resolve(file);
-    img.src = URL.createObjectURL(file);
-  });
-}
-
-function slugify(text: string): string {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-|-$/g, "");
-}
 
 @customElement("admin-gallery")
 export class AdminGallery extends LitElement {
   @state() private _activeTab: "photos" | "albums" = "photos";
   @state() private _photos: Photo[] = [];
   @state() private _albums: Album[] = [];
+  @state() private _tags: Tag[] = [];
   @state() private _searchQuery = "";
   @state() private _showUpload = false;
   @state() private _editingPhoto: Photo | null = null;
+  @state() private _viewingPhoto: Photo | null = null;
   @state() private _editingAlbum: Album | null = null;
   @state() private _loading = false;
   @state() private _initializing = true;
-  @state() private _uploading = false;
-  @state() private _savingAction: "none" | "saving" | "deleting" = "none";
   @state() private _saved = false;
-  @state() private _saveError = "";
-  @state() private _wizardStep = 1;
-  @state() private _wizardError = "";
-  @state() private _uploadFiles: File[] = [];
-  @state() private _uploadMeta: Array<{ title: string; caption: string }> = [];
-  @state() private _batchAlbumId: number | null = null;
-  @state() private _batchCategory = "";
-  @state() private _batchStatus = "draft";
-  @state() private _batchFeatured = false;
-  @state() private _batchLocation = "";
-  @state() private _creatingAlbum = false;
-  @state() private _batchLatitude: number | null = null;
-  @state() private _batchLongitude: number | null = null;
-  @state() private _newAlbumTitle = "";
   @state() private _viewingAlbum: Album | null = null;
   @state() private _albumPhotos: Photo[] = [];
-  @state() private _viewingPhoto: Photo | null = null;
-
-  @state() private _tags: Array<{ id: number; name: string; slug: string }> = [];
-  @state() private _batchTagIds: number[] = [];
-  @state() private _editingPhotoTagIds: number[] = [];
-  @state() private _creatingTag = false;
-  @state() private _newTagName = "";
   @state() private _regeneratingThumbs = false;
   @state() private _reuploadingPhotoId: number | null = null;
   @state() private _reuploadedPhotoId: number | null = null;
-  private _blobUrlCache = new Map<File, string>();
   @state() private _toastMessage = "";
   @state() private _toastStatus: "error" | "warning" | "success" = "error";
+
   static styles = css`
     :host {
       display: flex;
@@ -309,14 +158,13 @@ export class AdminGallery extends LitElement {
       cursor: pointer;
       transition: border-color 0.15s ease, box-shadow 0.15s ease;
       background: var(--fd-surface-primary, #fff);
+      position: relative;
     }
 
     .album-card:hover {
       border-color: var(--fd-border-moderate, #a1a1aa);
       box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
     }
-
-    .album-card { position: relative; overflow: hidden; }
 
     .album-card-overlay {
       position: absolute;
@@ -380,48 +228,12 @@ export class AdminGallery extends LitElement {
       margin-left: 8px;
     }
 
-
-    .modal-form {
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-    }
-
-    .field-row {
-      display: flex;
-      gap: 12px;
-    }
-
-    .field-row > * {
-      flex: 1;
-      min-width: 0;
-    }
-
-    .toggle-row {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-    }
-
-    .modal-actions {
-      display: flex;
-      justify-content: space-between;
-      gap: 8px;
-      margin-top: 16px;
-    }
-
-    .modal-actions-right {
-      display: flex;
-      gap: 8px;
-    }
-
     .empty {
       text-align: center;
       padding: 48px 24px;
       color: var(--fd-text-secondary, #71717a);
       font-size: 13px;
     }
-
 
     ui-tab-group {
       padding: 0 24px;
@@ -431,57 +243,7 @@ export class AdminGallery extends LitElement {
     ui-tab-item {
       min-width: 120px;
     }
-    .wizard-step { padding: 16px; min-height: 200px; }
-    .wizard-step-scroll { max-height: 400px; overflow-y: auto; }
-    .batch-fields { display: flex; flex-direction: column; gap: 12px; margin-bottom: 16px; }
-    .file-list-edit { display: flex; flex-direction: column; gap: 12px; }
-    .file-edit-row { display: flex; gap: 12px; align-items: start; }
-    .file-edit-row .file-thumb { width: 64px; height: 64px; object-fit: cover; border-radius: 6px; flex-shrink: 0; background: var(--fd-surface-secondary, #f4f4f5); }
-    .file-edit-row .file-fields { flex: 1; display: flex; flex-direction: column; gap: 8px; }
-    .summary-section { margin-bottom: 16px; }
-    .summary-label { font-size: 12px; color: var(--fd-text-secondary); margin-bottom: 4px; }
-    .summary-value { font-size: 14px; }
-    .summary-files { display: flex; flex-direction: column; gap: 4px; }
-    .summary-file { font-size: 13px; padding: 6px 8px; background: var(--fd-surface-secondary); border-radius: 4px; }
-    .file-count { font-size: 13px; color: var(--fd-text-secondary); margin-top: 8px; }
-    .selected-files-preview { margin-top: 12px; }
-    .selected-files-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; font-size: 13px; color: var(--fd-text-secondary); }
-    .selected-files-thumbs { display: flex; flex-wrap: wrap; gap: 8px; }
-    .selected-file-chip { display: flex; align-items: center; gap: 6px; padding: 4px 8px; background: var(--fd-surface-secondary, #f4f4f5); border-radius: 6px; font-size: 12px; }
-    .selected-file-img { width: 32px; height: 32px; object-fit: cover; border-radius: 4px; }
-    .selected-file-name { max-width: 100px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .selected-file-chip ui-icon { cursor: pointer; opacity: 0.5; }
-    .selected-file-chip ui-icon:hover { opacity: 1; }
-    .album-grid-step { display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: 12px; padding: 16px; }
-    .album-grid-step .album-card { display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 16px; border: 2px solid var(--fd-border-minimal, #e4e4e7); border-radius: 8px; cursor: pointer; text-align: center; transition: border-color 0.15s ease, background 0.15s ease; min-height: 100px; overflow: visible; box-shadow: none; }
-    .album-grid-step .album-card:hover { border-color: var(--fd-border-moderate, #a1a1aa); background: var(--fd-surface-secondary, #f4f4f5); box-shadow: none; }
-    .album-grid-step .album-card.selected { border-color: var(--fd-border-focus, #186ade); background: var(--fd-surface-secondary, #f4f4f5); }
-    .album-grid-step .album-card-title { font-size: 14px; font-weight: 500; margin-top: 8px; }
-    .album-grid-step .album-card-count { font-size: 12px; color: var(--fd-text-secondary, #71717a); }
-    .album-grid-step .album-card-new { border-style: dashed; color: var(--fd-text-secondary, #71717a); }
-    .album-grid-step .album-card-new:hover { color: var(--fd-text-primary, #27272a); }
-    .album-grid-step .album-card-editing { cursor: default; gap: 8px; padding: 12px; }
-    .album-grid-step .album-card-editing:hover { background: transparent; }
-    .album-grid-step .album-card-actions { display: flex; gap: 6px; }
 
-    .tag-section { margin-top: 12px; }
-    .tag-section ui-label { display: block; margin-bottom: 6px; }
-    .tag-list { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; }
-    .new-tag-inline { display: inline-flex; }
-    .new-tag-inline ui-input { width: 120px; }
-    .photo-detail { display: flex; gap: 24px; }
-    .photo-detail-preview { flex: 1; min-width: 0; }
-    .photo-detail-preview ui-image { width: 100%; border-radius: 8px; display: block; }
-    .photo-detail-info { width: 280px; flex-shrink: 0; display: flex; flex-direction: column; gap: 12px; overflow-y: auto; }
-    .detail-label { font-size: 11px; font-weight: 500; color: var(--fd-text-secondary, #71717a); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 2px; }
-    .detail-value { font-size: 14px; }
-    .detail-row { display: flex; gap: 16px; }
-    .detail-row .detail-section { flex: 1; }
-    .detail-tags { display: flex; flex-wrap: wrap; gap: 4px; }
-    .detail-exif { display: flex; flex-direction: column; gap: 4px; font-size: 13px; }
-    .exif-row { display: flex; justify-content: space-between; padding: 3px 0; border-bottom: 1px solid var(--fd-border-minimal, #e4e4e7); }
-    .exif-key { color: var(--fd-text-secondary, #71717a); }
-    .exif-val { font-weight: 500; }
     .toast { position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%); z-index: 9999; transition: opacity 0.3s ease; }
   `;
 
@@ -492,11 +254,6 @@ export class AdminGallery extends LitElement {
       this._activeTab = s.galleryTab;
       this._fetchAll().then(() => { this._initializing = false; });
     });
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this._revokeBlobUrls();
   }
 
   private _showToast(message: string, status: "error" | "warning" | "success" = "error") {
@@ -534,146 +291,10 @@ export class AdminGallery extends LitElement {
       const res = await api.api.tags.$get();
       if (!res.ok) return;
       const data = await res.json();
-      this._tags = data.tags as unknown as Array<{ id: number; name: string; slug: string }>;
+      this._tags = data.tags as unknown as Tag[];
     } catch { this._showToast("Failed to load tags"); }
   }
 
-  private _navigateBack() {
-    window.dispatchEvent(new CustomEvent("admin-navigate", {
-      detail: { path: "/admin" },
-    }));
-  }
-
-  // ── Photo CRUD ──
-
-  private async _executeUpload() {
-    this._uploading = true;
-    for (let i = 0; i < this._uploadFiles.length; i++) {
-      const file = this._uploadFiles[i];
-      if (!file.type.startsWith("image/")) continue;
-
-      // Extract EXIF from original file (minus GPS — location is manual)
-      let exif: Record<string, unknown> = {};
-      let width = 0;
-      let height = 0;
-      try {
-        const buffer = await file.arrayBuffer();
-        const tags = ExifReader.load(buffer, { expanded: true });
-        if (tags.exif) {
-          if (tags.exif.Make) exif.Make = tags.exif.Make.description;
-          if (tags.exif.Model) exif.Model = tags.exif.Model.description;
-          if (tags.exif.LensModel) exif.LensModel = tags.exif.LensModel.description;
-          if (tags.exif.FocalLength) exif.FocalLength = tags.exif.FocalLength.description;
-          if (tags.exif.FNumber) exif.FNumber = tags.exif.FNumber.description;
-          if (tags.exif.ExposureTime) exif.ExposureTime = tags.exif.ExposureTime.description;
-          if (tags.exif.ISOSpeedRatings) exif.ISO = tags.exif.ISOSpeedRatings.description;
-          if (tags.exif.DateTimeOriginal) exif.DateTimeOriginal = tags.exif.DateTimeOriginal.description;
-        }
-        if (tags.file) {
-          if (tags.file["Image Width"]) width = Number(tags.file["Image Width"].value);
-          if (tags.file["Image Height"]) height = Number(tags.file["Image Height"].value);
-        }
-      } catch { this._showToast("Could not read EXIF data — metadata will be missing", "warning"); }
-
-      let thumbhash = "";
-      try { thumbhash = await generateThumbHash(file); } catch { this._showToast("Thumbhash generation failed — no blur placeholder", "warning"); }
-
-      const optimized = await optimizeImage(file);
-
-      const formData = new FormData();
-      formData.append("file", optimized);
-      try {
-        const res = await fetch("/api/images?prefix=photos", { method: "POST", body: formData, credentials: "same-origin" });
-        if (!res.ok) continue;
-        const data = (await res.json()) as { url: string; name: string; r2_key?: string };
-
-        // Generate and upload thumbnail
-        let thumbnailUrl = "";
-        try {
-          const thumb = await generateThumbnail(file);
-          const thumbForm = new FormData();
-          thumbForm.append("file", thumb);
-          const thumbRes = await fetch("/api/images?prefix=thumb", { method: "POST", body: thumbForm, credentials: "same-origin" });
-          if (thumbRes.ok) {
-            const thumbData = (await thumbRes.json()) as { url: string };
-            thumbnailUrl = thumbData.url;
-          }
-        } catch { this._showToast("Thumbnail generation failed — uploading without thumbnail", "warning"); }
-
-        const meta = this._uploadMeta[i] ?? { title: file.name.replace(/\.[^.]+$/, ""), caption: "" };
-        await api.api.photos.$post({
-          json: {
-            r2_key: data.r2_key || data.name,
-            url: data.url,
-            thumbnail_url: thumbnailUrl,
-            title: meta.title,
-            caption: meta.caption,
-            album_id: this._batchAlbumId,
-            category: this._batchCategory,
-            location: this._batchLocation,
-            latitude: this._batchLatitude,
-            longitude: this._batchLongitude,
-            width,
-            height,
-            exif_json: JSON.stringify(exif),
-            status: this._batchStatus as "draft" | "published",
-            featured: this._batchFeatured,
-            thumbhash,
-            tag_ids: this._batchTagIds,
-          },
-        });
-      } catch { this._wizardError = `Failed to upload ${file.name}`; }
-    }
-    this._uploading = false;
-    this._showUpload = false;
-    this._resetUploadWizard();
-    await this._fetchAll();
-  }
-
-  private async _savePhoto() {
-    const p = this._editingPhoto;
-    if (!p) return;
-    this._savingAction = "saving";
-    try {
-      await api.api.photos[":id"].$put({
-        param: { id: String(p.id) },
-        json: {
-          title: p.title,
-          caption: p.caption,
-          album_id: p.album_id,
-          category: p.category,
-          featured: !!p.featured,
-          status: p.status as "draft" | "published",
-          tag_ids: this._editingPhotoTagIds,
-          location: p.location,
-          latitude: p.latitude ?? null,
-          longitude: p.longitude ?? null,
-        },
-      });
-      (this.shadowRoot!.querySelector('.photo-edit-modal') as HTMLElement & { close(): void })?.close();
-      this._saved = true;
-      setTimeout(() => { this._saved = false; }, 2000);
-      await this._fetchPhotos();
-    } catch {
-      this._saveError = "Failed to save photo. Please try again.";
-    } finally {
-      this._savingAction = "none";
-    }
-
-  }
-  private async _deletePhoto(id: number) {
-    this._savingAction = "deleting";
-    try {
-      await api.api.photos[":id"].$delete({ param: { id: String(id) } });
-      (this.shadowRoot!.querySelector('.photo-edit-modal') as HTMLElement & { close(): void })?.close();
-      await this._fetchAll();
-    } catch {
-      this._saveError = "Failed to delete photo.";
-    } finally {
-      this._savingAction = "none";
-    }
-
-  }
   private async _regenerateThumbnails() {
     this._regeneratingThumbs = true;
     try {
@@ -705,172 +326,12 @@ export class AdminGallery extends LitElement {
     }
   }
 
-
-  private async _regenerateSingleThumbnail(photo: Photo) {
-    this._regeneratingThumbs = true;
+  private async _deletePhoto(id: number) {
     try {
-      const res = await fetch(photo.url);
-      if (!res.ok) return;
-      const blob = await res.blob();
-      const file = new File([blob], `photo-${photo.id}.jpg`, { type: blob.type });
-      const thumb = await generateThumbnail(file);
-      const thumbForm = new FormData();
-      thumbForm.append("file", thumb);
-      const uploadRes = await fetch("/api/images?prefix=thumb", { method: "POST", body: thumbForm, credentials: "same-origin" });
-      if (!uploadRes.ok) return;
-      const uploadData = (await uploadRes.json()) as { url: string };
-      await fetch(`/api/photos/${photo.id}`, {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        credentials: "same-origin",
-        body: JSON.stringify({ thumbnail_url: uploadData.url }),
-      });
-      if (this._editingPhoto?.id === photo.id) {
-        this._editingPhoto = { ...this._editingPhoto, thumbnail_url: uploadData.url };
-      }
-      await this._fetchPhotos();
-    } finally {
-      this._regeneratingThumbs = false;
-    }
-  }
-
-  private async _reuploadPhoto(photo: Photo) {
-    const input = document.createElement("input");
-    input.type = "file";
-    input.accept = "image/*";
-    input.onchange = async () => {
-      const file = input.files?.[0];
-      if (!file) return;
-
-      this._reuploadingPhotoId = photo.id;
-      try {
-        const optimized = await optimizeImage(file);
-        const thumb = await generateThumbnail(file);
-
-        const dims = await new Promise<{ width: number; height: number }>((resolve) => {
-          const img = new Image();
-          img.onload = () => resolve({ width: img.naturalWidth, height: img.naturalHeight });
-          img.onerror = () => resolve({ width: 0, height: 0 });
-          img.src = URL.createObjectURL(optimized);
-        });
-
-        const formData = new FormData();
-        formData.append("file", optimized);
-        formData.append("thumbnail", thumb);
-        formData.append("width", String(dims.width));
-        formData.append("height", String(dims.height));
-
-        const res = await fetch(`/api/photos/${photo.id}/reupload`, {
-          method: "POST",
-          body: formData,
-          credentials: "same-origin",
-        });
-        if (res.ok) {
-          const data = (await res.json()) as { url: string; thumbnail_url: string; r2_key: string };
-          if (this._editingPhoto?.id === photo.id) {
-            this._editingPhoto = { ...this._editingPhoto, url: data.url, thumbnail_url: data.thumbnail_url, r2_key: data.r2_key, width: dims.width, height: dims.height, thumbhash: "" };
-          }
-          this._reuploadedPhotoId = photo.id;
-          setTimeout(() => { this._reuploadedPhotoId = null; }, 2000);
-          await this._fetchPhotos();
-        }
-      } finally {
-        this._reuploadingPhotoId = null;
-      }
-    };
-    input.click();
-  }
-
-  // ── Album CRUD ──
-
-  private _newAlbum() {
-    this._editingAlbum = {
-      id: 0,
-      slug: "",
-      title: "",
-      description: "",
-      location: "",
-      latitude: null,
-      longitude: null,
-      cover_photo_id: null,
-      sort_order: 0,
-      status: "draft",
-      created_at: "",
-    };
-  }
-
-  private async _saveAlbum() {
-    const a = this._editingAlbum;
-    if (!a) return;
-    this._savingAction = "saving";
-    this._saveError = "";
-    try {
-      if (a.id === 0) {
-        let slug = a.slug || slugify(a.title);
-        let res = await api.api.albums.$post({
-          json: {
-            title: a.title, slug, description: a.description, status: a.status as "draft" | "published",
-            location: a.location, latitude: a.latitude ?? null, longitude: a.longitude ?? null,
-          },
-        });
-        // Auto-resolve slug conflict by appending suffix
-        if (!res.ok && res.status === 409) {
-          for (let i = 2; i <= 10; i++) {
-            slug = `${slugify(a.title)}-${i}`;
-            res = await api.api.albums.$post({
-              json: {
-                title: a.title, slug, description: a.description, status: a.status as "draft" | "published",
-                location: a.location, latitude: a.latitude ?? null, longitude: a.longitude ?? null,
-              },
-            });
-            if (res.ok || res.status !== 409) break;
-          }
-        }
-        if (!res.ok) {
-          this._saveError = "Could not create album. Please try a different name.";
-          return;
-        }
-      } else {
-        const original = this._albums.find((x) => x.id === a.id);
-        if (!original) return;
-        const res = await api.api.albums[":slug"].$put({
-          param: { slug: original.slug },
-          json: {
-            title: a.title,
-            slug: a.slug,
-            description: a.description,
-            status: a.status as "draft" | "published",
-            location: a.location,
-            latitude: a.latitude ?? null,
-            longitude: a.longitude ?? null,
-          },
-        });
-        if (!res.ok) {
-          this._saveError = "Could not update album. Please try again.";
-          return;
-        }
-      }
-      (this.shadowRoot!.querySelector('.album-edit-modal') as HTMLElement & { close(): void })?.close();
-      this._saved = true;
-      setTimeout(() => { this._saved = false; }, 2000);
-      await this._fetchAlbums();
-    } finally {
-      this._savingAction = "none";
-    }
-  }
-
-  private async _deleteAlbum(slug: string) {
-    this._savingAction = "deleting";
-    try {
-      await api.api.albums[":slug"].$delete({ param: { slug } });
-      if (this._viewingAlbum?.slug === slug) {
-        this._viewingAlbum = null;
-        this._albumPhotos = [];
-      }
-      (this.shadowRoot!.querySelector('.album-edit-modal') as HTMLElement & { close(): void })?.close();
-      await this._fetchAlbums();
-    } finally {
-      this._savingAction = "none";
+      await api.api.photos[":id"].$delete({ param: { id: String(id) } });
+      await this._fetchAll();
+    } catch {
+      this._showToast("Failed to delete photo.");
     }
   }
 
@@ -891,8 +352,27 @@ export class AdminGallery extends LitElement {
     this._loading = false;
   }
 
+  private async _viewAlbum(a: Album) {
+    this._viewingAlbum = a;
+    try {
+      const res = await api.api.photos.$get({ query: { album: a.slug } });
+      if (res.ok) {
+        const data = await res.json();
+        this._albumPhotos = data.photos as unknown as Photo[];
+      }
+    } catch { this._showToast("Failed to load album photos"); }
+  }
 
-  // ── Filtered data ──
+  private async _deleteAlbum(slug: string) {
+    try {
+      await api.api.albums[":slug"].$delete({ param: { slug } });
+      if (this._viewingAlbum?.slug === slug) {
+        this._viewingAlbum = null;
+        this._albumPhotos = [];
+      }
+      await this._fetchAlbums();
+    } catch { this._showToast("Failed to delete album"); }
+  }
 
   private get _filteredPhotos(): Photo[] {
     if (!this._searchQuery) return this._photos;
@@ -917,10 +397,46 @@ export class AdminGallery extends LitElement {
       </ui-tab-group>
       ${this._renderContent()}
       `}
-      ${this._renderUploadOverlay()}
-      ${this._renderPhotoModal()}
-      ${this._renderPhotoDetail()}
-      ${this._renderAlbumModal()}
+      <gallery-upload-wizard
+        ?open=${this._showUpload}
+        .albums=${this._albums}
+        .tags=${this._tags}
+        @close=${() => { this._showUpload = false; }}
+        @upload-complete=${() => { this._showUpload = false; this._fetchAll(); }}
+        @tags-changed=${() => this._fetchTags()}
+        @show-warning=${(e: CustomEvent) => { this._showToast(e.detail.message, "warning"); }}
+      ></gallery-upload-wizard>
+      <gallery-photo-modal
+        .photo=${this._editingPhoto}
+        .viewPhoto=${this._viewingPhoto}
+        .albums=${this._albums}
+        .tags=${this._tags}
+        @close=${() => { this._editingPhoto = null; }}
+        @close-detail=${() => { this._viewingPhoto = null; }}
+        @edit-from-detail=${(e: CustomEvent) => {
+          const p = (e.detail as { photo: Photo }).photo;
+          this._viewingPhoto = null;
+          this._editingPhoto = { ...p };
+        }}
+        @photo-saved=${() => { this._saved = true; setTimeout(() => { this._saved = false; }, 2000); this._fetchPhotos(); }}
+        @photo-deleted=${() => { this._fetchAll(); }}
+        @tags-changed=${() => this._fetchTags()}
+      ></gallery-photo-modal>
+      <gallery-album-modal
+        .album=${this._editingAlbum}
+        .albums=${this._albums}
+        @close=${() => { this._editingAlbum = null; }}
+        @album-saved=${() => { this._editingAlbum = null; this._saved = true; setTimeout(() => { this._saved = false; }, 2000); this._fetchAlbums(); }}
+        @album-deleted=${(e: CustomEvent) => {
+          const slug = (e.detail as { slug: string }).slug;
+          this._editingAlbum = null;
+          if (this._viewingAlbum?.slug === slug) {
+            this._viewingAlbum = null;
+            this._albumPhotos = [];
+          }
+          this._fetchAlbums();
+        }}
+      ></gallery-album-modal>
       ${this._toastMessage ? html`<ui-alert class="toast" status=${this._toastStatus} size="s" emphasis="bold" dismissible @dismiss=${() => { this._toastMessage = ""; }}>${this._toastMessage}</ui-alert>` : nothing}
     `;
   }
@@ -1000,7 +516,6 @@ export class AdminGallery extends LitElement {
             </ui-button>
             <ui-button action="contrast" emphasis="bold" size="s" @click=${() => {
               this._editingPhoto = { ...p };
-              this._editingPhotoTagIds = (p as Photo & { tags?: Array<{ id: number }> }).tags?.map((t) => t.id) ?? [];
             }}>
               <ui-icon name="settings" size="s" slot="icon-start"></ui-icon>
               Edit
@@ -1032,6 +547,46 @@ export class AdminGallery extends LitElement {
       </ui-card>
       </div>
     `;
+  }
+
+  private async _reuploadPhoto(photo: Photo) {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = "image/*";
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      this._reuploadingPhotoId = photo.id;
+      try {
+        const { optimizeImage, generateThumbnail: genThumb } = await import("./gallery-utils.js");
+        const optimized = await optimizeImage(file);
+        const thumb = await genThumb(file);
+        const dims = await new Promise<{ width: number; height: number }>((resolve) => {
+          const img = new Image();
+          img.onload = () => resolve({ width: img.naturalWidth, height: img.naturalHeight });
+          img.onerror = () => resolve({ width: 0, height: 0 });
+          img.src = URL.createObjectURL(optimized);
+        });
+        const formData = new FormData();
+        formData.append("file", optimized);
+        formData.append("thumbnail", thumb);
+        formData.append("width", String(dims.width));
+        formData.append("height", String(dims.height));
+        const res = await fetch(`/api/photos/${photo.id}/reupload`, {
+          method: "POST",
+          body: formData,
+          credentials: "same-origin",
+        });
+        if (res.ok) {
+          this._reuploadedPhotoId = photo.id;
+          setTimeout(() => { this._reuploadedPhotoId = null; }, 2000);
+          await this._fetchPhotos();
+        }
+      } finally {
+        this._reuploadingPhotoId = null;
+      }
+    };
+    input.click();
   }
 
   private _renderAlbumsTab() {
@@ -1085,17 +640,6 @@ export class AdminGallery extends LitElement {
     `;
   }
 
-  private async _viewAlbum(a: Album) {
-    this._viewingAlbum = a;
-    try {
-      const res = await api.api.photos.$get({ query: { album: a.slug } });
-      if (res.ok) {
-        const data = await res.json();
-        this._albumPhotos = data.photos as unknown as Photo[];
-      }
-    } catch { this._showToast("Failed to load album photos"); }
-  }
-
   private _renderAlbumDetail() {
     const a = this._viewingAlbum!;
     return html`
@@ -1121,664 +665,19 @@ export class AdminGallery extends LitElement {
     `;
   }
 
-  private _renderUploadOverlay() {
-    return html`
-      <ui-modal size="l" style="--ui-modal-width: 800px" ?open=${this._showUpload} dismissible @close=${() => { this._showUpload = false; this._resetUploadWizard(); }}>
-        <span>Upload Photos</span>
-        <div slot="body">
-          ${this._wizardError ? html`<ui-alert status="error" size="s" dismissible @dismiss=${() => { this._wizardError = ""; }} style="margin-bottom:12px">${this._wizardError}</ui-alert>` : nothing}
-          <ui-wizard
-            headless
-            layout="horizontal"
-            current-step=${this._wizardStep}
-            status=${this._uploading ? "loading" : "none"}
-            @wizard-next=${(e: Event) => {
-              if (this._wizardStep === 1 && this._uploadFiles.length === 0) {
-                e.preventDefault();
-                return;
-              }
-              this._wizardStep = this._wizardStep + 1;
-            }}
-            @wizard-previous=${() => { this._wizardStep = this._wizardStep - 1; }}
-            @wizard-finish=${() => { this._executeUpload(); }}
-            @wizard-step-change=${(e: CustomEvent) => { this._wizardStep = (e as CustomEvent<{ step: number }>).detail.step; }}
-          >
-            <ui-step-group slot="steps">
-              <ui-step-item label="Select Files"></ui-step-item>
-              <ui-step-item label="Choose Album"></ui-step-item>
-              <ui-step-item label="Edit Details"></ui-step-item>
-              <ui-step-item label="Confirm"></ui-step-item>
-            </ui-step-group>
-            ${this._wizardStep === 1 ? this._renderStep1() : nothing}
-            ${this._wizardStep === 2 ? this._renderStep2() : nothing}
-            ${this._wizardStep === 3 ? this._renderStep3() : nothing}
-            ${this._wizardStep === 4 ? this._renderStep4() : nothing}
-          </ui-wizard>
-        </div>
-        <div slot="footer-start">
-          <ui-button action="secondary" emphasis="subtle" size="s" ?disabled=${this._wizardStep <= 1} @click=${() => { if (this._wizardStep > 1) this._wizardStep--; }}>Previous</ui-button>
-        </div>
-        <div slot="footer-end" style="display:flex;gap:8px">
-          <ui-button action="secondary" emphasis="subtle" size="s" @click=${() => { this._showUpload = false; this._resetUploadWizard(); }}>Cancel</ui-button>
-          ${this._wizardStep < 4 ? html`
-            <ui-button action="primary" size="s" ?disabled=${this._wizardStep === 1 && this._uploadFiles.length === 0} @click=${() => { this._wizardStep++; }}>Next</ui-button>
-          ` : html`
-            <ui-button action="primary" size="s" status=${this._uploading ? "loading" : "none"} @click=${() => this._executeUpload()}>Upload</ui-button>
-          `}
-        </div>
-      </ui-modal>
-    `;
-  }
-
-  private _renderStep1() {
-    return html`
-      <div class="wizard-step">
-        <ui-dropzone
-          accept="image/*"
-          multiple
-          size="m"
-          hint="PNG, JPG, WebP — optimized to WebP on upload"
-          @change=${(e: CustomEvent) => {
-            const files = (e as CustomEvent<{ files: FileList }>).detail.files;
-            if (files?.length) this._onFilesSelected([...this._uploadFiles, ...Array.from(files)]);
-          }}
-          @drop-files=${(e: CustomEvent) => {
-            const files = (e as CustomEvent<{ files: File[] }>).detail.files;
-            if (files?.length) this._onFilesSelected([...this._uploadFiles, ...files]);
-          }}
-        >
-          <ui-label slot="label" size="m">Photos</ui-label>
-        </ui-dropzone>
-        ${this._uploadFiles.length > 0 ? html`
-          <div class="selected-files-preview">
-            <div class="selected-files-header">
-              <span>${this._uploadFiles.length} file(s) selected</span>
-              <ui-button action="secondary" emphasis="minimal" size="s" @click=${() => { this._revokeBlobUrls(); this._uploadFiles = []; this._uploadMeta = []; }}>Clear all</ui-button>
-            </div>
-            <div class="selected-files-thumbs">
-              ${this._uploadFiles.map((f, i) => html`
-                <div class="selected-file-chip">
-                  <img class="selected-file-img" src=${this._getBlobUrl(f)} alt=${f.name} />
-                  <span class="selected-file-name">${f.name}</span>
-                  <ui-icon name="close" size="xs" @click=${() => {
-                    this._uploadFiles = this._uploadFiles.filter((_, idx) => idx !== i);
-                    this._uploadMeta = this._uploadMeta.filter((_, idx) => idx !== i);
-                  }}></ui-icon>
-                </div>
-              `)}
-            </div>
-          </div>
-        ` : nothing}
-      </div>
-    `;
-  }
-
-  private _renderStep2() {
-    return html`
-      <div class="wizard-step wizard-step-scroll">
-        <div class="album-grid-step">
-          ${this._albums.map((a) => html`
-            <div
-              class="album-card ${this._batchAlbumId === a.id ? "selected" : ""}"
-              @click=${() => { this._batchAlbumId = this._batchAlbumId === a.id ? null : a.id; }}
-            >
-              <ui-icon name="photo_album" size="m"></ui-icon>
-              <span class="album-card-title">${a.title}</span>
-              <span class="album-card-count">${a.photo_count ?? 0} photos</span>
-            </div>
-          `)}
-          ${this._creatingAlbum ? html`
-            <div class="album-card album-card-new album-card-editing">
-              <ui-input
-                size="s"
-                .value=${this._newAlbumTitle}
-                placeholder="Album name"
-                @input=${(e: Event) => { this._newAlbumTitle = (e.target as HTMLInputElement).value; }}
-                @keydown=${(e: KeyboardEvent) => { if (e.key === "Enter") this._createQuickAlbum(); if (e.key === "Escape") { this._creatingAlbum = false; this._newAlbumTitle = ""; } }}
-              ></ui-input>
-              <div class="album-card-actions">
-                <ui-button action="primary" size="s" @click=${this._createQuickAlbum}>Create</ui-button>
-                <ui-button action="secondary" emphasis="subtle" size="s" @click=${() => { this._creatingAlbum = false; this._newAlbumTitle = ""; }}>Cancel</ui-button>
-              </div>
-            </div>
-          ` : html`
-            <div class="album-card album-card-new" @click=${() => { this._creatingAlbum = true; }}>
-              <ui-icon name="add" size="m"></ui-icon>
-              <span class="album-card-title">New Album</span>
-            </div>
-          `}
-      </div>
-    `;
-  }
-
-  private _renderStep3() {
-    return html`
-      <div class="wizard-step wizard-step-scroll">
-        <div class="batch-fields">
-          <ui-input
-            size="m"
-            .value=${this._batchCategory}
-            @input=${(e: Event) => { this._batchCategory = (e.target as HTMLInputElement).value; }}
-          ><ui-label slot="label" size="m">Category</ui-label></ui-input>
-          <div>
-            <ui-label size="m">Location</ui-label>
-            <map-picker
-              .location=${this._batchLocation}
-              .latitude=${this._batchLatitude}
-              .longitude=${this._batchLongitude}
-              @location-picked=${(e: CustomEvent) => {
-                const d = e.detail as { location: string; latitude: number | null; longitude: number | null };
-                this._batchLocation = d.location;
-                this._batchLatitude = d.latitude;
-                this._batchLongitude = d.longitude;
-              }}
-            ></map-picker>
-          </div>
-          <div class="field-row">
-            <ui-select
-              size="m"
-              .value=${this._batchStatus}
-              @change=${(e: Event) => { this._batchStatus = (e.target as HTMLElement & { value: string }).value; }}
-            >
-              <ui-label slot="label" size="m">Status</ui-label>
-              <ui-dropdown-item value="draft">Draft</ui-dropdown-item>
-              <ui-dropdown-item value="published">Published</ui-dropdown-item>
-            </ui-select>
-          </div>
-          <div class="toggle-row">
-            <ui-checkbox-item
-              size="m"
-              label-position="right"
-              ?checked=${this._batchFeatured}
-              @change=${(e: Event) => { this._batchFeatured = (e.target as HTMLInputElement).checked; }}
-            ><ui-label slot="label" size="m">Featured</ui-label></ui-checkbox-item>
-          </div>
-        <div class="tag-section">
-          <ui-label size="m">Tags</ui-label>
-          <div class="tag-list">
-            ${this._tags.map((t) => html`
-              <ui-tag
-                size="s"
-                emphasis=${this._batchTagIds.includes(t.id) ? "subtle" : "minimal"}
-                @click=${() => {
-                  this._batchTagIds = this._batchTagIds.includes(t.id)
-                    ? this._batchTagIds.filter((id) => id !== t.id)
-                    : [...this._batchTagIds, t.id];
-                }}
-              >${t.name}</ui-tag>
-            `)}
-            ${this._creatingTag ? html`
-              <div class="new-tag-inline">
-                <ui-input
-                  size="s"
-                  .value=${this._newTagName}
-                  placeholder="Tag name"
-                  @input=${(e: Event) => { this._newTagName = (e.target as HTMLInputElement).value; }}
-                  @keydown=${(e: KeyboardEvent) => {
-                    if (e.key === "Enter") this._createQuickTag();
-                    if (e.key === "Escape") { this._creatingTag = false; this._newTagName = ""; }
-                  }}
-                ></ui-input>
-              </div>
-            ` : html`
-              <ui-tag
-                size="s"
-                type="basic"
-                emphasis="minimal"
-                @click=${() => { this._creatingTag = true; }}
-              >+ New</ui-tag>
-            `}
-          </div>
-        </div>
-        </div>
-        <div class="file-list-edit">
-          ${this._uploadMeta.map((m, i) => html`
-            <div class="file-edit-row">
-              <img class="file-thumb" src=${this._getBlobUrl(this._uploadFiles[i])} alt=${m.title} />
-              <div class="file-fields">
-                <ui-input
-                  size="s"
-                  .value=${m.title}
-                  @input=${(e: Event) => {
-                    const updated = [...this._uploadMeta];
-                    updated[i] = { ...updated[i], title: (e.target as HTMLInputElement).value };
-                    this._uploadMeta = updated;
-                  }}
-                ><ui-label slot="label" size="s">Title</ui-label></ui-input>
-                <ui-input
-                  size="s"
-                  .value=${m.caption}
-                  @input=${(e: Event) => {
-                    const updated = [...this._uploadMeta];
-                    updated[i] = { ...updated[i], caption: (e.target as HTMLInputElement).value };
-                    this._uploadMeta = updated;
-                  }}
-                ><ui-label slot="label" size="s">Caption</ui-label></ui-input>
-              </div>
-            </div>
-          `)}
-        </div>
-      </div>
-    `;
-  }
-
-  private _renderStep4() {
-    const albumName = this._batchAlbumId ? this._albums.find((a) => a.id === this._batchAlbumId)?.title ?? "—" : "None";
-    return html`
-      <div class="wizard-step wizard-step-scroll">
-        <div class="summary-section">
-          <div class="summary-label">Files</div>
-          <div class="summary-value">${this._uploadFiles.length} photo(s)</div>
-        </div>
-        <div class="summary-section">
-          <div class="summary-label">Album</div>
-          <div class="summary-value">${albumName}</div>
-        </div>
-        <div class="summary-section">
-          <div class="summary-label">Category</div>
-          <div class="summary-value">${this._batchCategory || "—"}</div>
-        </div>
-        <div class="summary-section">
-          <div class="summary-label">Location</div>
-          <div class="summary-value">${this._batchLocation || "None"}${this._batchLatitude != null ? ` (${this._batchLatitude.toFixed(4)}, ${this._batchLongitude!.toFixed(4)})` : ""}</div>
-        </div>
-        <div class="summary-section">
-          <div class="summary-label">Status</div>
-          <div class="summary-value">${this._batchStatus}</div>
-        </div>
-        <div class="summary-section">
-          <div class="summary-label">Featured</div>
-          <div class="summary-value">${this._batchFeatured ? "Yes" : "No"}</div>
-        </div>
-        <div class="summary-section">
-          <div class="summary-label">Tags</div>
-          <div class="summary-value">${this._batchTagIds.length > 0 ? this._tags.filter((t) => this._batchTagIds.includes(t.id)).map((t) => t.name).join(", ") : "None"}</div>
-        </div>
-        <div class="summary-section">
-          <div class="summary-label">Files</div>
-          <div class="summary-files">
-            ${this._uploadMeta.map((m, i) => html`
-              <div class="summary-file">${m.title}${m.caption ? ` — ${m.caption}` : ""}${this._uploadFiles[i] ? ` (${(this._uploadFiles[i].size / 1024).toFixed(0)} KB)` : ""}</div>
-            `)}
-          </div>
-        </div>
-        ${this._uploading ? html`<div class="file-count">Uploading…</div>` : nothing}
-      </div>
-    `;
-  }
-
-  private _onFilesSelected(files: File[]) {
-    this._uploadFiles = files;
-    this._uploadMeta = files.map((f) => ({
-      title: f.name.replace(/\.[^.]+$/, ""),
-      caption: "",
-    }));
-  }
-
-  private async _createQuickAlbum() {
-    if (!this._newAlbumTitle.trim()) return;
-    try {
-      const res = await api.api.albums.$post({
-        json: {
-          title: this._newAlbumTitle.trim(),
-          slug: slugify(this._newAlbumTitle.trim()),
-          description: "",
-          status: "draft",
-          location: "",
-          latitude: null,
-          longitude: null,
-        },
-      });
-      if (res.ok) {
-        await this._fetchAlbums();
-        const newAlbum = this._albums.find((a) => a.slug === slugify(this._newAlbumTitle.trim()));
-        if (newAlbum) this._batchAlbumId = newAlbum.id;
-        this._creatingAlbum = false;
-        this._newAlbumTitle = "";
-      }
-    } catch { this._wizardError = "Failed to create album"; }
-  }
-
-  private async _createQuickTag() {
-    if (!this._newTagName.trim()) return;
-    try {
-      const res = await api.api.tags.$post({
-        json: { name: this._newTagName.trim() },
-      });
-      if (res.ok) {
-        const data = await res.json() as { ok: boolean; id: number };
-        await this._fetchTags();
-        this._batchTagIds = [...this._batchTagIds, data.id];
-        this._creatingTag = false;
-        this._newTagName = "";
-      }
-    } catch { this._wizardError = "Failed to create tag"; }
-  }
-
-  private _resetUploadWizard() {
-    this._wizardError = "";
-    this._wizardStep = 1;
-    this._revokeBlobUrls();
-    this._uploadFiles = [];
-    this._uploadMeta = [];
-    this._batchAlbumId = null;
-    this._batchCategory = "";
-    this._batchStatus = "draft";
-    this._batchFeatured = false;
-    this._creatingAlbum = false;
-    this._newAlbumTitle = "";
-    this._batchTagIds = [];
-    this._batchLocation = "";
-    this._batchLatitude = null;
-    this._batchLongitude = null;
-    this._creatingTag = false;
-    this._newTagName = "";
-  }
-
-  private _getBlobUrl(file: File): string {
-    let url = this._blobUrlCache.get(file);
-    if (!url) {
-      url = URL.createObjectURL(file);
-      this._blobUrlCache.set(file, url);
-    }
-    return url;
-  }
-
-  private _revokeBlobUrls() {
-    for (const url of this._blobUrlCache.values()) {
-      URL.revokeObjectURL(url);
-    }
-    this._blobUrlCache.clear();
-  }
-
-  private _renderPhotoDetail() {
-    if (!this._viewingPhoto) return html`<ui-modal size="l" style="--ui-modal-width: 900px" dismissible></ui-modal>`;
-    const p = this._viewingPhoto;
-    const albumName = this._albums.find((a) => a.id === p.album_id)?.title ?? "None";
-    const tags = (p as Photo & { tags?: Array<{ id: number; name: string }> }).tags ?? [];
-
-    return html`
-      <ui-modal size="l" style="--ui-modal-width: 900px" open dismissible @close=${() => { this._viewingPhoto = null; }}>
-        <span>${p.title || "Photo Details"}</span>
-        <div slot="body" class="photo-detail">
-          <div class="photo-detail-preview">
-            <ui-image src=${p.url} alt=${p.title || "Photo"} style="width:100%;border-radius:8px;"></ui-image>
-          </div>
-          <div class="photo-detail-info">
-            <div class="detail-section">
-              <div class="detail-label">Title</div>
-              <div class="detail-value">${p.title || "—"}</div>
-            </div>
-            <div class="detail-section">
-              <div class="detail-label">Caption</div>
-              <div class="detail-value">${p.caption || "—"}</div>
-            </div>
-            <div class="detail-row">
-              <div class="detail-section">
-                <div class="detail-label">Album</div>
-                <div class="detail-value">${albumName}</div>
-              </div>
-              <div class="detail-section">
-                <div class="detail-label">Category</div>
-                <div class="detail-value">${p.category || "—"}</div>
-              </div>
-            </div>
-            <div class="detail-row">
-              <div class="detail-section">
-                <div class="detail-label">Status</div>
-                <div class="detail-value"><ui-badge size="xs" status=${p.status === "published" ? "success" : "warning"}>${p.status}</ui-badge></div>
-              </div>
-              <div class="detail-section">
-                <div class="detail-label">Featured</div>
-                <div class="detail-value">${p.featured ? "Yes" : "No"}</div>
-              </div>
-            </div>
-            ${tags.length > 0 ? html`
-              <div class="detail-section">
-                <div class="detail-label">Tags</div>
-                <div class="detail-value detail-tags">${tags.map((t) => html`<ui-tag size="xs" emphasis="subtle">${t.name}</ui-tag>`)}</div>
-              </div>
-            ` : nothing}
-            ${p.location ? html`
-              <div class="detail-section">
-                <div class="detail-label">Location</div>
-                <div class="detail-value">
-                  <a href=${p.latitude != null
-                    ? `https://www.google.com/maps?q=${p.latitude},${p.longitude}`
-                    : `https://www.google.com/maps?q=${encodeURIComponent(p.location)}`}
-                    target="_blank" rel="noopener" style="color:var(--fd-text-link);text-decoration:none">${p.location}</a>
-                </div>
-                </div>
-              </div>
-            ` : nothing}
-            <div class="detail-row">
-              <div class="detail-section">
-                <div class="detail-label">Dimensions</div>
-                <div class="detail-value">${p.width && p.height ? `${p.width} × ${p.height}` : "—"}</div>
-              </div>
-              <div class="detail-section">
-                <div class="detail-label">Created</div>
-                <div class="detail-value">${p.created_at ? new Date(p.created_at).toLocaleDateString() : "—"}</div>
-              </div>
-            </div>
-            ${(() => {
-              const exif = typeof p.exif_json === "string" ? JSON.parse(p.exif_json || "{}") : (p.exif_json || {});
-              return Object.keys(exif).length > 0 ? html`
-                <div class="detail-section">
-                  <div class="detail-label">Camera Info</div>
-                  <div class="detail-exif">
-                    ${exif.Make ? html`<div class="exif-row"><span class="exif-key">Camera</span><span class="exif-val">${exif.Make}${exif.Model ? ` ${exif.Model}` : ""}</span></div>` : nothing}
-                    ${exif.LensModel ? html`<div class="exif-row"><span class="exif-key">Lens</span><span class="exif-val">${exif.LensModel}</span></div>` : nothing}
-                    ${exif.FocalLength ? html`<div class="exif-row"><span class="exif-key">Focal Length</span><span class="exif-val">${exif.FocalLength}mm</span></div>` : nothing}
-                    ${exif.FNumber ? html`<div class="exif-row"><span class="exif-key">Aperture</span><span class="exif-val">ƒ/${String(exif.FNumber).replace(/^f\//, "")}</span></div>` : nothing}
-                    ${exif.ExposureTime ? html`<div class="exif-row"><span class="exif-key">Shutter</span><span class="exif-val">${exif.ExposureTime}s</span></div>` : nothing}
-                    ${exif.ISO ? html`<div class="exif-row"><span class="exif-key">ISO</span><span class="exif-val">${exif.ISO}</span></div>` : nothing}
-                    ${exif.DateTimeOriginal ? html`<div class="exif-row"><span class="exif-key">Date Taken</span><span class="exif-val">${exif.DateTimeOriginal}</span></div>` : nothing}
-                  </div>
-                </div>
-              ` : nothing;
-            })()}
-          </div>
-        </div>
-        <div slot="footer-end">
-          <ui-button action="primary" size="s" @click=${() => {
-            const p2 = this._viewingPhoto!;
-            this._viewingPhoto = null;
-            this._editingPhoto = { ...p2 };
-            this._editingPhotoTagIds = (p2 as Photo & { tags?: Array<{ id: number }> }).tags?.map((t) => t.id) ?? [];
-          }}>Edit</ui-button>
-        </div>
-      </ui-modal>
-    `;
-  }
-
-  private _renderPhotoModal() {
-    if (!this._editingPhoto) return html`<ui-modal size="m" dismissible></ui-modal>`;
-    const p = this._editingPhoto;
-    return html`
-      <ui-modal class="photo-edit-modal" size="l" style="--ui-modal-width: 900px" open dismissible @close=${() => { this._editingPhoto = null; }}>
-        <span>Edit Photo</span>
-        <div slot="body" class="photo-detail">
-          ${this._saveError ? html`<ui-alert status="error" size="s" dismissible @dismiss=${() => { this._saveError = ""; }} style="margin-bottom:12px">${this._saveError}</ui-alert>` : nothing}
-          <div class="photo-detail-preview">
-            <ui-image src=${p.url} alt=${p.title || "Photo"} style="width:100%;border-radius:8px;"></ui-image>
-          </div>
-          <div class="photo-detail-info modal-form" style="width:340px;">
-          <ui-input
-            size="m"
-            .value=${p.title}
-            @input=${(e: Event) => { this._editingPhoto = { ...p, title: (e.target as HTMLInputElement).value }; }}
-          ><ui-label slot="label" size="m">Title</ui-label></ui-input>
-          <ui-textarea
-            size="m"
-            rows="2"
-            .value=${p.caption}
-            @input=${(e: Event) => { this._editingPhoto = { ...p, caption: (e.target as HTMLTextAreaElement).value }; }}
-          ><ui-label slot="label" size="m">Caption</ui-label></ui-textarea>
-          <ui-select
-            size="m"
-            .value=${String(p.album_id ?? "")}
-            @change=${(e: Event) => {
-              const v = (e.target as HTMLElement & { value: string }).value;
-              this._editingPhoto = { ...p, album_id: v ? Number(v) : null };
-            }}
-          >
-            <ui-label slot="label" size="m">Album</ui-label>
-            <ui-dropdown-item value="">None</ui-dropdown-item>
-            ${this._albums.map((a) => html`<ui-dropdown-item value=${String(a.id)} ?selected=${p.album_id === a.id}>${a.title}</ui-dropdown-item>`)}
-          </ui-select>
-          <ui-input
-            size="m"
-            .value=${p.category}
-            @input=${(e: Event) => { this._editingPhoto = { ...p, category: (e.target as HTMLInputElement).value }; }}
-          ><ui-label slot="label" size="m">Category</ui-label></ui-input>
-          <div style="display:flex;flex-direction:column;gap:4px;">
-            <ui-label size="m">Location</ui-label>
-            <map-picker
-              .location=${p.location || ""}
-              .latitude=${p.latitude ?? null}
-              .longitude=${p.longitude ?? null}
-              @location-picked=${(e: CustomEvent) => {
-                const d = e.detail as { location: string; latitude: number | null; longitude: number | null };
-                this._editingPhoto = { ...p, location: d.location, latitude: d.latitude, longitude: d.longitude };
-              }}
-            ></map-picker>
-          </div>
-          <div class="field-row">
-            <ui-select
-              size="m"
-              .value=${p.status}
-              @change=${(e: Event) => { this._editingPhoto = { ...p, status: (e.target as HTMLElement & { value: string }).value }; }}
-            >
-              <ui-label slot="label" size="m">Status</ui-label>
-              <ui-dropdown-item value="draft">Draft</ui-dropdown-item>
-              <ui-dropdown-item value="published">Published</ui-dropdown-item>
-            </ui-select>
-          </div>
-          <div class="toggle-row">
-            <ui-checkbox-item
-              size="m"
-              label-position="right"
-              ?checked=${!!p.featured}
-              @change=${(e: Event) => { this._editingPhoto = { ...p, featured: (e.target as HTMLInputElement).checked ? 1 : 0 }; }}
-            ><ui-label slot="label" size="m">Featured</ui-label></ui-checkbox-item>
-          </div>
-          <div style="display:flex;gap:8px;align-items:center;">
-            <ui-button action="secondary" emphasis="subtle" size="s" ?disabled=${this._reuploadingPhotoId === p.id} status=${this._reuploadingPhotoId === p.id ? "loading" : this._reuploadedPhotoId === p.id ? "success" : "none"} @click=${() => this._reuploadPhoto(p)}>
-              <ui-icon name="upload" size="s" slot="icon-start"></ui-icon>
-              ${this._reuploadingPhotoId === p.id ? "Uploading..." : this._reuploadedPhotoId === p.id ? "Done" : "Reupload"}
-            </ui-button>
-            <ui-button action="secondary" emphasis="minimal" size="s" ?disabled=${this._regeneratingThumbs} status=${this._regeneratingThumbs ? "loading" : "none"} @click=${() => this._regenerateSingleThumbnail(p)}>
-              Regen Thumb
-            </ui-button>
-          </div>
-          ${p.thumbnail_url ? html`<span style="font-size:11px;color:var(--fd-text-secondary);">${p.thumbnail_url.split('/').pop()}</span>` : nothing}
-        <div class="tag-section">
-          <ui-label size="m">Tags</ui-label>
-          <div class="tag-list">
-            ${this._tags.map((t) => html`
-              <ui-tag
-                size="s"
-                emphasis=${this._editingPhotoTagIds.includes(t.id) ? "subtle" : "minimal"}
-                @click=${() => {
-                  this._editingPhotoTagIds = this._editingPhotoTagIds.includes(t.id)
-                    ? this._editingPhotoTagIds.filter((id) => id !== t.id)
-                    : [...this._editingPhotoTagIds, t.id];
-                }}
-              >${t.name}</ui-tag>
-            `)}
-            ${this._creatingTag ? html`
-              <div class="new-tag-inline">
-                <ui-input
-                  size="s"
-                  .value=${this._newTagName}
-                  placeholder="Tag name"
-                  @input=${(e: Event) => { this._newTagName = (e.target as HTMLInputElement).value; }}
-                  @keydown=${(e: KeyboardEvent) => {
-                    if (e.key === "Enter") this._createQuickTag();
-                    if (e.key === "Escape") { this._creatingTag = false; this._newTagName = ""; }
-                  }}
-                ></ui-input>
-              </div>
-            ` : html`
-              <ui-tag
-                size="s"
-                type="basic"
-                emphasis="minimal"
-                @click=${() => { this._creatingTag = true; }}
-              >+ New</ui-tag>
-            `}
-          </div>
-        </div>
-        </div>
-        </div>
-        <ui-button slot="footer-start" action="destructive" emphasis="minimal" size="s" status=${this._savingAction === "deleting" ? "loading" : "none"} ?disabled=${this._savingAction === "saving"} @click=${() => this._deletePhoto(p.id)}>Delete</ui-button>
-        <div slot="footer-end" class="modal-actions-right">
-          <ui-button action="secondary" emphasis="subtle" size="s" ?disabled=${this._savingAction !== "none"} @click=${() => { (this.shadowRoot!.querySelector('.photo-edit-modal') as HTMLElement & { close(): void })?.close(); }}>Cancel</ui-button>
-          <ui-button action="primary" size="s" status=${this._savingAction === "saving" ? "loading" : "none"} ?disabled=${this._savingAction === "deleting"} @click=${this._savePhoto}>Save</ui-button>
-        </div>
-      </ui-modal>
-    `;
-  }
-
-  private _renderAlbumModal() {
-    if (!this._editingAlbum) return html`<ui-modal size="m" dismissible></ui-modal>`;
-    const a = this._editingAlbum;
-    const isNew = a.id === 0;
-    return html`
-      <ui-modal class="album-edit-modal" size="m" open dismissible @close=${() => { this._editingAlbum = null; this._saveError = ""; }}>
-        <span>${isNew ? "New Album" : "Edit Album"}</span>
-        <div slot="body" class="modal-form">
-          ${this._saveError ? html`<ui-alert status="error" size="s" dismissible @dismiss=${() => { this._saveError = ""; }}>${this._saveError}</ui-alert>` : nothing}
-          <ui-input
-            size="m"
-            .value=${a.title}
-            @input=${(e: Event) => {
-              const title = (e.target as HTMLInputElement).value;
-              const updates: Partial<Album> = { title };
-              if (isNew) updates.slug = slugify(title);
-              this._editingAlbum = { ...a, ...updates };
-            }}
-          ><ui-label slot="label" size="m">Title</ui-label></ui-input>
-          <ui-input
-            size="m"
-            .value=${a.slug}
-            @input=${(e: Event) => { this._editingAlbum = { ...a, slug: (e.target as HTMLInputElement).value }; }}
-          ><ui-label slot="label" size="m">Slug</ui-label></ui-input>
-          <ui-textarea
-            size="m"
-            rows="2"
-            .value=${a.description}
-            @input=${(e: Event) => { this._editingAlbum = { ...a, description: (e.target as HTMLTextAreaElement).value }; }}
-          ><ui-label slot="label" size="m">Description</ui-label></ui-textarea>
-          <div>
-            <ui-label size="m">Location</ui-label>
-            <map-picker
-              .location=${a.location || ""}
-              .latitude=${a.latitude ?? null}
-              .longitude=${a.longitude ?? null}
-              @location-picked=${(e: CustomEvent) => {
-                const d = e.detail as { location: string; latitude: number | null; longitude: number | null };
-                this._editingAlbum = { ...a, location: d.location, latitude: d.latitude, longitude: d.longitude };
-              }}
-            ></map-picker>
-          </div>
-          <ui-select
-            size="m"
-            .value=${a.status}
-            @change=${(e: Event) => { this._editingAlbum = { ...a, status: (e.target as HTMLElement & { value: string }).value }; }}
-          >
-            <ui-label slot="label" size="m">Status</ui-label>
-            <ui-dropdown-item value="draft">Draft</ui-dropdown-item>
-            <ui-dropdown-item value="published">Published</ui-dropdown-item>
-          </ui-select>
-        </div>
-        ${isNew ? html`<div slot="footer-start"></div>` : html`<ui-button slot="footer-start" action="destructive" emphasis="minimal" size="s" status=${this._savingAction === "deleting" ? "loading" : "none"} ?disabled=${this._savingAction === "saving"} @click=${() => this._deleteAlbum(a.slug)}>Delete</ui-button>`}
-        <div slot="footer-end" class="modal-actions-right">
-          <ui-button action="secondary" emphasis="subtle" size="s" ?disabled=${this._savingAction !== "none"} @click=${() => { (this.shadowRoot!.querySelector('.album-edit-modal') as HTMLElement & { close(): void })?.close(); }}>Cancel</ui-button>
-          <ui-button action="primary" size="s" status=${this._savingAction === "saving" ? "loading" : "none"} ?disabled=${this._savingAction === "deleting"} @click=${this._saveAlbum}>${isNew ? "Create" : "Save"}</ui-button>
-        </div>
-      </ui-modal>
-    `;
+  private _newAlbum() {
+    this._editingAlbum = {
+      id: 0,
+      slug: "",
+      title: "",
+      description: "",
+      location: "",
+      latitude: null,
+      longitude: null,
+      cover_photo_id: null,
+      sort_order: 0,
+      status: "draft",
+      created_at: "",
+    };
   }
 }


### PR DESCRIPTION
## Summary
Break up the 1784-line `gallery.ts` god component into focused Lit components:

- `gallery-types.ts` (125 lines) — shared Photo, Album, Tag interfaces + utility functions (optimizeImage, generateThumbnail, slugify)
- `gallery-upload-wizard.ts` (561 lines) — multi-step upload wizard with EXIF extraction, thumbhash, batch upload
- `gallery-photo-modal.ts` (448 lines) — photo edit modal (preview, reupload, regen thumbnail, thumbnail URL, tags, location) + detail view with EXIF
- `gallery-album-modal.ts` (174 lines) — album create/edit modal with slug generation, conflict resolution, location picker
- `gallery.ts` (682 lines) — thin shell coordinating child components via properties + events

Parent passes data down via properties, children fire events up. All features preserved including reupload, regen thumbnails, thumbnail URL display.

Closes #362