### PR TITLE
refactor(blog): extract shared markdown renderer from Vite plugins

### DIFF
--- a/apps/blog/plugins/markdown-posts.ts
+++ b/apps/blog/plugins/markdown-posts.ts
@@ -14,6 +14,7 @@ import MarkdownIt from "markdown-it";
 import anchor from "markdown-it-anchor";
 import { createHighlighter } from "shiki";
 import { fromHighlighter } from "@shikijs/markdown-it";
+import { applyManekiRenderers } from "./markdown-utils.js";
 
 const POSTS_VIRTUAL_ID = "virtual:posts";
 const POSTS_RESOLVED_ID = "\0" + POSTS_VIRTUAL_ID;
@@ -51,38 +52,7 @@ async function getMd(): Promise<MarkdownIt> {
     permalink: false,
   });
 
-// ─── Custom renderers: output Maneki Web Components instead of plain HTML ───
-
-  // <a> → <ui-link>
-  const defaultLinkOpen = md.renderer.rules.link_open ||
-    function (tokens, idx, options, _env, self) {
-      return self.renderToken(tokens, idx, options);
-    };
-
-  md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
-    const token = tokens[idx];
-    const href = token.attrGet("href") ?? "";
-    const isExternal = /^https?:\/\//.test(href);
-    token.tag = "ui-link";
-    if (isExternal) {
-      token.attrSet("external", "");
-      token.attrSet("target", "_blank");
-      token.attrSet("rel", "noopener");
-    }
-    return defaultLinkOpen(tokens, idx, options, env, self);
-  };
-
-  md.renderer.rules.link_close = function () {
-    return "</ui-link>";
-  };
-
-  // <img> → <ui-image>
-  md.renderer.rules.image = function (tokens, idx) {
-    const token = tokens[idx];
-    const src = token.attrGet("src") ?? "";
-    const alt = token.content ?? "";
-    return `<ui-image src="${src}" alt="${alt}"></ui-image>`;
-  };
+  applyManekiRenderers(md);
 
   mdInstance = md;
   return md;

--- a/apps/blog/plugins/markdown-utils.ts
+++ b/apps/blog/plugins/markdown-utils.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared MarkdownIt renderer rules for Maneki Web Components.
+ * Transforms standard HTML output to use design system components:
+ *   <a> → <ui-link>  (with external link detection)
+ *   <img> → <ui-image>
+ */
+
+import type MarkdownIt from "markdown-it";
+
+/** Apply Maneki Web Component renderer rules to a MarkdownIt instance. */
+export function applyManekiRenderers(md: MarkdownIt): void {
+  // <a> → <ui-link>
+  const defaultLinkOpen =
+    md.renderer.rules.link_open ||
+    function (tokens, idx, options, _env, self) {
+      return self.renderToken(tokens, idx, options);
+    };
+
+  md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
+    const token = tokens[idx];
+    const href = token.attrGet("href") ?? "";
+    const isExternal = /^https?:\/\//.test(href);
+    token.tag = "ui-link";
+    if (isExternal) {
+      token.attrSet("external", "");
+      token.attrSet("target", "_blank");
+      token.attrSet("rel", "noopener");
+    }
+    return defaultLinkOpen(tokens, idx, options, env, self);
+  };
+
+  md.renderer.rules.link_close = function () {
+    return "</ui-link>";
+  };
+
+  // <img> → <ui-image>
+  md.renderer.rules.image = function (tokens, idx) {
+    const token = tokens[idx];
+    const src = token.attrGet("src") ?? "";
+    const alt = token.content ?? "";
+    return `<ui-image src="${src}" alt="${alt}"></ui-image>`;
+  };
+}

--- a/apps/blog/plugins/pages.ts
+++ b/apps/blog/plugins/pages.ts
@@ -12,6 +12,7 @@
 import { type Plugin } from "vite";
 import { getDb } from "./db.js";
 import MarkdownIt from "markdown-it";
+import { applyManekiRenderers } from "./markdown-utils.js";
 
 const VIRTUAL_MODULE_ID = "virtual:pages";
 const RESOLVED_ID = "\0" + VIRTUAL_MODULE_ID;
@@ -20,39 +21,7 @@ const EMPTY = "export const pages = [];\nexport function getPage(_slug) { return
 
 function createMd(): MarkdownIt {
   const md = new MarkdownIt({ html: true, linkify: true, typographer: true });
-
-  // <a> → <ui-link>
-  const defaultLinkOpen =
-    md.renderer.rules.link_open ||
-    function (tokens, idx, options, _env, self) {
-      return self.renderToken(tokens, idx, options);
-    };
-
-  md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
-    const token = tokens[idx];
-    const href = token.attrGet("href") ?? "";
-    const isExternal = /^https?:\/\//.test(href);
-    token.tag = "ui-link";
-    if (isExternal) {
-      token.attrSet("external", "");
-      token.attrSet("target", "_blank");
-      token.attrSet("rel", "noopener");
-    }
-    return defaultLinkOpen(tokens, idx, options, env, self);
-  };
-
-  md.renderer.rules.link_close = function () {
-    return "</ui-link>";
-  };
-
-  // <img> → <ui-image>
-  md.renderer.rules.image = function (tokens, idx) {
-    const token = tokens[idx];
-    const src = token.attrGet("src") ?? "";
-    const alt = token.content ?? "";
-    return `<ui-image src="${src}" alt="${alt}"></ui-image>`;
-  };
-
+  applyManekiRenderers(md);
   return md;
 }
 


### PR DESCRIPTION
## Summary

Extracts the duplicated MarkdownIt renderer rules (`<a>` → `<ui-link>`, `<img>` → `<ui-image>`) into a shared `plugins/markdown-utils.ts` utility. Both `markdown-posts` and `pages` plugins now call `applyManekiRenderers(md)` instead of duplicating the renderer setup.

Fixes #409.

## Changes
- New `apps/blog/plugins/markdown-utils.ts` — `applyManekiRenderers()` function
- `apps/blog/plugins/markdown-posts.ts` — replaced inline renderer rules with `applyManekiRenderers(md)`
- `apps/blog/plugins/pages.ts` — replaced inline `createMd()` body with `applyManekiRenderers(md)`

No functional changes — same renderer output.