### PR TITLE
docs: update README and architecture for trading projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # maneki-monorepo
 
-Personal engineering monorepo: a design system built with Web Components, and a full-stack blog/portfolio app built on top of it. TypeScript, Vite, Vitest.
+Polyglot engineering monorepo: a design system built with Web Components, a full-stack blog/portfolio app, an algorithmic BTC trading bot (Zig), a SwiftUI trading dashboard, and a Python research lab. TypeScript, Zig, Swift, Python.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -31,9 +31,14 @@ maneki-monorepo/
 │   ├── charts/              # 11 SVG chart components (@maneki/charts)
 │   ├── grid-layout/         # Drag/resize grid layout (@maneki/grid-layout)
 │   └── flex-layout/         # Panel-based flex layout (@maneki/flex-layout)
+├── services/
+│   └── dctrading-bot/       # BTC trading bot (Zig 0.16, Binance WS, Alpaca)
+├── labs/
+│   └── dctrading/           # Trading research lab (Python, MLX, backtesting)
 ├── apps/
 │   ├── catalog/             # Visual catalog + Playwright tests (@maneki/catalog)
-│   └── blog/                # Full-stack blog + portfolio (@maneki/blog)
+│   ├── blog/                # Full-stack blog + portfolio (@maneki/blog)
+│   └── neko-trade/          # Trading dashboard (SwiftUI, macOS + iOS)
 ```
 
 ---
@@ -54,7 +59,19 @@ maneki-monorepo/
 |---|---|
 | `catalog` | Visual catalog for all design system packages. 69 pages, 120 Playwright tests (58 visual + 58 a11y + sidebar + full layout). Lazy-loaded pages, History API routing, PWA, theme switcher. |
 | `blog` | Full-stack blog + portfolio. Hono API + Turso DB, CF Pages Functions, static prerendering, admin system (`/admin` hub, editor, gallery, pages editor), AI review/brainstorm panels (Claude via CF AI Gateway), photography management, deploy trigger, History API routing, PWA. |
+| `neko-trade` | SwiftUI dashboard for the DCTrading bot. Bot status, equity chart, trade history, account ledger, live BTC price. macOS 13+ / iOS 16+. |
 
+### Services
+
+| Service | Stack | Description |
+|---|---|---|
+| `dctrading-bot` | Zig 0.16 | BTC algorithmic trading bot. Directional Change theory, 3-regime strategy (BULL/SIDEWAYS/BEAR), Binance WebSocket, Alpaca paper trading, Turso DB, Telegram/ntfy notifications. 39 tests. |
+
+### Labs
+
+| Lab | Stack | Description |
+|---|---|---|
+| `dctrading` | Python 3.12 | Trading research: vectorized backtesting (numpy), MLX sentiment analysis (Qwen3.5-9B-4bit), real-time Alpaca news monitor, regime comparison. |
 ---
 
 ## Getting Started
@@ -81,6 +98,16 @@ moon run catalog:dev
 
 # Blog (dev)
 moon run blog:dev
+
+# Trading bot (build + test)
+moon run dctrading-bot:build
+moon run dctrading-bot:test
+
+# Trading research (backtest)
+moon run dctrading:backtest-fast
+
+# Neko Trade (build)
+moon run neko-trade:build
 ```
 
 ---

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -16,6 +16,9 @@ Unlike ADRs (which record individual decisions), these docs describe the overall
 | [Charts](../../packages/charts/ARCHITECTURE.md) | `packages/charts/` | SVG chart components |
 | [Catalog](../../apps/catalog/ARCHITECTURE.md) | `apps/catalog/` | Visual regression testing, page registration |
 | [Blog](../../apps/blog/ARCHITECTURE.md) | `apps/blog/` | Full-stack architecture, build-time data baking, editor |
+| [DCTrading Bot](../../services/dctrading-bot/AGENTS.md) | `services/dctrading-bot/` | Zig trading bot, Binance WS, Alpaca, Turso |
+| [Neko Trade](../../apps/neko-trade/AGENTS.md) | `apps/neko-trade/` | SwiftUI dashboard, macOS + iOS |
+| [DCTrading Lab](../../labs/dctrading/AGENTS.md) | `labs/dctrading/` | Python research, backtesting, MLX sentiment |
 
 ## When to Update
 

--- a/docs/architecture/monorepo.md
+++ b/docs/architecture/monorepo.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Design system monorepo shipping Web Components, design tokens, and layout primitives — plus a full-stack blog/portfolio app built on top of them. Everything is TypeScript, built with Vite, tested with Vitest and Playwright.
+Design system monorepo shipping Web Components, design tokens, and layout primitives — plus a full-stack blog/portfolio app, an algorithmic BTC trading bot (Zig), a SwiftUI trading dashboard, and a Python research lab. Polyglot: TypeScript, Zig, Swift, Python.
 
 ## Toolchain
 
@@ -25,7 +25,7 @@ No Webpack, no Lerna, no Turborepo. The stack is intentionally minimal.
 ## Dependency Graph
 
 ```
-                    @maneki/foundation (zero deps)
+@maneki/foundation (zero deps)
                    /     |      |       \        \
                   /      |      |        \        \
     ui-components  grid-layout  flex-layout  charts
@@ -37,6 +37,11 @@ No Webpack, no Lerna, no Turborepo. The stack is intentionally minimal.
               @maneki/catalog               @maneki/blog
            (all 5 packages)          (foundation + ui-components
                                       + grid-layout + hono/turso/lit)
+
+dctrading-bot (Zig)  ←→  neko-trade (SwiftUI)  ←→  dctrading lab (Python)
+    Binance WS              reads Turso DB            backtesting
+    Alpaca trading          reads Alpaca API           MLX sentiment
+    writes Turso DB         reads Binance API          Alpaca news WS
 ```
 
 Foundation is the root — zero runtime dependencies, pure token generation. The four library packages (ui-components, grid-layout, flex-layout, charts) are siblings that don't depend on each other. The two apps sit at the top of the graph.
@@ -52,10 +57,13 @@ Foundation is the root — zero runtime dependencies, pure token generation. The
 | charts | foundation | SVG chart components |
 | catalog (app) | all 5 packages | Visual catalog + Playwright tests |
 | blog (app) | foundation, ui-components, grid-layout, hono, @libsql/client, lit, zod, leaflet | Full-stack app |
+| neko-trade (app) | none | SwiftUI, no npm deps |
+| dctrading-bot (service) | none | Zig 0.16, single static binary |
+| dctrading (lab) | numpy, pandas, torch, mlx-lm, websocket-client | Python 3.12 |
 
 ## Build Orchestration
 
-Moon auto-discovers projects via `apps/*` and `packages/*` globs. Build tasks declare dependencies using Moon's `deps` and `dependsOn` fields.
+Moon auto-discovers projects via `apps/*`, `packages/*`, `services/*`, and `labs/*` globs. Build tasks declare dependencies using Moon's `deps` and `dependsOn` fields.
 
 ### Build Pipeline
 
@@ -76,6 +84,9 @@ Apps: `vite build` → `dist/`
 | flex-layout | none declared | Builds independently |
 | catalog | `^:build` | Waits for all npm deps to build |
 | blog | `^:build` | Waits for all npm deps to build |
+| dctrading-bot | none | Zig build, independent of npm |
+| neko-trade | none | Swift build via xcodegen, independent of npm |
+| dctrading | none | Python, no build step |
 
 ### Dev-Time Resolution
 


### PR DESCRIPTION
## Summary
- Update root README with dctrading-bot, neko-trade, and dctrading lab (structure, tables, moon tasks)
- Update `docs/architecture/monorepo.md` with trading projects in dependency graph, dependency details, and Moon task deps
- Update `docs/architecture/README.md` index with links to trading project docs