### PR TITLE
fix: build config issues found during architecture review

### DIFF
--- a/apps/blog/vite.config.ts
+++ b/apps/blog/vite.config.ts
@@ -38,8 +38,6 @@ export default defineConfig(({ command }) => ({
             "/admin/gallery": "/admin/gallery.html",
             "/admin/pages": "/admin/pages.html",
             "/admin": "/admin.html",
-            "/admin/gallery": "/admin/gallery.html",
-            "/admin": "/admin.html",
           };
           const rewrite = adminRoutes[req.url?.split("?")[0] ?? ""];
           if (rewrite) req.url = rewrite;

--- a/apps/catalog/moon.yml
+++ b/apps/catalog/moon.yml
@@ -5,6 +5,9 @@ language: 'typescript'
 dependsOn:
   - 'foundation'
   - 'ui-components'
+  - 'grid-layout'
+  - 'flex-layout'
+  - 'charts'
 
 tasks:
   dev:

--- a/packages/flex-layout/moon.yml
+++ b/packages/flex-layout/moon.yml
@@ -2,15 +2,20 @@ $schema: 'https://moonrepo.dev/schemas/project.json'
 
 language: 'typescript'
 
+dependsOn:
+  - 'foundation'
+
 tasks:
   build:
-    script: 'tsc && vite build'
+    script: 'vite build && tsc --emitDeclarationOnly'
     inputs:
       - 'src/**/*'
       - 'tsconfig.json'
       - 'vite.config.ts'
     outputs:
       - 'dist'
+    deps:
+      - '^:build'
 
   test:
     command: 'vitest --run'

--- a/packages/grid-layout/moon.yml
+++ b/packages/grid-layout/moon.yml
@@ -11,6 +11,8 @@ tasks:
       - 'vite.config.ts'
     outputs:
       - 'dist'
+    deps:
+      - '^:build'
 
   test:
     command: 'vitest --run'


### PR DESCRIPTION
## Summary

Batch of config fixes found during the architecture review (#411).

- Add missing Moon build deps (`^:build`) for grid-layout and flex-layout (fixes #406)
- Fix flex-layout build order: `tsc && vite build` → `vite build && tsc --emitDeclarationOnly` (fixes #407)
- Add missing `dependsOn` entries in catalog moon.yml for grid-layout, flex-layout, charts (fixes #408)
- Remove duplicate admin route entries in blog vite.config.ts (fixes #410)

No functional changes — all config/build fixes.