### PR TITLE
docs: add ADRs and architecture docs for trading projects

### DIFF
--- a/apps/neko-trade/ARCHITECTURE.md
+++ b/apps/neko-trade/ARCHITECTURE.md
@@ -1,0 +1,99 @@
+# Neko Trade Architecture
+
+*Snapshot: April 2026*
+
+## Overview
+
+SwiftUI dashboard app for monitoring the DCTrading bot. 5 tabs: Dashboard, Ledger, Equity, Trades, Settings. Native macOS 13+ / iOS 16+, no external dependencies. Reads from Turso DB, Alpaca API, and Binance API.
+
+## Structure
+
+```
+apps/neko-trade/
+├── Sources/DCTradingViewer/
+│   ├── DCTradingViewerApp.swift    # App entry, dark mode, macOS window size
+│   ├── Models/
+│   │   └── Models.swift            # Data types (EquityLog, TradeEvent, Position, BotStatus, LedgerEntry)
+│   ├── Services/
+│   │   ├── TursoClient.swift       # Turso HTTP client + AppSettings singleton
+│   │   ├── AlpacaClient.swift      # Alpaca REST client (position queries)
+│   │   └── BinanceClient.swift     # Binance REST client (BTC price + klines)
+│   ├── Views/
+│   │   ├── ContentView.swift       # Tab container (5 tabs)
+│   │   ├── DashboardView.swift     # Bot status, regime, equity, BTC price, open position (~470 lines)
+│   │   ├── LedgerView.swift        # Account ledger with cash balance summary
+│   │   ├── EquityChartView.swift   # Equity over time (Swift Charts)
+│   │   ├── TradeHistoryView.swift  # Trade list with PnL, signal vs fill drift (~474 lines)
+│   │   └── SettingsView.swift      # Credential management with status indicators
+│   └── Assets.xcassets/            # App icon
+└── project.yml                     # xcodegen project spec
+```
+
+## Data Sources
+
+The app reads from three independent APIs. No backend server needed.
+
+```
+┌─────────────┐     ┌──────────────┐     ┌──────────────┐
+│  Binance API │     │   Turso DB   │     │  Alpaca API  │
+│  (free, no   │     │  (bot writes │     │  (source of  │
+│   auth)      │     │   here)      │     │   truth for  │
+└──────┬───────┘     └──────┬───────┘     │   position)  │
+       │                    │             └──────┬───────┘
+       │                    │                    │
+       ▼                    ▼                    ▼
+  BTC price          Bot status            Open position
+  Price history      Equity log            Qty, entry price
+                     Trade events          Market value
+                     Account ledger
+                     ┌──────────────────────────────┐
+                     │        Neko Trade App         │
+                     │  Dashboard │ Ledger │ Equity  │
+                     │  Trades   │ Settings          │
+                     └──────────────────────────────┘
+```
+
+## Views
+
+### DashboardView (~470 lines)
+The main monitoring view. Shows:
+- Bot regime with color coding (BULL=green, SIDEWAYS=orange, BEAR=red)
+- Current equity and total PnL
+- Live BTC price from Binance (free, avoids Turso reads)
+- Open position with unrealized PnL (from Alpaca)
+- Mini equity chart (last 24h)
+- Auto-refreshes every 30s via `Timer.publish`
+
+### LedgerView
+Account ledger from Turso's `account_ledger` table. Shows cash balance summary at top, scrollable entry list below. Each entry: type, amount, balance_after, note, timestamp.
+
+### EquityChartView
+Equity over time using Swift Charts. Reads from `equity_log` table. Supports time range selection.
+
+### TradeHistoryView (~474 lines)
+Trade list with entry/exit prices, PnL per trade, and signal vs fill price drift for execution quality analysis.
+
+### SettingsView
+Credential management for Turso (URL + token) and Alpaca (key + secret). Persistent status indicators show connection health. Credentials stored in UserDefaults.
+
+## Services
+
+### TursoClient
+HTTP client for Turso's REST API. Queries all 5 bot tables. Also contains `AppSettings` — an `ObservableObject` singleton backed by UserDefaults for credential persistence.
+
+### AlpacaClient
+Alpaca REST client. Queries open position (qty, entry price, market value). Used by DashboardView for real-time position data.
+
+### BinanceClient
+Binance REST client. Current BTC/USDT price and kline history. Free API, no authentication needed. Used instead of Turso for price data to reduce DB reads.
+
+## Key Design Decisions
+
+- **ADR-037**: SwiftUI chosen for native performance, cross-platform (macOS + iOS), zero-ops deployment.
+- **Alpaca as position source of truth** (ADR-033): App reads position from Alpaca, not Turso, matching the bot's own convention.
+- **Binance for price**: Free API avoids unnecessary Turso reads for data that's publicly available.
+- **No push notifications**: Telegram/ntfy handle alerts from the bot. The app is for monitoring, not alerting.
+
+---
+
+*This document describes the architecture as of April 2026. See `docs/adr/` for individual decision records.*

--- a/docs/adr/031-zig-trading-bot.md
+++ b/docs/adr/031-zig-trading-bot.md
@@ -1,0 +1,33 @@
+# ADR-031: Zig for Production Trading Bot
+
+## Status
+
+Accepted
+
+## Context
+
+The trading bot needs to run 24/7 on a minimal GCP e2-micro instance, processing real-time Binance WebSocket data and executing Alpaca paper trades. Key requirements: low latency, small binary, no runtime dependencies, cross-compilation to Linux from macOS.
+
+## Decision
+
+Use Zig 0.16 for the production trading bot. Single static binary, no Python/curl runtime dependencies (except `feed.zig` bootstrap and `telegram.zig` shutdown fallback which still use `popen("curl")`).
+
+## Rationale
+
+- **Single static binary.** `zig build -Doptimize=ReleaseFast` produces one ~4MB binary. No interpreter, no virtual environment, no package manager on the server.
+- **Cross-compilation.** `-Dtarget=x86_64-linux` builds a Linux binary on macOS arm64 in seconds. No Docker, no CI pipeline needed for deployment.
+- **Native WebSocket + TLS.** `websocket.zig` library provides native TLS WebSocket connections. No external dependencies for Binance streaming.
+- **Deterministic memory.** No GC pauses during price processing. Arena allocators for request/response cycles, fixed-size ring buffers for MA and volatility windows.
+- **Async fire-and-forget.** `std.Thread.spawn` + `detach()` for Turso writes and Telegram notifications. Trading loop never blocks on I/O.
+
+## Consequences
+
+- Steeper learning curve than Python, but the bot is write-once-run-forever.
+- `popen("curl")` remains in two places: `feed.zig` REST bootstrap (separate refactor) and `telegram.zig` shutdown (native HTTP may have stale connections).
+- No REPL or hot-reload — changes require rebuild. Acceptable for a production bot that rarely changes.
+
+## Alternatives Considered
+
+- **Python** — prototyped first in the research lab. Too slow for real-time tick processing, GC pauses, heavy runtime.
+- **Rust** — similar performance profile but longer compile times, more complex ownership model for the fire-and-forget async pattern.
+- **Go** — GC pauses unacceptable for latency-sensitive trading. Larger binaries.

--- a/docs/adr/032-three-regime-dc-strategy.md
+++ b/docs/adr/032-three-regime-dc-strategy.md
@@ -1,0 +1,40 @@
+# ADR-032: Three-Regime Directional Change Strategy
+
+## Status
+
+Accepted
+
+## Context
+
+The initial 2-regime strategy (BULL/BEAR) used a 60-day MA to determine regime and applied DC trading + trailing stop in both. Backtesting showed the trailing stop was too aggressive in sideways markets, exiting positions prematurely during consolidation.
+
+## Decision
+
+Adopt a 3-regime strategy: BULL, SIDEWAYS, BEAR. Regime is determined by price relative to the 60-day MA with a 3% buffer zone:
+
+- **BULL** (price > MA + 3%): Hold position, no trailing stop, DC exits only.
+- **SIDEWAYS** (MA - 3% ≤ price ≤ MA + 3%): DC trading only, no trailing stop.
+- **BEAR** (price < MA - 3%): DC trading + vol-trailing stop (2% / 72h).
+
+Parameters: λ=0.07 (DC threshold), 60-day MA, 3% buffer, long-only.
+
+## Rationale
+
+Backtesting over 2019–2026 on $1K:
+- 3-regime: +4,071% ($40.7K), lower drawdown, higher Sharpe
+- 2-regime: +3,140% ($31.4K)
+
+The buffer zone prevents whipsawing at the MA boundary. Trailing stop only activates in BEAR, where downside protection matters most. SIDEWAYS lets DC theory work without premature exits.
+
+## Consequences
+
+- Checkpoint format upgraded to DCTRADE4 (magic `0x4443_5452_4144_4534`) with regime encoded as scalar[8]: 0=bear, 1=bull, 2=sideways.
+- Old DCTRADE3 checkpoints are rejected on load (test covers this).
+- Regime transitions logged to Turso and notified via Telegram.
+- 3 additional unit tests for regime transitions and sideways behavior.
+
+## Alternatives Considered
+
+- **2-regime (BULL/BEAR)** — simpler but worse returns and higher drawdown in sideways markets.
+- **HMM-based regime detection** — tested in Python lab (`hmmlearn`). More complex, no significant improvement over MA + buffer for this strategy.
+- **Adaptive λ** — varying DC threshold by regime. Tested, marginal improvement, added complexity.

--- a/docs/adr/033-alpaca-source-of-truth.md
+++ b/docs/adr/033-alpaca-source-of-truth.md
@@ -1,0 +1,37 @@
+# ADR-033: Alpaca as Source of Truth for Positions
+
+## Status
+
+Accepted
+
+## Context
+
+The bot calculates position size internally (`capital / price`), but Alpaca may fill a different quantity due to precision limits and price drift between signal and execution. This creates a discrepancy between internal state and actual position.
+
+## Decision
+
+Alpaca fill data is the source of truth for position quantity and entry price. After every buy order:
+
+1. Poll Alpaca for fill status (up to 10s).
+2. Use `fill_price` and `fill_qty` to update internal `strategy.entry_price` and `strategy.size`.
+3. Add back unspent capital from qty rounding to `strategy.capital` (internal adjustment only, not logged to ledger since the BUY ledger entry already uses actual fill qty).
+
+On startup, reconcile internal state with Alpaca's position endpoint.
+
+## Rationale
+
+- **Prevents PnL drift.** If internal state says 9.605 BTC but Alpaca holds 9.60, every equity calculation is wrong.
+- **Signal vs fill tracking.** `signal_price` is preserved in the `positions` table alongside `alpaca_order_id` for post-trade analysis of execution quality.
+- **Startup resilience.** If the bot restarts mid-position, Alpaca reconciliation restores correct state without relying on checkpoint freshness.
+
+## Consequences
+
+- `positions` table has `signal_price` and `alpaca_order_id` columns.
+- Bot fails to start without Alpaca credentials (intentional — no paper trading = no trading).
+- Neko Trade app reads position from Alpaca directly, not from Turso.
+- 3 unit tests cover qty rounding, exact fill, and price drift scenarios.
+
+## Alternatives Considered
+
+- **Internal state as source of truth** — simpler but accumulates drift over multiple trades.
+- **Turso as source of truth** — adds latency and a failure point. Alpaca is already the execution venue.

--- a/docs/adr/034-account-ledger.md
+++ b/docs/adr/034-account-ledger.md
@@ -1,0 +1,44 @@
+# ADR-034: Account Ledger for Capital Audit Trail
+
+## Status
+
+Accepted
+
+## Context
+
+The bot tracked equity via periodic snapshots (`equity_log` table, every 5 min), but there was no record of individual cash movements. Debugging capital discrepancies required reconstructing the flow from trade events manually.
+
+## Decision
+
+Add an `account_ledger` table that records every cash movement with a running balance:
+
+| Entry Type | Amount | When |
+|---|---|---|
+| `DEPOSIT` | +initial_capital | First run |
+| `ENTRY_FEE` | -(price × qty × 0.1%) | On buy |
+| `BUY` | -(price × qty) | On buy |
+| `SELL` | +(price × qty) | On sell |
+| `EXIT_FEE` | -(price × qty × 0.1%) | On sell |
+
+Each row stores: `type`, `amount`, `balance_after`, `note`, `timestamp`.
+
+PnL is derived from SELL - BUY, not stored as a separate entry.
+
+## Rationale
+
+- **Full audit trail.** Every dollar is accounted for. Balance can be reconstructed from the ledger alone.
+- **Startup capital restoration.** Bot reads `balance_after` from the latest ledger entry on startup (falls back to `equity_log` for backward compatibility).
+- **Debuggability.** Neko Trade's Ledger tab shows the full cash flow history.
+
+## Consequences
+
+- 5 entry types (DEPOSIT, ENTRY_FEE, BUY, SELL, EXIT_FEE). No UNSPENT entry — the BUY amount already reflects actual Alpaca fill qty.
+- Async writes via `std.Thread.spawn` + `detach()` (same pattern as other Turso writes).
+- Blocking read on startup (`logLedgerSync`) to restore capital before trading begins.
+- Neko Trade LedgerView consumes this table directly.
+
+## Alternatives Considered
+
+- **Derive everything from trade_events** — possible but requires fee recalculation and doesn't capture deposits.
+- **Store PnL as a ledger entry** — redundant since PnL = SELL - BUY. Removed TRADE_PNL entry during implementation.
+- **Store UNSPENT as a ledger entry** — removed because BUY already uses actual fill qty, so unspent capital was never deducted from the ledger in the first place.

--- a/docs/adr/035-native-zig-http-client.md
+++ b/docs/adr/035-native-zig-http-client.md
@@ -1,0 +1,37 @@
+# ADR-035: Native Zig HTTP Client
+
+## Status
+
+Accepted
+
+## Context
+
+The bot originally used `popen("curl ...")` for all HTTP calls (Turso, Alpaca, Telegram, ntfy). This worked but had problems: spawning a process per request, no connection pooling, string-based URL/header construction prone to injection, and a hard dependency on curl being installed.
+
+## Decision
+
+Replace `popen("curl")` with a shared `HttpClient` wrapper around `std.http.Client`. All modules (turso, alpaca, telegram) use the same client instance, passed from `main.zig`.
+
+Two exceptions remain:
+- `feed.zig` bootstrap: uses `popen("curl")` for Binance REST kline fetch (separate refactor).
+- `telegram.zig` shutdown: uses curl fallback because native HTTP connections may be stale after hours of idle.
+
+## Rationale
+
+- **Connection pooling.** Single `std.http.Client` reuses TCP connections across modules.
+- **No process spawning.** HTTP calls are in-process, ~10x faster than fork+exec curl.
+- **Type safety.** Headers and URLs are constructed programmatically, not via string interpolation.
+- **Zero external deps.** No curl binary required on the target system.
+
+## Consequences
+
+- `http_client.zig` provides `post()`, `get()`, `delete()` with custom headers.
+- All async Turso/Telegram writes allocate a context struct on the heap, freed in the worker thread after the HTTP call completes.
+- Sync reads (startup queries) use blocking HTTP calls on the main thread.
+- 10 new tests for JSON parsing (Alpaca + Turso response handling).
+
+## Alternatives Considered
+
+- **Keep popen("curl")** — works but wasteful and fragile.
+- **libcurl bindings** — adds a C dependency, defeats the purpose of a static Zig binary.
+- **Async I/O (io_uring)** — overkill for a bot that makes ~10 HTTP calls per trade.

--- a/docs/adr/036-mlx-local-sentiment.md
+++ b/docs/adr/036-mlx-local-sentiment.md
@@ -1,0 +1,39 @@
+# ADR-036: MLX Local Sentiment Analysis
+
+## Status
+
+Accepted
+
+## Context
+
+The research lab needed a sentiment scoring system for crypto news to evaluate whether sentiment could improve trade signal quality. Cloud LLM APIs (OpenAI, Anthropic) add latency, cost, and a network dependency for real-time scoring.
+
+## Decision
+
+Use Apple MLX framework with Qwen3.5-9B-4bit for local inference on Apple Silicon. The sentiment module has three layers:
+
+1. **News clients** — `AlpacaNews` (WebSocket real-time), `AlphaVantageNews`, `NewsAPIClient`.
+2. **LLM scorer** — `MLXLocalScorer` wraps `mlx-lm` for local inference. Base `LLMScorer` class allows swapping to cloud APIs.
+3. **Confidence aggregator** — `SentimentConfidence` combines multiple article scores into a trade confidence signal.
+
+The `news_monitor.py` daemon connects to Alpaca news WebSocket, scores each article with MLX, and sends Telegram/ntfy notifications for BTC/ETH/SOL/BNB.
+
+## Rationale
+
+- **Zero API cost.** Local inference on M-series Mac, no per-token billing.
+- **Low latency.** ~2-3s per article on M3, vs 5-10s for cloud API round-trip.
+- **Privacy.** No news data leaves the machine.
+- **Lazy loading.** Model loads on first use (~5s), then stays in memory.
+
+## Consequences
+
+- Requires Apple Silicon Mac with ≥16GB RAM for the 4-bit model.
+- Backtesting showed sentiment filter hurts returns (skipped a $371 winner). Not used for trade gating — monitoring only.
+- `--mock` flag on `test_sentiment.py` for fast CI without loading the model.
+- News monitor runs as a long-lived daemon (20h+ uptime observed).
+
+## Alternatives Considered
+
+- **OpenAI API** — works but costs money and adds latency for real-time monitoring.
+- **FinBERT** — smaller model, faster inference, but less nuanced for crypto-specific sentiment.
+- **No sentiment** — the current production choice. Sentiment is research/monitoring only.

--- a/docs/adr/037-swiftui-trading-dashboard.md
+++ b/docs/adr/037-swiftui-trading-dashboard.md
@@ -1,0 +1,39 @@
+# ADR-037: SwiftUI Trading Dashboard
+
+## Status
+
+Accepted
+
+## Context
+
+The trading bot writes data to Turso DB and Alpaca, but there was no way to monitor it without SSH-ing into the server or reading raw database rows. A dashboard was needed for real-time monitoring on macOS and iOS.
+
+## Decision
+
+Build a native SwiftUI app ("Neko Trade") with 5 tabs: Dashboard, Ledger, Equity, Trades, Settings. No external dependencies — pure SwiftUI + Swift Charts.
+
+Data sources:
+- **BTC price**: Binance REST API (free, no auth)
+- **Bot status, equity, trades, ledger**: Turso HTTP API
+- **Open position**: Alpaca REST API (source of truth for qty/entry price)
+
+## Rationale
+
+- **Native performance.** SwiftUI renders at 60fps with no web overhead. Charts are native Swift Charts, not a JS charting library in a WebView.
+- **Cross-platform.** Single codebase for macOS 13+ and iOS 16+. Same Views, same Services.
+- **No server needed.** App reads directly from Turso and Alpaca APIs. No backend to maintain.
+- **Credential management.** UserDefaults stores Turso URL/token and Alpaca key/secret. Persistent status indicators show connection health.
+
+## Consequences
+
+- Requires xcodegen to generate `.xcodeproj` from `project.yml`.
+- Auto-refresh every 30s via `Timer.publish` on Dashboard.
+- Regime colors consistent with bot: BULL=green, SIDEWAYS=orange, BEAR=red.
+- Signal vs fill price drift shown on trade history for execution quality analysis.
+- No push notifications from the bot — that's handled by Telegram/ntfy.
+
+## Alternatives Considered
+
+- **Web dashboard (React/Vue)** — would need hosting, adds a deployment target. Native app is zero-ops.
+- **Streamlit** — prototyped in the Python lab. Good for research, too slow and ugly for daily monitoring.
+- **Terminal UI (TUI)** — considered `bubbletea` (Go) or `ratatui` (Rust). Less useful on iOS, no charts.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,3 +35,10 @@ This directory contains Architectural Decision Records (ADRs) for the Maneki des
 | [028](028-lit-in-ui-components.md) | Lit in UI Components — Gradual Migration | Accepted | 2026-04 |
 | [029](029-generic-editable-pages.md) | Generic Editable Pages System | Accepted | 2026-04 |
 | [030](030-published-snapshot.md) | Published Snapshot for Change Detection | Accepted | 2026-04 |
+| [031](031-zig-trading-bot.md) | Zig for Production Trading Bot | Accepted | 2026-04 |
+| [032](032-three-regime-dc-strategy.md) | Three-Regime Directional Change Strategy | Accepted | 2026-04 |
+| [033](033-alpaca-source-of-truth.md) | Alpaca as Source of Truth for Positions | Accepted | 2026-04 |
+| [034](034-account-ledger.md) | Account Ledger for Capital Audit Trail | Accepted | 2026-04 |
+| [035](035-native-zig-http-client.md) | Native Zig HTTP Client | Accepted | 2026-04 |
+| [036](036-mlx-local-sentiment.md) | MLX Local Sentiment Analysis | Accepted | 2026-04 |
+| [037](037-swiftui-trading-dashboard.md) | SwiftUI Trading Dashboard | Accepted | 2026-04 |

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -16,9 +16,9 @@ Unlike ADRs (which record individual decisions), these docs describe the overall
 | [Charts](../../packages/charts/ARCHITECTURE.md) | `packages/charts/` | SVG chart components |
 | [Catalog](../../apps/catalog/ARCHITECTURE.md) | `apps/catalog/` | Visual regression testing, page registration |
 | [Blog](../../apps/blog/ARCHITECTURE.md) | `apps/blog/` | Full-stack architecture, build-time data baking, editor |
-| [DCTrading Bot](../../services/dctrading-bot/AGENTS.md) | `services/dctrading-bot/` | Zig trading bot, Binance WS, Alpaca, Turso |
-| [Neko Trade](../../apps/neko-trade/AGENTS.md) | `apps/neko-trade/` | SwiftUI dashboard, macOS + iOS |
-| [DCTrading Lab](../../labs/dctrading/AGENTS.md) | `labs/dctrading/` | Python research, backtesting, MLX sentiment |
+| [DCTrading Bot](../../services/dctrading-bot/ARCHITECTURE.md) | `services/dctrading-bot/` | Zig trading bot, DC strategy, Alpaca, Turso |
+| [Neko Trade](../../apps/neko-trade/ARCHITECTURE.md) | `apps/neko-trade/` | SwiftUI dashboard, macOS + iOS |
+| [DCTrading Lab](../../labs/dctrading/ARCHITECTURE.md) | `labs/dctrading/` | Python research, backtesting, MLX sentiment |
 
 ## When to Update
 

--- a/labs/dctrading/ARCHITECTURE.md
+++ b/labs/dctrading/ARCHITECTURE.md
@@ -1,0 +1,142 @@
+# DCTrading Research Lab Architecture
+
+*Snapshot: April 2026*
+
+## Overview
+
+Python research environment for the DCTrading system. Vectorized backtesting, MLX-based sentiment analysis, and real-time Alpaca news monitoring. Python 3.12, numpy/pandas for backtesting, Apple MLX for local LLM inference.
+
+## Structure
+
+```
+labs/dctrading/
+├── src/dctrading/
+│   ├── dc/                     # Directional Change core
+│   │   ├── detector.py         # Streaming DC event detector
+│   │   ├── indicators.py       # Technical indicators (MA, volatility)
+│   │   └── regime.py           # 3-regime classification (BULL/SIDEWAYS/BEAR)
+│   ├── backtest/
+│   │   └── runner.py           # Backtest engine
+│   ├── sentiment/
+│   │   ├── news_client.py      # AlpacaNews (WS), AlphaVantageNews, NewsAPIClient
+│   │   ├── llm_scorer.py       # LLMScorer base, MLXLocalScorer (Qwen3.5-9B-4bit)
+│   │   └── confidence.py       # SentimentConfidence aggregator
+│   ├── data/
+│   │   └── loader.py           # Binance kline data loading + caching
+│   ├── agents/                 # RL agents (experimental)
+│   │   ├── zi_dct0.py          # Zero-intelligence DC agent
+│   │   ├── dcrl.py             # DC + RL hybrid
+│   │   ├── deep_rl.py          # Deep RL agent
+│   │   ├── recurrent_rl.py     # Recurrent RL agent
+│   │   └── ensemble.py         # Ensemble agent
+│   ├── envs/                   # Gymnasium environments (experimental)
+│   │   ├── dc_trading_env.py   # DC trading environment v1
+│   │   ├── dc_trading_env_v2.py # DC trading environment v2
+│   │   └── adaptive_sl_env.py  # Adaptive stop-loss environment
+│   ├── live/                   # Live trading modules (experimental)
+│   │   ├── engine.py           # Live trading engine
+│   │   ├── executor.py         # Order executor
+│   │   └── feed.py             # Live data feed
+│   ├── risk/
+│   │   └── manager.py          # Risk management
+│   ├── store/
+│   │   └── database.py         # SQLite/aiosqlite storage
+│   ├── training/
+│   │   └── pipeline.py         # Training pipeline
+│   ├── dashboard/
+│   │   └── app.py              # Streamlit dashboard (experimental)
+│   └── types.py                # Shared type definitions
+├── scripts/
+│   ├── backtest_fast.py        # Vectorized 3-regime backtest (numpy, ~100x faster)
+│   ├── backtest_regimes.py     # 2-regime vs 3-regime comparison
+│   ├── backtest_sentiment.py   # Backtest with sentiment filter
+│   ├── backtest_yearly.py      # Year-by-year breakdown
+│   ├── fetch_1m_data.py        # Fetch Binance 1-min klines
+│   ├── news_monitor.py         # Real-time daemon: Alpaca WS → MLX → Telegram
+│   ├── test_sentiment.py       # Sentiment smoke test (--mock for CI)
+│   └── run_adaptive_sl.py      # Adaptive stop-loss experiment
+└── pyproject.toml              # Python 3.12, dependencies, ruff config
+```
+
+## Backtesting Pipeline
+
+The primary research tool. `backtest_fast.py` uses vectorized numpy operations for ~100x speedup over per-tick Python loops.
+
+```
+Binance 1-min klines (pickle cache)
+    │
+    ▼
+numpy arrays: prices, timestamps
+    │
+    ├── compute_ma() — rolling mean via cumsum trick
+    ├── detect_dc_events() — vectorized λ threshold detection
+    ├── classify_regime() — BULL/SIDEWAYS/BEAR from MA ± buffer
+    │
+    ▼
+simulate_trades() — walk forward through events
+    ├── Entry: DC UP event → buy (capital × (1 - fee))
+    ├── Exit: DC DOWN or trailing stop (BEAR only)
+    ├── Track: capital, equity, drawdown per trade
+    │
+    ▼
+Results: total return, max drawdown, Sharpe, trade count, win rate
+```
+
+**Key results (2019–2026, $1K initial):**
+- 3-regime: +4,071% ($40.7K), 47 trades
+- 2-regime: +3,140% ($31.4K), 52 trades
+- Sentiment filter: hurts returns (skipped $371 winner)
+
+## Sentiment Pipeline
+
+Real-time news monitoring with local LLM scoring (ADR-036).
+
+```
+Alpaca News WebSocket
+    │ (BTC, ETH, SOL, BNB)
+    ▼
+news_monitor.py
+    │
+    ├── Parse article (headline + summary)
+    ├── MLXLocalScorer (Qwen3.5-9B-4bit, lazy-loaded)
+    │   └── Prompt: "Score sentiment -1.0 to +1.0 for crypto trading"
+    ├── SentimentConfidence (aggregate if multiple articles)
+    │
+    ▼
+Telegram + ntfy notification
+    └── Symbol, headline, score, confidence
+```
+
+**Design choices:**
+- Lazy model loading (~5s on first article, then stays in memory)
+- `--mock` flag for testing without loading the 9B model
+- Monitoring only — not used for trade gating (backtesting showed it hurts returns)
+
+## Module Maturity
+
+| Module | Status | Used in Production |
+|--------|--------|-------------------|
+| `dc/` | Stable | Yes (logic mirrored in Zig bot) |
+| `backtest/` | Stable | Research tool |
+| `sentiment/` | Stable | News monitor daemon |
+| `data/` | Stable | Data loading for backtests |
+| `scripts/` | Stable | Daily use |
+| `agents/` | Experimental | No |
+| `envs/` | Experimental | No |
+| `live/` | Experimental | No (Zig bot is production) |
+| `risk/` | Experimental | No |
+| `training/` | Experimental | No |
+| `dashboard/` | Experimental | No (Neko Trade is production) |
+
+The experimental modules (`agents/`, `envs/`, `live/`, `risk/`, `training/`, `dashboard/`) were early prototypes before the Zig bot and Neko Trade app were built. They remain for reference but are not actively maintained.
+
+## Key Design Decisions
+
+- **ADR-032**: 3-regime strategy validated here before Zig implementation.
+- **ADR-036**: MLX local sentiment chosen over cloud APIs for cost and latency.
+- **Vectorized backtesting**: numpy operations avoid Python per-tick overhead.
+- **Research-first**: This lab validates ideas. Production runs in Zig.
+
+---
+
+*This document describes the architecture as of April 2026. See `docs/adr/` for individual decision records.*

--- a/services/dctrading-bot/ARCHITECTURE.md
+++ b/services/dctrading-bot/ARCHITECTURE.md
@@ -1,0 +1,131 @@
+# DCTrading Bot Architecture
+
+*Snapshot: April 2026*
+
+## Overview
+
+BTC algorithmic trading bot using Directional Change (DC) theory. Single Zig 0.16 static binary (~4MB), runs 24/7 on GCP e2-micro (Tokyo) or local macOS. Processes real-time Binance WebSocket ticks, executes Alpaca paper trades, persists to Turso DB, notifies via Telegram/ntfy.
+
+## Structure
+
+```
+services/dctrading-bot/
+├── src/
+│   ├── main.zig           # Entry point, CLI, runLive(), runBacktest()
+│   ├── strategy.zig       # 3-regime DC strategy, checkpoint save/load
+│   ├── dc_detector.zig    # Streaming DC event detector (λ threshold)
+│   ├── feed.zig           # Binance WebSocket + REST kline bootstrap
+│   ├── alpaca.zig         # Alpaca paper trading (sync orders, position queries)
+│   ├── turso.zig          # Turso HTTP client (5 tables, async writes, sync reads)
+│   ├── telegram.zig       # Telegram + ntfy notifications (async + curl fallback)
+│   ├── http_client.zig    # Shared std.http.Client wrapper
+│   ├── types.zig          # Core types: Tick, Trade, DCEvent, Direction
+│   └── tests.zig          # 39 unit tests
+├── scripts/
+│   ├── switch-to-gcp.sh   # Build Linux binary, upload, start GCP instance
+│   └── switch-to-local.sh # Build macOS binary, start local in tmux
+├── build.zig              # Zig build config
+└── build.zig.zon          # Dependencies (websocket.zig)
+```
+
+## Data Flow
+
+```
+Binance WebSocket (1s trades)
+    │
+    ▼
+feed.zig (downsample to 1-min candles)
+    │
+    ▼
+strategy.processTick()
+    ├── DC detector: UP/DOWN events when price reverses by λ=0.07
+    ├── Regime filter: BULL/SIDEWAYS/BEAR from 60-day MA ± 3% buffer
+    ├── Entry: DC UP event in any regime → BUY signal
+    ├── Exit: DC DOWN event → SELL (all regimes)
+    │         Vol-trailing stop → SELL (BEAR only)
+    │
+    ▼
+main.zig (trade lifecycle)
+    ├── alpaca.zig: sync market order → poll for fill (up to 10s)
+    ├── turso.zig: log to trade_events, positions, account_ledger (async)
+    ├── telegram.zig: notify buy/sell/regime change (async)
+    └── strategy: update capital, entry_price, size from Alpaca fill
+```
+
+## Strategy (ZI-DCT0)
+
+The core strategy in `strategy.zig` (~371 lines):
+
+**Parameters:**
+- λ = 0.07 (DC threshold — 7% price reversal triggers event)
+- MA period = 60 days (43,200 one-minute candles)
+- MA buffer = 3% (sideways zone width)
+- Trailing stop = 2% below peak, 72h volatility window
+- Fee = 0.1% per trade (entry + exit)
+- Long-only (no shorting)
+
+**Regime behavior:**
+
+| Regime | Entry | Exit | Trailing Stop |
+|--------|-------|------|---------------|
+| BULL | DC UP | DC DOWN | No |
+| SIDEWAYS | DC UP | DC DOWN | No |
+| BEAR | DC UP | DC DOWN + trailing | Yes (2% / 72h vol) |
+
+**Checkpoint (DCTRADE4):**
+Binary file with magic number validation (`0x4443_5452_4144_4534`). 24 f64 scalars (capital, entry price, regime, DC state, MA state, vol state) + two ring buffers (volatility window, MA window). Saved every 60 seconds. Old DCTRADE3 format rejected on load.
+
+## Database Schema (Turso)
+
+5 tables, all written asynchronously except startup reads:
+
+| Table | Purpose | Write | Read |
+|-------|---------|-------|------|
+| `trade_events` | BUY/SELL with price, size, fee, timestamp | Async | — |
+| `positions` | OPEN/CLOSED with entry/exit, PnL, signal_price, alpaca_order_id | Async | Startup (reconcile) |
+| `equity_log` | Snapshots every 5 min + on trades: capital, equity, unrealized, regime | Async | Startup (fallback capital) |
+| `bot_status` | Single row: regime, position, equity, version (DCTRADE4@instance) | Async (upsert) | — |
+| `account_ledger` | Cash flow audit: DEPOSIT, ENTRY_FEE, BUY, SELL, EXIT_FEE with running balance | Async | Startup (capital) |
+
+## Concurrency Model
+
+No async runtime. Simple threading model:
+
+- **Main thread**: WebSocket read loop → `processTick()` → trade decisions. All blocking.
+- **Fire-and-forget writes**: `std.Thread.spawn` + `detach()` for Turso and Telegram. Context struct heap-allocated (`allocator.create`), freed by worker thread after HTTP call.
+- **Sync reads**: Startup queries (capital, position, trade count) block the main thread before the WebSocket loop starts.
+- **Shutdown**: SIGINT/SIGTERM handler sets atomic flag. Main loop exits, saves checkpoint, sends final notifications via curl fallback (native HTTP may have stale connections).
+
+## Startup Sequence
+
+1. Parse CLI args (live mode, capital, checkpoint path)
+2. Initialize shared `HttpClient`
+3. Bootstrap: fetch 87,500 one-minute klines from Binance REST → fill MA + vol ring buffers → detect initial regime
+4. Load checkpoint (if exists) → restore strategy state
+5. Read capital from account_ledger (falls back to equity_log, then CLI arg)
+6. Reconcile with Alpaca position → sync internal state if position exists
+7. Log DEPOSIT to ledger (first run only)
+8. Start Binance WebSocket → enter main trading loop
+
+## Deployment
+
+Two deployment targets, switched via scripts:
+
+| Target | Instance | Binary | Script |
+|--------|----------|--------|--------|
+| GCP Tokyo | e2-micro, asia-northeast1-b | x86_64-linux | `switch-to-gcp.sh` |
+| Local macOS | M-series Mac | aarch64-macos | `switch-to-local.sh` |
+
+Only one instance runs at a time. Scripts handle build, upload (GCP), and process management. GCP instance is STOPPED when local is running (billing).
+
+## Key Design Decisions
+
+- **ADR-031**: Zig chosen for single static binary, cross-compilation, deterministic memory.
+- **ADR-032**: 3-regime strategy beats 2-regime by +931% over 2019–2026.
+- **ADR-033**: Alpaca fill data is source of truth for position qty/price.
+- **ADR-034**: Account ledger tracks every cash movement with running balance.
+- **ADR-035**: Native `std.http.Client` replaces `popen("curl")` for most HTTP calls.
+
+---
+
+*This document describes the architecture as of April 2026. See `docs/adr/` for individual decision records.*


### PR DESCRIPTION
## Summary
- 7 new ADRs (031–037): Zig bot, 3-regime strategy, Alpaca source of truth, account ledger, native HTTP client, MLX sentiment, SwiftUI dashboard
- 3 new ARCHITECTURE.md files: dctrading-bot, neko-trade, dctrading lab
- Update architecture index to link ARCHITECTURE.md instead of AGENTS.md