### PR TITLE
fix(editor): stop cursor jumping to end of textarea on keystroke

### DIFF
--- a/apps/blog/src/pages/editor/editor-page.ts
+++ b/apps/blog/src/pages/editor/editor-page.ts
@@ -314,7 +314,7 @@ export class EditorPage extends LitElement {
             </ui-toolbar>
             <div class="admin-split">
               <ui-scrollbar ${ref(this._textareaWrapRef)} emphasis="minimal" class="admin-textarea-wrap">
-                <textarea id="admin-content" ${ref(this._textareaRef)} placeholder="Write your post in Markdown..." spellcheck="false" .value=${this.postContent} @input=${this._onContentInput} @keydown=${this._onTextareaKeydown} @dragover=${this._onTextareaDragover} @dragleave=${this._onTextareaDragleave} @drop=${this._onTextareaDrop} @paste=${this._onTextareaPaste}></textarea>
+                <textarea id="admin-content" ${ref(this._textareaRef)} placeholder="Write your post in Markdown..." spellcheck="false" @input=${this._onContentInput} @keydown=${this._onTextareaKeydown} @dragover=${this._onTextareaDragover} @dragleave=${this._onTextareaDragleave} @drop=${this._onTextareaDrop} @paste=${this._onTextareaPaste}></textarea>
                 <div class="admin-textarea-spacer"></div>
               </ui-scrollbar>
               <ui-scrollbar ${ref(this._previewWrapRef)} emphasis="minimal"><div id="admin-preview" ${ref(this._previewRef)} class="admin-preview"></div></ui-scrollbar>
@@ -803,6 +803,8 @@ export class EditorPage extends LitElement {
     this.postTags = post.tags.split(",").map(t => t.trim()).filter(Boolean);
     this.postExcerpt = post.excerpt;
     this.postContent = post.content;
+    const ta = this._textareaRef.value;
+    if (ta) ta.value = post.content;
     renderPreview(this.shadowRoot!, this._previewRef.value);
   }
 
@@ -823,6 +825,8 @@ export class EditorPage extends LitElement {
     this.postTags = [];
     this.postExcerpt = "";
     this.postContent = "";
+    const ta = this._textareaRef.value;
+    if (ta) ta.value = "";
     renderPreview(this.shadowRoot!, this._previewRef.value);
   }
 
@@ -835,6 +839,8 @@ export class EditorPage extends LitElement {
     this.projectImage = project.image;
     this.projectPinned = project.pinned;
     this.postContent = project.content;
+    const ta = this._textareaRef.value;
+    if (ta) ta.value = project.content;
     renderPreview(this.shadowRoot!, this._previewRef.value);
   }
 
@@ -880,6 +886,8 @@ export class EditorPage extends LitElement {
     this.projectImage = "";
     this.projectPinned = false;
     this.postContent = "";
+    const ta = this._textareaRef.value;
+    if (ta) ta.value = "";
   }
 
   // ─── Event handlers ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #399

Fixes the cursor jumping to the end of the textarea when typing in the post/project editor.

## Root Cause

The content textarea used Lit's `.value` property binding:

```html
<textarea .value=${this.postContent} @input=${this._onContentInput}>
```

Every keystroke triggered: input → `this.postContent = textarea.value` (reactive state update) → Lit re-render → `.value` set on DOM → cursor reset to end.

## Fix

- Removed `.value=${this.postContent}` binding from the content textarea
- The textarea now owns its own value — Lit doesn't write back to it on re-render
- `postContent` is still kept in sync via `_onContentInput` for auto-save and preview
- `loadPost()`, `loadProject()`, `clearPost()`, `clearProject()` now imperatively set `textarea.value` when loading/clearing content

This is the standard fix for the Lit + textarea cursor jump problem. The other form fields (title, date, excerpt, etc.) use `<ui-input>` / `<ui-textarea>` components which handle this internally, so they're not affected.