### PR TITLE
docs: add architecture documentation for all packages and apps

### DIFF
--- a/apps/blog/ARCHITECTURE.md
+++ b/apps/blog/ARCHITECTURE.md
@@ -1,0 +1,300 @@
+# Blog Architecture
+
+*Snapshot: April 2026*
+
+## Overview
+
+Full-stack blog and portfolio app deployed on Cloudflare Pages. Two distinct frontends — a static public site (vanilla TS) and a Lit-based admin system — share a single Hono API backend backed by Turso (libSQL). All public content is baked into the JS bundle at build time via Vite virtual modules.
+
+## System Diagram
+
+```
++---------------------------------------------------------------+
+|                      Cloudflare Pages                         |
+|                                                               |
+|  Static Assets (dist/)         CF Pages Functions             |
+|  +----------------------+      +-----------------------+      |
+|  | index.html (SPA)     |      | functions/api/        |      |
+|  | admin.html           |      |   [[route]].ts        |      |
+|  | admin/editor.html    |      |     v                 |      |
+|  | admin/gallery.html   |      |   Hono app            |      |
+|  | admin/pages.html     |      |     v                 |      |
+|  | JS/CSS/woff2         |      |   Turso (libSQL)      |      |
+|  +----------------------+      |   R2 (images)         |      |
+|                                |   CF AI Gateway       |      |
+|                                +-----------------------+      |
+|                                                               |
+|  CF Access (JWT auth on /admin + /api)                        |
++---------------------------------------------------------------+
+```
+
+## Build System
+
+### Vite Plugin Chain
+
+9 custom plugins run during build, in this order:
+
+| Plugin | Phase | Responsibility |
+|---|---|---|
+| `admin-html-routes` | dev server | Rewrites `/admin/*` URLs to HTML files before SPA fallback |
+| `inject-tokens` | transformIndexHtml | Injects foundation + HeroUI CSS tokens into `<head>` (eliminates FOUC) |
+| `markdown-posts` | virtual module | `virtual:posts`, `virtual:drafts` — Turso → markdown-it + Shiki → HTML |
+| `portfolio-projects` | virtual module | `virtual:projects` — Turso → HTML |
+| `photography` | virtual module | `virtual:photos`, `virtual:albums` — Turso → JSON |
+| `auto-ui-components` | transform | Auto-registers `@maneki/ui-components` |
+| `sitemap` | closeBundle | Generates `sitemap.xml` from Turso slugs |
+| `rss-feed` | closeBundle | Generates `rss.xml` from Turso posts |
+| `pages` | virtual module | `virtual:pages` — generic CMS pages from Turso → HTML |
+
+### Virtual Modules
+
+The core architectural pattern: all content is fetched from Turso at build time and embedded as static data in the JS bundle.
+
+```
+Turso DB ──(build time)──→ Vite plugin ──→ virtual module ──→ JS bundle
+                                              │
+                              import { posts } from "virtual:posts"
+```
+
+6 virtual modules:
+- `virtual:posts` — published blog posts (markdown → HTML with Shiki highlighting)
+- `virtual:drafts` — draft posts (same pipeline)
+- `virtual:projects` — portfolio projects
+- `virtual:photos` — published photos with EXIF, tags, thumbhash
+- `virtual:albums` — published albums with photo counts
+- `virtual:pages` — generic CMS pages (about, resume)
+
+The markdown plugins also transform rendered HTML: `<a>` → `<ui-link>`, `<img>` → `<ui-image>`, so the output uses design system components.
+
+### Multi-Page Build
+
+5 HTML entry points built via Rolldown:
+
+```
+rolldownOptions.input:
+  main          → index.html          (public site)
+  admin         → admin.html          (admin hub)
+  admin-editor  → admin/editor.html   (post/project editor)
+  admin-gallery → admin/gallery.html  (photo management)
+  admin-pages   → admin/pages.html    (generic page editor)
+```
+
+Foundation tokens are extracted into a `vendor-foundation` manual chunk for caching across pages.
+
+### FOUC Prevention
+
+The `inject-tokens` plugin generates all CSS custom properties at build time and injects them into `<head>` before any JS executes. The runtime `injectAllTokens()` call becomes a no-op (idempotent check for existing `<style>` element).
+
+## API Layer
+
+### Hono App Structure
+
+```
+src/api/index.ts
+├── CORS middleware (all routes)
+├── DB middleware (creates Turso client per request)
+├── CF Access JWT auth middleware (all routes)
+└── 13 route modules mounted at /api/*
+```
+
+The CF Pages Functions adapter is a single file: `functions/api/[[route]].ts` calls `handle(app)` to route all `/api/*` requests to Hono.
+
+### Route Surface
+
+| Route | Purpose |
+|---|---|
+| `/api/posts` | Blog post CRUD |
+| `/api/projects` | Portfolio project CRUD |
+| `/api/tags` | Tag management (shared across posts + photos) |
+| `/api/pages` | Generic CMS page CRUD |
+| `/api/photos` | Photo CRUD (R2 storage) |
+| `/api/albums` | Album CRUD |
+| `/api/images` | Image upload to R2 |
+| `/api/ui-state` | Per-user UI state persistence |
+| `/api/deploy` | GitHub Actions `repository_dispatch` trigger |
+| `/api/review` | AI review (Claude streaming via CF AI Gateway) |
+| `/api/review-conversations` | Review conversation persistence |
+| `/api/brainstorm` | AI brainstorm (Claude streaming) |
+| `/api/brainstorm-conversations` | Brainstorm conversation persistence |
+
+### RPC Typing
+
+End-to-end type safety with zero codegen:
+
+```typescript
+// Server: Hono app exports its type
+export type AppType = typeof app;
+
+// Client: typed RPC client infers all routes
+import { hc } from "hono/client";
+import type { AppType } from "../api/index.js";
+export const api = hc<AppType>("/");
+```
+
+Route paths, request bodies, and response shapes are all inferred from the Hono route definitions.
+
+### Authentication
+
+CF Access sits in front of admin pages and API routes. The auth middleware:
+1. Reads `Cf-Access-Jwt-Assertion` header
+2. Fetches CF's public RSA certs (cached after first call)
+3. Validates JWT signature, expiration, issuer, audience
+4. Extracts email claim → sets on Hono context
+5. In local dev: bypasses auth entirely (`dev@localhost`)
+
+## Database Schema
+
+10 tables in Turso (libSQL):
+
+| Table | Purpose | Key patterns |
+|---|---|---|
+| `posts` | Blog posts | Soft delete (draft/published/deleted), `published_snapshot` JSON for change detection |
+| `projects` | Portfolio items | Same soft delete + snapshot pattern, `pinned` + `sort_order` for ordering |
+| `pages` | Generic CMS pages | Markdown content + custom CSS (`styles` column) |
+| `albums` | Photo albums | Location + lat/lng, `cover_photo_id` FK |
+| `photos` | Individual photos | R2 key, thumbhash, EXIF JSON, `featured` flag |
+| `tags` | Shared tag registry | Name + slug |
+| `post_tags` | Post↔tag junction | Cascade delete |
+| `photo_tags` | Photo↔tag junction | Cascade delete |
+| `ui_state` | Per-user UI state | Composite PK (user_email, page), JSON state |
+| `deployments` | Deploy tracking | Status (building/deploying/success/failure) |
+| `review_conversations` | AI review chat | Composite PK (slug, type), messages JSON |
+| `brainstorm_conversations` | AI brainstorm chat | Composite PK (slug, type), messages JSON |
+
+### Data Patterns
+
+- Soft delete throughout: `status IN ('draft', 'published', 'deleted')`
+- Published snapshot: JSON snapshot stored at publish time, compared against current fields to detect unpublished changes
+- Tags are denormalized: stored as JSON array in `posts.tags` column AND normalized in `post_tags` junction table (kept in sync by the API)
+
+## Frontend — Public Site
+
+### Routing
+
+History API routing with lazy-loaded page modules. 7 static routes + 3 dynamic routes:
+
+```
+routes.ts → Route[]
+  /              → home.ts
+  /blog          → blog.ts        (virtual:posts)
+  /portfolio     → portfolio.ts   (virtual:projects)
+  /photography   → photography.ts (virtual:photos, virtual:albums)
+  /map           → map.ts         (Leaflet, photo locations)
+  /resume        → resume.ts      (virtual:pages)
+  /about         → about.ts       (virtual:pages)
+  /post/:slug    → post.ts        (virtual:posts)
+  /project/:slug → project.ts     (virtual:projects)
+  /draft/:slug   → draft.ts       (virtual:drafts)
+```
+
+Each route has `meta` (title, description for SEO) and a lazy `load()` returning `{ render, setup? }`. No framework — vanilla TS with template literal HTML.
+
+### PWA
+
+Workbox service worker caches JS/CSS/woff2 only. HTML always comes from network (`navigateFallback: null`). This ensures content updates are visible immediately after deploy.
+
+## Frontend — Admin System
+
+4 separate HTML pages, each with its own entry script. No SPA routing — CF Pages serves them as static files.
+
+| Page | Entry | Component | Purpose |
+|---|---|---|---|
+| `/admin` | `hub-entry.ts` | `<admin-hub>` | Dashboard with cards linking to editor, gallery, pages |
+| `/admin/editor` | `editor-entry.ts` | `editor-page.ts` | Post/project editor |
+| `/admin/gallery` | `gallery-entry.ts` | `<admin-gallery>` | Photo/album CRUD with upload wizard |
+| `/admin/pages` | `pages-entry.ts` | `<admin-pages>` | Generic page editor (about, resume) |
+
+All admin pages share: `<theme-toggle fab>` (top-right), `<deploy-fab>` (floating deploy button), HeroUI theme.
+
+### Editor Architecture (20 modules)
+
+The editor is the most complex piece — a modular system with custom reactive state management:
+
+```
+editor/
+├── state.ts              — Global state + setState() with selective rendering
+├── editor-store.ts       — Lit ReactiveController bridge
+├── types.ts              — Post, Project, snapshot types
+├── editor-page.ts        — Main orchestrator
+├── sidebar.ts            — Lit: post/project list, multi-select, batch ops
+├── tabbar.ts             — Lit: open tabs, Map-based DOM patching
+├── toolbar.ts            — Formatting toolbar
+├── preview.ts            — Live markdown preview (Shiki)
+├── project-preview.ts    — Project-specific preview
+├── api.ts                — Editor API calls (wraps RPC client)
+├── upload.ts             — Image upload (R2 + client-side WebP)
+├── gallery.ts            — Image gallery side panel
+├── publish.ts            — Publish/unpublish with snapshot tracking
+├── delete-modal.ts       — Soft delete confirmation
+├── context-menu.ts       — Circular context menu
+├── scroll-sync.ts        — Editor↔preview scroll sync
+├── undo.ts               — setRangeText-based undo stack
+├── review-panel.ts       — AI review (Claude streaming, audience selector)
+├── brainstorm-panel.ts   — AI brainstorm (focus areas, streaming)
+└── streaming-chat-panel.ts — Shared streaming chat base
+```
+
+### State Management
+
+Hand-rolled reactive store. `setState()` tracks which keys changed, maps them to dependency lists (sidebar deps, tabbar deps, form deps), and batches renders via `queueMicrotask`. Lit components connect through `EditorStoreController` which subscribes to render callbacks.
+
+```
+setState({ currentSlug: "foo" })
+  → key "currentSlug" matches SIDEBAR_DEPS and TABBAR_DEPS
+  → pendingRenders.sidebar = true, pendingRenders.tabbar = true
+  → queueMicrotask fires registered callbacks
+  → Lit components call requestUpdate()
+```
+
+This avoids a full reactive framework while keeping selective re-rendering.
+
+### AI Panels
+
+Review and brainstorm panels stream Claude responses via CF AI Gateway (avoids Anthropic blocking CF Workers IPs). Raw `fetch` + SSE parsing, no SDK. Character queue drips text at 1 char/frame via `requestAnimationFrame` for smooth typing animation. Conversations are persisted server-side keyed by `(slug, type)`.
+
+### Gallery Module
+
+7 files for photo/album management:
+- `gallery.ts` — main Lit component
+- `gallery-album-modal.ts` — album create/edit modal
+- `gallery-photo-modal.ts` — photo detail/edit modal
+- `gallery-upload-wizard.ts` — multi-step upload flow
+- `gallery-types.ts` — shared types
+- `gallery-utils.ts` — utility functions
+- `theme.ts` — shared theme utility (backend persistence)
+
+## Deployment Pipeline
+
+```
+Editor "Publish" → API saves to Turso → API triggers GitHub Actions (repository_dispatch)
+  → GitHub Actions runs: vite build (fetches from Turso) → deploys to CF Pages
+  → Deploy FAB polls status → shows success/failure
+```
+
+Content changes require a full rebuild because all data is baked at build time. The deploy trigger automates this: the editor's publish flow saves to Turso, then fires a `repository_dispatch` event to GitHub Actions, which rebuilds and deploys.
+
+## Design Decisions
+
+1. **Build-time data baking.** All public content is embedded in the JS bundle at build time. The public site makes zero API calls at runtime. Trade-off: every content change requires rebuild + deploy, but the site is fully static and fast.
+
+2. **Two rendering paradigms.** Public pages use vanilla TS (zero framework overhead for readers). Admin pages use Lit (reactive rendering for complex CRUD UIs). The boundary is clean — they share design system components but not rendering approach.
+
+3. **Custom state management over framework.** The editor's `setState()` with dependency tracking is a simplified version of what Solid or Preact signals do. It works well for this specific component structure (sidebar/tabbar/form) without adding a framework dependency.
+
+4. **Separate HTML entry points for admin.** No SPA routing in admin — each page is a separate HTML file. Simpler deployment (CF Pages serves static files), simpler code splitting, independent loading.
+
+5. **CF AI Gateway for Claude.** Anthropic blocks requests from CF Workers IPs. Routing through CF AI Gateway solves this without an SDK dependency.
+
+6. **Denormalized tags.** Tags are stored both as a JSON array on posts (for fast reads) and in a junction table (for relational queries). The API keeps them in sync.
+
+## Known Issues
+
+1. **Duplicate admin route entries in vite.config.** `/admin/gallery` and `/admin` appear twice in the `adminRoutes` object. Second entries silently overwrite the first — no bug, but dead code.
+
+2. **Markdown renderer duplication.** The `markdown-posts` and `pages` plugins both create their own MarkdownIt instances with identical `<a>` → `<ui-link>` and `<img>` → `<ui-image>` renderer rules. Could be extracted into a shared utility.
+
+3. **Build-time DB dependency.** All virtual module plugins require Turso credentials at build time. If the DB is unavailable, the build fails. There's no graceful fallback for the production build (dev mode falls back to empty arrays).
+
+---
+
+*This document describes the architecture as of April 2026. See `docs/adr/` for individual decision records.*

--- a/apps/catalog/ARCHITECTURE.md
+++ b/apps/catalog/ARCHITECTURE.md
@@ -1,0 +1,101 @@
+# Catalog Architecture
+
+*Snapshot: April 2026*
+
+## Overview
+
+`@maneki/catalog` is a visual catalog app for the Maneki design system. It renders all foundation tokens and UI components with key variants on static pages, and serves as the target for Playwright visual regression and accessibility tests. Pure Vite + vanilla TypeScript — no framework.
+
+55 pages (6 foundation + 49 component). 114 Playwright tests (55 visual + 55 a11y + sidebar + full layout).
+
+## Structure
+
+```
+catalog/
+├── index.html              # App shell (sidebar + content area + theme toggle)
+├── src/
+│   ├── main.ts             # Entry: token injection, icon font, page imports, router
+│   └── pages/              # 55 page modules
+│       ├── colors.ts       # Foundation pages (6)
+│       ├── spacing.ts
+│       ├── typography.ts
+│       ├── elevation.ts
+│       ├── semantic-tokens.ts
+│       ├── shape.ts
+│       ├── badge.ts        # Component pages (49)
+│       ├── button.ts
+│       └── ...
+├── e2e/
+│   ├── helpers.ts          # Shared page list + test utilities
+│   ├── visual.spec.ts      # 55 visual screenshot tests + sidebar + full layout
+│   ├── a11y.spec.ts        # 55 accessibility tests (axe-core)
+│   └── snapshots/          # Baseline screenshots (committed)
+├── vite.config.ts
+├── playwright.config.ts
+└── moon.yml
+```
+
+## Page Registration System
+
+Each page module calls `registerPage(id, { title, section, render, setup? })`:
+
+- `id` — URL path segment (e.g., `"button"` → `/button`)
+- `title` — displayed as `<h2>` heading
+- `section` — sidebar group (`"Foundation"` or `"Components"`)
+- `render()` — returns plain HTML string with web component tags
+- `setup()` — optional post-render callback for imperative DOM manipulation (e.g., `setItems()`)
+
+Pages are imported in `main.ts`. The import triggers `registerPage()`, which adds the page to the sidebar and router.
+
+## Routing
+
+History API routing. `history.pushState()` + `popstate` event. Sidebar links intercept clicks and push state. `popstate` triggers re-render of the content area.
+
+No SPA framework, no hash routing. Clean URLs like `/button`, `/colors`.
+
+## Visual Regression Testing
+
+Playwright screenshots target the `#content` element (excludes sidebar for focused component comparison). One test per page, plus sidebar and full-layout tests.
+
+Configuration:
+- Browser: Chromium only
+- Viewport: 1280×900
+- Pixel diff threshold: 1% (`maxDiffPixelRatio: 0.01`)
+- Server: `vite preview` (production build) for deterministic rendering
+- Snapshots: platform-specific (chromium on macOS), committed to repo
+
+The shared `pages` array in `e2e/helpers.ts` drives both visual and a11y specs — adding a page ID there automatically creates both test types.
+
+## Accessibility Testing
+
+Per-page a11y tests using `@axe-core/playwright`. Each page is loaded and scanned for WCAG violations. Uses the same shared `pages` array from `helpers.ts`.
+
+## Theme Support
+
+Two theme systems supported via a toggle in the app shell:
+- Default: `[data-theme="dark"]` on `:root`
+- HeroUI: `[data-theme="heroui"]` / `[data-theme="heroui-dark"]`
+
+All semantic tokens switch to dark values when the theme attribute changes.
+
+## Design Decisions
+
+1. **Plain HTML strings, no framework.** `render()` returns template literal HTML. No Lit, no JSX, no CSF stories. This keeps the catalog simple and ensures screenshots capture the actual component rendering, not framework artifacts.
+
+2. **CSS classes from index.html.** Layout utilities (`variant-row`, `variant-col`, `variant-label`, `variant-group`) are defined in the app shell HTML, not per-page. Consistent layout across all pages.
+
+3. **Components auto-registered.** `import "@maneki/ui-components"` in `main.ts` registers all custom elements globally. Pages just write the HTML tags.
+
+4. **Production build for tests.** Playwright runs against `vite preview` (not dev server) for deterministic rendering. No HMR artifacts, no dev-only behavior.
+
+5. **Single `pages` array drives all tests.** Adding a page ID to `e2e/helpers.ts` automatically creates both a visual screenshot test and an a11y scan. No separate test registration needed.
+
+## Known Issues
+
+1. **Snapshots are platform-specific.** Baseline screenshots are generated on macOS Chromium. CI environments may need their own baselines if font rendering differs.
+
+2. **No open overlays in screenshots.** Dropdowns, modals, and popovers are not opened by default in page renders — they would overlay other content and break screenshots. This means overlay styling is not visually regression-tested.
+
+---
+
+*This document describes the architecture as of April 2026. See `docs/adr/` for individual decision records.*

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,31 @@
+# Architecture Documentation
+
+Historical architecture documentation for the Maneki monorepo. These documents capture the system design at a point in time — how things are built, why they're built that way, and what the known trade-offs are.
+
+Unlike ADRs (which record individual decisions), these docs describe the overall shape of the system.
+
+## Documents
+
+| Document | Location | Description |
+|---|---|---|
+| [Monorepo](./monorepo.md) | `docs/architecture/` | Toolchain, dependency graph, build orchestration, conventions |
+| [Foundation](../../packages/foundation/ARCHITECTURE.md) | `packages/foundation/` | Token architecture, CSS generation pipeline |
+| [UI Components](../../packages/ui-components/ARCHITECTURE.md) | `packages/ui-components/` | Component patterns, Lit migration, multi-entry build |
+| [Grid Layout](../../packages/grid-layout/ARCHITECTURE.md) | `packages/grid-layout/` | Core engine, drag/resize, keyboard a11y |
+| [Flex Layout](../../packages/flex-layout/ARCHITECTURE.md) | `packages/flex-layout/` | Panel system, constructable stylesheets |
+| [Charts](../../packages/charts/ARCHITECTURE.md) | `packages/charts/` | SVG chart components |
+| [Catalog](../../apps/catalog/ARCHITECTURE.md) | `apps/catalog/` | Visual regression testing, page registration |
+| [Blog](../../apps/blog/ARCHITECTURE.md) | `apps/blog/` | Full-stack architecture, build-time data baking, editor |
+
+## When to Update
+
+Update these docs when:
+- A major architectural change lands (new package, new build strategy, new deployment target)
+- A significant pattern shifts (e.g., vanilla → Lit migration)
+- The dependency graph changes materially
+
+These are living documents, not contracts. They describe what *is*, not what *must be*.
+
+---
+
+*Last updated: April 2026*

--- a/docs/architecture/monorepo.md
+++ b/docs/architecture/monorepo.md
@@ -1,0 +1,147 @@
+# Monorepo Architecture
+
+*Snapshot: April 2026*
+
+## Overview
+
+Design system monorepo shipping Web Components, design tokens, and layout primitives — plus a full-stack blog/portfolio app built on top of them. Everything is TypeScript, built with Vite, tested with Vitest and Playwright.
+
+## Toolchain
+
+| Tool | Role | Version |
+|---|---|---|
+| proto | Version pinning (Node, Moon) | `.prototools` |
+| Moon | Task runner, build orchestration | 2.0.4+ |
+| npm workspaces | Package linking | — |
+| Vite | Build (libraries + apps) | 8.x |
+| Vitest | Unit tests (happy-dom) | 4.x |
+| Playwright | Visual regression + a11y tests | — |
+| TypeScript | Strict mode, ES2022, bundler moduleResolution | 5.x |
+| ESLint + Prettier | Linting + formatting | — |
+| husky + lint-staged | Pre-commit: html-validate + stylelint + eslint + prettier | — |
+
+No Webpack, no Lerna, no Turborepo. The stack is intentionally minimal.
+
+## Dependency Graph
+
+```
+                    @maneki/foundation (zero deps)
+                   /     |      |       \        \
+                  /      |      |        \        \
+    ui-components  grid-layout  flex-layout  charts
+         (+ lit)
+                   \     |      |       /        /
+                    \    |      |      /        /
+                   ┌─────┴──────┴─────┴────────┘
+                   │                            │
+              @maneki/catalog               @maneki/blog
+           (all 5 packages)          (foundation + ui-components
+                                      + grid-layout + hono/turso/lit)
+```
+
+Foundation is the root — zero runtime dependencies, pure token generation. The four library packages (ui-components, grid-layout, flex-layout, charts) are siblings that don't depend on each other. The two apps sit at the top of the graph.
+
+### Dependency Details
+
+| Package | Production deps | Notes |
+|---|---|---|
+| foundation | none | Pure TypeScript, zero deps |
+| ui-components | foundation, lit | Lit for new components only |
+| grid-layout | foundation | Zero-dep layout engine |
+| flex-layout | foundation | ui-components is devDep only |
+| charts | foundation | SVG chart components |
+| catalog (app) | all 5 packages | Visual catalog + Playwright tests |
+| blog (app) | foundation, ui-components, grid-layout, hono, @libsql/client, lit, zod, leaflet | Full-stack app |
+
+## Build Orchestration
+
+Moon auto-discovers projects via `apps/*` and `packages/*` globs. Build tasks declare dependencies using Moon's `deps` and `dependsOn` fields.
+
+### Build Pipeline
+
+Libraries: `vite build && tsc --emitDeclarationOnly` → `dist/`
+- Vite builds JS first, then tsc generates `.d.ts` files
+- Order matters: tsc first would have its output wiped by Vite's `emptyOutDir`
+
+Apps: `vite build` → `dist/`
+
+### Moon Task Dependencies
+
+| Package | Build deps | Effect |
+|---|---|---|
+| foundation | none | Builds first, standalone |
+| ui-components | `^:build` | Waits for foundation |
+| charts | `foundation:build` | Waits for foundation (explicit) |
+| grid-layout | none declared | Builds independently |
+| flex-layout | none declared | Builds independently |
+| catalog | `^:build` | Waits for all npm deps to build |
+| blog | `^:build` | Waits for all npm deps to build |
+
+### Dev-Time Resolution
+
+`shared/vite-dev-aliases.ts` maps all `@maneki/*` imports to source (`src/index.ts`) during `vite serve`. This bypasses `dist/` entirely, giving instant HMR across package boundaries without rebuilding. Covers: foundation (+ assets + heroui-theme), ui-components (barrel + deep imports), grid-layout, flex-layout, charts.
+
+Production builds use `dist/` via package `exports` maps — no aliases.
+
+## Architectural Principles
+
+### Zero Runtime Dependencies (libraries)
+
+Foundation has zero deps. Layout packages depend only on foundation. ui-components adds Lit as its sole external dep (for new components). This keeps bundle sizes small and avoids version conflicts for consumers.
+
+### Web Components + Shadow DOM
+
+All UI is custom elements with Shadow DOM encapsulation. CSS custom properties (`--fd-*`, `--ui-*`, `--grid-*`, `--flex-*`, `--chart-*`) are the theming API. No global CSS leakage, no specificity wars.
+
+### Two Component Paradigms
+
+Existing components use vanilla `HTMLElement` with imperative DOM construction. New components use Lit (`LitElement`, decorators, `html` templates). This is a conscious transitional state documented in ADR-028 — no obligation to migrate existing components.
+
+### Design Tokens as Source of Truth
+
+Figma "Foundation UI Kit (Community)" is the source of truth. Tokens are extracted into TypeScript, generated as CSS custom properties via `injectAllTokens()`, and consumed by components through type-safe helpers (`colorVar()`, `semanticVar()`, `spaceVar()`). Pre-computed constants (`TEXT_PRIMARY`, `SP_1`) avoid repeated function calls.
+
+### Dark Theme via Data Attribute
+
+Two theme systems coexist:
+- Default: `[data-theme="dark"]` on `:root`
+- HeroUI: `[data-theme="heroui"]` / `[data-theme="heroui-dark"]`
+
+Blog uses HeroUI exclusively. Catalog supports both via theme switcher.
+
+### Branch-Per-Change Workflow
+
+Every change gets its own branch (`feat/ui-*`, `fix/*`, `refactor/*`). No direct pushes to `main`. PRs required. Visual Figma verification required for UI changes.
+
+## Testing Strategy
+
+| Layer | Tool | Scope |
+|---|---|---|
+| Unit tests | Vitest + happy-dom | All packages, co-located (`foo.ts` → `foo.test.ts`) |
+| Visual regression | Playwright screenshots | Catalog (55 pages), grid-layout (fixtures) |
+| Accessibility | axe-core via Playwright | Catalog (55 pages) |
+| Type checking | `tsc --noEmit` | Per-package |
+| Linting | ESLint, stylelint, html-validate | Pre-commit hook |
+
+CI runs on PRs (`.github/workflows/test.yml`). Deploy workflows for blog and catalog.
+
+## Deployment
+
+| App | Platform | Strategy |
+|---|---|---|
+| Catalog | Cloudflare Pages | Static site, deploy on PR merge |
+| Blog | Cloudflare Pages + Functions | Static + serverless API, deploy via GitHub Actions `repository_dispatch` |
+
+## Known Issues
+
+1. **Missing Moon build deps for grid-layout and flex-layout.** Both depend on `@maneki/foundation` at runtime but don't declare `^:build` or `foundation:build` in their moon.yml. Clean builds from scratch could fail if foundation hasn't been built yet.
+
+2. **Inconsistent build order in flex-layout.** Runs `tsc && vite build` while every other package runs `vite build && tsc --emitDeclarationOnly`. The tsc-first order means `.d.ts` files get wiped by Vite's `emptyOutDir`.
+
+3. **Incomplete `dependsOn` in catalog moon.yml.** Lists foundation and ui-components but not grid-layout, flex-layout, or charts. The `^:build` dep catches these at build time, but Moon's project graph is incomplete.
+
+4. **Duplicate admin route entries in blog vite.config.** `/admin/gallery` and `/admin` appear twice in the `adminRoutes` object. No bug (second overwrites first), but dead code.
+
+---
+
+*This document describes the architecture as of April 2026. See `docs/adr/` for individual decision records.*

--- a/packages/charts/ARCHITECTURE.md
+++ b/packages/charts/ARCHITECTURE.md
@@ -1,0 +1,114 @@
+# Charts Architecture
+
+*Snapshot: April 2026*
+
+## Overview
+
+`@maneki/charts` is a zero-dependency SVG chart Web Component library. 11 custom elements cover the common chart types: bar, line, pie, radar, scatter, polar, stacked bar, horizontal bar, stacked horizontal bar, multi-line, and multitype. All rendering is pure SVG inside Shadow DOM. Foundation tokens drive colors and typography.
+
+## Structure
+
+```
+packages/charts/
+├── src/
+│   ├── core/                          # Shared rendering utilities
+│   │   ├── types.ts                   # All shared interfaces and types
+│   │   ├── scales.ts                  # Linear + category scale functions
+│   │   ├── axis.ts                    # Grid line + axis label renderers
+│   │   ├── legend.ts                  # Legend layout + rendering
+│   │   ├── header.ts                  # Title + legend header block
+│   │   ├── math.ts                    # Cartesian layout computation
+│   │   └── colors.ts                  # Chart palette + dataset color resolution
+│   ├── components/
+│   │   ├── chart-bar.ts               # <chart-bar> grouped vertical bars
+│   │   ├── chart-line.ts              # <chart-line> line chart with optional fill
+│   │   ├── chart-pie.ts               # <chart-pie> pie / doughnut
+│   │   ├── chart-radar.ts             # <chart-radar> spider/radar
+│   │   ├── chart-scatter.ts           # <chart-scatter> scatter / bubble
+│   │   ├── chart-stacked-bar.ts       # <chart-stacked-bar> stacked vertical bars
+│   │   ├── chart-horizontal-bar.ts    # <chart-horizontal-bar> horizontal bars
+│   │   ├── chart-stacked-horizontal-bar.ts  # <chart-stacked-horizontal-bar>
+│   │   ├── chart-polar.ts             # <chart-polar> polar area
+│   │   ├── chart-multi-line.ts        # <chart-multi-line> multiple line series
+│   │   └── chart-multitype.ts         # <chart-multitype> mixed bar + line
+│   └── index.ts                       # Barrel export (types + utilities + components)
+├── package.json
+├── tsconfig.json
+└── vite.config.ts
+```
+
+## Components
+
+| Element | Description |
+|---|---|
+| `<chart-bar>` | Grouped vertical bar chart, multiple datasets |
+| `<chart-line>` | Line chart, optional fill, tension, gradient |
+| `<chart-pie>` | Pie or doughnut (configurable inner radius) |
+| `<chart-radar>` | Radar / spider chart with configurable axes |
+| `<chart-scatter>` | Scatter or bubble chart |
+| `<chart-stacked-bar>` | Stacked vertical bars |
+| `<chart-horizontal-bar>` | Horizontal bar chart |
+| `<chart-stacked-horizontal-bar>` | Stacked horizontal bars |
+| `<chart-polar>` | Polar area chart |
+| `<chart-multi-line>` | Multiple line series with shared axes |
+| `<chart-multitype>` | Mixed bar and line series on shared axes |
+
+All components support both a declarative attribute API (JSON-encoded `labels` and `datasets` attributes) and a programmatic property API (`chart.datasets = [...]`, `chart.options = {...}`). Attribute changes are batched via `requestAnimationFrame` to avoid redundant renders when multiple attributes change together.
+
+## Core Utilities
+
+### Scales (`scales.ts`)
+
+`linearScale(min, max, length, axisConfig)` computes tick marks and a pixel-mapping function for numeric axes. `categoryScale(labels, width, padding)` computes band widths and center/start positions for categorical axes. `dataExtent(datasets)` finds the global min/max across all datasets.
+
+### Axis (`axis.ts`)
+
+`renderYGridLines`, `renderYLabels`, `renderXGridLines`, `renderXLabels` write SVG elements directly into a provided `<g>` group. `renderTitle` places the chart title text.
+
+### Legend (`legend.ts`)
+
+`renderLegend` lays out color swatches and labels in rows. `legendHeight` and `legendRowWidth` compute the space the legend will occupy so the plot area can be sized accordingly. `splitLegendRows` handles wrapping for long legend lists.
+
+### Math (`math.ts`)
+
+`computeCartesianLayout(viewBoxW, viewBoxH, options)` returns a `CartesianLayout` with named `Rect` regions: `viewBox`, `title`, `legend`, `plot`, `xAxis`, `yAxis`. All rendering functions receive these regions rather than computing their own offsets.
+
+### Colors (`colors.ts`)
+
+`CHART_PALETTE` is a 10-color array derived from foundation semantic tokens. `getDatasetColor(index, override)` resolves a dataset's color — either the override value or the palette entry at `index % 10`. `GRID_LINE_COLOR` is a foundation semantic token reference.
+
+## Rendering Model
+
+Each component owns a fixed `960×960` SVG viewBox. The SVG scales to fill its container via `width: 100%; height: auto`. This means all coordinate math is done in viewBox units, not pixels, and the browser handles scaling. Tooltips are positioned in host-relative pixels using `getBoundingClientRect()` comparisons between the SVG and the hovered element.
+
+Rendering is imperative: each `_render()` call clears the SVG and rebuilds it from scratch. There's no diffing or incremental update. Renders are scheduled via `requestAnimationFrame` and deduplicated with a `_renderScheduled` flag.
+
+## Accessibility
+
+Each component sets `role="img"` on the host in `connectedCallback` (with a presence guard). The SVG receives a `<title>` element for screen readers and an optional `<desc>` for detailed descriptions. `aria-label` on the host mirrors the chart title.
+
+## CSS Custom Properties
+
+All components use the `--chart-*` prefix. Key properties: `--chart-font`, `--chart-title-font-size`, `--chart-axis-font-size`, `--chart-legend-font-size`, `--chart-text-color`, `--chart-grid-color`, `--chart-tooltip-bg`. Fallbacks reference foundation token constants (`TEXT_PRIMARY`, `SURFACE_PRIMARY`, `FONT_PRIMARY`, etc.).
+
+## Design Decisions
+
+**Fixed viewBox, fluid container.** A 960×960 viewBox with `preserveAspectRatio="xMidYMid meet"` means the chart always renders at the same internal resolution regardless of container size. This avoids re-rendering on resize and keeps coordinate math simple.
+
+**Imperative SVG construction.** Charts rebuild their SVG on every render rather than patching it. For the data sizes these charts handle (tens to low hundreds of points), a full rebuild is fast enough and far simpler than diffing SVG trees.
+
+**Core/components split.** Shared rendering logic (scales, axes, legend, layout math, colors) lives in `src/core/` and is exported from the package barrel. Components compose these utilities rather than duplicating them.
+
+**Render batching via `requestAnimationFrame`.** Multiple attribute or property changes in the same microtask queue up a single render rather than triggering one per change.
+
+## Known Issues
+
+1. **No unit tests for components.** The `src/core/` modules have tests (`colors.test.ts`, `legend.test.ts`, `math.test.ts`, `scales.test.ts`) but the 11 component files have none. Component behavior is only verified visually via the catalog.
+
+2. **No Playwright visual tests.** Unlike grid-layout, charts has no screenshot regression suite. Visual correctness depends on the catalog's per-page screenshots.
+
+3. **Tooltip positioning breaks on transformed ancestors.** The tooltip uses `getBoundingClientRect()` relative to the host element. If the host has a CSS transform applied by an ancestor, tooltip positions will be off.
+
+---
+
+*This document describes the architecture as of April 2026. See `docs/adr/` for individual decision records.*

--- a/packages/flex-layout/ARCHITECTURE.md
+++ b/packages/flex-layout/ARCHITECTURE.md
@@ -1,0 +1,116 @@
+# Flex Layout Architecture
+
+*Snapshot: April 2026*
+
+## Overview
+
+`@maneki/flex-layout` is a panel-based flex layout Web Component system for dashboard-style interfaces. Three custom elements (`<flex-layout>`, `<flex-panel>`, `<flex-panel-header>`) extracted from the Figma "Flex Layout" page. TypeScript, Vite, Shadow DOM, Constructable Stylesheets. 50 unit tests.
+
+## Structure
+
+```
+packages/flex-layout/
+├── src/
+│   ├── components/
+│   │   ├── flex-layout.ts           # <flex-layout> container
+│   │   ├── flex-layout.test.ts
+│   │   ├── flex-panel.ts            # <flex-panel> content panel
+│   │   ├── flex-panel.test.ts
+│   │   ├── flex-panel-header.ts     # <flex-panel-header> title/tabs header
+│   │   └── flex-panel-header.test.ts
+│   └── index.ts                     # Barrel export
+├── package.json
+├── tsconfig.json
+├── vite.config.ts
+└── moon.yml
+```
+
+## Components
+
+### `<flex-layout>`
+
+Flex container with size-based gap and padding presets. The `size` attribute selects a preset derived from Figma measurements. `direction` controls flex axis.
+
+| Attribute | Type | Default |
+|---|---|---|
+| `size` | `"large" \| "medium" \| "small"` | `"medium"` |
+| `direction` | `"row" \| "column"` | `"row"` |
+
+Size presets:
+
+| Size | Gap | Padding |
+|---|---|---|
+| large | 8px | 8px |
+| medium | 8px | 8px |
+| small | 4px | 4px |
+
+CSS custom properties: `--flex-bg`, `--flex-gap`, `--flex-padding`, `--flex-direction`, `--flex-align`.
+
+No ARIA role is set on the container. Consumers add `role="region"` and `aria-label` when the layout represents a named region.
+
+### `<flex-panel>`
+
+Content panel with an optional named `header` slot. Grows to fill available space by default. A `width` attribute pins the panel to a fixed pixel width, overriding flex growth. `no-padding` removes the default content padding for panels that need edge-to-edge content.
+
+| Attribute | Type | Default |
+|---|---|---|
+| `width` | `number \| null` | `null` |
+| `no-padding` | boolean | `false` |
+
+Carries `role="group"`. CSS custom properties: `--flex-panel-flex`, `--flex-panel-bg`, `--flex-panel-padding`, `--flex-panel-divider`.
+
+### `<flex-panel-header>`
+
+Header bar with title text and/or tab content. Three variants cover the common Figma patterns: title-only, tabs-only, and title-with-tabs. Size presets control height and font size.
+
+| Attribute | Type | Default |
+|---|---|---|
+| `variant` | `"title" \| "tabs" \| "title-tabs"` | `"title"` |
+| `size` | `"large" \| "medium" \| "small"` | `"medium"` |
+| `heading` | `string` | `""` |
+
+Slots: `action` (named, for an icon button), `tabs` (named, for tab content).
+
+Size presets:
+
+| Size | Height | Font Size |
+|---|---|---|
+| large | 32px | 12px |
+| medium | 24px | 12px |
+| small | 20px | 11px |
+
+Carries `role="toolbar"`. CSS custom properties: `--flex-header-bg`, `--flex-header-height`, `--flex-header-color`, `--flex-header-divider`, `--flex-header-font-size`, `--flex-header-font-weight`, `--flex-header-line-height`, `--flex-header-icon-size`, `--flex-header-icon-color`, `--flex-header-padding-*`.
+
+## Constructable Stylesheets
+
+All three components use Constructable Stylesheets rather than injecting `<style>` elements. A `CSSStyleSheet` is created at module level (`const sheet = new CSSStyleSheet(); sheet.replaceSync(STYLES)`), then adopted in the constructor (`shadow.adoptedStyleSheets = [sheet]`). The sheet is shared across all instances of a component, avoiding per-instance style parsing.
+
+## Nesting
+
+`<flex-layout>` inside `<flex-panel>` is supported and the primary way to build split layouts (top/bottom, left/right, or mixed). There's no depth limit.
+
+## Design Decisions
+
+**Constructable Stylesheets over template literals.** Injecting a `<style>` element per instance works but parses the CSS string once per element. Constructable Stylesheets parse once at module load and share the result across all instances. For a layout primitive that may appear many times on a page, this is a meaningful difference.
+
+**No default ARIA role on `<flex-layout>`.** The container is a generic layout primitive. Assigning `role="region"` unconditionally would require a unique `aria-label` on every instance to avoid landmark violations. Leaving it to consumers avoids false positives in accessibility audits.
+
+**`role="group"` on panels, `role="toolbar"` on headers.** Panels group related content without creating a landmark. Headers carry toolbar semantics because they typically contain interactive controls (action buttons, tabs).
+
+**`role="banner"` is explicitly avoided on headers.** Multiple `role="banner"` elements on a page cause duplicate landmark violations. `role="toolbar"` is the correct role for a panel header bar.
+
+## Testing
+
+50 unit tests (Vitest + happy-dom), co-located with source files.
+
+## Known Issues
+
+1. **No Playwright visual tests.** Unlike grid-layout, flex-layout has no screenshot regression tests. Visual correctness is verified manually against the catalog.
+
+2. **Inconsistent build order.** `moon.yml` runs `tsc && vite build` while every other package runs `vite build && tsc --emitDeclarationOnly`. The tsc-first order means `.d.ts` files get wiped by Vite's `emptyOutDir`. This is tracked in the monorepo known issues.
+
+3. **No Moon build dependency on foundation.** Depends on `@maneki/foundation` at runtime but doesn't declare it in `moon.yml`. Same issue as grid-layout.
+
+---
+
+*This document describes the architecture as of April 2026. See `docs/adr/` for individual decision records.*

--- a/packages/foundation/ARCHITECTURE.md
+++ b/packages/foundation/ARCHITECTURE.md
@@ -1,0 +1,201 @@
+# Foundation Architecture
+
+*Snapshot: April 2026*
+
+## Overview
+
+`@maneki/foundation` is the root package of the design system. It holds all design tokens extracted from the "Foundation UI Kit (Community)" Figma file and generates CSS custom properties from them. Zero runtime dependencies, pure TypeScript.
+
+Everything downstream (ui-components, grid-layout, flex-layout, charts, both apps) consumes foundation tokens. Nothing in foundation depends on any other package in the monorepo.
+
+## Module Structure
+
+```
+packages/foundation/
+├── assets/
+│   ├── material-symbols-outlined-subset.woff2  # Subsetted icon font (~45 KB)
+│   ├── icon-manifest.txt                       # Icon names in the subset
+│   └── subset-icons.py                         # Script to regenerate the subset
+└── src/
+    ├── index.ts              # Barrel export
+    ├── colors.ts             # 131 palette tokens (13 families x 10 steps + gray-110)
+    ├── semantic-tokens.ts    # Surface, elevation, border, text, icon, global, status, state, form, tag, button tokens
+    ├── dark-theme.ts         # Dark theme overrides (mirrors all semantic groups)
+    ├── heroui-theme.ts       # HeroUI theme variant (blog-specific)
+    ├── typography.ts         # 19 type tokens across 7 groups
+    ├── spacing.ts            # 17-step spacing scale (8px base unit)
+    ├── shape.ts              # Border-radius + border-width tokens
+    ├── breakpoints.ts        # 3 density variants x 7 breakpoints + helpers
+    ├── tokens.ts             # CSS generators + var() helpers
+    ├── token-constants.ts    # Pre-computed var() references
+    ├── icons.ts              # Icon codepoint constants + font/icon registry
+    ├── tokens.test.ts        # 32 tests
+    └── breakpoints.test.ts   # 27 tests
+```
+
+## Token Pipeline
+
+```
+Raw data modules
+(colors.ts, semantic-tokens.ts, typography.ts, spacing.ts, shape.ts)
+    |
+    v
+CSS generator functions in tokens.ts
+(*ToCssProperties() — one per token category)
+    |
+    v
+injectAllTokens()
+Writes a single <style id="maneki-foundation-all"> onto :root.
+Also writes [data-theme="dark"] overrides from dark-theme.ts.
+    |
+    v
+var() helpers
+colorVar(), semanticVar(), elevationVar(), typeVar(), spaceVar(),
+radiusVar(), borderWidthVar(), shadowVar()
+    |
+    v
+Pre-computed constants in token-constants.ts
+TEXT_PRIMARY, SP_1, TYPE_BODY_02, SURFACE_ACTION, etc.
+```
+
+### Raw Data Modules
+
+Each module exports plain TypeScript objects. No CSS, no DOM, no side effects.
+
+- `colors.ts` — 131 hex values keyed by family and step (e.g. `colors.blue[60]`)
+- `semantic-tokens.ts` — semantic groups keyed by name. Values are either hex strings, rgba strings, or `PaletteRef` objects (`{ family, step }`) that resolve to hex at generation time via `resolveSemanticValue()`
+- `typography.ts` — type tokens with `fontFamily`, `fontSize`, `lineHeight`, `fontWeight` per token
+- `spacing.ts` — numeric pixel values keyed by step (e.g. `spacing["2"] = 16`)
+- `shape.ts` — border-radius and border-width values
+
+### CSS Generators
+
+`tokens.ts` contains one generator function per token category. Each returns a plain string of CSS declarations, no wrapping selector. The `toKebab()` helper converts camelCase object keys to kebab-case for property names.
+
+`injectAllTokens()` calls all generators, wraps the combined output in `:root { ... }`, appends the dark theme overrides in `[data-theme="dark"] { ... }`, and writes a single `<style>` element to `document.head`. It checks for an existing element by id before injecting, making it idempotent. In dev mode with Vite HMR active, it replaces the existing element instead of skipping.
+
+### var() Helpers
+
+Each token category has a typed helper that returns a `var(--fd-...)` string. The helpers are type-safe: TypeScript enforces valid group/key combinations at call sites.
+
+`typeBlock()` is a convenience helper that emits all four typography properties (font-family, font-size, line-height, font-weight) as a single interpolatable block for use in CSS template literals.
+
+### Pre-Computed Constants
+
+`token-constants.ts` calls the var() helpers once at module load and exports the results as named constants. Components import `TEXT_PRIMARY` instead of calling `semanticVar("text", "primary")` at every use site. This is purely ergonomic — the output is identical.
+
+## CSS Custom Property Naming
+
+All foundation properties use the `--fd-` prefix. The naming pattern after the prefix follows the token category and key.
+
+| Category | Pattern | Example |
+|---|---|---|
+| Palette colors | `--fd-color-{family}-{step}` | `--fd-color-blue-60` |
+| Semantic surface | `--fd-surface-{name}` | `--fd-surface-primary` |
+| Semantic border | `--fd-border-{name}` | `--fd-border-minimal` |
+| Semantic text | `--fd-text-{name}` | `--fd-text-primary` |
+| Semantic icon | `--fd-icon-{name}` | `--fd-icon-action` |
+| Global | `--fd-global-{name}` | `--fd-global-brand` |
+| Status | `--fd-status-{group}-{name}` | `--fd-status-surface-error-bold` |
+| Elevation | `--fd-elevation-{level}` | `--fd-elevation-03` |
+| Shadow | `--fd-shadow-{name}` | `--fd-shadow-card` |
+| Typography | `--fd-type-{group}-{key}-{prop}` | `--fd-type-heading-01-font-size` |
+| Spacing | `--fd-space-{step}` | `--fd-space-2-5` |
+| Shape radius | `--fd-radius-{name}` | `--fd-radius-s` |
+| Shape border-width | `--fd-border-width-{name}` | `--fd-border-width-s` |
+| Tag | `--fd-tag-{name}` | `--fd-tag-bold` |
+| Button | `--fd-button-{name}` | `--fd-button-secondary` |
+| State | `--fd-state-{group}-{name}` | `--fd-state-hover-border-moderate` |
+| Form | `--fd-form-{name}` | `--fd-form-input-border` |
+
+Dots in spacing steps become hyphens in property names (`--fd-space-0-75`, not `--fd-space-0.75`). camelCase semantic keys are converted to kebab-case by `toKebab()` at generation time.
+
+## Dark Theme System
+
+Foundation ships two parallel token sets: light (default) and dark.
+
+Light values live in `semantic-tokens.ts`. Dark overrides live in `dark-theme.ts`, which mirrors every semantic group with dark-appropriate values. `injectAllTokens()` writes both into the same `<style>` block:
+
+```css
+:root {
+  /* all light tokens */
+}
+
+[data-theme="dark"] {
+  /* semantic + elevation + shadow overrides */
+}
+```
+
+Toggling dark mode is a single attribute change on `:root`. Palette color tokens (`--fd-color-*`) are not overridden — they're static. Only semantic tokens change between themes.
+
+Breakpoints, typography, spacing, and shape tokens have no dark variants.
+
+## HeroUI Theme System
+
+`heroui-theme.ts` is a second semantic token set targeting the HeroUI design language. It exports parallel data structures (`herouiSemanticTokens`, `herouiDarkSemanticTokens`, etc.) and a dedicated injection function `injectHerouiTheme()`.
+
+HeroUI tokens are scoped to `[data-theme="heroui"]` and `[data-theme="heroui-dark"]` selectors rather than `:root`. The blog app uses HeroUI exclusively. The catalog app supports both the default theme and HeroUI via a theme switcher.
+
+The two theme systems are independent. A page uses one or the other, not both simultaneously.
+
+## Breakpoints
+
+`breakpoints.ts` defines three layout densities (compact, standard, spacious), each with seven named breakpoints (xs through xxxl). Breakpoints are JS-only — no CSS custom properties are generated for them.
+
+The module exports helper functions: `getBreakpoint()` resolves a pixel width to a breakpoint name, `getBreakpointConfig()` returns the full config object for a given width and density, and `breakpointMediaQuery()` generates a media query string. Components and apps call these at runtime or build time rather than reading CSS variables.
+
+## Icon System
+
+### Subset Font
+
+Foundation ships a subsetted woff2 of Material Symbols Outlined (~45 KB). The subset contains only the glyphs used by the design system, identified by `assets/icon-manifest.txt`. The full Material Symbols font is not a dependency — the subset is committed directly to the repo.
+
+`registerIconFont()` injects a `@font-face` rule pointing at the woff2. Components render icons by setting `font-family: "Material Symbols Outlined"` and placing the Unicode codepoint character as text content.
+
+### Codepoint Constants
+
+`icons.ts` exports a named constant for each icon (e.g. `ICON_CLOSE = "\uE5CD"`). Components reference these constants rather than raw Unicode escapes or ligature strings. This keeps the font file small and makes icon usage greedable across the codebase.
+
+### Custom Icon Registry
+
+`registerIcon()`, `resolveIcon()`, `hasIcon()`, `unregisterIcon()`, and `clearIcons()` form a runtime registry for custom SVG icons. Custom icons are stored as SVG strings keyed by name. Components call `resolveIcon()` to get either a codepoint (Material Symbol) or an SVG string (custom), then render accordingly. This allows apps to extend the icon set without modifying foundation.
+
+`registerGeistFont()` is a separate utility that injects the Geist font face (self-hosted in foundation's assets) for use in the blog's signature animation.
+
+## Design Decisions
+
+### Zero Runtime Dependencies
+
+Foundation has no production dependencies. Token data is plain TypeScript objects. CSS generation is string concatenation. No build-time CSS preprocessor, no runtime CSS-in-JS library. This keeps the package trivially consumable and avoids version conflicts for downstream packages.
+
+### Figma as Source of Truth
+
+All token values are extracted from the "Foundation UI Kit (Community)" Figma file. Foundation does not invent tokens. The one exception is interactive state tokens (e.g. `text.linkHover`, `text.linkActive`) which may be added when components need them, even if Figma doesn't define them explicitly.
+
+Semantic tokens that resolve to the same hex value today are kept separate if they serve different semantic purposes in Figma. They may diverge in future Figma updates.
+
+### Idempotent Injection
+
+`injectAllTokens()` checks for an existing `<style id="maneki-foundation-all">` before writing. Calling it multiple times (e.g. from multiple components) is safe. In dev mode, HMR replaces the element so token changes are reflected without a full page reload.
+
+### JS-Only Breakpoints
+
+Breakpoints are not injected as CSS custom properties. The design system uses a JS-driven responsive layout model (via `grid-layout` and `flex-layout`) rather than CSS media queries in component stylesheets. Keeping breakpoints in JS makes them composable and testable without a browser.
+
+### PaletteRef Resolution at Generation Time
+
+Semantic tokens can reference palette colors by `{ family, step }` rather than hardcoding hex values. `resolveSemanticValue()` resolves these references when generating CSS, not at runtime. The generated CSS contains resolved hex values, so there's no runtime lookup cost and no dependency on the palette object after injection.
+
+### Single Injected Style Block
+
+All tokens are written into one `<style>` element rather than one per category. This minimizes DOM nodes and keeps the injection atomic. The element id (`maneki-foundation-all`) is stable, so HMR replacement is reliable.
+
+## Known Issues
+
+1. `injectColorTokens()` is exported as a standalone function but `injectAllTokens()` already includes palette colors. Calling both would inject colors twice (the second call is a no-op due to the id check, but the standalone function uses a different id `maneki-foundation-colors`, so they don't conflict — they just duplicate the palette properties).
+
+2. Typography font sizes are stored as numbers in `typography.ts` but emitted as `{value}px` in `typographyToCssProperties()`. The `typeVar()` helper returns a `var()` reference to the px value. Direct access via `typography.heading["01"].fontSize` returns the raw number, not a px string — callers must be aware of the unit difference.
+
+---
+
+*This document describes the architecture as of April 2026. See `docs/adr/` for individual decision records.*

--- a/packages/grid-layout/ARCHITECTURE.md
+++ b/packages/grid-layout/ARCHITECTURE.md
@@ -1,0 +1,153 @@
+# Grid Layout Architecture
+
+*Snapshot: April 2026*
+
+## Overview
+
+`@maneki/grid-layout` is a zero-dependency Web Component grid layout library inspired by react-grid-layout. Three custom elements (`<grid-layout>`, `<grid-item>`, `<responsive-grid-layout>`) provide drag, resize, responsive breakpoints, keyboard accessibility, and external drag-and-drop. ~3700 lines of TypeScript, ~44 kB / ~9.9 kB gzip as an ES module.
+
+## Structure
+
+```
+packages/grid-layout/
+├── src/
+│   ├── core/                    # Pure logic engine — no DOM
+│   │   ├── types.ts             # All shared types and interfaces
+│   │   ├── collision.ts         # AABB overlap detection
+│   │   ├── compact.ts           # Vertical + horizontal compaction
+│   │   ├── layout-engine.ts     # Move, push, bounded collision resolution
+│   │   ├── responsive.ts        # Breakpoint matching, layout generation
+│   │   └── math.ts              # Position/size calculations (calcColWidth, calcXY, etc.)
+│   ├── components/
+│   │   ├── grid-item.ts         # <grid-item> — individual cell, ARIA gridcell
+│   │   ├── grid-layout.ts       # <grid-layout> — container, drag/resize/keyboard (~923 lines)
+│   │   └── responsive-grid-layout.ts  # <responsive-grid-layout> — breakpoint wrapper
+│   └── index.ts                 # Barrel export (types + utilities + components)
+├── e2e/
+│   ├── fixtures.html            # 8 grid scenarios for visual tests
+│   ├── visual.spec.ts           # 16 Playwright screenshot tests
+│   └── snapshots/               # Baseline screenshots
+├── demo.html                    # Three demos: basic, responsive, customization
+├── stress-test.html             # FPS counter, auto-drag/resize
+└── playwright.config.ts
+```
+
+## Components
+
+### `<grid-layout>`
+
+The main container. Manages all layout state, drag, resize, keyboard navigation, and external drop for its child `<grid-item>` elements. The largest file in the package at ~923 lines.
+
+Carries `role="grid"` and `aria-roledescription="draggable grid"`. A live region inside the shadow root announces state changes to screen readers.
+
+Key properties: `layout`, `gridConfig`, `dragConfig`, `resizeConfig`, `compactType`, `preventCollision`, `isDroppable`, `droppingItem`.
+
+Events emitted: `drag-start`, `drag`, `drag-stop`, `resize-start`, `resize`, `resize-stop`, `layout-change`, `external-drop`.
+
+### `<grid-item>`
+
+Individual grid cell. Carries `role="gridcell"`, `tabindex="0"`, and `aria-grabbed`. Attributes (`item-id`, `x`, `y`, `w`, `h`, `min-w`, `max-w`, `min-h`, `max-h`, `static`) mirror the layout item fields. Per-item drag/resize overrides via `isDraggable` / `isResizable` properties.
+
+### `<responsive-grid-layout>`
+
+A thin breakpoint-aware wrapper around `<grid-layout>`. Observes container width via `ResizeObserver`, matches the current breakpoint, and swaps the active layout. Forwards all config properties and lifecycle hooks to the inner `<grid-layout>`. Emits `breakpoint-change` in addition to the standard layout events.
+
+Default breakpoints: `{ lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }`. Default cols: `{ lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 }`.
+
+## Core Engine
+
+The `src/core/` directory contains pure functions with no DOM dependency. This separation means the layout math can be unit-tested without a browser environment.
+
+### Collision Detection (`collision.ts`)
+
+AABB (axis-aligned bounding box) overlap check. `collides(a, b)` returns true if two layout items overlap. `getFirstCollision` and `getAllCollisions` scan a layout array.
+
+### Compaction (`compact.ts`)
+
+`compact(layout, compactType, cols)` produces a new layout with items packed toward the origin. Supports `"vertical"` (pack upward), `"horizontal"` (pack leftward), and `null` (no compaction).
+
+### Layout Engine (`layout-engine.ts`)
+
+`moveElement` moves an item and resolves collisions by pushing displaced items. Collision resolution uses a bounded loop (max 100 iterations) to prevent infinite recursion — a regression from an earlier recursive implementation.
+
+### Responsive Utils (`responsive.ts`)
+
+`getBreakpointFromWidth` maps a pixel width to a breakpoint name. `findOrGenerateResponsiveLayout` returns the stored layout for a breakpoint or generates one from the largest available layout.
+
+## Drag and Resize System
+
+Drag and resize are pointer-event driven. `handlePointerDown` on `<grid-layout>` uses `composedPath()` to find the target `<grid-item>` across shadow DOM boundaries (since `closest("grid-item")` can't cross shadow roots). `setPointerCapture` is called on the `<grid-layout>` element itself — not `e.target` — with `pointermove` and `pointerup` listeners on `this`. This keeps all pointer events within the component regardless of where the pointer moves.
+
+During interaction, the `[interacting]` attribute is set on the container to suppress height transitions and prevent layout jank. The placeholder element fades via opacity/visibility rather than appearing abruptly.
+
+`prefers-reduced-motion` is respected: near-zero transition durations are applied automatically. The `no-animation` attribute disables all transitions globally.
+
+## Keyboard Accessibility
+
+Full keyboard navigation is implemented in `handleKeyDown` on `<grid-layout>`:
+
+| Key | Context | Action |
+|---|---|---|
+| Enter / Space | Item focused | Start drag mode |
+| R | Item focused | Start resize mode |
+| Arrow keys | Drag mode | Move one cell |
+| Arrow keys | Resize mode | Grow/shrink one cell |
+| Enter | Drag or resize mode | Confirm |
+| Escape | Drag or resize mode | Cancel, revert |
+
+Keyboard state is tracked via private fields: `_kbDragActive`, `_kbResizeActive`, `_kbFocusedItemId`, `_kbOldLayout`. The live region announces pick-up, movement, drop, and cancel events.
+
+## External Drag-and-Drop
+
+HTML5 drag events (`dragenter`, `dragover`, `dragleave`, `drop`) on `<grid-layout>`. Enabled via `isDroppable = true`. The `droppingItem` property provides the size descriptor `{ i, w, h }` for the incoming item. A placeholder is shown as the user drags over the grid. On drop, an `external-drop` event fires with the final layout and placed item.
+
+External drop state is tracked via `_isDroppable`, `_droppingItem`, `_externalDragOver`, `_externalPlaceholderItem`.
+
+## Lifecycle Hooks
+
+Hooks are JS property setters, not attributes. Return `false` to cancel.
+
+| Hook | Fires | Cancel effect |
+|---|---|---|
+| `beforeDragStart` | Before drag begins | Prevents drag |
+| `beforeResizeStart` | Before resize begins | Prevents resize |
+| `layoutChangeFilter` | On every layout change | Rejects or modifies layout |
+| `afterDrop` | After drag ends | Reverts to pre-drag layout |
+
+`<responsive-grid-layout>` forwards all four hooks to its inner `<grid-layout>`.
+
+## CSS Custom Properties
+
+All 15 properties are set on the host element and cascade into Shadow DOM via `var(--grid-*, fallback)`. Fallbacks use `colorVar()` / `semanticVar()` from `@maneki/foundation`.
+
+Key properties: `--grid-item-transition-duration`, `--grid-item-active-opacity`, `--grid-handle-size`, `--grid-handle-color`, `--grid-placeholder-bg`, `--grid-placeholder-border`, `--grid-focus-ring-color`, `--grid-container-transition-duration`.
+
+## Design Decisions
+
+**Core/components split.** All layout math lives in `src/core/` as pure functions. Components are thin wrappers that translate DOM events into core function calls and apply the results. This makes the logic independently testable and keeps component files focused on DOM concerns.
+
+**Composition over inheritance.** `<responsive-grid-layout>` wraps `<grid-layout>` rather than extending it. This avoids the fragility of Web Component inheritance and keeps the two components independently usable.
+
+**Bounded collision resolution.** The layout engine uses a loop capped at 100 iterations instead of recursion. An earlier recursive implementation caused stack overflows on certain layouts.
+
+**Pointer capture on the container.** `setPointerCapture` on `<grid-layout>` (not the dragged item) ensures `pointermove` and `pointerup` events are always received even when the pointer leaves the component boundary mid-drag.
+
+**Layout always cloned on get/set.** The `layout` getter returns a deep clone. This prevents external code from mutating internal state directly, which would bypass compaction and event emission.
+
+**No attributes in constructors.** `role` and `aria-roledescription` are set in `connectedCallback` with a presence guard. Setting attributes in constructors causes `NotSupportedError` when elements are created via `document.createElement` during Lit template cloning.
+
+## Testing
+
+220 unit tests (Vitest + happy-dom), co-located with source. 21 Playwright visual screenshot tests against `e2e/fixtures.html` (8 grid scenarios). Benchmarks in `benchmark.test.ts`.
+
+## Known Issues
+
+1. **No Moon build dependency on foundation.** `grid-layout` depends on `@maneki/foundation` at runtime but doesn't declare `foundation:build` in `moon.yml`. A clean build from scratch could fail if foundation hasn't been built yet.
+
+2. **`src/styles/` is empty.** The directory exists but all CSS lives inside component files as template literals. The directory is vestigial.
+
+3. **`responsive-grid-layout` layouts setter bypasses `onWidthChange`.** The setter applies the layout for the current breakpoint directly rather than going through `onWidthChange`. This was intentional — it fixes a race condition where `ResizeObserver` fires before `setTimeout(0)` sets the layouts — but it means the two code paths are not symmetric.
+
+---
+
+*This document describes the architecture as of April 2026. See `docs/adr/` for individual decision records.*

--- a/packages/ui-components/ARCHITECTURE.md
+++ b/packages/ui-components/ARCHITECTURE.md
@@ -1,0 +1,283 @@
+# UI Components Architecture
+
+*Snapshot: April 2026*
+
+## Overview
+
+`@maneki/ui-components` is the largest package in the monorepo. It ships 78 Web Components covering the full Figma "Foundation UI Kit" spec: primitives, form controls, navigation, overlays, data display, calendar, datetime picker, and more. Shadow DOM encapsulation throughout. CSS custom properties for theming. TypeScript types for every attribute. 3564 unit tests.
+
+Dependencies: `@maneki/foundation` (production), `lit` (production, new components only).
+
+## Component Inventory
+
+| Category | Components |
+|---|---|
+| Primitives | `<ui-badge>`, `<ui-image>`, `<ui-button>`, `<ui-avatar>`, `<ui-alert>`, `<ui-label>`, `<ui-link>`, `<ui-tag>` |
+| Form Controls | `<ui-checkbox-item>`, `<ui-checkbox-group>`, `<ui-radio-item>`, `<ui-radio-group>`, `<ui-input>`, `<ui-input-group>`, `<ui-file-upload>`, `<ui-dropzone>`, `<ui-select>`, `<ui-textarea>` |
+| Containers | `<ui-card>`, `<ui-button-group>`, `<ui-toolbar>`, `<ui-toolbar-separator>` |
+| Navigation | `<ui-breadcrumb-item>`, `<ui-breadcrumb-group>`, `<ui-side-panel-menu>`, `<ui-side-panel-menu-item>`, `<ui-side-panel-menu-section>` |
+| Disclosure | `<ui-accordion-item>`, `<ui-accordion-group>` |
+| Menus & Dropdowns | `<ui-dropdown>`, `<ui-dropdown-item>`, `<ui-dropdown-heading>`, `<ui-dropdown-separator>`, `<ui-dropdown-split>`, `<ui-menu>` |
+| Overlays | `<ui-modal>`, `<ui-popover>`, `<ui-tooltip>` |
+| Tabs | `<ui-tab-item>`, `<ui-tab-group>` |
+| Icons | `<ui-icon>` |
+| Data Display | `<ui-table>`, `<ui-table-row>`, `<ui-table-cell>`, `<ui-metric>`, `<ui-metric-group>` |
+| Carousel | `<ui-carousel>`, `<ui-carousel-item>` |
+| Calendar | `<ui-calendar>`, `<ui-calendar-panel>`, `<ui-calendar-quicklinks>`, `<ui-calendar-time>` |
+| Datetime Picker | `<ui-datetime-picker-input>`, `<ui-datetime-picker>`, `<ui-clock>` |
+| List | `<ui-list-item>`, `<ui-list-header>`, `<ui-list-group>` |
+| Steps | `<ui-step-item>`, `<ui-step-group>` |
+| Tree | `<ui-tree-item>`, `<ui-tree-group>` |
+| Search | `<ui-search>`, `<ui-queryfield>`, `<ui-queryfield-tag>` |
+| Progress | `<ui-progress-bar>`, `<ui-progress-circle>` |
+| Misc | `<ui-pagination>`, `<ui-person-item>`, `<ui-person-group>`, `<ui-scrollbar>`, `<ui-separator>`, `<ui-side-panel>`, `<ui-skeleton>`, `<ui-slider>`, `<ui-switch>`, `<ui-pull-to-refresh>`, `<ui-wizard>` |
+
+Full API for each component is in `packages/ui-components/AGENTS.md`.
+
+## Two Component Paradigms
+
+The package contains two generations of components, coexisting without obligation to migrate.
+
+### Vanilla HTMLElement (existing components)
+
+The original pattern. Used by `<ui-button>`, `<ui-alert>`, most form controls, and the majority of the catalog.
+
+```ts
+class UiButton extends HTMLElement {
+  static observedAttributes = ["action", "emphasis", "size"];
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: "open" });
+    // DOM built imperatively with document.createElement()
+  }
+
+  attributeChangedCallback(name: string, _old: string, value: string) {
+    // update shadow DOM in response to attribute changes
+  }
+}
+
+customElements.define("ui-button", UiButton);
+```
+
+Key points:
+- `attachShadow({ mode: "open" })` in the constructor
+- DOM built with `document.createElement()`, not `innerHTML`
+- CSS lives in a `STYLES` template literal at module level
+- `customElements.define()` at module level (side-effectful import)
+
+### Lit / LitElement (new components, ADR-028)
+
+Required for all new components. Used by `<ui-side-panel-menu-section>`, `<ui-switch>`, `<ui-skeleton>`, and others added after ADR-028.
+
+```ts
+@customElement("ui-foo")
+class UiFoo extends LitElement {
+  @property() size: "s" | "m" | "l" = "m";
+
+  static styles = css`
+    :host { display: block; }
+  `;
+
+  render() {
+    return html`<div class="foo"><slot></slot></div>`;
+  }
+}
+```
+
+Key points:
+- `@customElement()` decorator handles registration
+- `@property()` decorators replace `observedAttributes` + `attributeChangedCallback`
+- `static styles` replaces the `STYLES` constant
+- `render()` returns a `html` template literal
+- Foundation tokens wrapped in `unsafeCSS()` inside `css` tagged literals
+
+The rationale is in [ADR-028](../adr/028-lit-in-ui-components.md). The short version: Lit eliminates the boilerplate of manual DOM diffing and attribute observation while keeping Shadow DOM encapsulation intact.
+
+## Shadow DOM Pattern
+
+Every component uses `attachShadow({ mode: "open" })`. No light DOM components exist.
+
+### CSS Custom Properties
+
+The theming API is CSS custom properties with the `--ui-*` prefix. Each component exposes override vars that fall back to foundation tokens:
+
+```css
+/* nested var pattern: consumer override → foundation token */
+:host {
+  background: var(--ui-btn-bg, var(--fd-color-blue-60));
+  color: var(--ui-btn-color, var(--fd-semantic-text-primary));
+}
+```
+
+This gives consumers a stable override surface without breaking the token chain. The foundation token is always the last fallback.
+
+### Font Access in Shadow DOM
+
+The Material Symbols font is loaded globally by the app (`registerIconFont()`), but Shadow DOM can't see global `@font-face` rules. Every component that uses icons declares a local `@font-face` pointing to `local("Material Symbols Outlined")`:
+
+```css
+@font-face {
+  font-family: "Material Symbols Outlined";
+  font-style: normal;
+  src: local("Material Symbols Outlined");
+}
+```
+
+This re-uses the already-loaded font without re-downloading it.
+
+## Foundation Token Wiring
+
+Components import token helpers from `@maneki/foundation` and define constants at module level:
+
+```ts
+import { colorVar, semanticVar, spaceVar, typeBlock } from "@maneki/foundation";
+import { TEXT_PRIMARY, SP_2, TYPE_BODY_02, BLUE_60 } from "@maneki/foundation";
+```
+
+Pre-computed constants (`TEXT_PRIMARY`, `SP_1`, etc.) are preferred over calling helpers inline. They're defined once in foundation and imported directly, avoiding repeated function calls at module evaluation time.
+
+Typography uses `typeBlock()` via the `TYPE_*` constants, which emit `font-family + font-size + line-height + font-weight` in a single interpolation:
+
+```css
+:host {
+  ${TYPE_BODY_02}  /* expands to all four font properties */
+}
+```
+
+The only values not covered by tokens: `#ffffff` (white, absent from the palette), `rgba()` overlays for hover/active/focus states, and shape constants like `2px`/`999px` border-radius.
+
+## Icon System
+
+Icons use a subsetted Material Symbols Outlined font (~45 KB) shipped in `@maneki/foundation/assets/`. The subset contains only the icons actually used by the design system.
+
+Icons are referenced by Unicode codepoint constants, not ligature strings:
+
+```ts
+import { ICON_CLOSE, ICON_EXPAND_MORE } from "@maneki/foundation";
+
+clearIcon.textContent = ICON_CLOSE;        // "\uE5CD"
+chevronIcon.textContent = ICON_EXPAND_MORE; // "\uE5CF"
+```
+
+Codepoints are compile-time constants. A typo in the import name is a build error, not a silent missing icon at runtime.
+
+The `<ui-icon>` component wraps this system with a `name` attribute API, `ICON_CODEPOINTS` lookup, ligature fallback, 5 sizes, 10 states, and filled variant support. Custom SVG icons can be registered alongside Material Symbols via `registerIcon()` / `registerIcons()`, re-exported from the package root.
+
+One constraint: `<ui-icon>` must be created in `connectedCallback()`, not the constructor. Creating custom elements with attributes in the constructor throws `NotSupportedError` when the parent is parsed from HTML.
+
+## Multi-Entry Build
+
+The Vite config emits two kinds of outputs:
+
+```
+dist/
+  index.js                    # barrel — all 78 components
+  components/
+    ui-badge.js               # per-component entry
+    ui-button.js
+    ...
+  shared/
+    [name]-[hash].js          # deduped foundation chunks
+```
+
+The entry map is generated dynamically at build time by scanning `src/components/` for files matching `ui-*.ts` (excluding `.test.ts` and `.styles.ts`):
+
+```ts
+entry: {
+  index: resolve(__dirname, "src/index.ts"),
+  ...Object.fromEntries(
+    readdirSync(resolve(__dirname, "src/components"))
+      .filter((f) => f.startsWith("ui-") && f.endsWith(".ts")
+                  && !f.includes(".test.") && !f.includes(".styles."))
+      .map((f) => [`components/${f.replace(".ts", "")}`, ...])
+  ),
+}
+```
+
+The `package.json` exports map exposes deep imports:
+
+```ts
+// imports only ui-badge + its foundation deps
+import "@maneki/ui-components/components/ui-badge.js";
+```
+
+The blog app uses this to import only the 4 components it needs, keeping its bundle lean. The catalog imports the barrel.
+
+A custom Vite plugin (`minifyCssLiterals`) minifies CSS inside `/* css */`-tagged template literals at build time. This strips comments and collapses whitespace without affecting DX during development or test runs.
+
+## Styles Extraction
+
+Components that grow past ~700 lines split into two files:
+
+- `ui-foo.ts` — component class, DOM construction, event handling
+- `ui-foo.styles.ts` — `STYLES` constant, token constants, shared maps (e.g., `STATUS_ICON_MAP`)
+
+Currently extracted: `ui-input`, `ui-select`, `ui-textarea`, `ui-dropdown-item`, `ui-dropdown-split`, `ui-side-panel-menu`, `ui-calendar`, `ui-calendar-quicklinks`, `ui-calendar-time`, `ui-calendar-panel`, `ui-datetime-picker-input`, `ui-datetime-picker`, `ui-clock`, `ui-list-item`, `ui-list-header`, `ui-popover`.
+
+The `.styles.ts` files are excluded from the Vite entry map — they're imported by their companion `.ts` file and bundled into the same output chunk.
+
+## Panel Transition Pattern
+
+Dropdown, menu, select, and popover panels share a consistent open/close animation:
+
+```css
+.panel {
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-4px);
+  pointer-events: none;
+  transition: opacity 0.15s ease, visibility 0.15s ease, transform 0.15s ease;
+}
+
+.panel[open] {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .panel { transition: none; }
+}
+```
+
+`visibility: hidden` (not `display: none`) keeps the panel in the layout tree so transitions work. `pointer-events: none` prevents interaction while hidden.
+
+## Type Safety
+
+Every attribute has a corresponding exported union type:
+
+```ts
+export type ButtonAction   = "primary" | "secondary" | "destructive" | "info" | "contrast";
+export type ButtonEmphasis = "bold" | "subtle" | "minimal";
+export type AlertStatus    = "none" | "information" | "success" | "error" | "warning";
+```
+
+Property setters accept these types. Passing an invalid value is a TypeScript error. The barrel export re-exports all types alongside the class, so consumers get full type coverage from a single import.
+
+## Design Decisions
+
+**Shadow DOM always.** No light DOM components. Encapsulation is non-negotiable — it's what makes the components safe to drop into any host app without style leakage.
+
+**Composition over inheritance.** Components don't extend each other. `<ui-dropdown>` composes `<ui-button>` as its trigger. `<ui-input-group>` wraps `<ui-input>`. This keeps the inheritance chain flat and avoids the fragile base class problem.
+
+**Lit for new components.** The vanilla pattern works but requires significant boilerplate for attribute observation and DOM diffing. Lit eliminates that without changing the Shadow DOM model. Existing components stay vanilla — migration is not required.
+
+**Type-safe tokens, no hardcoded values.** Raw hex colors, pixel spacing, and font sizes are banned. Every design value traces back to a foundation token. The only exceptions are white (`#ffffff`), `rgba()` overlays, and a handful of shape constants with no token equivalent.
+
+**Codepoint constants over ligature strings.** Icon ligatures are fragile — a missing glyph silently renders as text. Codepoints are explicit Unicode values. A wrong import is a compile error.
+
+**Branch per component.** Every new component lives on its own branch. No direct pushes to `main`. Visual Figma verification is required before merge.
+
+## Known Issues
+
+1. **AGENTS.md component list is behind the index.** The AGENTS.md overview section documents the original ~50 components. The actual `src/index.ts` exports 78. The newer categories (metric, pagination, person, progress, queryfield, scrollbar, search, separator, side-panel, skeleton, slider, steps, switch, tree, wizard) are missing from the AGENTS.md overview.
+
+2. **`<ui-icon>` size not inherited from parent `font-size`.** Because `<ui-icon>` uses Shadow DOM, `font-size` on a parent element doesn't control icon size. Every component that embeds `<ui-icon>` must set `--ui-icon-size` explicitly for each size variant. Easy to miss when adding a new size.
+
+3. **No lazy registration.** Importing the barrel (`import "@maneki/ui-components"`) registers all 78 custom elements immediately. Apps that need only a subset should use deep imports via the exports map.
+
+---
+
+*This document describes the architecture as of April 2026. See `docs/adr/` for individual decision records, and `packages/ui-components/AGENTS.md` for the full component API reference.*


### PR DESCRIPTION
## Summary

- Added historical architecture documentation across the monorepo
- Cross-cutting monorepo doc in `docs/architecture/monorepo.md` (toolchain, dependency graph, build orchestration, principles)
- Per-project `ARCHITECTURE.md` files colocated with each package/app:
  - `packages/foundation/ARCHITECTURE.md`
  - `packages/ui-components/ARCHITECTURE.md`
  - `packages/grid-layout/ARCHITECTURE.md`
  - `packages/flex-layout/ARCHITECTURE.md`
  - `packages/charts/ARCHITECTURE.md`
  - `apps/catalog/ARCHITECTURE.md`
  - `apps/blog/ARCHITECTURE.md`
- Index at `docs/architecture/README.md` linking to all docs

These are historical snapshots (April 2026), separate from ADRs. They describe the overall system shape — how things are built, why, and known trade-offs.

Also filed 5 issues for fixable items found during the review:
- #406 — Missing Moon build deps for grid-layout and flex-layout
- #407 — Incorrect build order in flex-layout moon.yml
- #408 — Incomplete dependsOn in catalog moon.yml
- #409 — Extract shared markdown renderer from blog Vite plugins
- #410 — Remove duplicate admin route entries in blog vite.config