### PR TITLE
fix: eliminate as any in ui-components test files

### DIFF
--- a/packages/ui-components/src/components/ui-accordion-group.test.ts
+++ b/packages/ui-components/src/components/ui-accordion-group.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import "./ui-accordion-item.js";
 import "./ui-accordion-group.js";
+import { UiAccordionGroup } from "./ui-accordion-group.js";
 
 describe("ui-accordion-group", () => {
   let el: HTMLElement;
@@ -21,7 +22,7 @@ describe("ui-accordion-group", () => {
     }
     document.body.appendChild(group);
     // happy-dom may not fire slotchange, so call propagate manually
-    (group as any)._propagateAttributes();
+    (group as UiAccordionGroup)._propagateAttributes();
     return group;
   }
 
@@ -33,15 +34,13 @@ describe("ui-accordion-group", () => {
     el = document.createElement("ui-accordion-group");
     document.body.appendChild(el);
 
-    expect((el as any).size).toBeNull();
-    expect((el as any).emphasis).toBeNull();
-    expect((el as any).exclusive).toBe(false);
+    expect((el as UiAccordionGroup).size).toBeNull();
+    expect((el as UiAccordionGroup).emphasis).toBeNull();
+    expect((el as UiAccordionGroup).exclusive).toBe(false);
   });
 
   it("has observedAttributes for size, emphasis, exclusive", () => {
-    const Ctor = customElements.get("ui-accordion-group") as unknown as {
-      observedAttributes: string[];
-    };
+    const Ctor = customElements.get("ui-accordion-group") as typeof UiAccordionGroup;
     expect(Ctor.observedAttributes).toEqual(["size", "emphasis", "exclusive", "variant"]);
   });
 
@@ -51,8 +50,8 @@ describe("ui-accordion-group", () => {
     el = createGroup();
     const items = el.querySelectorAll("ui-accordion-item");
 
-    (el as any).size = "s";
-    (el as any)._propagateAttributes();
+    (el as UiAccordionGroup).size = "s";
+    (el as UiAccordionGroup)._propagateAttributes();
 
     expect(items[0].getAttribute("size")).toBe("s");
     expect(items[1].getAttribute("size")).toBe("s");
@@ -65,8 +64,8 @@ describe("ui-accordion-group", () => {
     el = createGroup();
     const items = el.querySelectorAll("ui-accordion-item");
 
-    (el as any).emphasis = "bold";
-    (el as any)._propagateAttributes();
+    (el as UiAccordionGroup).emphasis = "bold";
+    (el as UiAccordionGroup)._propagateAttributes();
 
     expect(items[0].getAttribute("emphasis")).toBe("bold");
     expect(items[1].getAttribute("emphasis")).toBe("bold");
@@ -81,8 +80,8 @@ describe("ui-accordion-group", () => {
 
     expect(items[0].getAttribute("size")).toBe("l");
 
-    (el as any).size = null;
-    (el as any)._propagateAttributes();
+    (el as UiAccordionGroup).size = null;
+    (el as UiAccordionGroup)._propagateAttributes();
 
     expect(items[0].getAttribute("size")).toBeNull();
     expect(items[1].getAttribute("size")).toBeNull();
@@ -95,13 +94,13 @@ describe("ui-accordion-group", () => {
     el = document.createElement("ui-accordion-group");
     document.body.appendChild(el);
 
-    (el as any).size = "m";
+    (el as UiAccordionGroup).size = "m";
     expect(el.getAttribute("size")).toBe("m");
-    expect((el as any).size).toBe("m");
+    expect((el as UiAccordionGroup).size).toBe("m");
 
-    (el as any).size = null;
+    (el as UiAccordionGroup).size = null;
     expect(el.getAttribute("size")).toBeNull();
-    expect((el as any).size).toBeNull();
+    expect((el as UiAccordionGroup).size).toBeNull();
   });
 
   // ── Emphasis property accessor ────────────────────────────────────────
@@ -110,13 +109,13 @@ describe("ui-accordion-group", () => {
     el = document.createElement("ui-accordion-group");
     document.body.appendChild(el);
 
-    (el as any).emphasis = "bold";
+    (el as UiAccordionGroup).emphasis = "bold";
     expect(el.getAttribute("emphasis")).toBe("bold");
-    expect((el as any).emphasis).toBe("bold");
+    expect((el as UiAccordionGroup).emphasis).toBe("bold");
 
-    (el as any).emphasis = null;
+    (el as UiAccordionGroup).emphasis = null;
     expect(el.getAttribute("emphasis")).toBeNull();
-    expect((el as any).emphasis).toBeNull();
+    expect((el as UiAccordionGroup).emphasis).toBeNull();
   });
 
   // ── Exclusive property accessor ───────────────────────────────────────
@@ -125,13 +124,13 @@ describe("ui-accordion-group", () => {
     el = document.createElement("ui-accordion-group");
     document.body.appendChild(el);
 
-    (el as any).exclusive = true;
+    (el as UiAccordionGroup).exclusive = true;
     expect(el.hasAttribute("exclusive")).toBe(true);
-    expect((el as any).exclusive).toBe(true);
+    expect((el as UiAccordionGroup).exclusive).toBe(true);
 
-    (el as any).exclusive = false;
+    (el as UiAccordionGroup).exclusive = false;
     expect(el.hasAttribute("exclusive")).toBe(false);
-    expect((el as any).exclusive).toBe(false);
+    expect((el as UiAccordionGroup).exclusive).toBe(false);
   });
 
   // ── Exclusive mode: one item expanded, others collapse ────────────────

--- a/packages/ui-components/src/components/ui-calendar-panel.test.ts
+++ b/packages/ui-components/src/components/ui-calendar-panel.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach } from "vitest";
 import "./ui-calendar-panel.js";
+import type { UiCalendarPanel } from "./ui-calendar-panel.js";
 
 function create(attrs = "", inner = ""): HTMLElement {
   const el = document.createElement("div");
@@ -53,7 +54,7 @@ describe("ui-calendar-panel", () => {
   });
 
   it("should update size via property", () => {
-    const el = create() as any;
+    const el = create() as unknown as UiCalendarPanel;
     el.size = "l";
     expect(el.getAttribute("size")).toBe("l");
   });

--- a/packages/ui-components/src/components/ui-calendar.test.ts
+++ b/packages/ui-components/src/components/ui-calendar.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import "./ui-calendar.js";
-import type { UiCalendar } from "./ui-calendar.js";
+import { UiCalendar } from "./ui-calendar.js";
 
 const tick = () => new Promise((r) => setTimeout(r, 0));
 
@@ -867,7 +867,7 @@ describe("ui-calendar", () => {
       el.navigateTo(2024, 5); // June 2024
       const events = new Map<string, Array<{ color: string; label?: string }>>();
       events.set("2024-06-15", [{ color: "#FC9162", label: "Meeting" }]);
-      (el as any).setEvents(events);
+      el.setEvents(events);
       await tick();
       const cell15 = Array.from(cells()).find(
         (c) => !c.hasAttribute("data-outside") && c.textContent?.startsWith("15"),
@@ -887,7 +887,7 @@ describe("ui-calendar", () => {
         { color: "#C89AFC" },
         { color: "#F5C518" },
       ]);
-      (el as any).setEvents(events);
+      el.setEvents(events);
       await tick();
       const cell15 = Array.from(cells()).find(
         (c) => !c.hasAttribute("data-outside") && c.textContent?.startsWith("15"),
@@ -900,9 +900,9 @@ describe("ui-calendar", () => {
       el.navigateTo(2024, 5);
       const events = new Map<string, Array<{ color: string; label?: string }>>();
       events.set("2024-06-15", [{ color: "#FC9162" }]);
-      (el as any).setEvents(events);
+      el.setEvents(events);
       await tick();
-      (el as any).clearEvents();
+      el.clearEvents();
       await tick();
       const allDots = shadow().querySelectorAll(".event-dot");
       expect(allDots.length).toBe(0);
@@ -913,7 +913,7 @@ describe("ui-calendar", () => {
       const events = new Map<string, Array<{ color: string; label?: string }>>();
       events.set("2024-06-15", [{ color: "#FC9162", label: "Meeting" }]);
       events.set("2024-06-20", [{ color: "#4EBFB9", label: "Holiday" }]);
-      (el as any).setEvents(events);
+      el.setEvents(events);
       await tick();
       const legend = shadow().querySelector(".legend") as HTMLElement;
       expect(legend.style.display).not.toBe("none");
@@ -926,7 +926,7 @@ describe("ui-calendar", () => {
       const events = new Map<string, Array<{ color: string; label?: string }>>();
       events.set("2024-06-15", [{ color: "#FC9162", label: "Meeting" }]);
       events.set("2024-06-20", [{ color: "#FC9162", label: "Meeting" }]);
-      (el as any).setEvents(events);
+      el.setEvents(events);
       await tick();
       const items = shadow().querySelectorAll(".legend-item");
       expect(items.length).toBe(1);
@@ -936,7 +936,7 @@ describe("ui-calendar", () => {
       el.navigateTo(2024, 5);
       const events = new Map<string, Array<{ color: string; label?: string }>>();
       events.set("2024-06-15", [{ color: "#FC9162" }]); // no label
-      (el as any).setEvents(events);
+      el.setEvents(events);
       await tick();
       const legend = shadow().querySelector(".legend") as HTMLElement;
       expect(legend.style.display).toBe("none");

--- a/packages/ui-components/src/components/ui-checkbox-group.test.ts
+++ b/packages/ui-components/src/components/ui-checkbox-group.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import "../components/ui-checkbox-group.js";
 import "../components/ui-checkbox-item.js";
+import { UiCheckboxGroup } from "../components/ui-checkbox-group.js";
 
 describe("UiCheckboxGroup", () => {
   let group: HTMLElement;
@@ -38,12 +39,12 @@ describe("UiCheckboxGroup", () => {
   describe("default attributes", () => {
     it("should default to size='m'", () => {
       expect(group.getAttribute("size")).toBeNull();
-      expect((group as any).size).toBe("m");
+      expect((group as UiCheckboxGroup).size).toBe("m");
     });
 
     it("should default to orientation='vertical'", () => {
       expect(group.getAttribute("orientation")).toBeNull();
-      expect((group as any).orientation).toBe("vertical");
+      expect((group as UiCheckboxGroup).orientation).toBe("vertical");
     });
   });
 
@@ -112,23 +113,23 @@ describe("UiCheckboxGroup", () => {
 
   describe("property accessors", () => {
     it("should get/set size property", () => {
-      (group as any).size = "l";
+      (group as UiCheckboxGroup).size = "l";
       expect(group.getAttribute("size")).toBe("l");
-      expect((group as any).size).toBe("l");
+      expect((group as UiCheckboxGroup).size).toBe("l");
     });
 
     it("should get/set orientation property", () => {
-      (group as any).orientation = "horizontal";
+      (group as UiCheckboxGroup).orientation = "horizontal";
       expect(group.getAttribute("orientation")).toBe("horizontal");
-      expect((group as any).orientation).toBe("horizontal");
+      expect((group as UiCheckboxGroup).orientation).toBe("horizontal");
     });
 
     it("should default size to 'm' when not set", () => {
-      expect((group as any).size).toBe("m");
+      expect((group as UiCheckboxGroup).size).toBe("m");
     });
 
     it("should default orientation to 'vertical' when not set", () => {
-      expect((group as any).orientation).toBe("vertical");
+      expect((group as UiCheckboxGroup).orientation).toBe("vertical");
     });
   });
 

--- a/packages/ui-components/src/components/ui-dropdown-split.test.ts
+++ b/packages/ui-components/src/components/ui-dropdown-split.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { UiDropdownSplit } from "./ui-dropdown-split.js";
 import "./ui-dropdown-split.js";
 import "./ui-dropdown-item.js";
 import "./ui-dropdown-heading.js";
@@ -20,7 +21,7 @@ describe("UiDropdownSplit — registration", () => {
 // ─── DOM structure ──────────────────────────────────────────────────────────
 
 describe("UiDropdownSplit — DOM structure", () => {
-  let el: HTMLElement;
+  let el: UiDropdownSplit;
 
   beforeEach(() => {
     el = document.createElement("ui-dropdown-split");
@@ -94,7 +95,7 @@ describe("UiDropdownSplit — DOM structure", () => {
 // ─── Default attribute values ───────────────────────────────────────────────
 
 describe("UiDropdownSplit — defaults", () => {
-  let el: HTMLElement;
+  let el: UiDropdownSplit;
 
   beforeEach(() => {
     el = document.createElement("ui-dropdown-split");
@@ -106,46 +107,46 @@ describe("UiDropdownSplit — defaults", () => {
   });
 
   it("should default size to 'm'", () => {
-    expect((el as any).size).toBe("m");
+    expect(el.size).toBe("m");
   });
 
   it("should default action to 'primary'", () => {
-    expect((el as any).action).toBe("primary");
+    expect(el.action).toBe("primary");
   });
 
   it("should default emphasis to 'bold'", () => {
-    expect((el as any).emphasis).toBe("bold");
+    expect(el.emphasis).toBe("bold");
   });
 
   it("should default shape to 'basic'", () => {
-    expect((el as any).shape).toBe("basic");
+    expect(el.shape).toBe("basic");
   });
 
   it("should default icon to 'text-only'", () => {
-    expect((el as any).icon).toBe("text-only");
+    expect(el.icon).toBe("text-only");
   });
 
   it("should default disabled to false", () => {
-    expect((el as any).disabled).toBe(false);
+    expect(el.disabled).toBe(false);
   });
 
   it("should default open to false", () => {
-    expect((el as any).open).toBe(false);
+    expect(el.open).toBe(false);
   });
 
   it("should default label to 'Button'", () => {
-    expect((el as any).label).toBe("Button");
+    expect(el.label).toBe("Button");
   });
 
   it("should default multiple to false", () => {
-    expect((el as any).multiple).toBe(false);
+    expect(el.multiple).toBe(false);
   });
 });
 
 // ─── Size variants ──────────────────────────────────────────────────────────
 
 describe("UiDropdownSplit — sizes", () => {
-  let el: HTMLElement;
+  let el: UiDropdownSplit;
 
   beforeEach(() => {
     el = document.createElement("ui-dropdown-split");
@@ -158,26 +159,26 @@ describe("UiDropdownSplit — sizes", () => {
 
   it("should accept size='s'", () => {
     el.setAttribute("size", "s");
-    expect((el as any).size).toBe("s");
+    expect(el.size).toBe("s");
   });
 
   it("should accept size='m'", () => {
     el.setAttribute("size", "m");
-    expect((el as any).size).toBe("m");
+    expect(el.size).toBe("m");
   });
 
   it("should accept size='l'", () => {
     el.setAttribute("size", "l");
-    expect((el as any).size).toBe("l");
+    expect(el.size).toBe("l");
   });
 
   it("should accept size='xl'", () => {
     el.setAttribute("size", "xl");
-    expect((el as any).size).toBe("xl");
+    expect(el.size).toBe("xl");
   });
 
   it("should set size via property accessor", () => {
-    (el as any).size = "l";
+    el.size = "l";
     expect(el.getAttribute("size")).toBe("l");
   });
 });
@@ -185,7 +186,7 @@ describe("UiDropdownSplit — sizes", () => {
 // ─── Action variants ────────────────────────────────────────────────────────
 
 describe("UiDropdownSplit — actions", () => {
-  let el: HTMLElement;
+  let el: UiDropdownSplit;
 
   beforeEach(() => {
     el = document.createElement("ui-dropdown-split");
@@ -198,31 +199,31 @@ describe("UiDropdownSplit — actions", () => {
 
   it("should accept action='primary'", () => {
     el.setAttribute("action", "primary");
-    expect((el as any).action).toBe("primary");
+    expect(el.action).toBe("primary");
   });
 
   it("should accept action='secondary'", () => {
     el.setAttribute("action", "secondary");
-    expect((el as any).action).toBe("secondary");
+    expect(el.action).toBe("secondary");
   });
 
   it("should accept action='destructive'", () => {
     el.setAttribute("action", "destructive");
-    expect((el as any).action).toBe("destructive");
+    expect(el.action).toBe("destructive");
   });
 
   it("should accept action='info'", () => {
     el.setAttribute("action", "info");
-    expect((el as any).action).toBe("info");
+    expect(el.action).toBe("info");
   });
 
   it("should accept action='contrast'", () => {
     el.setAttribute("action", "contrast");
-    expect((el as any).action).toBe("contrast");
+    expect(el.action).toBe("contrast");
   });
 
   it("should set action via property accessor", () => {
-    (el as any).action = "destructive";
+    el.action = "destructive";
     expect(el.getAttribute("action")).toBe("destructive");
   });
 });
@@ -230,7 +231,7 @@ describe("UiDropdownSplit — actions", () => {
 // ─── Emphasis variants ──────────────────────────────────────────────────────
 
 describe("UiDropdownSplit — emphases", () => {
-  let el: HTMLElement;
+  let el: UiDropdownSplit;
 
   beforeEach(() => {
     el = document.createElement("ui-dropdown-split");
@@ -243,21 +244,21 @@ describe("UiDropdownSplit — emphases", () => {
 
   it("should accept emphasis='bold'", () => {
     el.setAttribute("emphasis", "bold");
-    expect((el as any).emphasis).toBe("bold");
+    expect(el.emphasis).toBe("bold");
   });
 
   it("should accept emphasis='subtle'", () => {
     el.setAttribute("emphasis", "subtle");
-    expect((el as any).emphasis).toBe("subtle");
+    expect(el.emphasis).toBe("subtle");
   });
 
   it("should accept emphasis='minimal'", () => {
     el.setAttribute("emphasis", "minimal");
-    expect((el as any).emphasis).toBe("minimal");
+    expect(el.emphasis).toBe("minimal");
   });
 
   it("should set emphasis via property accessor", () => {
-    (el as any).emphasis = "minimal";
+    el.emphasis = "minimal";
     expect(el.getAttribute("emphasis")).toBe("minimal");
   });
 });
@@ -265,7 +266,7 @@ describe("UiDropdownSplit — emphases", () => {
 // ─── Shape variants ─────────────────────────────────────────────────────────
 
 describe("UiDropdownSplit — shapes", () => {
-  let el: HTMLElement;
+  let el: UiDropdownSplit;
 
   beforeEach(() => {
     el = document.createElement("ui-dropdown-split");
@@ -278,16 +279,16 @@ describe("UiDropdownSplit — shapes", () => {
 
   it("should accept shape='basic'", () => {
     el.setAttribute("shape", "basic");
-    expect((el as any).shape).toBe("basic");
+    expect(el.shape).toBe("basic");
   });
 
   it("should accept shape='rounded'", () => {
     el.setAttribute("shape", "rounded");
-    expect((el as any).shape).toBe("rounded");
+    expect(el.shape).toBe("rounded");
   });
 
   it("should set shape via property accessor", () => {
-    (el as any).shape = "rounded";
+    el.shape = "rounded";
     expect(el.getAttribute("shape")).toBe("rounded");
   });
 });
@@ -295,7 +296,7 @@ describe("UiDropdownSplit — shapes", () => {
 // ─── Icon modes ─────────────────────────────────────────────────────────────
 
 describe("UiDropdownSplit — icon modes", () => {
-  let el: HTMLElement;
+  let el: UiDropdownSplit;
 
   beforeEach(() => {
     el = document.createElement("ui-dropdown-split");
@@ -308,26 +309,26 @@ describe("UiDropdownSplit — icon modes", () => {
 
   it("should accept icon='text-only'", () => {
     el.setAttribute("icon", "text-only");
-    expect((el as any).icon).toBe("text-only");
+    expect(el.icon).toBe("text-only");
   });
 
   it("should accept icon='leading-icon'", () => {
     el.setAttribute("icon", "leading-icon");
-    expect((el as any).icon).toBe("leading-icon");
+    expect(el.icon).toBe("leading-icon");
   });
 
   it("should accept icon='trailing-icon'", () => {
     el.setAttribute("icon", "trailing-icon");
-    expect((el as any).icon).toBe("trailing-icon");
+    expect(el.icon).toBe("trailing-icon");
   });
 
   it("should accept icon='icon-only'", () => {
     el.setAttribute("icon", "icon-only");
-    expect((el as any).icon).toBe("icon-only");
+    expect(el.icon).toBe("icon-only");
   });
 
   it("should set icon via property accessor", () => {
-    (el as any).icon = "leading-icon";
+    el.icon = "leading-icon";
     expect(el.getAttribute("icon")).toBe("leading-icon");
   });
 });
@@ -335,7 +336,7 @@ describe("UiDropdownSplit — icon modes", () => {
 // ─── Disabled state ─────────────────────────────────────────────────────────
 
 describe("UiDropdownSplit — disabled", () => {
-  let el: HTMLElement;
+  let el: UiDropdownSplit;
 
   beforeEach(() => {
     el = document.createElement("ui-dropdown-split");
@@ -347,9 +348,9 @@ describe("UiDropdownSplit — disabled", () => {
   });
 
   it("should set disabled via property accessor", () => {
-    (el as any).disabled = true;
+    el.disabled = true;
     expect(el.hasAttribute("disabled")).toBe(true);
-    (el as any).disabled = false;
+    el.disabled = false;
     expect(el.hasAttribute("disabled")).toBe(false);
   });
 
@@ -378,14 +379,14 @@ describe("UiDropdownSplit — disabled", () => {
     el.setAttribute("disabled", "");
     const right = el.shadowRoot!.querySelector(".right") as HTMLElement;
     right.click();
-    expect((el as any).open).toBe(false);
+    expect(el.open).toBe(false);
   });
 });
 
 // ─── Open/close behavior ────────────────────────────────────────────────────
 
 describe("UiDropdownSplit — open/close", () => {
-  let el: HTMLElement;
+  let el: UiDropdownSplit;
 
   beforeEach(() => {
     el = document.createElement("ui-dropdown-split");
@@ -399,47 +400,47 @@ describe("UiDropdownSplit — open/close", () => {
   it("should toggle open on right button click", () => {
     const right = el.shadowRoot!.querySelector(".right") as HTMLElement;
     right.click();
-    expect((el as any).open).toBe(true);
+    expect(el.open).toBe(true);
     right.click();
-    expect((el as any).open).toBe(false);
+    expect(el.open).toBe(false);
   });
 
   it("should close on Escape key", () => {
-    (el as any).open = true;
+    el.open = true;
     el.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
-    expect((el as any).open).toBe(false);
+    expect(el.open).toBe(false);
   });
 
   it("should close on outside click", () => {
-    (el as any).open = true;
+    el.open = true;
     document.body.click();
-    expect((el as any).open).toBe(false);
+    expect(el.open).toBe(false);
   });
 
   it("should not close when clicking inside the component", () => {
-    (el as any).open = true;
+    el.open = true;
     el.click();
-    expect((el as any).open).toBe(true);
+    expect(el.open).toBe(true);
   });
 
   it("should set open via property accessor", () => {
-    (el as any).open = true;
+    el.open = true;
     expect(el.hasAttribute("open")).toBe(true);
-    (el as any).open = false;
+    el.open = false;
     expect(el.hasAttribute("open")).toBe(false);
   });
 
   it("should not open when left button is clicked", () => {
     const left = el.shadowRoot!.querySelector(".left") as HTMLElement;
     left.click();
-    expect((el as any).open).toBe(false);
+    expect(el.open).toBe(false);
   });
 });
 
 // ─── Left button action event ───────────────────────────────────────────────
 
 describe("UiDropdownSplit — action event", () => {
-  let el: HTMLElement;
+  let el: UiDropdownSplit;
 
   beforeEach(() => {
     el = document.createElement("ui-dropdown-split");
@@ -472,7 +473,7 @@ describe("UiDropdownSplit — action event", () => {
 // ─── Aria attributes ────────────────────────────────────────────────────────
 
 describe("UiDropdownSplit — aria", () => {
-  let el: HTMLElement;
+  let el: UiDropdownSplit;
 
   beforeEach(() => {
     el = document.createElement("ui-dropdown-split");
@@ -503,7 +504,7 @@ describe("UiDropdownSplit — aria", () => {
 // ─── Label ──────────────────────────────────────────────────────────────────
 
 describe("UiDropdownSplit — label", () => {
-  let el: HTMLElement;
+  let el: UiDropdownSplit;
 
   beforeEach(() => {
     el = document.createElement("ui-dropdown-split");
@@ -526,7 +527,7 @@ describe("UiDropdownSplit — label", () => {
   });
 
   it("should set label via property accessor", () => {
-    (el as any).label = "Menu";
+    el.label = "Menu";
     expect(el.getAttribute("label")).toBe("Menu");
   });
 });
@@ -534,7 +535,7 @@ describe("UiDropdownSplit — label", () => {
 // ─── Single-select behavior ─────────────────────────────────────────────────
 
 describe("UiDropdownSplit — single-select", () => {
-  let el: HTMLElement;
+  let el: UiDropdownSplit;
 
   beforeEach(() => {
     el = document.createElement("ui-dropdown-split");
@@ -579,14 +580,14 @@ describe("UiDropdownSplit — single-select", () => {
 
   it("should close menu after single selection", () => {
     el.setAttribute("selectable", "");
-    (el as any).open = true;
+    el.open = true;
     const item = document.createElement("ui-dropdown-item");
     el.appendChild(item);
 
     const button = item.shadowRoot!.querySelector("button")!;
     button.click();
 
-    expect((el as any).open).toBe(false);
+    expect(el.open).toBe(false);
   });
 
   it("should dispatch 'change' event on selection", () => {
@@ -612,7 +613,7 @@ describe("UiDropdownSplit — single-select", () => {
 
     item.shadowRoot!.querySelector("button")!.click();
 
-    expect((el as any).value).toBe("foo");
+    expect(el.value).toBe("foo");
   });
 
   });
@@ -624,11 +625,11 @@ describe("UiDropdownSplit — single-select", () => {
 // ─── Multi-select behavior ──────────────────────────────────────────────────
 
 describe("UiDropdownSplit — multi-select", () => {
-  let el: HTMLElement;
+  let el: UiDropdownSplit;
 
   beforeEach(() => {
     el = document.createElement("ui-dropdown-split");
-    (el as any).multiple = true;
+    el.multiple = true;
     document.body.appendChild(el);
   });
 
@@ -656,13 +657,13 @@ describe("UiDropdownSplit — multi-select", () => {
 
   it("should NOT close menu after multi-select", () => {
     el.setAttribute("selectable", "");
-    (el as any).open = true;
+    el.open = true;
     const item = document.createElement("ui-dropdown-item");
     el.appendChild(item);
 
     item.shadowRoot!.querySelector("button")!.click();
 
-    expect((el as any).open).toBe(true);
+    expect(el.open).toBe(true);
   });
 
   it("should return array from value getter", () => {
@@ -677,12 +678,12 @@ describe("UiDropdownSplit — multi-select", () => {
     item1.shadowRoot!.querySelector("button")!.click();
     item2.shadowRoot!.querySelector("button")!.click();
 
-    expect((el as any).value).toEqual(["a", "b"]);
+    expect(el.value).toEqual(["a", "b"]);
   });
 
   it("should set multiple via property accessor", () => {
     expect(el.hasAttribute("multiple")).toBe(true);
-    (el as any).multiple = false;
+    el.multiple = false;
     expect(el.hasAttribute("multiple")).toBe(false);
   });
 
@@ -703,7 +704,7 @@ describe("UiDropdownSplit — multi-select", () => {
 // ─── Size propagation to children ───────────────────────────────────────────
 
 describe("UiDropdownSplit — size propagation", () => {
-  let el: HTMLElement;
+  let el: UiDropdownSplit;
 
   beforeEach(() => {
     el = document.createElement("ui-dropdown-split");
@@ -759,7 +760,7 @@ describe("UiDropdownSplit — size propagation", () => {
 // ─── Chevron rotation ───────────────────────────────────────────────────────
 
 describe("UiDropdownSplit — chevron", () => {
-  let el: HTMLElement;
+  let el: UiDropdownSplit;
 
   beforeEach(() => {
     el = document.createElement("ui-dropdown-split");
@@ -780,7 +781,7 @@ describe("UiDropdownSplit — chevron", () => {
 // ─── Styles verification ────────────────────────────────────────────────────
 
 describe("UiDropdownSplit — styles", () => {
-  let el: HTMLElement;
+  let el: UiDropdownSplit;
 
   beforeEach(() => {
     el = document.createElement("ui-dropdown-split");
@@ -846,9 +847,9 @@ describe("UiDropdownSplit — styles", () => {
 
 describe("UiDropdownSplit — cleanup", () => {
   it("should remove document click listener on disconnect", () => {
-    const el = document.createElement("ui-dropdown-split");
+    const el = document.createElement("ui-dropdown-split") as UiDropdownSplit;
     document.body.appendChild(el);
-    (el as any).open = true;
+    el.open = true;
     el.remove();
     // Should not throw when clicking after removal
     document.body.click();

--- a/packages/ui-components/src/components/ui-dropdown.test.ts
+++ b/packages/ui-components/src/components/ui-dropdown.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import "./ui-dropdown.js";
-import { STYLES as DROPDOWN_STYLES } from "./ui-dropdown.js";
+import { UiDropdown, STYLES as DROPDOWN_STYLES } from "./ui-dropdown.js";
 import "./ui-dropdown-item.js";
+import { UiDropdownItem } from "./ui-dropdown-item.js";
 import { STYLES as ITEM_STYLES } from "./ui-dropdown-item.styles.js";
 import "./ui-dropdown-heading.js";
+import { UiDropdownHeading } from "./ui-dropdown-heading.js";
 import "./ui-dropdown-separator.js";
 
 // ─── ui-dropdown-separator ───────────────────────────────────────────────────
@@ -67,16 +69,16 @@ describe("UiDropdownHeading", () => {
   });
 
   it("should default size to 'm'", () => {
-    expect((el as any).size).toBe("m");
+    expect((el as UiDropdownHeading).size).toBe("m");
   });
 
   it("should accept size='s'", () => {
     el.setAttribute("size", "s");
-    expect((el as any).size).toBe("s");
+    expect((el as UiDropdownHeading).size).toBe("s");
   });
 
   it("should set size via property accessor", () => {
-    (el as any).size = "s";
+    (el as UiDropdownHeading).size = "s";
     expect(el.getAttribute("size")).toBe("s");
   });
 
@@ -150,27 +152,27 @@ describe("UiDropdownItem", () => {
   });
 
   it("should default size to 'm'", () => {
-    expect((el as any).size).toBe("m");
+    expect((el as UiDropdownItem).size).toBe("m");
   });
 
   it("should accept size='s'", () => {
     el.setAttribute("size", "s");
-    expect((el as any).size).toBe("s");
+    expect((el as UiDropdownItem).size).toBe("s");
   });
 
   it("should set size via property accessor", () => {
-    (el as any).size = "s";
+    (el as UiDropdownItem).size = "s";
     expect(el.getAttribute("size")).toBe("s");
   });
 
   it("should default disabled to false", () => {
-    expect((el as any).disabled).toBe(false);
+    expect((el as UiDropdownItem).disabled).toBe(false);
   });
 
   it("should set disabled via property accessor", () => {
-    (el as any).disabled = true;
+    (el as UiDropdownItem).disabled = true;
     expect(el.hasAttribute("disabled")).toBe(true);
-    (el as any).disabled = false;
+    (el as UiDropdownItem).disabled = false;
     expect(el.hasAttribute("disabled")).toBe(false);
   });
 
@@ -190,13 +192,13 @@ describe("UiDropdownItem", () => {
     expect(styles).toContain(".item:hover");
   });
   it("should default selected to false", () => {
-    expect((el as any).selected).toBe(false);
+    expect((el as UiDropdownItem).selected).toBe(false);
   });
 
   it("should set selected via property accessor", () => {
-    (el as any).selected = true;
+    (el as UiDropdownItem).selected = true;
     expect(el.hasAttribute("selected")).toBe(true);
-    (el as any).selected = false;
+    (el as UiDropdownItem).selected = false;
     expect(el.hasAttribute("selected")).toBe(false);
   });
 
@@ -217,25 +219,25 @@ describe("UiDropdownItem", () => {
   });
 
   it("should default value to empty string", () => {
-    expect((el as any).value).toBe("");
+    expect((el as UiDropdownItem).value).toBe("");
   });
 
   it("should set value via property accessor", () => {
-    (el as any).value = "apple";
+    (el as UiDropdownItem).value = "apple";
     expect(el.getAttribute("value")).toBe("apple");
-    expect((el as any).value).toBe("apple");
+    expect((el as UiDropdownItem).value).toBe("apple");
   });
   it("should accept size='l'", () => {
-    (el as any).size = "l";
-    expect((el as any).size).toBe("l");
+    (el as UiDropdownItem).size = "l";
+    expect((el as UiDropdownItem).size).toBe("l");
   });
 
   it("should default leading to null", () => {
-    expect((el as any).leading).toBe(null);
+    expect((el as UiDropdownItem).leading).toBe(null);
   });
 
   it("should set leading='icon' via property", () => {
-    (el as any).leading = "icon";
+    (el as UiDropdownItem).leading = "icon";
     expect(el.getAttribute("leading")).toBe("icon");
   });
 
@@ -265,14 +267,14 @@ describe("UiDropdownItem", () => {
 
   it("should remove leading element when leading is removed", () => {
     el.setAttribute("leading", "icon");
-    (el as any).leading = null;
+    (el as UiDropdownItem).leading = null;
     const leading = el.shadowRoot!.querySelector(".leading");
     expect(leading).toBe(null);
   });
 
 
   it("should default secondary to null", () => {
-    expect((el as any).secondary).toBe(null);
+    expect((el as UiDropdownItem).secondary).toBe(null);
   });
 
   it("should render secondary text", () => {
@@ -290,13 +292,13 @@ describe("UiDropdownItem", () => {
 
   it("should remove secondary when cleared", () => {
     el.setAttribute("secondary", "A");
-    (el as any).secondary = null;
+    (el as UiDropdownItem).secondary = null;
     const secondary = el.shadowRoot!.querySelector(".secondary");
     expect(secondary).toBe(null);
   });
 
   it("should default description to null", () => {
-    expect((el as any).description).toBe(null);
+    expect((el as UiDropdownItem).description).toBe(null);
   });
 
   it("should render description text", () => {
@@ -307,13 +309,13 @@ describe("UiDropdownItem", () => {
 
   it("should remove description when cleared", () => {
     el.setAttribute("description", "X");
-    (el as any).description = null;
+    (el as UiDropdownItem).description = null;
     const description = el.shadowRoot!.querySelector(".description");
     expect(description).toBe(null);
   });
 
   it("should default submenu to false", () => {
-    expect((el as any).submenu).toBe(false);
+    expect((el as UiDropdownItem).submenu).toBe(false);
   });
 
   it("should render submenu arrow when set", () => {
@@ -330,9 +332,9 @@ describe("UiDropdownItem", () => {
   });
 
   it("should set submenu via property", () => {
-    (el as any).submenu = true;
+    (el as UiDropdownItem).submenu = true;
     expect(el.hasAttribute("submenu")).toBe(true);
-    (el as any).submenu = false;
+    (el as UiDropdownItem).submenu = false;
     expect(el.hasAttribute("submenu")).toBe(false);
   });
 
@@ -450,41 +452,41 @@ describe("UiDropdown", () => {
   // ── Open/close behavior ────────────────────────────────────────────────
 
   it("should default to closed", () => {
-    expect((el as any).open).toBe(false);
+    expect((el as UiDropdown).open).toBe(false);
   });
 
   it("should toggle open on trigger click", () => {
     const trigger = el.shadowRoot!.querySelector("ui-button") as HTMLElement;
     trigger.click();
-    expect((el as any).open).toBe(true);
+    expect((el as UiDropdown).open).toBe(true);
 
     trigger.click();
-    expect((el as any).open).toBe(false);
+    expect((el as UiDropdown).open).toBe(false);
   });
 
   it("should close on Escape key", () => {
-    (el as any).open = true;
+    (el as UiDropdown).open = true;
     el.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
-    expect((el as any).open).toBe(false);
+    expect((el as UiDropdown).open).toBe(false);
   });
 
   it("should close on outside click", () => {
-    (el as any).open = true;
+    (el as UiDropdown).open = true;
     document.body.click();
-    expect((el as any).open).toBe(false);
+    expect((el as UiDropdown).open).toBe(false);
   });
 
   it("should not close when clicking inside the dropdown", () => {
-    (el as any).open = true;
+    (el as UiDropdown).open = true;
     el.click();
-    expect((el as any).open).toBe(true);
+    expect((el as UiDropdown).open).toBe(true);
   });
 
   it("should dispatch 'toggle' event when open changes", () => {
     const handler = vi.fn();
     el.addEventListener("toggle", handler);
 
-    (el as any).open = true;
+    (el as UiDropdown).open = true;
     expect(handler).toHaveBeenCalled();
     const event = handler.mock.calls[0][0] as CustomEvent;
     expect(event.detail.open).toBe(true);
@@ -494,13 +496,13 @@ describe("UiDropdown", () => {
     el.setAttribute("disabled", "");
     const trigger = el.shadowRoot!.querySelector("ui-button") as HTMLElement;
     trigger.click();
-    expect((el as any).open).toBe(false);
+    expect((el as UiDropdown).open).toBe(false);
   });
 
   // ── Label ──────────────────────────────────────────────────────────────
 
   it("should default label to 'Button'", () => {
-    expect((el as any).label).toBe("Button");
+    expect((el as UiDropdown).label).toBe("Button");
   });
 
   it("should update trigger text when label changes", () => {
@@ -510,7 +512,7 @@ describe("UiDropdown", () => {
   });
 
   it("should set label via property accessor", () => {
-    (el as any).label = "Menu";
+    (el as UiDropdown).label = "Menu";
     expect(el.getAttribute("label")).toBe("Menu");
   });
 
@@ -592,56 +594,56 @@ describe("UiDropdown", () => {
   // ── Property accessors ─────────────────────────────────────────────────
 
   it("should default size to 'm'", () => {
-    expect((el as any).size).toBe("m");
+    expect((el as UiDropdown).size).toBe("m");
   });
 
   it("should default action to 'primary'", () => {
-    expect((el as any).action).toBe("primary");
+    expect((el as UiDropdown).action).toBe("primary");
   });
 
   it("should default emphasis to 'bold'", () => {
-    expect((el as any).emphasis).toBe("bold");
+    expect((el as UiDropdown).emphasis).toBe("bold");
   });
 
   it("should default shape to 'basic'", () => {
-    expect((el as any).shape).toBe("basic");
+    expect((el as UiDropdown).shape).toBe("basic");
   });
 
   it("should get/set size property", () => {
-    (el as any).size = "xl";
+    (el as UiDropdown).size = "xl";
     expect(el.getAttribute("size")).toBe("xl");
-    expect((el as any).size).toBe("xl");
+    expect((el as UiDropdown).size).toBe("xl");
   });
 
   it("should get/set action property", () => {
-    (el as any).action = "destructive";
+    (el as UiDropdown).action = "destructive";
     expect(el.getAttribute("action")).toBe("destructive");
-    expect((el as any).action).toBe("destructive");
+    expect((el as UiDropdown).action).toBe("destructive");
   });
 
   it("should get/set emphasis property", () => {
-    (el as any).emphasis = "minimal";
+    (el as UiDropdown).emphasis = "minimal";
     expect(el.getAttribute("emphasis")).toBe("minimal");
-    expect((el as any).emphasis).toBe("minimal");
+    expect((el as UiDropdown).emphasis).toBe("minimal");
   });
 
   it("should get/set shape property", () => {
-    (el as any).shape = "rounded";
+    (el as UiDropdown).shape = "rounded";
     expect(el.getAttribute("shape")).toBe("rounded");
-    expect((el as any).shape).toBe("rounded");
+    expect((el as UiDropdown).shape).toBe("rounded");
   });
 
   it("should get/set disabled property", () => {
-    (el as any).disabled = true;
+    (el as UiDropdown).disabled = true;
     expect(el.hasAttribute("disabled")).toBe(true);
-    (el as any).disabled = false;
+    (el as UiDropdown).disabled = false;
     expect(el.hasAttribute("disabled")).toBe(false);
   });
 
   it("should get/set open property", () => {
-    (el as any).open = true;
+    (el as UiDropdown).open = true;
     expect(el.hasAttribute("open")).toBe(true);
-    (el as any).open = false;
+    (el as UiDropdown).open = false;
     expect(el.hasAttribute("open")).toBe(false);
   });
   // ── Selection behavior ──────────────────────────────────────────────
@@ -680,19 +682,19 @@ describe("UiDropdown", () => {
 
   it("should close menu after single selection", () => {
     el.setAttribute("selectable", "");
-    (el as any).open = true;
+    (el as UiDropdown).open = true;
     const item = document.createElement("ui-dropdown-item");
     el.appendChild(item);
 
     const button = item.shadowRoot!.querySelector("button")!;
     button.click();
 
-    expect((el as any).open).toBe(false);
+    expect((el as UiDropdown).open).toBe(false);
   });
 
   it("should toggle selection in multi-select mode", () => {
     el.setAttribute("selectable", "");
-    (el as any).multiple = true;
+    (el as UiDropdown).multiple = true;
     const item1 = document.createElement("ui-dropdown-item");
     const item2 = document.createElement("ui-dropdown-item");
     el.appendChild(item1);
@@ -711,14 +713,14 @@ describe("UiDropdown", () => {
 
   it("should NOT close menu after multi-select", () => {
     el.setAttribute("selectable", "");
-    (el as any).multiple = true;
-    (el as any).open = true;
+    (el as UiDropdown).multiple = true;
+    (el as UiDropdown).open = true;
     const item = document.createElement("ui-dropdown-item");
     el.appendChild(item);
 
     item.shadowRoot!.querySelector("button")!.click();
 
-    expect((el as any).open).toBe(true);
+    expect((el as UiDropdown).open).toBe(true);
   });
 
   it("should dispatch 'change' event on selection", () => {
@@ -744,12 +746,12 @@ describe("UiDropdown", () => {
 
     item.shadowRoot!.querySelector("button")!.click();
 
-    expect((el as any).value).toBe("foo");
+    expect((el as UiDropdown).value).toBe("foo");
   });
 
   it("should return array from value getter (multiple)", () => {
     el.setAttribute("selectable", "");
-    (el as any).multiple = true;
+    (el as UiDropdown).multiple = true;
     const item1 = document.createElement("ui-dropdown-item");
     const item2 = document.createElement("ui-dropdown-item");
     item1.setAttribute("value", "a");
@@ -760,17 +762,17 @@ describe("UiDropdown", () => {
     item1.shadowRoot!.querySelector("button")!.click();
     item2.shadowRoot!.querySelector("button")!.click();
 
-    expect((el as any).value).toEqual(["a", "b"]);
+    expect((el as UiDropdown).value).toEqual(["a", "b"]);
   });
 
   it("should default multiple to false", () => {
-    expect((el as any).multiple).toBe(false);
+    expect((el as UiDropdown).multiple).toBe(false);
   });
 
   it("should set multiple via property accessor", () => {
-    (el as any).multiple = true;
+    (el as UiDropdown).multiple = true;
     expect(el.hasAttribute("multiple")).toBe(true);
-    (el as any).multiple = false;
+    (el as UiDropdown).multiple = false;
     expect(el.hasAttribute("multiple")).toBe(false);
   });
 
@@ -821,7 +823,7 @@ describe("UiDropdown", () => {
   // ── Cleanup ────────────────────────────────────────────────────────────
 
   it("should remove document click listener on disconnect", () => {
-    (el as any).open = true;
+    (el as UiDropdown).open = true;
     el.remove();
     // Should not throw when clicking after removal
     document.body.click();

--- a/packages/ui-components/src/components/ui-menu.test.ts
+++ b/packages/ui-components/src/components/ui-menu.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import "./ui-menu.js";
-import { STYLES as MENU_STYLES } from "./ui-menu.js";
+import { UiMenu, STYLES as MENU_STYLES } from "./ui-menu.js";
 import "./ui-dropdown-item.js";
 import "./ui-dropdown-heading.js";
 import "./ui-dropdown-separator.js";
@@ -35,50 +35,50 @@ describe("UiMenu", () => {
   // ── Open/close behavior ─────────────────────────────────────────────────
 
   it("should default to closed", () => {
-    expect((el as any).open).toBe(false);
+    expect((el as UiMenu).open).toBe(false);
   });
 
   it("should open when open attribute is set", () => {
     el.setAttribute("open", "");
-    expect((el as any).open).toBe(true);
+    expect((el as UiMenu).open).toBe(true);
   });
 
   it("should close when open attribute is removed", () => {
     el.setAttribute("open", "");
     el.removeAttribute("open");
-    expect((el as any).open).toBe(false);
+    expect((el as UiMenu).open).toBe(false);
   });
 
   it("should set open via property accessor", () => {
-    (el as any).open = true;
+    (el as UiMenu).open = true;
     expect(el.hasAttribute("open")).toBe(true);
-    (el as any).open = false;
+    (el as UiMenu).open = false;
     expect(el.hasAttribute("open")).toBe(false);
   });
 
   it("should close on Escape key", () => {
-    (el as any).open = true;
+    (el as UiMenu).open = true;
     el.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
-    expect((el as any).open).toBe(false);
+    expect((el as UiMenu).open).toBe(false);
   });
 
   it("should close on outside click", () => {
-    (el as any).open = true;
+    (el as UiMenu).open = true;
     document.body.click();
-    expect((el as any).open).toBe(false);
+    expect((el as UiMenu).open).toBe(false);
   });
 
   it("should not close when clicking inside the menu", () => {
-    (el as any).open = true;
+    (el as UiMenu).open = true;
     el.click();
-    expect((el as any).open).toBe(true);
+    expect((el as UiMenu).open).toBe(true);
   });
 
   it("should dispatch 'toggle' event when open changes", () => {
     const handler = vi.fn();
     el.addEventListener("toggle", handler);
 
-    (el as any).open = true;
+    (el as UiMenu).open = true;
     expect(handler).toHaveBeenCalled();
     const event = handler.mock.calls[0][0] as CustomEvent;
     expect(event.detail.open).toBe(true);
@@ -88,7 +88,7 @@ describe("UiMenu", () => {
     const handler = vi.fn();
     el.addEventListener("toggle", handler);
 
-    (el as any).open = true;
+    (el as UiMenu).open = true;
     const event = handler.mock.calls[0][0] as CustomEvent;
     expect(event.bubbles).toBe(true);
     expect(event.composed).toBe(true);
@@ -97,13 +97,13 @@ describe("UiMenu", () => {
   // ── Size ────────────────────────────────────────────────────────────────
 
   it("should default size to 'm'", () => {
-    expect((el as any).size).toBe("m");
+    expect((el as UiMenu).size).toBe("m");
   });
 
   it("should get/set size property", () => {
-    (el as any).size = "s";
+    (el as UiMenu).size = "s";
     expect(el.getAttribute("size")).toBe("s");
-    expect((el as any).size).toBe("s");
+    expect((el as UiMenu).size).toBe("s");
   });
 
   it("should propagate size to dropdown-item children", () => {
@@ -137,14 +137,14 @@ describe("UiMenu", () => {
   });
 
   it("should accept size='l'", () => {
-    (el as any).size = "l";
+    (el as UiMenu).size = "l";
     expect(el.getAttribute("size")).toBe("l");
   });
 
   it("should propagate size='l' to children", () => {
     const item = document.createElement("ui-dropdown-item");
     el.appendChild(item);
-    (el as any).size = "l";
+    (el as UiMenu).size = "l";
     // Wait for slotchange
     return new Promise((resolve) => {
       setTimeout(() => {
@@ -157,13 +157,13 @@ describe("UiMenu", () => {
   // ── Selectable / single-select ──────────────────────────────────────────
 
   it("should default selectable to false", () => {
-    expect((el as any).selectable).toBe(false);
+    expect((el as UiMenu).selectable).toBe(false);
   });
 
   it("should set selectable via property accessor", () => {
-    (el as any).selectable = true;
+    (el as UiMenu).selectable = true;
     expect(el.hasAttribute("selectable")).toBe(true);
-    (el as any).selectable = false;
+    (el as UiMenu).selectable = false;
     expect(el.hasAttribute("selectable")).toBe(false);
   });
 
@@ -222,14 +222,14 @@ describe("UiMenu", () => {
 
   it("should close menu after single selection", () => {
     el.setAttribute("selectable", "");
-    (el as any).open = true;
+    (el as UiMenu).open = true;
     const item = document.createElement("ui-dropdown-item");
     el.appendChild(item);
 
     const button = item.shadowRoot!.querySelector("button")!;
     button.click();
 
-    expect((el as any).open).toBe(false);
+    expect((el as UiMenu).open).toBe(false);
   });
 
   it("should dispatch 'change' event on selection", () => {
@@ -255,25 +255,25 @@ describe("UiMenu", () => {
 
     item.shadowRoot!.querySelector("button")!.click();
 
-    expect((el as any).value).toBe("foo");
+    expect((el as UiMenu).value).toBe("foo");
   });
 
   // ── Multiple select ─────────────────────────────────────────────────────
 
   it("should default multiple to false", () => {
-    expect((el as any).multiple).toBe(false);
+    expect((el as UiMenu).multiple).toBe(false);
   });
 
   it("should set multiple via property accessor", () => {
-    (el as any).multiple = true;
+    (el as UiMenu).multiple = true;
     expect(el.hasAttribute("multiple")).toBe(true);
-    (el as any).multiple = false;
+    (el as UiMenu).multiple = false;
     expect(el.hasAttribute("multiple")).toBe(false);
   });
 
   it("should toggle selection in multi-select mode", () => {
     el.setAttribute("selectable", "");
-    (el as any).multiple = true;
+    (el as UiMenu).multiple = true;
     const item1 = document.createElement("ui-dropdown-item");
     const item2 = document.createElement("ui-dropdown-item");
     el.appendChild(item1);
@@ -292,19 +292,19 @@ describe("UiMenu", () => {
 
   it("should NOT close menu after multi-select", () => {
     el.setAttribute("selectable", "");
-    (el as any).multiple = true;
-    (el as any).open = true;
+    (el as UiMenu).multiple = true;
+    (el as UiMenu).open = true;
     const item = document.createElement("ui-dropdown-item");
     el.appendChild(item);
 
     item.shadowRoot!.querySelector("button")!.click();
 
-    expect((el as any).open).toBe(true);
+    expect((el as UiMenu).open).toBe(true);
   });
 
   it("should return array from value getter (multiple)", () => {
     el.setAttribute("selectable", "");
-    (el as any).multiple = true;
+    (el as UiMenu).multiple = true;
     const item1 = document.createElement("ui-dropdown-item");
     const item2 = document.createElement("ui-dropdown-item");
     item1.setAttribute("value", "a");
@@ -315,13 +315,13 @@ describe("UiMenu", () => {
     item1.shadowRoot!.querySelector("button")!.click();
     item2.shadowRoot!.querySelector("button")!.click();
 
-    expect((el as any).value).toEqual(["a", "b"]);
+    expect((el as UiMenu).value).toEqual(["a", "b"]);
   });
 
   // ── Cleanup ─────────────────────────────────────────────────────────────
 
   it("should remove document click listener on disconnect", () => {
-    (el as any).open = true;
+    (el as UiMenu).open = true;
     el.remove();
     // Should not throw when clicking after removal
     document.body.click();

--- a/packages/ui-components/src/components/ui-pagination.test.ts
+++ b/packages/ui-components/src/components/ui-pagination.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import "./ui-pagination.js";
-import type { PaginationSize, PaginationType } from "./ui-pagination.js";
+import { UiPagination, type PaginationSize, type PaginationType } from "./ui-pagination.js";
 import { STYLES } from "./ui-pagination.styles.js";
 
 describe("ui-pagination", () => {
-  let el: HTMLElement;
+  let el: UiPagination;
 
   beforeEach(() => {
-    el = document.createElement("ui-pagination");
+    el = document.createElement("ui-pagination") as UiPagination;
     document.body.appendChild(el);
   });
 
@@ -43,88 +43,88 @@ describe("ui-pagination", () => {
   // ── Property accessors ─────────────────────────────────────────────────────
 
   it("size defaults to m", () => {
-    expect((el as any).size).toBe("m");
+    expect(el.size).toBe("m");
   });
 
   it("size getter/setter works", () => {
     const sizes: PaginationSize[] = ["xs", "s", "m"];
     for (const s of sizes) {
-      (el as any).size = s;
-      expect((el as any).size).toBe(s);
+      el.size = s;
+      expect(el.size).toBe(s);
       expect(el.getAttribute("size")).toBe(s);
     }
   });
 
   it("type defaults to data-grid", () => {
-    expect((el as any).type).toBe("data-grid");
+    expect(el.type).toBe("data-grid");
   });
 
   it("type getter/setter works", () => {
     const types: PaginationType[] = ["minimal", "basic", "data-grid"];
     for (const t of types) {
-      (el as any).type = t;
-      expect((el as any).type).toBe(t);
+      el.type = t;
+      expect(el.type).toBe(t);
       expect(el.getAttribute("type")).toBe(t);
     }
   });
 
   it("currentPage defaults to 1", () => {
-    expect((el as any).currentPage).toBe(1);
+    expect(el.currentPage).toBe(1);
   });
 
   it("currentPage getter/setter works", () => {
-    (el as any).currentPage = 5;
-    expect((el as any).currentPage).toBe(5);
+    el.currentPage = 5;
+    expect(el.currentPage).toBe(5);
     expect(el.getAttribute("current-page")).toBe("5");
   });
 
   it("currentPage clamps to minimum 1", () => {
-    (el as any).currentPage = -3;
-    expect((el as any).currentPage).toBe(1);
+    el.currentPage = -3;
+    expect(el.currentPage).toBe(1);
   });
 
   it("totalPages defaults to 1", () => {
-    expect((el as any).totalPages).toBe(1);
+    expect(el.totalPages).toBe(1);
   });
 
   it("totalPages getter/setter works", () => {
-    (el as any).totalPages = 20;
-    expect((el as any).totalPages).toBe(20);
+    el.totalPages = 20;
+    expect(el.totalPages).toBe(20);
     expect(el.getAttribute("total-pages")).toBe("20");
   });
 
   it("totalPages clamps to minimum 1", () => {
-    (el as any).totalPages = 0;
-    expect((el as any).totalPages).toBe(1);
+    el.totalPages = 0;
+    expect(el.totalPages).toBe(1);
   });
 
   it("pageSize defaults to 10", () => {
-    expect((el as any).pageSize).toBe(10);
+    expect(el.pageSize).toBe(10);
   });
 
   it("pageSize getter/setter works", () => {
-    (el as any).pageSize = 25;
-    expect((el as any).pageSize).toBe(25);
+    el.pageSize = 25;
+    expect(el.pageSize).toBe(25);
     expect(el.getAttribute("page-size")).toBe("25");
   });
 
   it("totalItems defaults to 0", () => {
-    expect((el as any).totalItems).toBe(0);
+    expect(el.totalItems).toBe(0);
   });
 
   it("totalItems getter/setter works", () => {
-    (el as any).totalItems = 200;
-    expect((el as any).totalItems).toBe(200);
+    el.totalItems = 200;
+    expect(el.totalItems).toBe(200);
     expect(el.getAttribute("total-items")).toBe("200");
   });
 
   it("pageSizeOptions defaults to [10, 25, 50, 100]", () => {
-    expect((el as any).pageSizeOptions).toEqual([10, 25, 50, 100]);
+    expect(el.pageSizeOptions).toEqual([10, 25, 50, 100]);
   });
 
   it("pageSizeOptions getter/setter works", () => {
-    (el as any).pageSizeOptions = [5, 10, 20];
-    expect((el as any).pageSizeOptions).toEqual([5, 10, 20]);
+    el.pageSizeOptions = [5, 10, 20];
+    expect(el.pageSizeOptions).toEqual([5, 10, 20]);
     expect(el.getAttribute("page-size-options")).toBe("5,10,20");
   });
 
@@ -132,43 +132,43 @@ describe("ui-pagination", () => {
 
   it("reflects size attribute", () => {
     el.setAttribute("size", "s");
-    expect((el as any).size).toBe("s");
+    expect(el.size).toBe("s");
   });
 
   it("reflects type attribute", () => {
     el.setAttribute("type", "minimal");
-    expect((el as any).type).toBe("minimal");
+    expect(el.type).toBe("minimal");
   });
 
   it("reflects current-page attribute", () => {
     el.setAttribute("current-page", "3");
-    expect((el as any).currentPage).toBe(3);
+    expect(el.currentPage).toBe(3);
   });
 
   it("reflects total-pages attribute", () => {
     el.setAttribute("total-pages", "10");
-    expect((el as any).totalPages).toBe(10);
+    expect(el.totalPages).toBe(10);
   });
 
   it("reflects page-size attribute", () => {
     el.setAttribute("page-size", "50");
-    expect((el as any).pageSize).toBe(50);
+    expect(el.pageSize).toBe(50);
   });
 
   it("reflects total-items attribute", () => {
     el.setAttribute("total-items", "500");
-    expect((el as any).totalItems).toBe(500);
+    expect(el.totalItems).toBe(500);
   });
 
   it("reflects page-size-options attribute", () => {
     el.setAttribute("page-size-options", "5,15,30");
-    expect((el as any).pageSizeOptions).toEqual([5, 15, 30]);
+    expect(el.pageSizeOptions).toEqual([5, 15, 30]);
   });
 
   // ── observedAttributes ─────────────────────────────────────────────────────
 
   it("has correct observedAttributes list", () => {
-    const ctor = customElements.get("ui-pagination") as typeof HTMLElement & { observedAttributes: string[] };
+    const ctor = customElements.get("ui-pagination") as typeof UiPagination;
     expect(ctor.observedAttributes).toEqual([
       "size", "type", "current-page", "total-pages", "page-size", "total-items", "page-size-options",
     ]);

--- a/packages/ui-components/src/components/ui-pull-to-refresh.test.ts
+++ b/packages/ui-components/src/components/ui-pull-to-refresh.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import "./ui-pull-to-refresh.js";
-import type { PullToRefreshVariant } from "./ui-pull-to-refresh.js";
+import { UiPullToRefresh, type PullToRefreshVariant } from "./ui-pull-to-refresh.js";
 import { STYLES } from "./ui-pull-to-refresh.styles.js";
 
 describe("ui-pull-to-refresh", () => {
-  let el: HTMLElement;
+  let el: UiPullToRefresh;
 
   beforeEach(() => {
     document.body.innerHTML = "";
-    el = document.createElement("ui-pull-to-refresh");
+    el = document.createElement("ui-pull-to-refresh") as UiPullToRefresh;
     document.body.appendChild(el);
   });
 
@@ -74,50 +74,50 @@ describe("ui-pull-to-refresh", () => {
   });
 
   it("active property getter returns false by default", () => {
-    expect((el as any).active).toBe(false);
+    expect(el.active).toBe(false);
   });
 
   it("active property getter returns true when attribute is set", () => {
     el.setAttribute("active", "");
-    expect((el as any).active).toBe(true);
+    expect(el.active).toBe(true);
   });
 
   it("active property setter adds the attribute", () => {
-    (el as any).active = true;
+    el.active = true;
     expect(el.hasAttribute("active")).toBe(true);
   });
 
   it("active property setter removes the attribute", () => {
     el.setAttribute("active", "");
-    (el as any).active = false;
+    el.active = false;
     expect(el.hasAttribute("active")).toBe(false);
   });
 
   // ── Variant attribute ─────────────────────────────────────────────────────
 
   it("defaults to light variant", () => {
-    expect((el as any).variant).toBe("light");
+    expect(el.variant).toBe("light");
   });
 
   it("reflects variant attribute via property getter", () => {
     el.setAttribute("variant", "dark");
-    expect((el as any).variant).toBe("dark");
+    expect(el.variant).toBe("dark");
   });
 
   it("variant property setter updates the attribute", () => {
-    (el as any).variant = "dark";
+    el.variant = "dark";
     expect(el.getAttribute("variant")).toBe("dark");
   });
 
   it("variant property setter sets light", () => {
-    (el as any).variant = "light" as PullToRefreshVariant;
+    el.variant = "light" as PullToRefreshVariant;
     expect(el.getAttribute("variant")).toBe("light");
   });
 
   // ── Text attribute ────────────────────────────────────────────────────────
 
   it("default text property is 'Refreshing content'", () => {
-    expect((el as any).text).toBe("Refreshing content");
+    expect(el.text).toBe("Refreshing content");
   });
 
   it("text attribute updates the displayed text", () => {
@@ -128,16 +128,16 @@ describe("ui-pull-to-refresh", () => {
 
   it("text property getter reflects the attribute", () => {
     el.setAttribute("text", "Please wait");
-    expect((el as any).text).toBe("Please wait");
+    expect(el.text).toBe("Please wait");
   });
 
   it("text property setter updates the attribute", () => {
-    (el as any).text = "Syncing";
+    el.text = "Syncing";
     expect(el.getAttribute("text")).toBe("Syncing");
   });
 
   it("text property setter updates the displayed text", () => {
-    (el as any).text = "Syncing";
+    el.text = "Syncing";
     const text = el.shadowRoot!.querySelector(".text");
     expect(text!.textContent).toBe("Syncing");
   });
@@ -162,7 +162,7 @@ describe("ui-pull-to-refresh", () => {
   // ── observedAttributes ────────────────────────────────────────────────────
 
   it("observes active, variant, and text attributes", () => {
-    const Ctor = customElements.get("ui-pull-to-refresh") as any;
+    const Ctor = customElements.get("ui-pull-to-refresh") as typeof UiPullToRefresh;
     expect(Ctor.observedAttributes).toEqual(["active", "variant", "text", "size"]);
   });
 

--- a/packages/ui-components/src/components/ui-radio-group.test.ts
+++ b/packages/ui-components/src/components/ui-radio-group.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import "../components/ui-radio-group.js";
 import "../components/ui-radio-item.js";
+import { UiRadioGroup } from "../components/ui-radio-group.js";
 
 describe("UiRadioGroup", () => {
   let group: HTMLElement;
@@ -38,12 +39,12 @@ describe("UiRadioGroup", () => {
   describe("default attributes", () => {
     it("should default to size='m'", () => {
       expect(group.getAttribute("size")).toBeNull();
-      expect((group as any).size).toBe("m");
+      expect((group as UiRadioGroup).size).toBe("m");
     });
 
     it("should default to orientation='vertical'", () => {
       expect(group.getAttribute("orientation")).toBeNull();
-      expect((group as any).orientation).toBe("vertical");
+      expect((group as UiRadioGroup).orientation).toBe("vertical");
     });
   });
 
@@ -112,23 +113,23 @@ describe("UiRadioGroup", () => {
 
   describe("property accessors", () => {
     it("should get/set size property", () => {
-      (group as any).size = "l";
+      (group as UiRadioGroup).size = "l";
       expect(group.getAttribute("size")).toBe("l");
-      expect((group as any).size).toBe("l");
+      expect((group as UiRadioGroup).size).toBe("l");
     });
 
     it("should get/set orientation property", () => {
-      (group as any).orientation = "horizontal";
+      (group as UiRadioGroup).orientation = "horizontal";
       expect(group.getAttribute("orientation")).toBe("horizontal");
-      expect((group as any).orientation).toBe("horizontal");
+      expect((group as UiRadioGroup).orientation).toBe("horizontal");
     });
 
     it("should default size to 'm' when not set", () => {
-      expect((group as any).size).toBe("m");
+      expect((group as UiRadioGroup).size).toBe("m");
     });
 
     it("should default orientation to 'vertical' when not set", () => {
-      expect((group as any).orientation).toBe("vertical");
+      expect((group as UiRadioGroup).orientation).toBe("vertical");
     });
   });
 

--- a/packages/ui-components/src/components/ui-scrollbar.test.ts
+++ b/packages/ui-components/src/components/ui-scrollbar.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import "./ui-scrollbar.js";
+import { UiScrollbar } from "./ui-scrollbar.js";
 import type { ScrollbarEmphasis, ScrollbarOrientation } from "./ui-scrollbar.js";
 import { STYLES } from "./ui-scrollbar.styles.js";
 
@@ -80,46 +81,46 @@ describe("ui-scrollbar", () => {
 
   it("emphasis getter returns the attribute value", () => {
     el.setAttribute("emphasis", "minimal");
-    expect((el as any).emphasis).toBe("minimal");
+    expect((el as UiScrollbar).emphasis).toBe("minimal");
   });
 
   it("emphasis setter updates the attribute", () => {
-    (el as any).emphasis = "minimal";
+    (el as UiScrollbar).emphasis = "minimal";
     expect(el.getAttribute("emphasis")).toBe("minimal");
   });
 
   it("emphasis getter defaults to 'bold'", () => {
-    expect((el as any).emphasis).toBe("bold");
+    expect((el as UiScrollbar).emphasis).toBe("bold");
   });
 
   it("orientation getter returns the attribute value", () => {
     el.setAttribute("orientation", "horizontal");
-    expect((el as any).orientation).toBe("horizontal");
+    expect((el as UiScrollbar).orientation).toBe("horizontal");
   });
 
   it("orientation setter updates the attribute", () => {
-    (el as any).orientation = "horizontal";
+    (el as UiScrollbar).orientation = "horizontal";
     expect(el.getAttribute("orientation")).toBe("horizontal");
   });
 
   it("orientation getter defaults to 'vertical'", () => {
-    expect((el as any).orientation).toBe("vertical");
+    expect((el as UiScrollbar).orientation).toBe("vertical");
   });
 
   // ── observedAttributes ─────────────────────────────────────────────────────
 
   it("observes 'emphasis' attribute", () => {
-    const observed = (customElements.get("ui-scrollbar") as any).observedAttributes;
+    const observed = (customElements.get("ui-scrollbar") as typeof UiScrollbar).observedAttributes;
     expect(observed).toContain("emphasis");
   });
 
   it("observes 'orientation' attribute", () => {
-    const observed = (customElements.get("ui-scrollbar") as any).observedAttributes;
+    const observed = (customElements.get("ui-scrollbar") as typeof UiScrollbar).observedAttributes;
     expect(observed).toContain("orientation");
   });
 
   it("observedAttributes has exactly 2 entries", () => {
-    const observed = (customElements.get("ui-scrollbar") as any).observedAttributes;
+    const observed = (customElements.get("ui-scrollbar") as typeof UiScrollbar).observedAttributes;
     expect(observed).toHaveLength(2);
   });
 

--- a/packages/ui-components/src/components/ui-select.test.ts
+++ b/packages/ui-components/src/components/ui-select.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import "./ui-select.js";
+import { UiSelect } from "./ui-select.js";
 import "./ui-dropdown-item.js";
 
 function createSelect(attrs: Record<string, string> = {}, items: { value: string; text: string; disabled?: boolean }[] = []): HTMLElement {
@@ -46,73 +47,73 @@ describe("ui-select", () => {
 
   it("defaults size to 'm'", () => {
     el = createSelect();
-    expect((el as any).size).toBe("m");
+    expect((el as UiSelect).size).toBe("m");
   });
 
   it("defaults status to 'none'", () => {
     el = createSelect();
-    expect((el as any).status).toBe("none");
+    expect((el as UiSelect).status).toBe("none");
   });
 
   it("defaults placeholder to 'Select an option'", () => {
     el = createSelect();
-    expect((el as any).placeholder).toBe("Select an option");
+    expect((el as UiSelect).placeholder).toBe("Select an option");
   });
 
   it("defaults disabled to false", () => {
     el = createSelect();
-    expect((el as any).disabled).toBe(false);
+    expect((el as UiSelect).disabled).toBe(false);
   });
 
   it("defaults readonly to false", () => {
     el = createSelect();
-    expect((el as any).readonly).toBe(false);
+    expect((el as UiSelect).readonly).toBe(false);
   });
 
   it("defaults open to false", () => {
     el = createSelect();
-    expect((el as any).open).toBe(false);
+    expect((el as UiSelect).open).toBe(false);
   });
 
   it("defaults multiple to false", () => {
     el = createSelect();
-    expect((el as any).multiple).toBe(false);
+    expect((el as UiSelect).multiple).toBe(false);
   });
 
   it("defaults error to false", () => {
     el = createSelect();
-    expect((el as any).error).toBe(false);
+    expect((el as UiSelect).error).toBe(false);
   });
 
   it("defaults value to empty string", () => {
     el = createSelect();
-    expect((el as any).value).toBe("");
+    expect((el as UiSelect).value).toBe("");
   });
 
 
 
   it("defaults name to empty string", () => {
     el = createSelect();
-    expect((el as any).name).toBe("");
+    expect((el as UiSelect).name).toBe("");
   });
 
   // ── Size attribute ───────────────────────────────────────────────────────
 
   it("reflects size='s' to attribute", () => {
     el = createSelect();
-    (el as any).size = "s";
+    (el as UiSelect).size = "s";
     expect(el.getAttribute("size")).toBe("s");
   });
 
   it("reflects size='l' to attribute", () => {
     el = createSelect();
-    (el as any).size = "l";
+    (el as UiSelect).size = "l";
     expect(el.getAttribute("size")).toBe("l");
   });
 
   it("propagates size to slotted items", () => {
     el = createSelect({}, DEFAULT_ITEMS);
-    (el as any).size = "l";
+    (el as UiSelect).size = "l";
     // Trigger slotchange manually in test env
     const items = el.querySelectorAll("ui-dropdown-item");
     // In happy-dom, slotchange may not fire automatically
@@ -156,26 +157,26 @@ describe("ui-select", () => {
 
   it("opens panel when open attribute is set", () => {
     el = createSelect();
-    (el as any).open = true;
+    (el as UiSelect).open = true;
     expect(el.hasAttribute("open")).toBe(true);
   });
 
   it("sets aria-expanded on trigger when open", () => {
     el = createSelect();
-    (el as any).open = true;
+    (el as UiSelect).open = true;
     const trigger = el.shadowRoot!.querySelector(".trigger");
     expect(trigger?.getAttribute("aria-expanded")).toBe("true");
   });
 
   it("does not open when disabled", () => {
     el = createSelect({ disabled: "" });
-    (el as any).open = true;
+    (el as UiSelect).open = true;
     expect(el.hasAttribute("open")).toBe(false);
   });
 
   it("does not open when readonly", () => {
     el = createSelect({ readonly: "" });
-    (el as any).open = true;
+    (el as UiSelect).open = true;
     expect(el.hasAttribute("open")).toBe(false);
   });
 
@@ -183,7 +184,7 @@ describe("ui-select", () => {
     el = createSelect();
     const handler = vi.fn();
     el.addEventListener("toggle", handler);
-    (el as any).open = true;
+    (el as UiSelect).open = true;
     expect(handler).toHaveBeenCalled();
     expect(handler.mock.calls[0][0].detail.open).toBe(true);
   });
@@ -192,7 +193,7 @@ describe("ui-select", () => {
 
   it("reflects disabled property to attribute", () => {
     el = createSelect();
-    (el as any).disabled = true;
+    (el as UiSelect).disabled = true;
     expect(el.hasAttribute("disabled")).toBe(true);
   });
 
@@ -211,7 +212,7 @@ describe("ui-select", () => {
 
   it("reflects readonly property to attribute", () => {
     el = createSelect();
-    (el as any).readonly = true;
+    (el as UiSelect).readonly = true;
     expect(el.hasAttribute("readonly")).toBe(true);
   });
 
@@ -224,7 +225,7 @@ describe("ui-select", () => {
 
   it("reflects status property", () => {
     el = createSelect();
-    (el as any).status = "error";
+    (el as UiSelect).status = "error";
     expect(el.getAttribute("status")).toBe("error");
   });
 
@@ -262,7 +263,7 @@ describe("ui-select", () => {
 
   it("reflects error property", () => {
     el = createSelect();
-    (el as any).error = true;
+    (el as UiSelect).error = true;
     expect(el.hasAttribute("error")).toBe(true);
   });
 
@@ -310,8 +311,8 @@ describe("ui-select", () => {
     el = createSelect();
     el.setAttribute("aria-label", "Country");
     // re-trigger _syncAria
-    (el as any).disabled = true;
-    (el as any).disabled = false;
+    (el as UiSelect).disabled = true;
+    (el as UiSelect).disabled = false;
     const trigger = el.shadowRoot!.querySelector(".trigger");
     expect(trigger?.getAttribute("aria-label")).toBe("Country");
   });
@@ -320,7 +321,7 @@ describe("ui-select", () => {
 
   it("reflects multiple property", () => {
     el = createSelect();
-    (el as any).multiple = true;
+    (el as UiSelect).multiple = true;
     expect(el.hasAttribute("multiple")).toBe(true);
   });
 
@@ -328,33 +329,33 @@ describe("ui-select", () => {
 
   it("returns empty string when nothing selected (single)", () => {
     el = createSelect({}, DEFAULT_ITEMS);
-    expect((el as any).value).toBe("");
+    expect((el as UiSelect).value).toBe("");
   });
 
   it("sets value programmatically (single)", () => {
     el = createSelect({}, DEFAULT_ITEMS);
-    (el as any).value = "b";
-    expect((el as any).value).toBe("b");
+    (el as UiSelect).value = "b";
+    expect((el as UiSelect).value).toBe("b");
   });
 
   // ── Value (multi select) ─────────────────────────────────────────────────
 
   it("returns empty array when nothing selected (multi)", () => {
     el = createSelect({ multiple: "" }, DEFAULT_ITEMS);
-    expect((el as any).value).toEqual([]);
+    expect((el as UiSelect).value).toEqual([]);
   });
 
   it("sets value programmatically (multi)", () => {
     el = createSelect({ multiple: "" }, DEFAULT_ITEMS);
-    (el as any).value = ["a", "c"];
-    expect((el as any).value).toEqual(["a", "c"]);
+    (el as UiSelect).value = ["a", "c"];
+    expect((el as UiSelect).value).toEqual(["a", "c"]);
   });
 
   // ── Clear button ─────────────────────────────────────────────────────────
 
   it("shows clear button when value is set", () => {
     el = createSelect({}, DEFAULT_ITEMS);
-    (el as any).value = "a";
+    (el as UiSelect).value = "a";
     const clearBtn = el.shadowRoot!.querySelector(".clear-btn");
     expect(clearBtn?.classList.contains("visible")).toBe(true);
   });
@@ -367,7 +368,7 @@ describe("ui-select", () => {
 
   it("hides clear button when disabled", () => {
     el = createSelect({ disabled: "" }, DEFAULT_ITEMS);
-    (el as any).value = "a";
+    (el as UiSelect).value = "a";
     const clearBtn = el.shadowRoot!.querySelector(".clear-btn");
     expect(clearBtn?.classList.contains("visible")).toBe(false);
   });
@@ -375,7 +376,7 @@ describe("ui-select", () => {
   it("hides clear button when readonly", () => {
     el = createSelect({ readonly: "" }, DEFAULT_ITEMS);
     // Set value before readonly to populate _selectedValues
-    (el as any).value = "a";
+    (el as UiSelect).value = "a";
     // readonly prevents clear
     const clearBtn = el.shadowRoot!.querySelector(".clear-btn");
     expect(clearBtn?.classList.contains("visible")).toBe(false);
@@ -383,15 +384,15 @@ describe("ui-select", () => {
 
   it("clears selection on clear button click", () => {
     el = createSelect({}, DEFAULT_ITEMS);
-    (el as any).value = "a";
+    (el as UiSelect).value = "a";
     const clearBtn = el.shadowRoot!.querySelector(".clear-btn") as HTMLElement;
     clearBtn.click();
-    expect((el as any).value).toBe("");
+    expect((el as UiSelect).value).toBe("");
   });
 
   it("dispatches clear event on clear button click", () => {
     el = createSelect({}, DEFAULT_ITEMS);
-    (el as any).value = "a";
+    (el as UiSelect).value = "a";
     const handler = vi.fn();
     el.addEventListener("clear", handler);
     const clearBtn = el.shadowRoot!.querySelector(".clear-btn") as HTMLElement;
@@ -401,7 +402,7 @@ describe("ui-select", () => {
 
   it("dispatches change event on clear button click", () => {
     el = createSelect({}, DEFAULT_ITEMS);
-    (el as any).value = "a";
+    (el as UiSelect).value = "a";
     const handler = vi.fn();
     el.addEventListener("change", handler);
     const clearBtn = el.shadowRoot!.querySelector(".clear-btn") as HTMLElement;
@@ -421,7 +422,7 @@ describe("ui-select", () => {
 
   it("shows selected text for single select", () => {
     el = createSelect({}, DEFAULT_ITEMS);
-    (el as any).value = "b";
+    (el as UiSelect).value = "b";
     const display = el.shadowRoot!.querySelector(".display-value");
     expect(display?.textContent).toContain("Beta");
     expect(display?.classList.contains("placeholder")).toBe(false);
@@ -429,7 +430,7 @@ describe("ui-select", () => {
 
   it("shows tags for multi select", () => {
     el = createSelect({ multiple: "" }, DEFAULT_ITEMS);
-    (el as any).value = ["a", "c"];
+    (el as UiSelect).value = ["a", "c"];
     const tags = el.shadowRoot!.querySelectorAll(".tag");
     expect(tags.length).toBe(2);
     expect(tags[0].querySelector(".tag-label")?.textContent).toBe("Alpha");
@@ -438,8 +439,8 @@ describe("ui-select", () => {
 
   it("shows placeholder when value is cleared", () => {
     el = createSelect({}, DEFAULT_ITEMS);
-    (el as any).value = "a";
-    (el as any).value = "";
+    (el as UiSelect).value = "a";
+    (el as UiSelect).value = "";
     const display = el.shadowRoot!.querySelector(".display-value");
     expect(display?.classList.contains("placeholder")).toBe(true);
   });
@@ -448,16 +449,16 @@ describe("ui-select", () => {
 
   it("removes tag on dismiss click (multi)", () => {
     el = createSelect({ multiple: "" }, DEFAULT_ITEMS);
-    (el as any).value = ["a", "b"];
+    (el as UiSelect).value = ["a", "b"];
     const dismissBtns = el.shadowRoot!.querySelectorAll(".tag-dismiss");
     expect(dismissBtns.length).toBe(2);
     (dismissBtns[0] as HTMLElement).click();
-    expect((el as any).value).toEqual(["b"]);
+    expect((el as UiSelect).value).toEqual(["b"]);
   });
 
   it("dispatches change event on tag dismiss", () => {
     el = createSelect({ multiple: "" }, DEFAULT_ITEMS);
-    (el as any).value = ["a", "b"];
+    (el as UiSelect).value = ["a", "b"];
     const handler = vi.fn();
     el.addEventListener("change", handler);
     const dismissBtns = el.shadowRoot!.querySelectorAll(".tag-dismiss");
@@ -469,14 +470,14 @@ describe("ui-select", () => {
 
   it("reflects name property", () => {
     el = createSelect();
-    (el as any).name = "country";
+    (el as UiSelect).name = "country";
     expect(el.getAttribute("name")).toBe("country");
   });
 
   // ── observedAttributes ───────────────────────────────────────────────────
 
   it("has correct observedAttributes", () => {
-    const observed = (customElements.get("ui-select") as any).observedAttributes;
+    const observed = (customElements.get("ui-select") as typeof UiSelect).observedAttributes;
     expect(observed).toContain("size");
     expect(observed).toContain("placeholder");
     expect(observed).toContain("disabled");
@@ -495,23 +496,23 @@ describe("ui-select", () => {
     el = createSelect();
     const trigger = el.shadowRoot!.querySelector(".trigger") as HTMLElement;
     trigger.click();
-    expect((el as any).open).toBe(true);
+    expect((el as UiSelect).open).toBe(true);
     trigger.click();
-    expect((el as any).open).toBe(false);
+    expect((el as UiSelect).open).toBe(false);
   });
 
   it("does not toggle when disabled", () => {
     el = createSelect({ disabled: "" });
     const trigger = el.shadowRoot!.querySelector(".trigger") as HTMLElement;
     trigger.click();
-    expect((el as any).open).toBe(false);
+    expect((el as UiSelect).open).toBe(false);
   });
 
   it("does not toggle when readonly", () => {
     el = createSelect({ readonly: "" });
     const trigger = el.shadowRoot!.querySelector(".trigger") as HTMLElement;
     trigger.click();
-    expect((el as any).open).toBe(false);
+    expect((el as UiSelect).open).toBe(false);
   });
 
   // ── Keyboard navigation ──────────────────────────────────────────────────
@@ -520,65 +521,65 @@ describe("ui-select", () => {
     el = createSelect({}, DEFAULT_ITEMS);
     const trigger = el.shadowRoot!.querySelector(".trigger") as HTMLElement;
     trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
-    expect((el as any).open).toBe(true);
+    expect((el as UiSelect).open).toBe(true);
   });
 
   it("opens on ArrowUp key when closed", () => {
     el = createSelect({}, DEFAULT_ITEMS);
     const trigger = el.shadowRoot!.querySelector(".trigger") as HTMLElement;
     trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true }));
-    expect((el as any).open).toBe(true);
+    expect((el as UiSelect).open).toBe(true);
   });
 
   it("opens on Enter key when closed", () => {
     el = createSelect({}, DEFAULT_ITEMS);
     const trigger = el.shadowRoot!.querySelector(".trigger") as HTMLElement;
     trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
-    expect((el as any).open).toBe(true);
+    expect((el as UiSelect).open).toBe(true);
   });
 
   it("opens on Space key when closed", () => {
     el = createSelect({}, DEFAULT_ITEMS);
     const trigger = el.shadowRoot!.querySelector(".trigger") as HTMLElement;
     trigger.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
-    expect((el as any).open).toBe(true);
+    expect((el as UiSelect).open).toBe(true);
   });
 
   it("closes on Escape key when open", () => {
     el = createSelect({}, DEFAULT_ITEMS);
-    (el as any).open = true;
+    (el as UiSelect).open = true;
     const trigger = el.shadowRoot!.querySelector(".trigger") as HTMLElement;
     trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
-    expect((el as any).open).toBe(false);
+    expect((el as UiSelect).open).toBe(false);
   });
 
   it("closes on Tab key when open", () => {
     el = createSelect({}, DEFAULT_ITEMS);
-    (el as any).open = true;
+    (el as UiSelect).open = true;
     const trigger = el.shadowRoot!.querySelector(".trigger") as HTMLElement;
     trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true }));
-    expect((el as any).open).toBe(false);
+    expect((el as UiSelect).open).toBe(false);
   });
 
   it("does not open on ArrowDown when disabled", () => {
     el = createSelect({ disabled: "" }, DEFAULT_ITEMS);
     const trigger = el.shadowRoot!.querySelector(".trigger") as HTMLElement;
     trigger.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
-    expect((el as any).open).toBe(false);
+    expect((el as UiSelect).open).toBe(false);
   });
 
   // ── Outside click ────────────────────────────────────────────────────────
 
   it("closes on outside click", () => {
     el = createSelect({}, DEFAULT_ITEMS);
-    (el as any).open = true;
+    (el as UiSelect).open = true;
     document.body.click();
-    expect((el as any).open).toBe(false);
+    expect((el as UiSelect).open).toBe(false);
   });
 
   it("does not close on click inside", () => {
     el = createSelect({}, DEFAULT_ITEMS);
-    (el as any).open = true;
+    (el as UiSelect).open = true;
     el.click();
     // Clicking the host itself — the trigger click handler toggles
     // but the outside click handler should not close it

--- a/packages/ui-components/src/components/ui-side-panel-menu-item.test.ts
+++ b/packages/ui-components/src/components/ui-side-panel-menu-item.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { UiSidePanelMenuItem } from "./ui-side-panel-menu-item.js";
 import "./ui-side-panel-menu-item.js";
 
 describe("ui-side-panel-menu-item", () => {
-  let el: HTMLElement;
+  let el: UiSidePanelMenuItem;
 
   beforeEach(() => {
     document.body.innerHTML = "";
-    el = document.createElement("ui-side-panel-menu-item");
+    el = document.createElement("ui-side-panel-menu-item") as UiSidePanelMenuItem;
     document.body.appendChild(el);
   });
 
@@ -23,35 +24,35 @@ describe("ui-side-panel-menu-item", () => {
   // ── Default attributes ───────────────────────────────────────────────────
 
   it("defaults level to 'primary'", () => {
-    expect((el as any).level).toBe("primary");
+    expect(el.level).toBe("primary");
   });
 
   it("defaults type to 'basic'", () => {
-    expect((el as any).type).toBe("basic");
+    expect(el.type).toBe("basic");
   });
 
   it("defaults selected to false", () => {
-    expect((el as any).selected).toBe(false);
+    expect(el.selected).toBe(false);
   });
 
   it("defaults childParentSelected to false", () => {
-    expect((el as any).childParentSelected).toBe(false);
+    expect(el.childParentSelected).toBe(false);
   });
 
   it("defaults disabled to false", () => {
-    expect((el as any).disabled).toBe(false);
+    expect(el.disabled).toBe(false);
   });
 
   it("defaults leadingIcon to false", () => {
-    expect((el as any).leadingIcon).toBe(false);
+    expect(el.leadingIcon).toBe(false);
   });
 
   it("defaults expandable to false", () => {
-    expect((el as any).expandable).toBe(false);
+    expect(el.expandable).toBe(false);
   });
 
   it("defaults expanded to false", () => {
-    expect((el as any).expanded).toBe(false);
+    expect(el.expanded).toBe(false);
   });
 
   // ── observedAttributes ───────────────────────────────────────────────────
@@ -76,82 +77,82 @@ describe("ui-side-panel-menu-item", () => {
   // ── Level attribute ──────────────────────────────────────────────────────
 
   it("reflects level='primary' to attribute", () => {
-    (el as any).level = "primary";
+    el.level = "primary";
     expect(el.getAttribute("level")).toBe("primary");
   });
 
   it("reflects level='secondary' to attribute", async () => {
-    (el as any).level = "secondary";
-    await (el as any).updateComplete;
+    el.level = "secondary";
+    await el.updateComplete;
     expect(el.getAttribute("level")).toBe("secondary");
   });
 
   it("reflects level='tertiary' to attribute", async () => {
-    (el as any).level = "tertiary";
-    await (el as any).updateComplete;
+    el.level = "tertiary";
+    await el.updateComplete;
     expect(el.getAttribute("level")).toBe("tertiary");
   });
 
   // ── Type attribute ───────────────────────────────────────────────────────
 
   it("reflects type='basic' to attribute", () => {
-    (el as any).type = "basic";
+    el.type = "basic";
     expect(el.getAttribute("type")).toBe("basic");
   });
 
   it("reflects type='icon-only' to attribute", async () => {
-    (el as any).type = "icon-only";
-    await (el as any).updateComplete;
+    el.type = "icon-only";
+    await el.updateComplete;
     expect(el.getAttribute("type")).toBe("icon-only");
   });
 
   // ── Boolean attributes ───────────────────────────────────────────────────
 
   it("reflects selected=true to attribute", async () => {
-    (el as any).selected = true;
-    await (el as any).updateComplete;
+    el.selected = true;
+    await el.updateComplete;
     expect(el.hasAttribute("selected")).toBe(true);
   });
 
   it("removes selected attribute when set to false", () => {
-    (el as any).selected = true;
-    (el as any).selected = false;
+    el.selected = true;
+    el.selected = false;
     expect(el.hasAttribute("selected")).toBe(false);
   });
 
   it("reflects childParentSelected=true to attribute", async () => {
-    (el as any).childParentSelected = true;
-    await (el as any).updateComplete;
+    el.childParentSelected = true;
+    await el.updateComplete;
     expect(el.hasAttribute("child-parent-selected")).toBe(true);
   });
 
   it("removes child-parent-selected attribute when set to false", () => {
-    (el as any).childParentSelected = true;
-    (el as any).childParentSelected = false;
+    el.childParentSelected = true;
+    el.childParentSelected = false;
     expect(el.hasAttribute("child-parent-selected")).toBe(false);
   });
 
   it("reflects disabled=true to attribute", async () => {
-    (el as any).disabled = true;
-    await (el as any).updateComplete;
+    el.disabled = true;
+    await el.updateComplete;
     expect(el.hasAttribute("disabled")).toBe(true);
   });
 
   it("reflects leadingIcon=true to attribute", async () => {
-    (el as any).leadingIcon = true;
-    await (el as any).updateComplete;
+    el.leadingIcon = true;
+    await el.updateComplete;
     expect(el.hasAttribute("leading-icon")).toBe(true);
   });
 
   it("reflects expandable=true to attribute", async () => {
-    (el as any).expandable = true;
-    await (el as any).updateComplete;
+    el.expandable = true;
+    await el.updateComplete;
     expect(el.hasAttribute("expandable")).toBe(true);
   });
 
   it("reflects expanded=true to attribute", async () => {
-    (el as any).expanded = true;
-    await (el as any).updateComplete;
+    el.expanded = true;
+    await el.updateComplete;
     expect(el.hasAttribute("expanded")).toBe(true);
   });
 
@@ -245,7 +246,7 @@ describe("ui-side-panel-menu-item", () => {
   });
 
   it("does not dispatch events when disabled", () => {
-    (el as any).disabled = true;
+    el.disabled = true;
     let fired = false;
     el.addEventListener("select", () => {
       fired = true;
@@ -260,17 +261,17 @@ describe("ui-side-panel-menu-item", () => {
   // ── Expandable behavior ──────────────────────────────────────────────────
 
   it("toggles expanded on click when expandable", () => {
-    (el as any).expandable = true;
-    expect((el as any).expanded).toBe(false);
+    el.expandable = true;
+    expect(el.expanded).toBe(false);
 
     const row = el.shadowRoot!.querySelector(".row") as HTMLElement;
     row.click();
 
-    expect((el as any).expanded).toBe(true);
+    expect(el.expanded).toBe(true);
   });
 
   it("dispatches toggle event when expandable item is clicked", () => {
-    (el as any).expandable = true;
+    el.expandable = true;
     let detail: any = null;
     el.addEventListener("toggle", ((e: CustomEvent) => {
       detail = e.detail;
@@ -283,7 +284,7 @@ describe("ui-side-panel-menu-item", () => {
   });
 
   it("dispatches both toggle and select events when expandable", () => {
-    (el as any).expandable = true;
+    el.expandable = true;
     const events: string[] = [];
     el.addEventListener("toggle", () => events.push("toggle"));
     el.addEventListener("select", () => events.push("select"));
@@ -295,8 +296,8 @@ describe("ui-side-panel-menu-item", () => {
   });
 
   it("shows expand_more icon when expandable and collapsed", async () => {
-    (el as any).expandable = true;
-    await (el as any).updateComplete;
+    el.expandable = true;
+    await el.updateComplete;
     const expandIcon = el.shadowRoot!.querySelector(".expand-icon");
     const icon = expandIcon!.querySelector("ui-icon");
     expect(icon).toBeTruthy();
@@ -304,9 +305,9 @@ describe("ui-side-panel-menu-item", () => {
   });
 
   it("shows expand_less icon when expandable and expanded", async () => {
-    (el as any).expandable = true;
-    (el as any).expanded = true;
-    await (el as any).updateComplete;
+    el.expandable = true;
+    el.expanded = true;
+    await el.updateComplete;
     const expandIcon = el.shadowRoot!.querySelector(".expand-icon");
     const icon = expandIcon!.querySelector("ui-icon");
     expect(icon).toBeTruthy();
@@ -316,8 +317,8 @@ describe("ui-side-panel-menu-item", () => {
   // ── ARIA ─────────────────────────────────────────────────────────────────
 
   it("sets aria-selected=true when selected", async () => {
-    (el as any).selected = true;
-    await (el as any).updateComplete;
+    el.selected = true;
+    await el.updateComplete;
     const row = el.shadowRoot!.querySelector(".row");
     expect(row!.getAttribute("aria-selected")).toBe("true");
   });
@@ -328,20 +329,20 @@ describe("ui-side-panel-menu-item", () => {
   });
 
   it("sets aria-disabled=true when disabled", async () => {
-    (el as any).disabled = true;
-    await (el as any).updateComplete;
+    el.disabled = true;
+    await el.updateComplete;
     const row = el.shadowRoot!.querySelector(".row");
     expect(row!.getAttribute("aria-disabled")).toBe("true");
   });
 
   it("sets aria-expanded when expandable", async () => {
-    (el as any).expandable = true;
-    await (el as any).updateComplete;
+    el.expandable = true;
+    await el.updateComplete;
     const row = el.shadowRoot!.querySelector(".row");
     expect(row!.getAttribute("aria-expanded")).toBe("false");
 
-    (el as any).expanded = true;
-    await (el as any).updateComplete;
+    el.expanded = true;
+    await el.updateComplete;
     expect(row!.getAttribute("aria-expanded")).toBe("true");
   });
 
@@ -353,19 +354,19 @@ describe("ui-side-panel-menu-item", () => {
   // ── Keyboard ─────────────────────────────────────────────────────────────
 
   it("toggles expanded on Enter key when expandable", () => {
-    (el as any).expandable = true;
+    el.expandable = true;
     const row = el.shadowRoot!.querySelector(".row") as HTMLElement;
 
     row.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
-    expect((el as any).expanded).toBe(true);
+    expect(el.expanded).toBe(true);
   });
 
   it("toggles expanded on Space key when expandable", () => {
-    (el as any).expandable = true;
+    el.expandable = true;
     const row = el.shadowRoot!.querySelector(".row") as HTMLElement;
 
     row.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
-    expect((el as any).expanded).toBe(true);
+    expect(el.expanded).toBe(true);
   });
 
   it("dispatches select on Enter key", () => {

--- a/packages/ui-components/src/components/ui-side-panel-menu.test.ts
+++ b/packages/ui-components/src/components/ui-side-panel-menu.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import "./ui-side-panel-menu-item.js";
 import "./ui-side-panel-menu.js";
+import { UiSidePanelMenu } from "./ui-side-panel-menu.js";
+import { UiSidePanelMenuItem } from "./ui-side-panel-menu-item.js";
+import { UiSidePanel } from "./ui-side-panel.js";
 
 describe("ui-side-panel-menu", () => {
   let el: HTMLElement;
@@ -49,46 +52,44 @@ describe("ui-side-panel-menu", () => {
   // ── Default attributes ───────────────────────────────────────────────────
 
   it("defaults state to 'expanded'", () => {
-    expect((el as any).state).toBe("expanded");
+    expect((el as UiSidePanelMenu).state).toBe("expanded");
   });
 
   it("defaults overlay to false", () => {
-    expect((el as any).overlay).toBe(false);
+    expect((el as UiSidePanelMenu).overlay).toBe(false);
   });
 
   // ── observedAttributes ───────────────────────────────────────────────────
 
   it("has correct observedAttributes", () => {
-    const Ctor = customElements.get("ui-side-panel-menu") as unknown as {
-      observedAttributes: string[];
-    };
+    const Ctor = customElements.get("ui-side-panel-menu") as typeof UiSidePanelMenu;
     expect(Ctor.observedAttributes).toEqual(["state", "overlay", "mobile", "no-collapse"]);
   });
 
   // ── State attribute ──────────────────────────────────────────────────────
 
   it("reflects state='expanded' to attribute", () => {
-    (el as any).state = "expanded";
+    (el as UiSidePanelMenu).state = "expanded";
     expect(el.getAttribute("state")).toBe("expanded");
   });
 
   it("reflects state='collapsed' to attribute", async () => {
-    (el as any).state = "collapsed";
-    await (el as any).updateComplete;
+    (el as UiSidePanelMenu).state = "collapsed";
+    await (el as UiSidePanelMenu).updateComplete;
     expect(el.getAttribute("state")).toBe("collapsed");
   });
 
   // ── Overlay attribute ────────────────────────────────────────────────────
 
   it("reflects overlay=true to attribute", async () => {
-    (el as any).overlay = true;
-    await (el as any).updateComplete;
+    (el as UiSidePanelMenu).overlay = true;
+    await (el as UiSidePanelMenu).updateComplete;
     expect(el.hasAttribute("overlay")).toBe(true);
   });
 
   it("removes overlay attribute when set to false", () => {
-    (el as any).overlay = true;
-    (el as any).overlay = false;
+    (el as UiSidePanelMenu).overlay = true;
+    (el as UiSidePanelMenu).overlay = false;
     expect(el.hasAttribute("overlay")).toBe(false);
   });
 
@@ -151,24 +152,24 @@ describe("ui-side-panel-menu", () => {
   // ── Toggle behavior ──────────────────────────────────────────────────────
 
   it("toggles state when toggle button is clicked", async () => {
-    expect((el as any).state).toBe("expanded");
+    expect((el as UiSidePanelMenu).state).toBe("expanded");
 
     const toggle = panelShadow(el).querySelector(".header-toggle") as HTMLElement;
     toggle.click();
     const panel = el.shadowRoot!.querySelector("ui-side-panel")!;
-    await (panel as any).updateComplete;
-    await (el as any).updateComplete;
+    await (panel as UiSidePanel).updateComplete;
+    await (el as UiSidePanelMenu).updateComplete;
 
-    expect((el as any).state).toBe("collapsed");
+    expect((el as UiSidePanelMenu).state).toBe("collapsed");
 
     toggle.click();
-    await (panel as any).updateComplete;
-    await (el as any).updateComplete;
-    expect((el as any).state).toBe("expanded");
+    await (panel as UiSidePanel).updateComplete;
+    await (el as UiSidePanelMenu).updateComplete;
+    expect((el as UiSidePanelMenu).state).toBe("expanded");
   });
 
   it("dispatches toggle event when toggle button is clicked", () => {
-    let detail: any = null;
+    let detail: Record<string, unknown> | null = null;
     el.addEventListener("toggle", ((e: CustomEvent) => {
       detail = e.detail;
     }) as EventListener);
@@ -180,9 +181,9 @@ describe("ui-side-panel-menu", () => {
   });
 
   it("dispatches toggle event with state=expanded when expanding", async () => {
-    (el as any).state = "collapsed";
-    await (el as any).updateComplete;
-    let detail: any = null;
+    (el as UiSidePanelMenu).state = "collapsed";
+    await (el as UiSidePanelMenu).updateComplete;
+    let detail: Record<string, unknown> | null = null;
     el.addEventListener("toggle", ((e: CustomEvent) => {
       detail = e.detail;
     }) as EventListener);
@@ -202,7 +203,7 @@ describe("ui-side-panel-menu", () => {
   });
 
   it("shows chevron-right icon when collapsed", () => {
-    (el as any).state = "collapsed";
+    (el as UiSidePanelMenu).state = "collapsed";
     const toggle = panelShadow(el).querySelector(".header-toggle");
     const icon = toggle!.querySelector(".material-symbols-outlined");
     expect(icon).toBeTruthy();
@@ -216,8 +217,8 @@ describe("ui-side-panel-menu", () => {
   });
 
   it("has aria-label 'Expand panel' when collapsed", async () => {
-    (el as any).state = "collapsed";
-    await (el as any).updateComplete;
+    (el as UiSidePanelMenu).state = "collapsed";
+    await (el as UiSidePanelMenu).updateComplete;
     const toggle = panelShadow(el).querySelector(".header-toggle");
     expect(toggle!.getAttribute("aria-label")).toBe("Expand panel");
   });
@@ -226,9 +227,9 @@ describe("ui-side-panel-menu", () => {
 
   it("sets type=icon-only on child items when collapsed", async () => {
     const menu = createMenu();
-    (menu as any).state = "collapsed";
+    (menu as UiSidePanelMenu).state = "collapsed";
     // happy-dom may not fire slotchange, so call sync manually
-    (menu as any)._syncItemTypes();
+    (menu as UiSidePanelMenu)._syncItemTypes();
     const items = menu.querySelectorAll("ui-side-panel-menu-item");
     for (const item of items) {
       expect(item.getAttribute("type")).toBe("icon-only");
@@ -237,10 +238,10 @@ describe("ui-side-panel-menu", () => {
 
   it("removes type attribute from child items when expanded", () => {
     const menu = createMenu({ state: "collapsed" });
-    (menu as any)._syncItemTypes();
+    (menu as UiSidePanelMenu)._syncItemTypes();
 
     menu.setAttribute("state", "expanded");
-    (menu as any)._syncItemTypes();
+    (menu as UiSidePanelMenu)._syncItemTypes();
 
     const items = menu.querySelectorAll("ui-side-panel-menu-item");
     for (const item of items) {
@@ -335,7 +336,7 @@ describe("ui-side-panel-menu", () => {
   it("selects a non-expandable item when clicked", async () => {
     const menu = createMenu();
     const items = menu.querySelectorAll("ui-side-panel-menu-item");
-    await (items[1] as any).updateComplete;
+    await (items[1] as UiSidePanelMenuItem).updateComplete;
     const row = items[1].shadowRoot!.querySelector(".row") as HTMLElement;
     row.click();
 
@@ -347,7 +348,7 @@ describe("ui-side-panel-menu", () => {
   it("deselects previously selected item when another is clicked", async () => {
     const menu = createMenu();
     const items = menu.querySelectorAll("ui-side-panel-menu-item");
-    await (items[0] as any).updateComplete;
+    await (items[0] as UiSidePanelMenuItem).updateComplete;
 
     // Select first item
     const row0 = items[0].shadowRoot!.querySelector(".row") as HTMLElement;
@@ -369,7 +370,7 @@ describe("ui-side-panel-menu", () => {
     item.textContent = "Expandable";
     menu.appendChild(item);
     document.body.appendChild(menu);
-    await (item as any).updateComplete;
+    await (item as UiSidePanelMenuItem).updateComplete;
 
     const row = item.shadowRoot!.querySelector(".row") as HTMLElement;
     row.click();
@@ -393,7 +394,7 @@ describe("ui-side-panel-menu", () => {
 
     menu.appendChild(parent);
     document.body.appendChild(menu);
-    await (child as any).updateComplete;
+    await (child as UiSidePanelMenuItem).updateComplete;
 
     // Click the child
     const childRow = child.shadowRoot!.querySelector(".row") as HTMLElement;
@@ -421,7 +422,7 @@ describe("ui-side-panel-menu", () => {
     item.appendChild(child);
     menu.appendChild(item);
     document.body.appendChild(menu);
-    await (item as any).updateComplete;
+    await (item as UiSidePanelMenuItem).updateComplete;
     menu.setAttribute("state", "collapsed");
     const row = item.shadowRoot!.querySelector(".row") as HTMLElement;
     row.click();
@@ -441,9 +442,9 @@ describe("ui-side-panel-menu", () => {
     item.appendChild(child);
     menu.appendChild(item);
     document.body.appendChild(menu);
-    await (item as any).updateComplete;
-    (menu as any).state = "collapsed";
-    await (menu as any).updateComplete;
+    await (item as UiSidePanelMenuItem).updateComplete;
+    (menu as UiSidePanelMenu).state = "collapsed";
+    await (menu as UiSidePanelMenu).updateComplete;
     const row = item.shadowRoot!.querySelector(".row") as HTMLElement;
     row.click();
     const flyout = menu.shadowRoot!.querySelector(".flyout");
@@ -462,9 +463,9 @@ describe("ui-side-panel-menu", () => {
     item.appendChild(child);
     menu.appendChild(item);
     document.body.appendChild(menu);
-    await (item as any).updateComplete;
-    (menu as any).state = "collapsed";
-    await (menu as any).updateComplete;
+    await (item as UiSidePanelMenuItem).updateComplete;
+    (menu as UiSidePanelMenu).state = "collapsed";
+    await (menu as UiSidePanelMenu).updateComplete;
     const row = item.shadowRoot!.querySelector(".row") as HTMLElement;
     row.click();
     expect(menu.shadowRoot!.querySelector(".flyout")!.hasAttribute("open")).toBe(true);
@@ -484,9 +485,9 @@ describe("ui-side-panel-menu", () => {
     item.appendChild(child);
     menu.appendChild(item);
     document.body.appendChild(menu);
-    await (item as any).updateComplete;
-    (menu as any).state = "collapsed";
-    await (menu as any).updateComplete;
+    await (item as UiSidePanelMenuItem).updateComplete;
+    (menu as UiSidePanelMenu).state = "collapsed";
+    await (menu as UiSidePanelMenu).updateComplete;
     const row = item.shadowRoot!.querySelector(".row") as HTMLElement;
     row.click();
     expect(menu.shadowRoot!.querySelector(".flyout")!.hasAttribute("open")).toBe(true);
@@ -506,14 +507,14 @@ describe("ui-side-panel-menu", () => {
     item.appendChild(child);
     menu.appendChild(item);
     document.body.appendChild(menu);
-    await (item as any).updateComplete;
-    (menu as any).state = "collapsed";
-    await (menu as any).updateComplete;
+    await (item as UiSidePanelMenuItem).updateComplete;
+    (menu as UiSidePanelMenu).state = "collapsed";
+    await (menu as UiSidePanelMenu).updateComplete;
     const row = item.shadowRoot!.querySelector(".row") as HTMLElement;
     row.click();
     expect(menu.shadowRoot!.querySelector(".flyout")!.hasAttribute("open")).toBe(true);
-    (menu as any).state = "expanded";
-    await (menu as any).updateComplete;
+    (menu as UiSidePanelMenu).state = "expanded";
+    await (menu as UiSidePanelMenu).updateComplete;
     expect(menu.shadowRoot!.querySelector(".flyout")!.hasAttribute("open")).toBe(false);
   });
   it("does not open flyout when expanded and expandable item is clicked", async () => {
@@ -529,10 +530,10 @@ describe("ui-side-panel-menu", () => {
     item.appendChild(child);
     menu.appendChild(item);
     document.body.appendChild(menu);
-    await (item as any).updateComplete;
+    await (item as UiSidePanelMenuItem).updateComplete;
     const row = item.shadowRoot!.querySelector(".row") as HTMLElement;
     row.click();
-    await (item as any).updateComplete;
+    await (item as UiSidePanelMenuItem).updateComplete;
     const flyout = menu.shadowRoot!.querySelector(".flyout");
     expect(flyout!.hasAttribute("open")).toBe(false);
     // But item should be expanded inline
@@ -552,68 +553,68 @@ describe("ui-side-panel-menu", () => {
     const menu = createMenu();
     expect(menu.getAttribute("state")).not.toBe("collapsed");
     menu.setAttribute("mobile", "");
-    await (menu as any).updateComplete;
+    await (menu as UiSidePanelMenu).updateComplete;
     expect(menu.getAttribute("state")).toBe("collapsed");
   });
 
   it("restores expanded state when mobile attribute is removed", async () => {
     const menu = createMenu();
     menu.setAttribute("mobile", "");
-    await (menu as any).updateComplete;
+    await (menu as UiSidePanelMenu).updateComplete;
     expect(menu.getAttribute("state")).toBe("collapsed");
     menu.removeAttribute("mobile");
-    await (menu as any).updateComplete;
+    await (menu as UiSidePanelMenu).updateComplete;
     expect(menu.getAttribute("state")).toBe("expanded");
     expect(menu.hasAttribute("overlay")).toBe(false);
   });
 
   it("sets overlay when toggling to expanded on mobile", async () => {
     const menu = createMenu();
-    (menu as any).mobile = true;
-    (menu as any).state = "collapsed";
-    await (menu as any).updateComplete;
+    (menu as UiSidePanelMenu).mobile = true;
+    (menu as UiSidePanelMenu).state = "collapsed";
+    await (menu as UiSidePanelMenu).updateComplete;
     expect(menu.getAttribute("state")).toBe("collapsed");
     // Click toggle to expand
     const toggleBtn = panelShadow(menu).querySelector(".header-toggle") as HTMLElement;
     const panel = menu.shadowRoot!.querySelector("ui-side-panel")!;
     toggleBtn.click();
-    await (panel as any).updateComplete;
-    await (menu as any).updateComplete;
+    await (panel as UiSidePanel).updateComplete;
+    await (menu as UiSidePanelMenu).updateComplete;
     expect(menu.getAttribute("state")).toBe("expanded");
     expect(menu.hasAttribute("overlay")).toBe(true);
   });
   it("removes overlay when toggling back to collapsed on mobile", async () => {
     const menu = createMenu();
-    (menu as any).mobile = true;
-    (menu as any).state = "collapsed";
-    await (menu as any).updateComplete;
+    (menu as UiSidePanelMenu).mobile = true;
+    (menu as UiSidePanelMenu).state = "collapsed";
+    await (menu as UiSidePanelMenu).updateComplete;
     const toggleBtn = panelShadow(menu).querySelector(".header-toggle") as HTMLElement;
     const panel = menu.shadowRoot!.querySelector("ui-side-panel")!;
     // Expand
     toggleBtn.click();
-    await (panel as any).updateComplete;
-    await (menu as any).updateComplete;
+    await (panel as UiSidePanel).updateComplete;
+    await (menu as UiSidePanelMenu).updateComplete;
     expect(menu.hasAttribute("overlay")).toBe(true);
     // Collapse again
     toggleBtn.click();
-    await (panel as any).updateComplete;
-    await (menu as any).updateComplete;
+    await (panel as UiSidePanel).updateComplete;
+    await (menu as UiSidePanelMenu).updateComplete;
     expect(menu.getAttribute("state")).toBe("collapsed");
     expect(menu.hasAttribute("overlay")).toBe(false);
   });
   it("clears overlay when leaving mobile after expanded toggle", async () => {
     const menu = createMenu();
-    (menu as any).mobile = true;
-    (menu as any).state = "collapsed";
-    await (menu as any).updateComplete;
+    (menu as UiSidePanelMenu).mobile = true;
+    (menu as UiSidePanelMenu).state = "collapsed";
+    await (menu as UiSidePanelMenu).updateComplete;
     const toggleBtn = panelShadow(menu).querySelector(".header-toggle") as HTMLElement;
     const panel = menu.shadowRoot!.querySelector("ui-side-panel")!;
     toggleBtn.click(); // expand on mobile
-    await (panel as any).updateComplete;
-    await (menu as any).updateComplete;
+    await (panel as UiSidePanel).updateComplete;
+    await (menu as UiSidePanelMenu).updateComplete;
     expect(menu.hasAttribute("overlay")).toBe(true);
     menu.removeAttribute("mobile");
-    await (menu as any).updateComplete;
+    await (menu as UiSidePanelMenu).updateComplete;
     expect(menu.getAttribute("state")).toBe("expanded");
   });
 });

--- a/packages/ui-components/src/components/ui-side-panel.test.ts
+++ b/packages/ui-components/src/components/ui-side-panel.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import "./ui-side-panel.js";
+import { UiSidePanel } from "./ui-side-panel.js";
 import type { SidePanelState } from "./ui-side-panel.js";
 import { STYLES } from "./ui-side-panel.styles.js";
 import { ICON_CHEVRON_LEFT, ICON_CHEVRON_RIGHT } from "@maneki/foundation";
@@ -107,31 +108,31 @@ describe("ui-side-panel", () => {
   // ── Property accessors ────────────────────────────────────────────────────
 
   it("state getter returns current state", () => {
-    const panel = el as any;
+    const panel = el as UiSidePanel;
     expect(panel.state).toBe("expanded");
   });
 
   it("state setter updates attribute", async () => {
-    const panel = el as any;
+    const panel = el as UiSidePanel;
     panel.state = "collapsed";
     await panel.updateComplete;
     expect(el.getAttribute("state")).toBe("collapsed");
   });
 
   it("overlay getter returns false by default", () => {
-    const panel = el as any;
+    const panel = el as UiSidePanel;
     expect(panel.overlay).toBe(false);
   });
 
   it("overlay setter adds attribute when true", async () => {
-    const panel = el as any;
+    const panel = el as UiSidePanel;
     panel.overlay = true;
     await panel.updateComplete;
     expect(el.hasAttribute("overlay")).toBe(true);
   });
 
   it("overlay setter removes attribute when false", () => {
-    const panel = el as any;
+    const panel = el as UiSidePanel;
     panel.overlay = true;
     panel.overlay = false;
     expect(el.hasAttribute("overlay")).toBe(false);
@@ -139,12 +140,12 @@ describe("ui-side-panel", () => {
 
 
   it("mobile getter returns false by default on desktop", () => {
-    const panel = el as any;
+    const panel = el as UiSidePanel;
     expect(panel.mobile).toBe(false);
   });
 
   it("mobile is settable", async () => {
-    const panel = el as any;
+    const panel = el as UiSidePanel;
     // mobile is now a Lit @property (no longer read-only)
     expect(panel.mobile).toBe(false);
     panel.mobile = true;
@@ -155,13 +156,13 @@ describe("ui-side-panel", () => {
   // ── Toggle ────────────────────────────────────────────────────────────────
 
   it("toggle() switches from expanded to collapsed", () => {
-    const panel = el as any;
+    const panel = el as UiSidePanel;
     panel.toggle();
     expect(panel.state).toBe("collapsed");
   });
 
   it("toggle() switches from collapsed to expanded", async () => {
-    const panel = el as any;
+    const panel = el as UiSidePanel;
     panel.state = "collapsed";
     await panel.updateComplete;
     panel.toggle();
@@ -171,7 +172,7 @@ describe("ui-side-panel", () => {
   it("toggle() dispatches toggle event with detail.state", () => {
     const handler = vi.fn();
     el.addEventListener("toggle", handler);
-    const panel = el as any;
+    const panel = el as UiSidePanel;
     panel.toggle();
     expect(handler).toHaveBeenCalledTimes(1);
     const event = handler.mock.calls[0][0] as CustomEvent;
@@ -181,7 +182,7 @@ describe("ui-side-panel", () => {
   it("toggle event bubbles and is composed", () => {
     const handler = vi.fn();
     el.addEventListener("toggle", handler);
-    const panel = el as any;
+    const panel = el as UiSidePanel;
     panel.toggle();
     const event = handler.mock.calls[0][0] as CustomEvent;
     expect(event.bubbles).toBe(true);
@@ -193,7 +194,7 @@ describe("ui-side-panel", () => {
       ".header-toggle",
     ) as HTMLButtonElement;
     toggleBtn.click();
-    await (el as any).updateComplete;
+    await (el as UiSidePanel).updateComplete;
     expect(el.getAttribute("state")).toBe("collapsed");
   });
 
@@ -211,7 +212,7 @@ describe("ui-side-panel", () => {
   });
 
   it("updates icon after toggle()", async () => {
-    const panel = el as any;
+    const panel = el as UiSidePanel;
     const iconBefore = el.shadowRoot!.querySelector(".material-symbols-outlined")!.textContent;
     panel.toggle();
     await panel.updateComplete;
@@ -250,7 +251,7 @@ describe("ui-side-panel", () => {
 
   it("toggle button has aria-label when collapsed", async () => {
     el.setAttribute("state", "collapsed");
-    await (el as any).updateComplete;
+    await (el as UiSidePanel).updateComplete;
     const toggleBtn = el.shadowRoot!.querySelector(".header-toggle");
     expect(toggleBtn!.getAttribute("aria-label")).toBe("Expand panel");
   });
@@ -265,18 +266,18 @@ describe("ui-side-panel", () => {
   // ── observedAttributes ────────────────────────────────────────────────────
 
   it("observedAttributes includes state", () => {
-    const Ctor = customElements.get("ui-side-panel") as any;
+    const Ctor = customElements.get("ui-side-panel") as typeof UiSidePanel;
     expect(Ctor.observedAttributes).toContain("state");
   });
 
   it("observedAttributes includes overlay", () => {
-    const Ctor = customElements.get("ui-side-panel") as any;
+    const Ctor = customElements.get("ui-side-panel") as typeof UiSidePanel;
     expect(Ctor.observedAttributes).toContain("overlay");
   });
 
 
   it("observedAttributes includes mobile", () => {
-    const Ctor = customElements.get("ui-side-panel") as any;
+    const Ctor = customElements.get("ui-side-panel") as typeof UiSidePanel;
     expect(Ctor.observedAttributes).toContain("mobile");
   });
 

--- a/packages/ui-components/src/components/ui-step-group.test.ts
+++ b/packages/ui-components/src/components/ui-step-group.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import "./ui-step-group.js";
 import "./ui-step-item.js";
+import { UiStepGroup } from "./ui-step-group.js";
 
 describe("ui-step-group", () => {
   let el: HTMLElement;
@@ -44,48 +45,48 @@ describe("ui-step-group", () => {
 
   it("size getter returns attribute value", () => {
     el.setAttribute("size", "s");
-    expect((el as any).size).toBe("s");
+    expect((el as UiStepGroup).size).toBe("s");
   });
 
   it("size setter updates attribute", () => {
-    (el as any).size = "s";
+    (el as UiStepGroup).size = "s";
     expect(el.getAttribute("size")).toBe("s");
   });
 
   it("orientation getter returns attribute value", () => {
     el.setAttribute("orientation", "vertical");
-    expect((el as any).orientation).toBe("vertical");
+    expect((el as UiStepGroup).orientation).toBe("vertical");
   });
 
   it("orientation setter updates attribute", () => {
-    (el as any).orientation = "vertical";
+    (el as UiStepGroup).orientation = "vertical";
     expect(el.getAttribute("orientation")).toBe("vertical");
   });
 
   it("currentStep getter returns parsed number", () => {
     el.setAttribute("current-step", "3");
-    expect((el as any).currentStep).toBe(3);
+    expect((el as UiStepGroup).currentStep).toBe(3);
   });
 
   it("currentStep setter updates attribute", () => {
-    (el as any).currentStep = 5;
+    (el as UiStepGroup).currentStep = 5;
     expect(el.getAttribute("current-step")).toBe("5");
   });
 
   it("currentStep defaults to 0 when not set", () => {
-    expect((el as any).currentStep).toBe(0);
+    expect((el as UiStepGroup).currentStep).toBe(0);
   });
 
   it("labels getter returns boolean", () => {
-    expect((el as any).labels).toBe(false);
+    expect((el as UiStepGroup).labels).toBe(false);
     el.setAttribute("labels", "");
-    expect((el as any).labels).toBe(true);
+    expect((el as UiStepGroup).labels).toBe(true);
   });
 
   it("labels setter toggles attribute", () => {
-    (el as any).labels = true;
+    (el as UiStepGroup).labels = true;
     expect(el.hasAttribute("labels")).toBe(true);
-    (el as any).labels = false;
+    (el as UiStepGroup).labels = false;
     expect(el.hasAttribute("labels")).toBe(false);
   });
 
@@ -199,7 +200,7 @@ describe("ui-step-group", () => {
   // ── observedAttributes ────────────────────────────────────────────────────
 
   it("has correct observedAttributes list", () => {
-    const Ctor = customElements.get("ui-step-group") as any;
+    const Ctor = customElements.get("ui-step-group") as typeof UiStepGroup;
     expect(Ctor.observedAttributes).toEqual(["size", "orientation", "current-step", "labels"]);
   });
 });

--- a/packages/ui-components/src/components/ui-step-item.test.ts
+++ b/packages/ui-components/src/components/ui-step-item.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import "./ui-step-item.js";
+import { UiStepItem } from "./ui-step-item.js";
 import type { StepSize, StepStatus, StepOrientation } from "./ui-step-item.styles.js";
 import { STEP_ITEM_STYLES } from "./ui-step-item.styles.js";
 
@@ -138,51 +139,51 @@ describe("ui-step-item", () => {
 
   it("size property getter returns attribute value", () => {
     el.setAttribute("size", "s");
-    expect((el as any).size).toBe("s");
+    expect((el as UiStepItem).size).toBe("s");
   });
 
   it("size property setter updates attribute", () => {
-    (el as any).size = "s";
+    (el as UiStepItem).size = "s";
     expect(el.getAttribute("size")).toBe("s");
   });
 
   it("status property getter returns attribute value", () => {
     el.setAttribute("status", "active");
-    expect((el as any).status).toBe("active");
+    expect((el as UiStepItem).status).toBe("active");
   });
 
   it("status property setter updates attribute", () => {
-    (el as any).status = "error";
+    (el as UiStepItem).status = "error";
     expect(el.getAttribute("status")).toBe("error");
   });
 
   it("orientation property getter returns attribute value", () => {
     el.setAttribute("orientation", "vertical");
-    expect((el as any).orientation).toBe("vertical");
+    expect((el as UiStepItem).orientation).toBe("vertical");
   });
 
   it("orientation property setter updates attribute", () => {
-    (el as any).orientation = "vertical";
+    (el as UiStepItem).orientation = "vertical";
     expect(el.getAttribute("orientation")).toBe("vertical");
   });
 
   it("label property getter returns attribute value", () => {
     el.setAttribute("label", "Hello");
-    expect((el as any).label).toBe("Hello");
+    expect((el as UiStepItem).label).toBe("Hello");
   });
 
   it("label property setter updates attribute", () => {
-    (el as any).label = "World";
+    (el as UiStepItem).label = "World";
     expect(el.getAttribute("label")).toBe("World");
   });
 
   it("sublabel property getter returns attribute value", () => {
     el.setAttribute("sublabel", "Sub");
-    expect((el as any).sublabel).toBe("Sub");
+    expect((el as UiStepItem).sublabel).toBe("Sub");
   });
 
   it("sublabel property setter updates attribute", () => {
-    (el as any).sublabel = "Info";
+    (el as UiStepItem).sublabel = "Info";
     expect(el.getAttribute("sublabel")).toBe("Info");
   });
 
@@ -311,7 +312,7 @@ describe("ui-step-item", () => {
   // ── observedAttributes ────────────────────────────────────────────────────
 
   it("has correct observedAttributes list", () => {
-    const Ctor = customElements.get("ui-step-item") as any;
+    const Ctor = customElements.get("ui-step-item") as typeof UiStepItem;
     expect(Ctor.observedAttributes).toEqual([
       "size",
       "status",

--- a/packages/ui-components/src/components/ui-switch.test.ts
+++ b/packages/ui-components/src/components/ui-switch.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import "./ui-switch.js";
 import "./ui-label.js";
+import { UiSwitch, type SwitchSize, type SwitchLabelPosition } from "./ui-switch.js";
 
 describe("ui-switch", () => {
   let el: HTMLElement;
@@ -160,50 +161,50 @@ describe("ui-switch", () => {
 
   it("size getter returns current size", () => {
     el.setAttribute("size", "l");
-    expect((el as any).size).toBe("l");
+    expect((el as UiSwitch).size).toBe("l");
   });
 
   it("size setter updates attribute", () => {
-    (el as any).size = "s";
+    (el as UiSwitch).size = "s";
     expect(el.getAttribute("size")).toBe("s");
   });
 
   it("checked getter returns false by default", () => {
-    expect((el as any).checked).toBe(false);
+    expect((el as UiSwitch).checked).toBe(false);
   });
 
   it("checked setter adds attribute when true", () => {
-    (el as any).checked = true;
+    (el as UiSwitch).checked = true;
     expect(el.hasAttribute("checked")).toBe(true);
   });
 
   it("checked setter removes attribute when false", () => {
-    (el as any).checked = true;
-    (el as any).checked = false;
+    (el as UiSwitch).checked = true;
+    (el as UiSwitch).checked = false;
     expect(el.hasAttribute("checked")).toBe(false);
   });
 
   it("disabled getter returns false by default", () => {
-    expect((el as any).disabled).toBe(false);
+    expect((el as UiSwitch).disabled).toBe(false);
   });
 
   it("disabled setter adds attribute when true", () => {
-    (el as any).disabled = true;
+    (el as UiSwitch).disabled = true;
     expect(el.hasAttribute("disabled")).toBe(true);
   });
 
   it("disabled setter removes attribute when false", () => {
-    (el as any).disabled = true;
-    (el as any).disabled = false;
+    (el as UiSwitch).disabled = true;
+    (el as UiSwitch).disabled = false;
     expect(el.hasAttribute("disabled")).toBe(false);
   });
 
   it("labelPosition getter returns none by default", () => {
-    expect((el as any).labelPosition).toBe("none");
+    expect((el as UiSwitch).labelPosition).toBe("none");
   });
 
   it("labelPosition setter updates attribute", () => {
-    (el as any).labelPosition = "right";
+    (el as UiSwitch).labelPosition = "right";
     expect(el.getAttribute("label-position")).toBe("right");
   });
 
@@ -343,22 +344,22 @@ describe("ui-switch", () => {
   // ── observedAttributes ────────────────────────────────────────────────────
 
   it("observedAttributes includes size", () => {
-    const observed = (customElements.get("ui-switch") as any).observedAttributes;
+    const observed = (customElements.get("ui-switch") as typeof UiSwitch).observedAttributes;
     expect(observed).toContain("size");
   });
 
   it("observedAttributes includes checked", () => {
-    const observed = (customElements.get("ui-switch") as any).observedAttributes;
+    const observed = (customElements.get("ui-switch") as typeof UiSwitch).observedAttributes;
     expect(observed).toContain("checked");
   });
 
   it("observedAttributes includes disabled", () => {
-    const observed = (customElements.get("ui-switch") as any).observedAttributes;
+    const observed = (customElements.get("ui-switch") as typeof UiSwitch).observedAttributes;
     expect(observed).toContain("disabled");
   });
 
   it("observedAttributes includes label-position", () => {
-    const observed = (customElements.get("ui-switch") as any).observedAttributes;
+    const observed = (customElements.get("ui-switch") as typeof UiSwitch).observedAttributes;
     expect(observed).toContain("label-position");
   });
 });

--- a/packages/ui-components/src/components/ui-tree-group.test.ts
+++ b/packages/ui-components/src/components/ui-tree-group.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import "./ui-tree-group.js";
 import "./ui-tree-item.js";
+import { UiTreeGroup } from "./ui-tree-group.js";
 
 describe("ui-tree-group", () => {
   let el: HTMLElement;
@@ -74,16 +75,16 @@ describe("ui-tree-group", () => {
 
   it("size getter returns attribute value", () => {
     el.setAttribute("size", "l");
-    expect((el as any).size).toBe("l");
+    expect((el as UiTreeGroup).size).toBe("l");
   });
 
   it("size setter updates attribute", () => {
-    (el as any).size = "s";
+    (el as UiTreeGroup).size = "s";
     expect(el.getAttribute("size")).toBe("s");
   });
 
   it("size getter defaults to m when no attribute", () => {
-    expect((el as any).size).toBe("m");
+    expect((el as UiTreeGroup).size).toBe("m");
   });
 
   // ── Size propagation ──────────────────────────────────────────────────────
@@ -115,7 +116,7 @@ describe("ui-tree-group", () => {
   // ── observedAttributes ────────────────────────────────────────────────────
 
   it("observes the correct attributes", () => {
-    const observed = (customElements.get("ui-tree-group") as any).observedAttributes;
+    const observed = (customElements.get("ui-tree-group") as typeof UiTreeGroup).observedAttributes;
     expect(observed).toEqual(["size", "searchable"]);
   });
 });

--- a/packages/ui-components/src/components/ui-tree-item.test.ts
+++ b/packages/ui-components/src/components/ui-tree-item.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import "./ui-tree-item.js";
+import { UiTreeItem } from "./ui-tree-item.js";
 import type { TreeItemSize, TreeItemLevel, TreeItemArrow } from "./ui-tree-item.styles.js";
 import { TREE_ITEM_STYLES } from "./ui-tree-item.styles.js";
 import { ICON_CHEVRON_RIGHT, ICON_EXPAND_MORE } from "@maneki/foundation";
@@ -156,74 +157,74 @@ describe("ui-tree-item", () => {
 
   it("size getter returns attribute value", () => {
     el.setAttribute("size", "l");
-    expect((el as any).size).toBe("l");
+    expect((el as UiTreeItem).size).toBe("l");
   });
 
   it("size setter updates attribute", () => {
-    (el as any).size = "s";
+    (el as UiTreeItem).size = "s";
     expect(el.getAttribute("size")).toBe("s");
   });
 
   it("level getter returns attribute value", () => {
     el.setAttribute("level", "child-2");
-    expect((el as any).level).toBe("child-2");
+    expect((el as UiTreeItem).level).toBe("child-2");
   });
 
   it("level setter updates attribute", () => {
-    (el as any).level = "child-1";
+    (el as UiTreeItem).level = "child-1";
     expect(el.getAttribute("level")).toBe("child-1");
   });
 
   it("arrow getter returns attribute value", () => {
     el.setAttribute("arrow", "open");
-    expect((el as any).arrow).toBe("open");
+    expect((el as UiTreeItem).arrow).toBe("open");
   });
 
   it("arrow setter updates attribute", () => {
-    (el as any).arrow = "closed";
+    (el as UiTreeItem).arrow = "closed";
     expect(el.getAttribute("arrow")).toBe("closed");
   });
 
   it("selected getter returns boolean", () => {
-    expect((el as any).selected).toBe(false);
+    expect((el as UiTreeItem).selected).toBe(false);
     el.setAttribute("selected", "");
-    expect((el as any).selected).toBe(true);
+    expect((el as UiTreeItem).selected).toBe(true);
   });
 
   it("selected setter adds/removes attribute", () => {
-    (el as any).selected = true;
+    (el as UiTreeItem).selected = true;
     expect(el.hasAttribute("selected")).toBe(true);
-    (el as any).selected = false;
+    (el as UiTreeItem).selected = false;
     expect(el.hasAttribute("selected")).toBe(false);
   });
 
   it("label getter returns attribute value", () => {
     el.setAttribute("label", "Foo");
-    expect((el as any).label).toBe("Foo");
+    expect((el as UiTreeItem).label).toBe("Foo");
   });
 
   it("label setter updates attribute", () => {
-    (el as any).label = "Bar";
+    (el as UiTreeItem).label = "Bar";
     expect(el.getAttribute("label")).toBe("Bar");
   });
 
   it("secondaryLabelText getter returns attribute value", () => {
     el.setAttribute("secondary-label", "sub");
-    expect((el as any).secondaryLabelText).toBe("sub");
+    expect((el as UiTreeItem).secondaryLabelText).toBe("sub");
   });
 
   it("secondaryLabelText setter updates attribute", () => {
-    (el as any).secondaryLabelText = "info";
+    (el as UiTreeItem).secondaryLabelText = "info";
     expect(el.getAttribute("secondary-label")).toBe("info");
   });
 
   it("iconName getter returns attribute value", () => {
     el.setAttribute("icon-name", "home");
-    expect((el as any).iconName).toBe("home");
+    expect((el as UiTreeItem).iconName).toBe("home");
   });
 
   it("iconName setter updates attribute", () => {
-    (el as any).iconName = "settings";
+    (el as UiTreeItem).iconName = "settings";
     expect(el.getAttribute("icon-name")).toBe("settings");
   });
 
@@ -366,7 +367,7 @@ describe("ui-tree-item", () => {
   // ── observedAttributes ────────────────────────────────────────────────────
 
   it("observes the correct attributes", () => {
-    const observed = (customElements.get("ui-tree-item") as any).observedAttributes;
+    const observed = (customElements.get("ui-tree-item") as typeof UiTreeItem).observedAttributes;
     expect(observed).toEqual([
       "size",
       "level",


### PR DESCRIPTION
## Summary

Closes #383

Replaced all ~500 `as any` casts across 20 test files in `packages/ui-components` with proper typed casts. This was the single largest type safety gap in the codebase — test assertions were completely untyped, meaning renamed/removed properties would silently pass as `undefined`.

### Approach

Each test file now imports the component class and casts `el` to the proper type instead of `any`:

```ts
// Before
(el as any).size = "s";
expect((el as any).open).toBe(false);

// After  
(el as UiDropdown).size = "s";
expect((el as UiDropdown).open).toBe(false);
```

For files with many casts in a single describe block, the `let el` declaration was retyped directly:
```ts
let el: UiDropdownSplit;  // was: let el: HTMLElement;
```

### Files changed (20 test files)

- `ui-side-panel.test.ts` — 21 casts → `UiSidePanel`
- `ui-side-panel-menu.test.ts` — 65 casts → `UiSidePanelMenu` / `UiSidePanelMenuItem` / `UiSidePanel`
- `ui-side-panel-menu-item.test.ts` — 50 casts → `UiSidePanelMenuItem`
- `ui-dropdown.test.ts` — 90 casts → `UiDropdown` / `UiDropdownItem` / `UiDropdownHeading`
- `ui-dropdown-split.test.ts` — 80 casts → `UiDropdownSplit`
- `ui-menu.test.ts` — 40 casts → `UiMenu`
- `ui-select.test.ts` — 60 casts → `UiSelect`
- `ui-checkbox-group.test.ts` — 8 casts → `UiCheckboxGroup`
- `ui-radio-group.test.ts` — 8 casts → `UiRadioGroup`
- `ui-accordion-group.test.ts` — 18 casts → `UiAccordionGroup`
- `ui-switch.test.ts` — 15 casts → `UiSwitch`
- `ui-step-group.test.ts` — 12 casts → `UiStepGroup`
- `ui-step-item.test.ts` — 11 casts → `UiStepItem`
- `ui-tree-group.test.ts` — 4 casts → `UiTreeGroup`
- `ui-tree-item.test.ts` — 17 casts → `UiTreeItem`
- `ui-scrollbar.test.ts` — 9 casts → `UiScrollbar`
- `ui-pagination.test.ts` — 30 casts → `UiPagination`
- `ui-pull-to-refresh.test.ts` — 15 casts → `UiPullToRefresh`
- `ui-calendar.test.ts` — 7 casts → `UiCalendar`
- `ui-calendar-panel.test.ts` — 1 cast → `UiCalendarPanel`

### Verification

- `tsc --noEmit` passes clean
- All 3632 tests pass
- Zero `as any` remaining in test files