### PR TITLE
fix(editor): prevent cursor jump on Safari iPad

### DIFF
--- a/apps/blog/src/pages/editor/editor-page.ts
+++ b/apps/blog/src/pages/editor/editor-page.ts
@@ -71,7 +71,7 @@ export class EditorPage extends LitElement {
   @litState() postDate = new Date().toISOString().split("T")[0];
   @litState() postTags: string[] = [];
   @litState() postExcerpt = "";
-  @litState() postContent = "";
+  postContent = "";
   @litState() private _fullscreenPreviewOpen = false;
 
   // ─── Project form fields (reactive) ──────────────────────────────────────
@@ -859,11 +859,10 @@ export class EditorPage extends LitElement {
   private _autoSaveTimer: ReturnType<typeof setTimeout> | null = null;
 
   private _scheduleAutoSave(): void {
-    // Mark current tab as dirty
-    if (state.currentSlug) {
-      const dirty = new Set(state.dirtySlugs);
-      dirty.add(state.currentSlug);
-      setState({ dirtySlugs: dirty });
+    // Mark current tab as dirty (mutate in-place to avoid triggering re-render on every keystroke)
+    if (state.currentSlug && !state.dirtySlugs.has(state.currentSlug)) {
+      state.dirtySlugs.add(state.currentSlug);
+      setState({ dirtySlugs: state.dirtySlugs });
     }
     if (this._autoSaveTimer) clearTimeout(this._autoSaveTimer);
     this._autoSaveTimer = setTimeout(() => {


### PR DESCRIPTION
## Summary

Fixes #399 (reopened — still occurring on Safari iPad)

## Root Cause

PR #400 removed the `.value` binding from the textarea template, but `postContent` was still decorated with `@litState()`. Every keystroke set `this.postContent`, triggering a full Lit re-render cycle. While Chrome handles this gracefully, Safari on iPad resets the textarea cursor position during re-render even without a `.value` binding.

## Fix

Removed `@litState()` from `postContent` — it's now a plain class field. Since the `.value` binding was already removed in #400, `postContent` isn't used in the template and doesn't need to be reactive. This eliminates unnecessary re-renders on every keystroke.

The field is still read by auto-save, preview, publish, and export — all of which access it imperatively, not through Lit's render cycle.