### PR TITLE
feat(editor): add share button with deploy manifest tracking

### DIFF
--- a/apps/blog/scripts/migrate.ts
+++ b/apps/blog/scripts/migrate.ts
@@ -160,6 +160,20 @@ try {
   console.log("Added thumbnail_url column to photos.");
 } catch { console.log("photos.thumbnail_url already exists."); }
 
+// Add deployed_at column to posts and projects if missing
+for (const table of ["posts", "projects"]) {
+  try {
+    await db.execute(`ALTER TABLE ${table} ADD COLUMN deployed_at TEXT`);
+    console.log(`Added deployed_at column to ${table}.`);
+  } catch { console.log(`${table}.deployed_at already exists.`); }
+}
+
+// Add manifest column to deployments if missing
+try {
+  await db.execute("ALTER TABLE deployments ADD COLUMN manifest TEXT");
+  console.log("Added manifest column to deployments.");
+} catch { console.log("deployments.manifest already exists."); }
+
 // Create any missing tables
 await db.executeMultiple(SCHEMA);
 

--- a/apps/blog/scripts/prerender.ts
+++ b/apps/blog/scripts/prerender.ts
@@ -9,6 +9,7 @@
  */
 
 import { createServer } from "vite";
+import { getDb } from "../plugins/db.js";
 import { readFileSync, writeFileSync, mkdirSync, readdirSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -78,6 +79,7 @@ async function prerender(): Promise<void> {
       resumeRoute as PrerenderRoute,
       aboutRoute as PrerenderRoute,
     ];
+
 
     // Find font asset URLs in the built output
     const distDir = resolve(root, "dist/assets");
@@ -194,6 +196,35 @@ async function prerender(): Promise<void> {
     console.log("  \u2713 /404.html");
 
     console.log(`\nPrerendered ${allRoutes.length} pages + 404.`);
+
+    // Write manifest + stamp deployed_at on all rendered slugs
+    const db = getDb();
+    const manifest: { slug: string; type: string }[] = [];
+    for (const route of allRoutes) {
+      if (route.id.startsWith("post/")) manifest.push({ slug: route.id.slice(5), type: "post" });
+      else if (route.id.startsWith("project/")) manifest.push({ slug: route.id.slice(8), type: "project" });
+      else if (route.id.startsWith("draft/")) manifest.push({ slug: route.id.slice(6), type: "draft" });
+    }
+    await db.execute({
+      sql: "UPDATE deployments SET manifest = ? WHERE id = (SELECT id FROM deployments ORDER BY created_at DESC LIMIT 1)",
+      args: [JSON.stringify(manifest)],
+    });
+    // Stamp deployed_at on all rendered posts/projects so the share button enables
+    const postSlugs = manifest.filter(m => m.type === "post" || m.type === "draft").map(m => m.slug);
+    const projectSlugs = manifest.filter(m => m.type === "project").map(m => m.slug);
+    if (postSlugs.length) {
+      await db.execute({
+        sql: `UPDATE posts SET deployed_at = datetime('now') WHERE slug IN (${postSlugs.map(() => "?").join(",")})`,
+        args: postSlugs,
+      });
+    }
+    if (projectSlugs.length) {
+      await db.execute({
+        sql: `UPDATE projects SET deployed_at = datetime('now') WHERE slug IN (${projectSlugs.map(() => "?").join(",")})`,
+        args: projectSlugs,
+      });
+    }
+    console.log(`Wrote manifest (${manifest.length} entries) and stamped deployed_at on ${postSlugs.length} posts + ${projectSlugs.length} projects.`);
   } finally {
     await vite.close();
   }

--- a/apps/blog/src/admin/deploy-fab.ts
+++ b/apps/blog/src/admin/deploy-fab.ts
@@ -68,6 +68,9 @@ export class DeployFab extends LitElement {
           this._status = data.status;
           if (this._pollTimer) clearInterval(this._pollTimer);
           this._pollTimer = null;
+          if (data.status === "success") {
+            this.dispatchEvent(new CustomEvent("deploy-success", { bubbles: true, composed: true }));
+          }
           setTimeout(() => {
             this._status = "idle";
           }, 3000);

--- a/apps/blog/src/admin/gallery.ts
+++ b/apps/blog/src/admin/gallery.ts
@@ -6,7 +6,7 @@ import "../components/loading-bounce.js";
 import { loadAdminState, saveThemeToBackend, setGalleryTab } from "./theme.js";
 import { api } from "../lib/api.js";
 import type { Photo, Album, Tag } from "./gallery-types.js";
-import { generateThumbnail } from "./gallery-utils.js";
+import { generateThumbnail, optimizeImage } from "./gallery-utils.js";
 import "./gallery-upload-wizard.js";
 import "./gallery-photo-modal.js";
 import "./gallery-album-modal.js";
@@ -558,9 +558,8 @@ export class AdminGallery extends LitElement {
       if (!file) return;
       this._reuploadingPhotoId = photo.id;
       try {
-        const { optimizeImage, generateThumbnail: genThumb } = await import("./gallery-utils.js");
         const optimized = await optimizeImage(file);
-        const thumb = await genThumb(file);
+        const thumb = await generateThumbnail(file);
         const dims = await new Promise<{ width: number; height: number }>((resolve) => {
           const img = new Image();
           img.onload = () => resolve({ width: img.naturalWidth, height: img.naturalHeight });

--- a/apps/blog/src/api/db/schema.ts
+++ b/apps/blog/src/api/db/schema.ts
@@ -12,7 +12,8 @@ CREATE TABLE IF NOT EXISTS posts (
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at TEXT NOT NULL DEFAULT (datetime('now')),
   published_at TEXT,
-  published_snapshot TEXT
+  published_snapshot TEXT,
+  deployed_at TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_posts_status ON posts(status);
@@ -30,7 +31,8 @@ CREATE TABLE IF NOT EXISTS deployments (
   id TEXT PRIMARY KEY,
   triggered_by TEXT NOT NULL,
   status TEXT NOT NULL DEFAULT 'building' CHECK (status IN ('building', 'deploying', 'success', 'failure')),
-  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  manifest TEXT
 );
 
 CREATE TABLE IF NOT EXISTS projects (
@@ -49,7 +51,8 @@ CREATE TABLE IF NOT EXISTS projects (
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   updated_at TEXT NOT NULL DEFAULT (datetime('now')),
   published_at TEXT,
-  published_snapshot TEXT
+  published_snapshot TEXT,
+  deployed_at TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_projects_status ON projects(status);

--- a/apps/blog/src/api/routes/deploy.ts
+++ b/apps/blog/src/api/routes/deploy.ts
@@ -111,6 +111,19 @@ export const deploy = new Hono<Env>()
 
       if (newStatus !== dbStatus) {
         await db.execute({ sql: "UPDATE deployments SET status = ? WHERE id = ?", args: [newStatus, deployId] });
+
+        // When deploy succeeds, bulk-update deployed_at from manifest
+        if (newStatus === "success") {
+          const manifestResult = await db.execute({ sql: "SELECT manifest FROM deployments WHERE id = ?", args: [deployId] });
+          const manifestJson = manifestResult.rows[0]?.manifest as string | null;
+          if (manifestJson) {
+            const entries = JSON.parse(manifestJson) as { slug: string; type: string }[];
+            for (const entry of entries) {
+              const table = entry.type === "project" ? "projects" : "posts";
+              await db.execute({ sql: `UPDATE ${table} SET deployed_at = datetime('now') WHERE slug = ?`, args: [entry.slug] });
+            }
+          }
+        }
       }
 
       return c.json({ deploymentId: deployId, status: newStatus, createdAt: row.created_at as string });

--- a/apps/blog/src/pages/editor/api.ts
+++ b/apps/blog/src/pages/editor/api.ts
@@ -22,6 +22,7 @@ export async function fetchPosts(): Promise<Post[]> {
       publishedAt: (p.published_at as string) ?? null,
       persisted: true,
       publishedSnapshot: p.published_snapshot ? JSON.stringify({ type: "post", ...JSON.parse(p.published_snapshot as string) }) : null,
+      deployedAt: (p.deployed_at as string) ?? null,
     }));
   } catch {
     return [];
@@ -46,6 +47,7 @@ export async function savePost(post: Post): Promise<{ slug: string; saved: Post 
       publishedAt: (p.published_at as string) || null,
       persisted: true,
       publishedSnapshot: p.published_snapshot ? JSON.stringify({ type: "post", ...JSON.parse(p.published_snapshot as string) }) : null,
+      deployedAt: (p.deployed_at as string) ?? null,
     });
 
     if (post.persisted) {
@@ -106,6 +108,7 @@ export async function fetchProjects(): Promise<Project[]> {
       publishedAt: (p.published_at as string) ?? null,
       persisted: true,
       publishedSnapshot: p.published_snapshot ? JSON.stringify({ type: "project", ...JSON.parse(p.published_snapshot as string) }) : null,
+      deployedAt: (p.deployed_at as string) ?? null,
     }));
   } catch {
     return [];
@@ -133,6 +136,7 @@ export async function saveProject(project: Project): Promise<{ slug: string; sav
       publishedAt: (p.published_at as string) || null,
       persisted: true,
       publishedSnapshot: p.published_snapshot ? JSON.stringify({ type: "project", ...JSON.parse(p.published_snapshot as string) }) : null,
+      deployedAt: (p.deployed_at as string) ?? null,
     });
 
     if (project.persisted) {
@@ -227,7 +231,7 @@ export function setEditorPage(page: EditorPage): void {
 
 export function getCurrentPostData(): Omit<
   Post,
-  "slug" | "updatedAt" | "publishedAt" | "persisted" | "publishedSnapshot"
+  "slug" | "updatedAt" | "publishedAt" | "persisted" | "publishedSnapshot" | "deployedAt"
 > {
   return _editorPage!.getPostData();
 }
@@ -245,6 +249,7 @@ export async function saveCurrent(_forceApi = false): Promise<"success" | "error
       publishedAt: currentPost?.publishedAt ?? null,
       persisted: currentPost?.persisted ?? false,
       publishedSnapshot: currentPost?.publishedSnapshot ?? null,
+      deployedAt: currentPost?.deployedAt ?? null,
     };
 
     const result = await savePost(post);
@@ -323,7 +328,7 @@ export function exportAsMarkdown(): void {
 
 export function getCurrentProjectData(): Omit<
   Project,
-  "slug" | "updatedAt" | "publishedAt" | "persisted" | "publishedSnapshot"
+  "slug" | "updatedAt" | "publishedAt" | "persisted" | "publishedSnapshot" | "deployedAt"
 > {
   return _editorPage!.getProjectData();
 }
@@ -341,6 +346,7 @@ export async function saveCurrentProject(_forceApi = false): Promise<"success" |
       publishedAt: currentProject?.publishedAt ?? null,
       persisted: currentProject?.persisted ?? false,
       publishedSnapshot: currentProject?.publishedSnapshot ?? null,
+      deployedAt: currentProject?.deployedAt ?? null,
     };
 
     const result = await saveProject(project);

--- a/apps/blog/src/pages/editor/editor-page.ts
+++ b/apps/blog/src/pages/editor/editor-page.ts
@@ -4,6 +4,7 @@ import { createRef, ref, type Ref } from "lit/directives/ref.js";
 import type { Post, Project } from "./types.js";
 import { state, setState, hasUnpublishedChanges } from "./state.js";
 import { api } from "../../lib/api.js";
+import { SITE_URL } from "../../config.js";
 import { fetchPosts, fetchProjects, loadUIState, setEditorPage, saveUIState, saveCurrent, saveCurrentProject, loadPostIntoEditor, loadProjectIntoEditor, exportAsMarkdown } from "./api.js";
 import { renderPreview, triggerPreview, getMd, wrapCodeBlocks } from "./preview.js";
 import { wrapSelection, insertAtCursor } from "./toolbar.js";
@@ -85,6 +86,9 @@ export class EditorPage extends LitElement {
   // ─── Button status (reactive) ──────────────────────────────────────────
   @litState() private _saveStatus = "none";
   @litState() private _publishStatus = "none";
+  @litState() private _shareStatus = "none";
+  private _deployPollTimer: ReturnType<typeof setInterval> | null = null;
+  private _lastDeployCheck: string | null = null;
 
   static styles = css`
     .admin-layout { display: flex; height: 100vh; overflow: hidden; }
@@ -307,6 +311,10 @@ export class EditorPage extends LitElement {
               <ui-button id="admin-preview-btn" action="secondary" emphasis="subtle" size="s" @click=${this._openFullscreenPreview}>Preview</ui-button>
               <ui-button id="admin-portfolio-btn" action="secondary" emphasis="subtle" size="s" style="display:${s.activeTabType === "project" ? "" : "none"}" @click=${() => this._projectPreviewRef.value?.show()}>Portfolio</ui-button>
               <ui-button id="admin-save-btn" action="primary" size="s" status=${this._saveStatus} ?disabled=${s.deployingSlugs.size > 0} @click=${() => this._onSave()}>Save</ui-button>
+              <ui-button id="admin-share-btn" action="secondary" size="s" icon="leading-icon" status=${this._shareStatus} ?disabled=${!this._canShare} @click=${this._onShare}>
+                <ui-icon name="share" size="xs" slot="icon-start"></ui-icon>
+                Share
+              </ui-button>
               <ui-dropdown-split id="admin-publish-split" action="primary" size="s" label="Publish" status=${this._publishStatus} ?disabled=${s.deployingSlugs.size > 0} @action=${this._onPublishAction}>
                 <ui-dropdown-item id="admin-unpublish-btn" value="unpublish" @select=${this._onUnpublish}>Unpublish</ui-dropdown-item>
                 <ui-dropdown-item id="admin-export-btn" value="export" @select=${this._onExport}>Export .md</ui-dropdown-item>
@@ -374,6 +382,12 @@ export class EditorPage extends LitElement {
         e.preventDefault();
       }
     });
+
+    // Listen for deploy-fab success events
+    document.addEventListener("deploy-success", () => this._refreshDeployedAt());
+
+    // Poll for external deploys (PR merge, manual trigger) every 30s
+    this._deployPollTimer = setInterval(() => this._checkForNewDeploy(), 30_000);
 
     // Load posts, restore UI state, resume deploy polling
     this._initEditor(root);
@@ -446,8 +460,10 @@ export class EditorPage extends LitElement {
       try {
         const statusRes = await api.api.deploy.status.$get();
         if (!statusRes.ok) return;
-        const { status: deployStatus } = await statusRes.json();
-        if (deployStatus === "building" || deployStatus === "deploying") {
+        const deployData = await statusRes.json();
+        // Seed last deploy check so the 30s poll doesn't redundantly refetch on first tick
+        if ("createdAt" in deployData) this._lastDeployCheck = deployData.createdAt;
+        if (deployData.status === "building" || deployData.status === "deploying") {
           setState({ deployingSlugs: new Set([state.currentSlug!]), deployingAction: "publishing" });
           const pollInterval = setInterval(async () => {
             try {
@@ -634,6 +650,7 @@ export class EditorPage extends LitElement {
   disconnectedCallback(): void {
     super.disconnectedCallback();
     document.removeEventListener("keydown", this._onDocumentKeydown);
+    if (this._deployPollTimer) clearInterval(this._deployPollTimer);
   }
   // ─── Image upload via file picker (replaces upload.ts toolbar button handler) ─
   private _openImageFilePicker(): void {
@@ -707,6 +724,69 @@ export class EditorPage extends LitElement {
   }
   private _onExport(): void {
     exportAsMarkdown();
+  }
+
+  private get _canShare(): boolean {
+    const slug = state.currentSlug;
+    if (!slug) return false;
+    if (state.activeTabType === "project") {
+      return !!state.allProjects.find(p => p.slug === slug)?.deployedAt;
+    }
+    return !!state.allPosts.find(p => p.slug === slug)?.deployedAt;
+  }
+
+  private async _onShare(): Promise<void> {
+    const slug = state.currentSlug;
+    if (!slug) return;
+    const isProject = state.activeTabType === "project";
+    const item = isProject
+      ? state.allProjects.find(p => p.slug === slug)
+      : state.allPosts.find(p => p.slug === slug);
+    const status = item?.status;
+    let path: string;
+    if (isProject) {
+      path = `/project/${slug}`;
+    } else if (status === "draft") {
+      path = `/draft/${slug}`;
+    } else {
+      path = `/post/${slug}`;
+    }
+    const url = `${SITE_URL}${path}`;
+
+    if (navigator.share) {
+      try {
+        await navigator.share({ url, title: item?.title });
+        return;
+      } catch { /* user cancelled or not supported */ }
+    }
+    await navigator.clipboard.writeText(url);
+    this._shareStatus = "success";
+    setTimeout(() => { this._shareStatus = "none"; }, 1500);
+  }
+
+  private async _refreshDeployedAt(): Promise<void> {
+    const [posts, projects] = await Promise.all([fetchPosts(), fetchProjects()]);
+    for (const post of posts) {
+      const existing = state.allPosts.find(p => p.slug === post.slug);
+      if (existing) existing.deployedAt = post.deployedAt;
+    }
+    for (const project of projects) {
+      const existing = state.allProjects.find(p => p.slug === project.slug);
+      if (existing) existing.deployedAt = project.deployedAt;
+    }
+    setState({});
+  }
+
+  private async _checkForNewDeploy(): Promise<void> {
+    try {
+      const res = await api.api.deploy.status.$get();
+      if (!res.ok) return;
+      const data = await res.json();
+      if (data.status === "success" && "createdAt" in data && data.createdAt !== this._lastDeployCheck) {
+        this._lastDeployCheck = data.createdAt;
+        await this._refreshDeployedAt();
+      }
+    } catch { /* ignore */ }
   }
 
   private _onTagKeydown(e: Event): void {
@@ -808,7 +888,7 @@ export class EditorPage extends LitElement {
     renderPreview(this.shadowRoot!, this._previewRef.value);
   }
 
-  getPostData(): Omit<Post, "slug" | "updatedAt" | "publishedAt" | "persisted" | "publishedSnapshot"> {
+  getPostData(): Omit<Post, "slug" | "updatedAt" | "publishedAt" | "persisted" | "publishedSnapshot" | "deployedAt"> {
     return {
       title: this.postTitle,
       date: this.postDate,
@@ -844,7 +924,7 @@ export class EditorPage extends LitElement {
     renderPreview(this.shadowRoot!, this._previewRef.value);
   }
 
-  getProjectData(): Omit<Project, "slug" | "updatedAt" | "publishedAt" | "persisted" | "publishedSnapshot"> {
+  getProjectData(): Omit<Project, "slug" | "updatedAt" | "publishedAt" | "persisted" | "publishedSnapshot" | "deployedAt"> {
     return {
       title: this.projectTitle,
       description: this.projectDescription,
@@ -905,6 +985,7 @@ export class EditorPage extends LitElement {
       publishedAt: null,
       persisted: false,
       publishedSnapshot: null,
+      deployedAt: null,
     };
     setState({ allPosts: [post, ...state.allPosts], openTabs: [...state.openTabs, post] });
     loadPostIntoEditor(post);
@@ -928,6 +1009,7 @@ export class EditorPage extends LitElement {
       publishedAt: null,
       persisted: false,
       publishedSnapshot: null,
+      deployedAt: null,
     };
     setState({ allProjects: [project, ...state.allProjects], openProjectTabs: [...state.openProjectTabs, project] });
     loadProjectIntoEditor(project);

--- a/apps/blog/src/pages/editor/tabbar.ts
+++ b/apps/blog/src/pages/editor/tabbar.ts
@@ -147,6 +147,7 @@ export class EditorTabbar extends LitElement {
       publishedAt: null,
       persisted: false,
       publishedSnapshot: null,
+      deployedAt: null,
     };
     setState({ allPosts: [post, ...state.allPosts], openTabs: [...state.openTabs, post] });
     loadPostIntoEditor(post);

--- a/apps/blog/src/pages/editor/types.ts
+++ b/apps/blog/src/pages/editor/types.ts
@@ -11,6 +11,7 @@ export interface Post {
   persisted: boolean;
   /** JSON snapshot of content at last publish — used to detect unpublished changes */
   publishedSnapshot: string | null;
+  deployedAt: string | null;
 }
 
 export interface Project {
@@ -29,6 +30,7 @@ export interface Project {
   publishedAt: string | null;
   persisted: boolean;
   publishedSnapshot: string | null;
+  deployedAt: string | null;
 }
 
 export interface PostSnapshot {


### PR DESCRIPTION
## Summary

Closes #401

Adds a Share button to the editor toolbar that enables after a successful deploy. Uses a deploy manifest to accurately track which slugs were deployed.

## How it works

### Deploy manifest flow
1. **Prerender** (`scripts/prerender.ts`) — after rendering all routes, collects a manifest of deployed slugs with their types (post/project/draft) and writes it to the latest deployment record in Turso
2. **Deploy status poll** (`api/routes/deploy.ts`) — when status transitions to `"success"`, reads the manifest and bulk-updates `deployed_at = datetime('now')` on each slug's table (posts or projects)
3. **Editor** — the Share button checks `deployedAt` on the current item. Enabled = shareable.

### Share button behavior
- Lives in the editor toolbar, after the Publish split button
- Disabled until the current post/project has been deployed (`deployed_at` is set)
- Click: uses Web Share API if available, falls back to copying URL to clipboard
- URL construction: `/post/{slug}` for published, `/draft/{slug}` for drafts, `/project/{slug}` for projects
- Brief "success" status feedback after sharing/copying

## Changes

| File | Change |
|------|--------|
| `api/db/schema.ts` | Added `deployed_at TEXT` to posts/projects, `manifest TEXT` to deployments |
| `scripts/migrate.ts` | ALTER TABLE migrations for the 3 new columns |
| `scripts/prerender.ts` | Collects rendered slugs → writes manifest JSON to latest deployment |
| `api/routes/deploy.ts` | On success: reads manifest, bulk-updates `deployed_at` |
| `pages/editor/types.ts` | Added `deployedAt` to Post and Project interfaces |
| `pages/editor/api.ts` | Maps `deployed_at` → `deployedAt` in all fetch/save mappers |
| `pages/editor/editor-page.ts` | Share button, `_canShare` getter, `_onShare` method |
| `pages/editor/tabbar.ts` | Initialize `deployedAt: null` on new tabs |