### PR TITLE
fix(dctrading-bot): handle gzip responses and prevent sleep during trading

### DIFF
--- a/services/dctrading-bot/scripts/switch-to-local.sh
+++ b/services/dctrading-bot/scripts/switch-to-local.sh
@@ -28,7 +28,7 @@ echo "  macOS binary ready."
 # Start local bot
 echo "  Starting local bot..."
 tmux has-session -t trading 2>/dev/null || tmux new-session -d -s trading
-tmux send-keys -t trading "source $PROJECT_DIR/.env && cd $PROJECT_DIR && ./zig-out/bin/dctrading -" Enter
+tmux send-keys -t trading "source $PROJECT_DIR/.env && cd $PROJECT_DIR && caffeinate -s -i ./zig-out/bin/dctrading -" Enter
 
 sleep 8
 echo "  Checking local bot..."

--- a/services/dctrading-bot/src/http_client.zig
+++ b/services/dctrading-bot/src/http_client.zig
@@ -88,7 +88,22 @@ pub const HttpClient = struct {
         }
 
         var response = try req.receiveHead(&.{});
-        const resp_body = try response.reader(&.{}).allocRemaining(self.allocator, .limited(max_response_bytes));
+
+        // Decompress gzip/deflate if server sent compressed response
+        var transfer_buf: [64]u8 = undefined;
+        var decompress: http.Decompress = undefined;
+        const decompress_buf = switch (response.head.content_encoding) {
+            .identity => @as([]u8, &.{}),
+            .deflate, .gzip => try self.allocator.alloc(u8, std.compress.flate.max_window_len),
+            .zstd => try self.allocator.alloc(u8, std.compress.zstd.default_window_len),
+            .compress => return error.UnsupportedCompression,
+        };
+        defer if (decompress_buf.len > 0) self.allocator.free(decompress_buf);
+
+        const resp_body = if (response.head.content_encoding == .identity)
+            try response.reader(&transfer_buf).allocRemaining(self.allocator, .limited(max_response_bytes))
+        else
+            try response.readerDecompressing(&transfer_buf, &decompress, decompress_buf).allocRemaining(self.allocator, .limited(max_response_bytes));
 
         return .{
             .status = response.head.status,


### PR DESCRIPTION
## Summary
- Add transparent gzip/deflate/zstd decompression in `HttpClient` — Binance REST returns gzip-compressed kline data which the native `std.http.Client` doesn't auto-decompress (unlike curl), causing catch-up to silently parse 0 candles
- Add `caffeinate -s -i` to `switch-to-local.sh` to prevent macOS sleep during overnight trading

## Testing
- `zig build` passes
- All 46 tests pass
- Verified live: catch-up now correctly fetches and parses klines after restart