### PR TITLE
fix: batch small fixes (#380, #384, #385, #388)

### DIFF
--- a/apps/blog/src/api/routes/photos.ts
+++ b/apps/blog/src/api/routes/photos.ts
@@ -86,12 +86,14 @@ export const photos = new Hono<Env>()
     const result = await db.execute({ sql, args });
     const rows = result.rows.map((r) => ({
       ...r,
+      id: r.id as number,
       featured: !!r.featured,
       exif_json: JSON.parse((r.exif_json as string) || "{}"),
+      tags: [] as Array<{ id: number; name: string; slug: string }>,
     }));
     // Attach tags to each photo
     if (rows.length > 0) {
-      const ids = rows.map((r: any) => r.id);
+      const ids = rows.map((r) => r.id);
       const tagResult = await db.execute({
         sql: `SELECT pt.photo_id, t.id, t.name, t.slug FROM photo_tags pt JOIN tags t ON pt.tag_id = t.id WHERE pt.photo_id IN (${ids.map(() => "?").join(",")})`,
         args: ids,
@@ -103,7 +105,7 @@ export const photos = new Hono<Env>()
         tagMap.get(pid)!.push({ id: tr.id as number, name: tr.name as string, slug: tr.slug as string });
       }
       for (const row of rows) {
-        (row as any).tags = tagMap.get((row as any).id as number) ?? [];
+        row.tags = tagMap.get(row.id) ?? [];
       }
     }
     return c.json({ photos: rows });
@@ -123,13 +125,14 @@ export const photos = new Hono<Env>()
       ...result.rows[0],
       featured: !!result.rows[0].featured,
       exif_json: JSON.parse((result.rows[0].exif_json as string) || "{}"),
+      tags: [] as Array<{ id: number; name: string; slug: string }>,
     };
     // Attach tags
     const tagResult = await db.execute({
       sql: "SELECT t.id, t.name, t.slug FROM photo_tags pt JOIN tags t ON pt.tag_id = t.id WHERE pt.photo_id = ?",
       args: [Number(c.req.param("id"))],
     });
-    (photo as any).tags = tagResult.rows.map((t) => ({ id: t.id as number, name: t.name as string, slug: t.slug as string }));
+    photo.tags = tagResult.rows.map((t) => ({ id: t.id as number, name: t.name as string, slug: t.slug as string }));
     return c.json({ photo });
   })
 

--- a/apps/blog/src/components/theme-toggle.ts
+++ b/apps/blog/src/components/theme-toggle.ts
@@ -52,7 +52,7 @@ class ThemeToggle extends HTMLElement {
   private _toggle() {
     this._dark = !this._dark;
     document.documentElement.setAttribute("data-theme", this._dark ? "heroui-dark" : "heroui");
-    localStorage.setItem("blog-theme", this._dark ? "dark" : "light");
+    try { localStorage.setItem("blog-theme", this._dark ? "dark" : "light"); } catch {}
     this._render();
     this.dispatchEvent(new CustomEvent("theme-change", { detail: { dark: this._dark }, bubbles: true, composed: true }));
   }

--- a/packages/charts/src/components/chart-polar.ts
+++ b/packages/charts/src/components/chart-polar.ts
@@ -121,7 +121,7 @@ class ChartPolarElement extends HTMLElement {
       description: this.getAttribute("description") ?? this._options.description,
       showLegend: boolAttr(this, "show-legend", this._options.showLegend ?? true),
       showTooltips: boolAttr(this, "show-tooltips", this._options.showTooltips ?? true),
-      levels: numAttr(this, "levels") ?? (this._options as any).levels,
+      levels: numAttr(this, "levels") ?? this._options.levels,
     };
   }
 
@@ -186,7 +186,7 @@ class ChartPolarElement extends HTMLElement {
     const cy = headerH + 20 + availableH / 2;
 
     // Concentric grid circles
-    const levels = (opts as any).levels ?? 5;
+    const levels = opts.levels ?? 5;
     const maxValue = Math.max(...slices.map(s => s.value));
     if (maxValue <= 0) return;
 

--- a/packages/flex-layout/package.json
+++ b/packages/flex-layout/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build && tsc --emitDeclarationOnly",
     "preview": "vite preview",
     "test": "vitest --run",
     "test:watch": "vitest"

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build && tsc --emitDeclarationOnly",
     "preview": "vite preview",
     "test": "vitest --run",
     "test:watch": "vitest"


### PR DESCRIPTION
## Summary

Batches four small fixes from the codebase review backlog.

### #384 — Fix `as any` in charts (chart-polar.ts)
The `_options` type was missing the `levels` field. The type was already `PieChartOptions & { levels?: number }` on the class field, but `_syncFromAttributes` and `_render` were casting to `any` to access it. Removed both `as any` casts — the intersection type already has `levels`.

### #380 — Type DB result rows in photos.ts
Replaced `(row as any).tags` / `(row as any).id` pattern with a properly typed `tags` field initialized as an empty array in the row mapper. Both the list and single-photo endpoints now build typed objects without `as any`.

### #385 — Wrap localStorage in try/catch (theme-toggle.ts)
Wrapped `localStorage.setItem()` in try/catch so it degrades gracefully in Safari private browsing or when storage quota is exceeded.

### #388 — Fix build script order inconsistency
`ui-components` and `flex-layout` had `tsc && vite build` — tsc runs first, then Vite wipes the output with `emptyOutDir`. Flipped both to `vite build && tsc --emitDeclarationOnly` to match `grid-layout`, `foundation`, and `charts`.

Closes #380, closes #384, closes #385, closes #388