### PR TITLE
feat: capital injection via Neko Trade app

### DIFF
--- a/apps/neko-trade/Sources/DCTradingViewer/Services/TursoClient.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Services/TursoClient.swift
@@ -263,6 +263,20 @@ final class TursoClient {
             updatedAt: getString(row, result.cols, "updated_at")
         )
     }
+
+    /// Insert a deposit into the account_ledger. Returns the new balance.
+    func insertDeposit(amount: Double) async throws -> Double {
+        // First get current balance
+        let balanceSQL = "SELECT balance_after FROM account_ledger ORDER BY id DESC LIMIT 1"
+        let balResult = try await executeSQL(balanceSQL)
+        let currentBalance = balResult.rows.first.flatMap { getDouble($0, balResult.cols, "balance_after") } ?? 0
+        let newBalance = currentBalance + amount
+        let timestamp = Date().timeIntervalSince1970
+
+        let insertSQL = "INSERT INTO account_ledger (type, amount, balance_after, note, timestamp) VALUES ('DEPOSIT', \(amount), \(newBalance), 'Manual deposit via Neko Trade', \(timestamp))"
+        _ = try await executeSQL(insertSQL)
+        return newBalance
+    }
 }
 
 // MARK: - Errors

--- a/apps/neko-trade/Sources/DCTradingViewer/Services/TursoClient.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Services/TursoClient.swift
@@ -243,6 +243,13 @@ final class TursoClient {
         return getDouble(row, result.cols, "total_pnl")
     }
 
+    func fetchTotalDeposits() async throws -> Double {
+        let sql = "SELECT COALESCE(SUM(amount), 0) as total FROM account_ledger WHERE type = 'DEPOSIT'"
+        let result = try await executeSQL(sql)
+        guard let row = result.rows.first else { return 0 }
+        return getDouble(row, result.cols, "total")
+    }
+
     func fetchBotStatus() async throws -> BotStatus? {
         let sql = "SELECT * FROM bot_status WHERE id = 1"
         let result = try await executeSQL(sql)

--- a/apps/neko-trade/Sources/DCTradingViewer/Views/DashboardView.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Views/DashboardView.swift
@@ -73,9 +73,9 @@ struct DashboardView: View {
                 )
                 statCard(
                     title: "REALIZED P&L",
-                    value: formatCurrency((latestEquity?.capital ?? 0) - totalDeposits),
+                    value: formatCurrency(totalPnL),
                     icon: "banknote",
-                    color: ((latestEquity?.capital ?? 0) - totalDeposits) >= 0 ? .green : .red
+                    color: totalPnL >= 0 ? .green : .red
                 )
             }
 

--- a/apps/neko-trade/Sources/DCTradingViewer/Views/DashboardView.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Views/DashboardView.swift
@@ -72,9 +72,9 @@ struct DashboardView: View {
                 )
                 statCard(
                     title: "REALIZED P&L",
-                    value: formatCurrency((latestEquity?.capital ?? 0) - 1000.0),
+                    value: formatCurrency(totalPnL),
                     icon: "banknote",
-                    color: ((latestEquity?.capital ?? 0) - 1000.0) >= 0 ? .green : .red
+                    color: totalPnL >= 0 ? .green : .red
                 )
             }
 

--- a/apps/neko-trade/Sources/DCTradingViewer/Views/DashboardView.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Views/DashboardView.swift
@@ -73,9 +73,9 @@ struct DashboardView: View {
                 )
                 statCard(
                     title: "REALIZED P&L",
-                    value: formatCurrency(totalPnL),
+                    value: formatCurrency((latestEquity?.capital ?? 0) - totalDeposits),
                     icon: "banknote",
-                    color: totalPnL >= 0 ? .green : .red
+                    color: ((latestEquity?.capital ?? 0) - totalDeposits) >= 0 ? .green : .red
                 )
             }
 
@@ -358,6 +358,7 @@ struct DashboardView: View {
         do {
             async let equityTask = client.fetchLatestEquity()
             async let pnlTask = client.fetchTotalRealizedPnL()
+            async let depositsTask = client.fetchTotalDeposits()
             async let historyTask = client.fetchRecentEquity(limit: 50)
             async let priceTask = BinanceClient.fetchPrice()
             async let klinesTask = BinanceClient.fetchKlines(interval: "5m", limit: 60)
@@ -370,7 +371,7 @@ struct DashboardView: View {
                 )
             }
 
-            let (equity, pnl, history) = try await (equityTask, pnlTask, historyTask)
+            let (equity, pnl, history, deposits) = try await (equityTask, pnlTask, historyTask, depositsTask)
             let price = try? await priceTask
             let klines = (try? await klinesTask) ?? []
 
@@ -393,6 +394,7 @@ struct DashboardView: View {
                 }
                 latestEquity = equity
                 totalPnL = pnl
+                totalDeposits = deposits
                 equityHistory = history
                 if let price { btcPrice = price }
                 btcPriceHistory = klines

--- a/apps/neko-trade/Sources/DCTradingViewer/Views/DashboardView.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Views/DashboardView.swift
@@ -6,6 +6,7 @@ struct DashboardView: View {
     @State private var openPosition: Position?
     @State private var latestEquity: EquityLog?
     @State private var totalPnL: Double = 0
+    @State private var totalDeposits: Double = 0
     @State private var isLoading = false
     @State private var errorMessage: String?
     @State private var lastRefresh: Date?

--- a/apps/neko-trade/Sources/DCTradingViewer/Views/LedgerView.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Views/LedgerView.swift
@@ -5,6 +5,9 @@ struct LedgerView: View {
     @State private var ledger: [LedgerEntry] = []
     @State private var isLoading = false
     @State private var errorMessage: String?
+    @State private var showDepositSheet = false
+    @State private var depositAmount = ""
+    @State private var isDepositing = false
 
     private let client = TursoClient()
     private let timer = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
@@ -28,11 +31,20 @@ struct LedgerView: View {
         .navigationTitle("Ledger")
         .toolbar {
             ToolbarItem(placement: .automatic) {
+                Button(action: { showDepositSheet = true }) {
+                    Image(systemName: "plus.circle")
+                }
+                .disabled(!settings.isConfigured)
+            }
+            ToolbarItem(placement: .automatic) {
                 Button(action: { Task { await loadData() } }) {
                     Image(systemName: "arrow.clockwise")
                 }
                 .disabled(isLoading)
             }
+        }
+        .sheet(isPresented: $showDepositSheet) {
+            depositSheet
         }
         .task { await loadData() }
         .onReceive(timer) { _ in
@@ -42,6 +54,63 @@ struct LedgerView: View {
     }
 
     // MARK: - Ledger List
+
+    // MARK: - Deposit Sheet
+
+    private var depositSheet: some View {
+        VStack(spacing: 16) {
+            Text("Deposit Capital")
+                .font(.system(.headline, design: .monospaced))
+
+            TextField("Amount ($)", text: $depositAmount)
+                .font(.system(.body, design: .monospaced))
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 200)
+                #if os(iOS)
+                .keyboardType(.decimalPad)
+                #endif
+
+            HStack(spacing: 12) {
+                Button("Cancel") {
+                    depositAmount = ""
+                    showDepositSheet = false
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Button("Deposit") {
+                    Task { await submitDeposit() }
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(Double(depositAmount) == nil || Double(depositAmount)! <= 0 || isDepositing)
+            }
+
+            if isDepositing {
+                ProgressView()
+                    .controlSize(.small)
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 280)
+    }
+
+    private func submitDeposit() async {
+        guard let amount = Double(depositAmount), amount > 0 else { return }
+        isDepositing = true
+        do {
+            _ = try await client.insertDeposit(amount: amount)
+            await MainActor.run {
+                depositAmount = ""
+                showDepositSheet = false
+                isDepositing = false
+            }
+            await loadData()
+        } catch {
+            await MainActor.run {
+                errorMessage = error.localizedDescription
+                isDepositing = false
+            }
+        }
+    }
 
     private var ledgerList: some View {
         ScrollView {

--- a/apps/neko-trade/Sources/DCTradingViewer/Views/LedgerView.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Views/LedgerView.swift
@@ -30,9 +30,9 @@ struct LedgerView: View {
         }
         .navigationTitle("Ledger")
         .toolbar {
-            ToolbarItem(placement: .automatic) {
+            ToolbarItem(placement: .primaryAction) {
                 Button(action: { showDepositSheet = true }) {
-                    Image(systemName: "plus.circle")
+                    Label("Deposit", systemImage: "plus.circle")
                 }
                 .disabled(!settings.isConfigured)
             }

--- a/services/dctrading-bot/scripts/nuke.sh
+++ b/services/dctrading-bot/scripts/nuke.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Nuke all trading state: Turso tables, checkpoint, Alpaca positions
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+source "$PROJECT_DIR/.env"
+
+TURSO_HOST=$(echo "$TURSO_URL" | sed 's|libsql://||; s|https://||')
+
+echo "⚠️  This will destroy ALL trading data. Press Ctrl-C to cancel."
+sleep 3
+
+echo "  Dropping Turso tables..."
+curl -s "https://$TURSO_HOST/v2/pipeline" \
+  -H "Authorization: Bearer $TURSO_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"requests": [
+    {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS account_ledger"}},
+    {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS trade_events"}},
+    {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS positions"}},
+    {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS equity_log"}},
+    {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS bot_status"}}
+  ]}' > /dev/null
+echo "  ✓ Tables dropped"
+
+echo "  Deleting checkpoint..."
+rm -f "$PROJECT_DIR/dctrading.checkpoint"
+echo "  ✓ Checkpoint deleted"
+
+echo "  Closing Alpaca positions..."
+curl -s -X DELETE "https://paper-api.alpaca.markets/v2/positions" \
+  -H "APCA-API-KEY-ID: $ALPACA_API_KEY" \
+  -H "APCA-API-SECRET-KEY: $ALPACA_API_SECRET" > /dev/null 2>&1
+echo "  ✓ Alpaca positions closed"
+
+echo "🔥 All nuked. Ready for fresh start."

--- a/services/dctrading-bot/src/alpaca.zig
+++ b/services/dctrading-bot/src/alpaca.zig
@@ -99,75 +99,79 @@ pub const Alpaca = struct {
 
     fn submitOrder(self: *const Alpaca, body: []const u8) ?OrderFill {
         const h = self.headersWithJson();
-        const resp = self.http.post(
-            "https://paper-api.alpaca.markets/v2/orders",
-            &h,
-            body,
-        ) catch return null;
-        defer resp.deinit();
+        var attempt: u32 = 0;
+        while (attempt < 2) : (attempt += 1) {
+            const resp = self.http.post(
+                "https://paper-api.alpaca.markets/v2/orders",
+                &h,
+                body,
+            ) catch |err| {
+                std.debug.print("  [alpaca] HTTP error (attempt {d}): {s}\n", .{ attempt + 1, @errorName(err) });
+                _ = usleep(1_000_000);
+                continue;
+            };
+            defer resp.deinit();
 
-        const r = resp.body;
+            const r = resp.body;
+            std.debug.print("  [alpaca] Order response ({d} bytes): {s}\n", .{ r.len, r[0..@min(r.len, 300)] });
 
-        // Check for error
-        if (std.mem.indexOf(u8, r, "\"message\"") != null and std.mem.indexOf(u8, r, "\"id\"") == null) {
-            std.debug.print("  [alpaca] Order error: {s}\n", .{r[0..@min(r.len, 200)]});
-            return null;
-        }
+            if (std.mem.indexOf(u8, r, "\"message\"") != null and std.mem.indexOf(u8, r, "\"id\"") == null) {
+                return null;
+            }
 
-        // Parse order ID
-        var fill: OrderFill = .{ .fill_price = 0, .fill_qty = 0, .status = .accepted };
-        if (parseJsonString(r, "\"id\":")) |id| {
-            const len = @min(id.len, fill.order_id.len);
-            @memcpy(fill.order_id[0..len], id[0..len]);
-            fill.order_id_len = len;
-        }
+            var fill: OrderFill = .{ .fill_price = 0, .fill_qty = 0, .status = .accepted };
+            if (parseJsonString(r, "\"id\":")) |id| {
+                const len = @min(id.len, fill.order_id.len);
+                @memcpy(fill.order_id[0..len], id[0..len]);
+                fill.order_id_len = len;
+            }
 
-        // Check if already filled
-        if (std.mem.indexOf(u8, r, "\"status\":\"filled\"") != null) {
-            fill.status = .filled;
-            fill.fill_price = parseJsonFloat(r, "\"filled_avg_price\":") orelse 0;
-            fill.fill_qty = parseJsonFloat(r, "\"filled_qty\":") orelse 0;
-            std.debug.print("  [alpaca] Filled: price=${d:.2} qty={d:.8}\n", .{ fill.fill_price, fill.fill_qty });
+            if (std.mem.indexOf(u8, r, "\"status\":\"filled\"") != null) {
+                fill.status = .filled;
+                fill.fill_price = parseJsonFloat(r, "\"filled_avg_price\":") orelse 0;
+                fill.fill_qty = parseJsonFloat(r, "\"filled_qty\":") orelse 0;
+                std.debug.print("  [alpaca] Filled: price=${d:.2} qty={d:.8}\n", .{ fill.fill_price, fill.fill_qty });
+                return fill;
+            }
+
+            if (fill.order_id_len > 0) {
+                const order_id = fill.order_id[0..fill.order_id_len];
+                var poll: u32 = 0;
+                while (poll < 10) : (poll += 1) {
+                    _ = usleep(1_000_000);
+                    var poll_url_buf: [256]u8 = undefined;
+                    const poll_url = std.fmt.bufPrint(&poll_url_buf,
+                        "https://paper-api.alpaca.markets/v2/orders/{s}",
+                        .{order_id},
+                    ) catch break;
+
+                    const ph = self.headers();
+                    const poll_resp = self.http.get(poll_url, &ph) catch continue;
+                    defer poll_resp.deinit();
+
+                    const pr = poll_resp.body;
+                    if (std.mem.indexOf(u8, pr, "\"status\":\"filled\"") != null) {
+                        fill.status = .filled;
+                        fill.fill_price = parseJsonFloat(pr, "\"filled_avg_price\":") orelse 0;
+                        fill.fill_qty = parseJsonFloat(pr, "\"filled_qty\":") orelse 0;
+                        std.debug.print("  [alpaca] Filled (poll {d}): price=${d:.2} qty={d:.8}\n", .{ poll + 1, fill.fill_price, fill.fill_qty });
+                        return fill;
+                    }
+                    if (std.mem.indexOf(u8, pr, "\"status\":\"canceled\"") != null or
+                        std.mem.indexOf(u8, pr, "\"status\":\"expired\"") != null or
+                        std.mem.indexOf(u8, pr, "\"status\":\"rejected\"") != null)
+                    {
+                        std.debug.print("  [alpaca] Order failed.\n", .{});
+                        fill.status = .failed;
+                        return fill;
+                    }
+                }
+                std.debug.print("  [alpaca] Order not filled after 10s, treating as failed.\n", .{});
+                fill.status = .failed;
+            }
             return fill;
         }
-
-        // If accepted but not filled, poll for up to 10 seconds
-        if (fill.order_id_len > 0) {
-            const order_id = fill.order_id[0..fill.order_id_len];
-            var poll: u32 = 0;
-            while (poll < 10) : (poll += 1) {
-                _ = usleep(1_000_000); // 1s
-                var poll_url_buf: [256]u8 = undefined;
-                const poll_url = std.fmt.bufPrint(&poll_url_buf,
-                    "https://paper-api.alpaca.markets/v2/orders/{s}",
-                    .{order_id},
-                ) catch break;
-
-                const ph = self.headers();
-                const poll_resp = self.http.get(poll_url, &ph) catch continue;
-                defer poll_resp.deinit();
-
-                const pr = poll_resp.body;
-                if (std.mem.indexOf(u8, pr, "\"status\":\"filled\"") != null) {
-                    fill.status = .filled;
-                    fill.fill_price = parseJsonFloat(pr, "\"filled_avg_price\":") orelse 0;
-                    fill.fill_qty = parseJsonFloat(pr, "\"filled_qty\":") orelse 0;
-                    std.debug.print("  [alpaca] Filled (poll {d}): price=${d:.2} qty={d:.8}\n", .{ poll + 1, fill.fill_price, fill.fill_qty });
-                    return fill;
-                }
-                if (std.mem.indexOf(u8, pr, "\"status\":\"canceled\"") != null or
-                    std.mem.indexOf(u8, pr, "\"status\":\"expired\"") != null or
-                    std.mem.indexOf(u8, pr, "\"status\":\"rejected\"") != null)
-                {
-                    std.debug.print("  [alpaca] Order failed.\n", .{});
-                    fill.status = .failed;
-                    return fill;
-                }
-            }
-            std.debug.print("  [alpaca] Order not filled after 10s, treating as failed.\n", .{});
-            fill.status = .failed;
-        }
-        return fill;
+        return null; // all retries exhausted
     }
 
     pub fn parseJsonFloat(json: []const u8, key: []const u8) ?f64 {

--- a/services/dctrading-bot/src/main.zig
+++ b/services/dctrading-bot/src/main.zig
@@ -394,8 +394,10 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
                             std.debug.print("  DEPOSIT BUY: +{d:.8} BTC @ ${d:.2}, blended entry=${d:.2}\n", .{ buy_size, buy_price, strategy.entry_price });
                             if (tg) |tel| tel.notifyBuy(buy_price, buy_size, regime_str, instance);
                             turso.?.logBuy(buy_price, buy_size, fee, t.timestamp);
-                            turso.?.logLedger("ENTRY_FEE", -fee, strategy.capital + usable, "Deposit buy fee", t.timestamp);
-                            turso.?.logLedger("BUY", -usable, strategy.capital, "Deposit buy", t.timestamp);
+                            const buy_cost = buy_price * buy_size;
+                            const cash_after_fee = strategy.capital - buy_cost;
+                            turso.?.logLedger("ENTRY_FEE", -fee, strategy.capital, "Deposit buy fee", t.timestamp);
+                            turso.?.logLedger("BUY", -buy_cost, cash_after_fee, "Deposit buy", t.timestamp);
                         }
 
                         turso.?.logEquity(t.timestamp, strategy.tick_count, strategy.capital, strategy.capital + unrealized, unrealized, regime_str, t.price);

--- a/services/dctrading-bot/src/main.zig
+++ b/services/dctrading-bot/src/main.zig
@@ -395,9 +395,10 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
                             if (tg) |tel| tel.notifyBuy(buy_price, buy_size, regime_str, instance);
                             turso.?.logBuy(buy_price, buy_size, fee, t.timestamp);
                             const buy_cost = buy_price * buy_size;
-                            const cash_after_fee = strategy.capital - buy_cost;
-                            turso.?.logLedger("ENTRY_FEE", -fee, strategy.capital, "Deposit buy fee", t.timestamp);
-                            turso.?.logLedger("BUY", -buy_cost, cash_after_fee, "Deposit buy", t.timestamp);
+                            // balance_after tracks actual cash, not strategy.capital
+                            const cash_before = deposit; // deposit just arrived, previous cash ~0
+                            turso.?.logLedger("ENTRY_FEE", -fee, cash_before - fee, "Deposit buy fee", t.timestamp);
+                            turso.?.logLedger("BUY", -buy_cost, cash_before - fee - buy_cost, "Deposit buy", t.timestamp);
                         }
 
                         turso.?.logEquity(t.timestamp, strategy.tick_count, strategy.capital, strategy.capital + unrealized, unrealized, regime_str, t.price);

--- a/services/dctrading-bot/src/main.zig
+++ b/services/dctrading-bot/src/main.zig
@@ -132,10 +132,14 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
                 strategy.capital = cap;
                 std.debug.print("  Restored capital from equity_log: ${d:.2}\n", .{cap});
             } else {
-                // First run — log initial deposit
-                const now: f64 = @floatFromInt(time(null));
-                turso.?.logLedgerSync("DEPOSIT", capital, capital, "Initial capital", now);
-                std.debug.print("  Logged initial deposit: ${d:.2}\n", .{capital});
+                // First run — log initial deposit (skip if $0)
+                if (capital > 0) {
+                    const now: f64 = @floatFromInt(time(null));
+                    turso.?.logLedgerSync("DEPOSIT", capital, capital, "Initial capital", now);
+                    std.debug.print("  Logged initial deposit: ${d:.2}\n", .{capital});
+                } else {
+                    std.debug.print("  No initial capital. Waiting for deposit.\n", .{});
+                }
             }
             // Restore open position
             if (turso.?.queryOpenPosition()) |pos| {

--- a/services/dctrading-bot/src/main.zig
+++ b/services/dctrading-bot/src/main.zig
@@ -50,7 +50,7 @@ pub fn main(init: std.process.Init) !void {
     const threshold_str = args.next();
     const capital_str = args.next();
     const threshold = if (threshold_str) |s| try std.fmt.parseFloat(f64, s) else 0.07;
-    const capital = if (capital_str) |s| try std.fmt.parseFloat(f64, s) else 1000.0;
+    const capital: f64 = if (capital_str) |s| try std.fmt.parseFloat(f64, s) else if (live_mode) 0.0 else 1000.0;
 
     if (live_mode) {
         try runLive(allocator, init.io, threshold, capital);
@@ -162,13 +162,12 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
         }
     }
 
-    // Reconcile deposits made while bot was down
-    if (loaded_checkpoint and turso != null) {
-        if (turso.?.queryLedgerBalance()) |ledger_bal| {
-            if (ledger_bal > strategy.capital + 0.01) {
-                const deposit = ledger_bal - strategy.capital;
-                strategy.capital = ledger_bal;
-                std.debug.print("  Deposit reconciled: +${d:.2} (capital now ${d:.2})\n", .{ deposit, strategy.capital });
+    // Set initial_capital from total deposits (survives restarts without checkpoint change)
+    if (turso != null) {
+        if (turso.?.queryTotalDeposits()) |total_deps| {
+            if (total_deps > strategy.initial_capital + 0.01) {
+                strategy.initial_capital = total_deps;
+                std.debug.print("  Initial capital from deposits: ${d:.2}\n", .{total_deps});
             }
         }
     }
@@ -363,10 +362,36 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
                     if (total > known_total_deposits) {
                         const deposit = total - known_total_deposits;
                         strategy.capital += deposit;
+                        strategy.initial_capital += deposit;
                         known_total_deposits = total;
                         std.debug.print("  DEPOSIT detected: +${d:.2} (capital now ${d:.2})\n", .{ deposit, strategy.capital });
-                        turso.?.logEquity(t.timestamp, strategy.tick_count, strategy.capital, strategy.capital + unrealized, unrealized, regime_str, t.price);
                         if (tg) |tel| tel.notifyDeposit(deposit, strategy.capital, instance);
+
+                        // If in BULL with open position, immediately buy with the deposit
+                        if (strategy.regime == .bull and strategy.in_position and deposit > 10.0) {
+                            const fee = deposit * strategy.fee_pct;
+                            const usable = deposit - fee;
+                            const add_size = usable / t.price;
+                            var buy_price = t.price;
+                            var buy_size = add_size;
+                            if (alpaca.buy(add_size)) |fill| {
+                                if (fill.status == .filled and fill.fill_price > 0) {
+                                    buy_price = fill.fill_price;
+                                    buy_size = fill.fill_qty;
+                                }
+                            }
+                            strategy.entry_price = (strategy.entry_price * strategy.size + buy_price * buy_size) / (strategy.size + buy_size);
+                            strategy.size += buy_size;
+                            strategy.capital -= (usable + fee);
+                            if (buy_price > strategy.peak_price) strategy.peak_price = buy_price;
+                            std.debug.print("  DEPOSIT BUY: +{d:.8} BTC @ ${d:.2}, blended entry=${d:.2}\n", .{ buy_size, buy_price, strategy.entry_price });
+                            if (tg) |tel| tel.notifyBuy(buy_price, buy_size, regime_str, instance);
+                            turso.?.logBuy(buy_price, buy_size, fee, t.timestamp);
+                            turso.?.logLedger("ENTRY_FEE", -fee, strategy.capital + usable, "Deposit buy fee", t.timestamp);
+                            turso.?.logLedger("BUY", -usable, strategy.capital, "Deposit buy", t.timestamp);
+                        }
+
+                        turso.?.logEquity(t.timestamp, strategy.tick_count, strategy.capital, strategy.capital + unrealized, unrealized, regime_str, t.price);
                     }
                 }
             }

--- a/services/dctrading-bot/src/main.zig
+++ b/services/dctrading-bot/src/main.zig
@@ -389,7 +389,7 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
                             }
                             strategy.entry_price = (strategy.entry_price * strategy.size + buy_price * buy_size) / (strategy.size + buy_size);
                             strategy.size += buy_size;
-                            strategy.capital -= (usable + fee);
+                            strategy.capital -= fee;
                             if (buy_price > strategy.peak_price) strategy.peak_price = buy_price;
                             std.debug.print("  DEPOSIT BUY: +{d:.8} BTC @ ${d:.2}, blended entry=${d:.2}\n", .{ buy_size, buy_price, strategy.entry_price });
                             if (tg) |tel| tel.notifyBuy(buy_price, buy_size, regime_str, instance);

--- a/services/dctrading-bot/src/main.zig
+++ b/services/dctrading-bot/src/main.zig
@@ -300,13 +300,16 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
                 if (fill.status == .filled and fill.fill_price > 0) {
                     buy_price = fill.fill_price;
                     buy_size = fill.fill_qty;
-                    // Add back unspent capital from Alpaca qty rounding
                     unspent_amt = (strategy.size - buy_size) * buy_price;
                     strategy.capital += unspent_amt;
                     strategy.entry_price = buy_price;
                     strategy.size = buy_size;
                     alpaca_oid = fill.order_id[0..fill.order_id_len];
+                } else {
+                    std.debug.print("  [alpaca] Buy order not filled: status={s}\n", .{if (fill.status == .accepted) "accepted" else "failed"});
                 }
+            } else {
+                std.debug.print("  [alpaca] Buy order failed (null)\n", .{});
             }
             if (turso != null) {
                 const fee = buy_price * buy_size * 0.001;

--- a/services/dctrading-bot/src/main.zig
+++ b/services/dctrading-bot/src/main.zig
@@ -395,10 +395,10 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
                             if (tg) |tel| tel.notifyBuy(buy_price, buy_size, regime_str, instance);
                             turso.?.logBuy(buy_price, buy_size, fee, t.timestamp);
                             const buy_cost = buy_price * buy_size;
-                            // balance_after tracks actual cash, not strategy.capital
-                            const cash_before = deposit; // deposit just arrived, previous cash ~0
-                            turso.?.logLedger("ENTRY_FEE", -fee, cash_before - fee, "Deposit buy fee", t.timestamp);
-                            turso.?.logLedger("BUY", -buy_cost, cash_before - fee - buy_cost, "Deposit buy", t.timestamp);
+                            // Query actual cash balance from ledger for correct balance_after
+                            const cash_bal = turso.?.queryLedgerBalance() orelse deposit;
+                            turso.?.logLedger("ENTRY_FEE", -fee, cash_bal - fee, "Deposit buy fee", t.timestamp);
+                            turso.?.logLedger("BUY", -buy_cost, cash_bal - fee - buy_cost, "Deposit buy", t.timestamp);
                         }
 
                         turso.?.logEquity(t.timestamp, strategy.tick_count, strategy.capital, strategy.capital + unrealized, unrealized, regime_str, t.price);

--- a/services/dctrading-bot/src/main.zig
+++ b/services/dctrading-bot/src/main.zig
@@ -162,6 +162,17 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
         }
     }
 
+    // Reconcile deposits made while bot was down
+    if (loaded_checkpoint and turso != null) {
+        if (turso.?.queryLedgerBalance()) |ledger_bal| {
+            if (ledger_bal > strategy.capital + 0.01) {
+                const deposit = ledger_bal - strategy.capital;
+                strategy.capital = ledger_bal;
+                std.debug.print("  Deposit reconciled: +${d:.2} (capital now ${d:.2})\n", .{ deposit, strategy.capital });
+            }
+        }
+    }
+
     // Reconcile with Alpaca position (source of truth for execution)
     if (alpaca.getPosition()) |pos| {
         if (pos.qty > 0) {
@@ -198,6 +209,8 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
     }
     var last_feed_ts: f64 = 0;
     var last_equity_ts: f64 = 0;
+    var last_deposit_check: f64 = 0;
+    var known_total_deposits: f64 = if (turso != null) (turso.?.queryTotalDeposits() orelse capital) else capital;
     var last_price: f64 = 0;
     var prev_regime = strategy.regime;
     const uptime_start: f64 = @floatFromInt(time(null));
@@ -342,6 +355,20 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
             if (equity_interval or traded) {
                 turso.?.logEquity(t.timestamp, strategy.tick_count, strategy.capital, equity, unrealized, regime_str, t.price);
                 last_equity_ts = t.timestamp;
+            }
+            // Check for new deposits every 5 min
+            if (t.timestamp - last_deposit_check >= 300.0) {
+                last_deposit_check = t.timestamp;
+                if (turso.?.queryTotalDeposits()) |total| {
+                    if (total > known_total_deposits) {
+                        const deposit = total - known_total_deposits;
+                        strategy.capital += deposit;
+                        known_total_deposits = total;
+                        std.debug.print("  DEPOSIT detected: +${d:.2} (capital now ${d:.2})\n", .{ deposit, strategy.capital });
+                        turso.?.logEquity(t.timestamp, strategy.tick_count, strategy.capital, strategy.capital + unrealized, unrealized, regime_str, t.price);
+                        if (tg) |tel| tel.notifyDeposit(deposit, strategy.capital, instance);
+                    }
+                }
             }
         }
     }

--- a/services/dctrading-bot/src/strategy.zig
+++ b/services/dctrading-bot/src/strategy.zig
@@ -140,7 +140,7 @@ pub const Strategy = struct {
 
         // BULL mode: hold passively
         if (self.regime == .bull) {
-            if (!self.in_position) {
+            if (!self.in_position and self.capital > 10.0) {
                 self.openPosition(price, tick.timestamp);
             }
             return null;

--- a/services/dctrading-bot/src/telegram.zig
+++ b/services/dctrading-bot/src/telegram.zig
@@ -40,6 +40,15 @@ pub const Telegram = struct {
         self.send(msg);
     }
 
+    pub fn notifyDeposit(self: *const Telegram, amount: f64, capital: f64, instance: []const u8) void {
+        var buf: [256]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf,
+            "\xf0\x9f\x92\xb0 Deposit: +${d:.2}\nCapital: ${d:.2}\nInstance: {s}",
+            .{ amount, capital, instance },
+        ) catch return;
+        self.send(msg);
+    }
+
     pub fn notifySell(self: *const Telegram, price: f64, pnl: f64, exit_type: []const u8, regime: []const u8, instance: []const u8) void {
         var buf: [512]u8 = undefined;
         const emoji = if (pnl >= 0) "🟢" else "🔴";

--- a/services/dctrading-bot/src/telegram.zig
+++ b/services/dctrading-bot/src/telegram.zig
@@ -4,6 +4,7 @@ const http_mod = @import("http_client.zig");
 const HttpClient = http_mod.HttpClient;
 
 extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
+extern "c" fn usleep(usec: c_uint) c_int;
 extern "c" fn popen(cmd: [*:0]const u8, mode: [*:0]const u8) ?*anyopaque;
 extern "c" fn pclose(fp: *anyopaque) c_int;
 extern "c" fn fread(buf: [*]u8, size: usize, count: usize, fp: *anyopaque) usize;
@@ -114,7 +115,7 @@ pub const Telegram = struct {
     }
 
     fn doSend(self: *const Telegram, text: []const u8) void {
-        // Send to Telegram
+        // Send to Telegram (retry once on stale connection)
         var url_buf: [256]u8 = undefined;
         const url = std.fmt.bufPrint(&url_buf,
             "https://api.telegram.org/bot{s}/sendMessage",
@@ -131,10 +132,18 @@ pub const Telegram = struct {
             .{ .name = "content-type", .value = "application/json" },
         };
 
-        if (self.http.post(url, &headers, body)) |resp| {
-            resp.deinit();
-        } else |_| {
-            std.debug.print("  [telegram] Send failed.\n", .{});
+        var tg_attempt: u32 = 0;
+        while (tg_attempt < 2) : (tg_attempt += 1) {
+            if (self.http.post(url, &headers, body)) |resp| {
+                resp.deinit();
+                break;
+            } else |_| {
+                if (tg_attempt == 0) {
+                    _ = usleep(1_000_000);
+                } else {
+                    std.debug.print("  [telegram] Send failed.\n", .{});
+                }
+            }
         }
 
 
@@ -146,10 +155,18 @@ pub const Telegram = struct {
                 .{self.ntfy_topic},
             ) catch return;
 
-            if (self.http.post(ntfy_url, &.{}, text)) |resp| {
-                resp.deinit();
-            } else |_| {
-                std.debug.print("  [ntfy] Send failed.\n", .{});
+            var ntfy_attempt: u32 = 0;
+            while (ntfy_attempt < 2) : (ntfy_attempt += 1) {
+                if (self.http.post(ntfy_url, &.{}, text)) |resp| {
+                    resp.deinit();
+                    break;
+                } else |_| {
+                    if (ntfy_attempt == 0) {
+                        _ = usleep(1_000_000);
+                    } else {
+                        std.debug.print("  [ntfy] Send failed.\n", .{});
+                    }
+                }
             }
 
         }

--- a/services/dctrading-bot/src/tests.zig
+++ b/services/dctrading-bot/src/tests.zig
@@ -720,3 +720,134 @@ test "strategy: equity correct after Alpaca fill with price drift" {
     try testing.expect(final_capital < 1000.0);
     try testing.expect(final_capital > 996.0);
 }
+
+
+// ============================================================
+// Capital Injection Tests
+// ============================================================
+
+test "strategy: no position opened when capital is zero" {
+    const allocator = testing.allocator;
+    var s = try Strategy.init(allocator, .{
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 0.0,
+    });
+    defer s.deinit(allocator);
+
+    // Fill MA to trigger BULL
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        _ = s.processTick(tick(100.0, @floatFromInt(i)));
+    }
+    _ = s.processTick(tick(104.0, 6.0));
+
+    try testing.expect(s.regime == .bull);
+    try testing.expect(!s.in_position); // no capital, no position
+    try testing.expectApproxEqAbs(s.capital, 0.0, 0.001);
+}
+
+test "strategy: no position opened when capital below minimum" {
+    const allocator = testing.allocator;
+    var s = try Strategy.init(allocator, .{
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 5.0, // below $10 minimum
+    });
+    defer s.deinit(allocator);
+
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        _ = s.processTick(tick(100.0, @floatFromInt(i)));
+    }
+    _ = s.processTick(tick(104.0, 6.0));
+
+    try testing.expect(s.regime == .bull);
+    try testing.expect(!s.in_position);
+    try testing.expectApproxEqAbs(s.capital, 5.0, 0.001);
+}
+
+test "strategy: position opened after deposit brings capital above minimum" {
+    const allocator = testing.allocator;
+    var s = try Strategy.init(allocator, .{
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 0.0,
+    });
+    defer s.deinit(allocator);
+
+    // Fill MA to trigger BULL
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        _ = s.processTick(tick(100.0, @floatFromInt(i)));
+    }
+    _ = s.processTick(tick(104.0, 6.0));
+    try testing.expect(!s.in_position); // no capital yet
+
+    // Simulate deposit
+    s.capital = 1000.0;
+    s.initial_capital = 1000.0;
+
+    // Next tick in BULL should open position
+    _ = s.processTick(tick(105.0, 7.0));
+    try testing.expect(s.in_position);
+    try testing.expectApproxEqAbs(s.entry_price, 105.0, 0.01);
+}
+
+test "deposit: capital and initial_capital both increase" {
+    const allocator = testing.allocator;
+    var s = try Strategy.init(allocator, .{
+        .initial_capital = 1000.0,
+        .fee_pct = 0.001,
+    });
+    defer s.deinit(allocator);
+
+    // Simulate deposit
+    const deposit = 500.0;
+    s.capital += deposit;
+    s.initial_capital += deposit;
+
+    try testing.expectApproxEqAbs(s.capital, 1500.0, 0.01);
+    try testing.expectApproxEqAbs(s.initial_capital, 1500.0, 0.01);
+    // Realized PnL should still be 0
+    try testing.expectApproxEqAbs(s.totalReturn(), 0.0, 0.01);
+}
+
+test "deposit: buy in BULL blends entry price correctly" {
+    const allocator = testing.allocator;
+    var s = try Strategy.init(allocator, .{
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 1000.0,
+        .fee_pct = 0.001,
+    });
+    defer s.deinit(allocator);
+
+    // Existing position
+    s.in_position = true;
+    s.entry_price = 80000.0;
+    s.size = 0.01;
+    s.peak_price = 80000.0;
+    s.capital = 1.0; // after initial buy
+    s.regime = .bull;
+
+    // Deposit arrives, buy at current price
+    const deposit = 1000.0;
+    s.capital += deposit;
+    s.initial_capital += deposit;
+    const buy_price = 82000.0;
+    const fee = deposit * s.fee_pct; // 1.0
+    const usable = deposit - fee; // 999.0
+    const add_size = usable / buy_price; // ~0.01218
+
+    // Blend entry
+    s.entry_price = (s.entry_price * s.size + buy_price * add_size) / (s.size + add_size);
+    s.size += add_size;
+    s.capital -= (usable + fee);
+
+    // Blended: (80000*0.01 + 82000*0.01218) / (0.01 + 0.01218) = ~81094
+    try testing.expect(s.entry_price > 80000.0);
+    try testing.expect(s.entry_price < 82000.0);
+    try testing.expectApproxEqAbs(s.size, 0.01 + add_size, 0.0001);
+    try testing.expectApproxEqAbs(s.capital, 1.0, 0.01); // back to ~$1 cash
+}

--- a/services/dctrading-bot/src/turso.zig
+++ b/services/dctrading-bot/src/turso.zig
@@ -188,6 +188,16 @@ pub const Turso = struct {
         return parseFirstValueFloat(resp.body);
     }
 
+    /// Query total deposits from account_ledger (blocking).
+    pub fn queryTotalDeposits(self: *const Turso) ?f64 {
+        const sql =
+            \\{"requests": [{"type": "execute", "stmt": {"sql": "SELECT COALESCE(SUM(amount), 0) as total FROM account_ledger WHERE type='DEPOSIT'"}}]}
+        ;
+        const resp = self.execSyncRead(sql) orelse return null;
+        defer resp.deinit();
+        return parseFirstValueFloat(resp.body);
+    }
+
     /// Query latest capital from equity_log (blocking).
     pub fn queryLatestCapital(self: *const Turso) ?f64 {
         const sql =


### PR DESCRIPTION
## Summary
Add deposit button to Neko Trade's Ledger tab. Inserts DEPOSIT into Turso `account_ledger`. Bot detects new deposits every 5 min and adjusts capital.

## What's included
- **Neko Trade**: Deposit button (primaryAction toolbar) + amount sheet + `insertDeposit()` in TursoClient
- **Zig bot**: `queryTotalDeposits()` in turso.zig, periodic detection in live loop, deposit reconciliation on restart, Telegram notification

## What's NOT included (separate PR)
- Manual Alpaca trade reconciliation (buy/sell/partial) — needs more work on startup sync and bot_traded guard

## Testing
- Zig: `zig build` passes, 46 tests pass
- Swift: `xcodebuild` passes for macOS target