### PR TITLE
fix(dctrading): add missing websocket-client and mlx-lm dependencies

### DIFF
--- a/labs/dctrading/pyproject.toml
+++ b/labs/dctrading/pyproject.toml
@@ -18,6 +18,8 @@ dependencies = [
     "prometheus-client>=0.20",
     "openai>=1.0",
     "requests>=2.31",
+    "websocket-client>=1.6",
+    "mlx-lm>=0.19",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Add `websocket-client` and `mlx-lm` to `pyproject.toml` dependencies — both are required by `news_monitor.py` but were missing, causing `ModuleNotFoundError` on fresh `pip install -e .`