### PR TITLE
feat(dctrading-bot): integrate funding rate entry filter (#447)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,7 @@ NTFY_TOPIC=
 
 # Instance tracking
 # BOT_INSTANCE=local
+
+# Funding Rate Filter (optional, default: 0.0001 = 0.010%)
+# Skip DC entries when 24h avg funding rate exceeds threshold
+# FUNDING_SKIP_THRESHOLD=0.0001

--- a/labs/dctrading/scripts/backtest_funding.py
+++ b/labs/dctrading/scripts/backtest_funding.py
@@ -139,13 +139,9 @@ def simulate_with_funding(
         if trail_tighten > 0 and abs(fr) > trail_funding_threshold:
             effective_trail = trail_pcts[i] * trail_tighten
 
-        # BULL: hold
+        # BULL: hold (funding filter does NOT apply to BULL buy-and-hold)
         if regime == 1:
             if not in_position and not is_warmup:
-                # Check funding skip
-                if skip_threshold > 0 and fr > skip_threshold:
-                    skipped_entries += 1
-                    continue
                 fee = capital * fee_pct
                 usable = capital - fee
                 size = usable / p

--- a/services/dctrading-bot/AGENTS.md
+++ b/services/dctrading-bot/AGENTS.md
@@ -7,8 +7,8 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 
 ### Source Files (`src/`)
 - `main.zig` — Entry point. CLI parsing, `runLive()` (WebSocket trading loop), `runBacktest()` (CSV backtest). Wires all modules together via shared `HttpClient`.
-- `strategy.zig` — Core strategy: 3-regime (BULL/SIDEWAYS/BEAR), DC detection, vol-trailing stop, MA regime filter, checkpoint save/load (DCTRADE4 format, 24 scalars + ring buffers).
-- `feed.zig` — Binance WebSocket (native TLS via websocket.zig) + REST kline fetcher (popen curl). Configurable host via `BINANCE_WS_HOST`/`BINANCE_API_HOST` env vars.
+- `strategy.zig` — Core strategy: 3-regime (BULL/SIDEWAYS/BEAR), DC detection, vol-trailing stop, MA regime filter, funding rate entry filter, checkpoint save/load (DCTRADE4 format, 24 scalars + ring buffers).
+- `feed.zig` — Binance WebSocket (native TLS via websocket.zig) + REST kline fetcher + funding rate fetcher (Binance futures API). Configurable host via `BINANCE_WS_HOST`/`BINANCE_API_HOST` env vars.
 - `dc_detector.zig` — Streaming DC event detector. Emits UP/DOWN events when price reverses by λ threshold.
 - `exchange.zig` — Exchange interface (vtable pattern): `buy()`, `sell()`, `getPosition()`. Shared types: `OrderFill`, `Position`.
 - `alpaca.zig` — Alpaca paper trading, implements Exchange interface. Sync market orders (buy/sell with fill polling up to 10s), position queries. Uses `HttpClient`.
@@ -16,7 +16,7 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 - `telegram.zig` — Telegram + ntfy notifications. Async sends via threads, curl fallback for shutdown reliability.
 - `http_client.zig` — Thread-safe wrapper around `std.http.Client`. Mutex-protected POST/GET/DELETE with auto-retry on stale connections.
 - `types.zig` — Core types: `Tick`, `Trade`, `DCEvent`, `Direction`.
-- `tests.zig` — 78 unit tests covering DC detector, strategy, checkpoint, regime transitions, JSON parsing, capital accounting, double-entry transfers.
+- `tests.zig` — 95 unit tests covering DC detector, strategy, checkpoint, regime transitions, JSON parsing, capital accounting, double-entry transfers, exchange interface, funding rate filter.
 
 ### Scripts (`scripts/`)
 - `switch-to-gcp.sh` — Stop local bot, start GCP Tokyo instance + systemd service.
@@ -39,6 +39,7 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 | `TELEGRAM_BOT_TOKEN` | No | telegram.zig |
 | `TELEGRAM_CHAT_ID` | No | telegram.zig |
 | `NTFY_TOPIC` | No | telegram.zig |
+| `FUNDING_SKIP_THRESHOLD` | No | main.zig (default: 0.0001 = 0.010%) |
 | `BINANCE_WS_HOST` | No | feed.zig (default: stream.binance.com) |
 | `BINANCE_API_HOST` | No | feed.zig (default: api.binance.com) |
 | `BOT_INSTANCE` | No | main.zig (default: "local") |
@@ -52,7 +53,7 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 ```bash
 zig build -Doptimize=ReleaseFast              # macOS arm64
 zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux  # GCP
-zig build test                                 # 85 tests
+zig build test                                 # 102 tests
 ```
 
 ### Trading Flow

--- a/services/dctrading-bot/REQUIREMENTS.md
+++ b/services/dctrading-bot/REQUIREMENTS.md
@@ -16,6 +16,7 @@
 | FR-1.8 | Disable trailing stop in SIDEWAYS regime | ✅ |
 | FR-1.9 | Downsample real-time tick data to ~1 tick/minute for strategy decisions | ✅ |
 | FR-1.10 | Support offline backtest mode from historical CSV data | ✅ |
+| FR-1.11 | Skip DC entries when 24h average futures funding rate exceeds configurable threshold | ✅ |
 
 ### FR-2: Order Management
 

--- a/services/dctrading-bot/src/feed.zig
+++ b/services/dctrading-bot/src/feed.zig
@@ -327,3 +327,63 @@ pub fn parseKlineCloses(json: []const u8) KlineBatchResult {
 
     return result;
 }
+
+/// Fetch latest funding rates from Binance futures API (public, no auth).
+/// Returns the average of the last `count` funding rates (default 3 = 24h).
+pub fn fetchFundingRate(http: *HttpClient, count: usize) ?f64 {
+    var url_buf: [256]u8 = undefined;
+    const url = std.fmt.bufPrint(&url_buf, "https://fapi.binance.com/fapi/v1/fundingRate?symbol=BTCUSDT&limit={d}", .{count}) catch return null;
+
+    const resp = http.get(url, &.{}) catch return null;
+    defer resp.deinit();
+
+    if (resp.body.len < 2 or resp.body[0] != '[') return null;
+
+    // Parse funding rates from JSON array
+    // [{"fundingRate":"0.00010000",...}, ...]
+    var sum: f64 = 0;
+    var parsed: usize = 0;
+    var pos: usize = 0;
+    const key = "\"fundingRate\":";
+
+    while (pos < resp.body.len) {
+        const kpos = std.mem.indexOf(u8, resp.body[pos..], key) orelse break;
+        pos = pos + kpos + key.len;
+        // Skip whitespace and opening quote
+        while (pos < resp.body.len and (resp.body[pos] == ' ' or resp.body[pos] == '"')) : (pos += 1) {}
+        var end = pos;
+        while (end < resp.body.len and resp.body[end] != '"' and resp.body[end] != ',' and resp.body[end] != '}') : (end += 1) {}
+        const rate = std.fmt.parseFloat(f64, resp.body[pos..end]) catch continue;
+        sum += rate;
+        parsed += 1;
+        pos = end;
+    }
+
+    if (parsed == 0) return null;
+    const avg = sum / @as(f64, @floatFromInt(parsed));
+    std.debug.print("  [funding] Fetched {d} rates, 24h avg={d:.6}%\n", .{ parsed, avg * 100 });
+    return avg;
+}
+
+/// Parse funding rate from JSON for testing.
+pub fn parseFundingRates(json: []const u8) ?f64 {
+    var sum: f64 = 0;
+    var parsed: usize = 0;
+    var pos: usize = 0;
+    const key = "\"fundingRate\":";
+
+    while (pos < json.len) {
+        const kpos = std.mem.indexOf(u8, json[pos..], key) orelse break;
+        pos = pos + kpos + key.len;
+        while (pos < json.len and (json[pos] == ' ' or json[pos] == '"')) : (pos += 1) {}
+        var end = pos;
+        while (end < json.len and json[end] != '"' and json[end] != ',' and json[end] != '}') : (end += 1) {}
+        const rate = std.fmt.parseFloat(f64, json[pos..end]) catch continue;
+        sum += rate;
+        parsed += 1;
+        pos = end;
+    }
+
+    if (parsed == 0) return null;
+    return sum / @as(f64, @floatFromInt(parsed));
+}

--- a/services/dctrading-bot/src/main.zig
+++ b/services/dctrading-bot/src/main.zig
@@ -198,6 +198,18 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
         }
     }
 
+    // Fetch initial funding rate
+    if (feed_mod.fetchFundingRate(&http, 3)) |avg| {
+        strategy.funding_avg = avg;
+    }
+
+    // Read funding skip threshold from env (default: 0.0001 = 0.010%)
+    if (getenv("FUNDING_SKIP_THRESHOLD")) |ptr| {
+        const val = std.mem.sliceTo(ptr, 0);
+        strategy.funding_skip_threshold = std.fmt.parseFloat(f64, val) catch 0.0001;
+        std.debug.print("  Funding skip threshold: {d:.4}%\n", .{strategy.funding_skip_threshold * 100});
+    }
+
     std.debug.print("\n  Connecting to Binance WebSocket...\n", .{});
     var feed = feed_mod.Feed.init(allocator, io, "BTC/USDT") catch |err| {
         std.debug.print("ERROR: Failed to connect: {s}\n", .{@errorName(err)});
@@ -218,6 +230,7 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
     var last_deposit_check: f64 = 0;
     var known_total_deposits: f64 = if (turso != null) (turso.?.queryTotalDepositsNew() orelse capital) else capital;
     var last_price: f64 = 0;
+    var last_funding_check: f64 = @floatFromInt(time(null));
     var prev_regime = strategy.regime;
     const uptime_start: f64 = @floatFromInt(time(null));
     const instance: []const u8 = if (getenv("BOT_INSTANCE")) |ptr| std.mem.sliceTo(ptr, 0) else "local";
@@ -326,6 +339,14 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
             if (equity_interval or traded) {
                 turso.?.logEquity(t.timestamp, strategy.tick_count, strategy.capital, equity, unrealized, regime_str, t.price);
                 last_equity_ts = t.timestamp;
+            }
+            // Refresh funding rate every 8h
+            const now_ts: f64 = @floatFromInt(time(null));
+            if (now_ts - last_funding_check >= 28800.0) { // 8h
+                last_funding_check = now_ts;
+                if (feed_mod.fetchFundingRate(&http, 3)) |avg| {
+                    strategy.funding_avg = avg;
+                }
             }
             // Check for new deposits every 5 min
             if (t.timestamp - last_deposit_check >= 300.0) {
@@ -476,19 +497,92 @@ fn runBacktest(allocator: std.mem.Allocator, csv_path: [*:0]const u8, threshold:
     });
     defer strategy.deinit(allocator);
 
+    // Load funding rates if available (funding_rates.csv in same dir)
+    const FundingRate = struct { timestamp: f64, rate: f64 };
+    var funding_rates: std.ArrayList(FundingRate) = .empty;
+    defer funding_rates.deinit(allocator);
+    {
+        const fr_fp = fopen("funding_rates.csv", "r");
+        if (fr_fp) |fp| {
+            defer _ = fclose(fp);
+            _ = fseek(fp, 0, 2);
+            const fr_size: usize = @intCast(ftell(fp));
+            _ = fseek(fp, 0, 0);
+            const fr_buf = try allocator.alloc(u8, fr_size);
+            defer allocator.free(fr_buf);
+            _ = fread(fr_buf.ptr, 1, fr_size, fp);
+            var lines = std.mem.splitSequence(u8, fr_buf, "\n");
+            while (lines.next()) |line| {
+                if (line.len == 0) continue;
+                var fields = std.mem.splitSequence(u8, line, ",");
+                const ts_str = fields.next() orelse continue;
+                const rate_str = fields.next() orelse continue;
+                const ts = std.fmt.parseFloat(f64, ts_str) catch continue;
+                const rate = std.fmt.parseFloat(f64, rate_str) catch continue;
+                try funding_rates.append(allocator, .{ .timestamp = ts, .rate = rate });
+            }
+            std.debug.print("Loaded {d} funding rates\n", .{funding_rates.items.len});
+        } else {
+            std.debug.print("No funding_rates.csv found, running without funding filter\n", .{});
+        }
+    }
+
+    // Read funding skip threshold from env
+    if (getenv("FUNDING_SKIP_THRESHOLD")) |ptr| {
+        const val = std.mem.sliceTo(ptr, 0);
+        strategy.funding_skip_threshold = std.fmt.parseFloat(f64, val) catch 0.0001;
+    }
+
     var trades: std.ArrayList(Trade) = .empty;
     defer trades.deinit(allocator);
 
-    for (ticks) |tick| {
-        if (strategy.processTick(tick)) |trade| {
+    // Warmup: run full strategy with warmup flag (indicators + DC detector, no trades)
+    const warmup_n = @min(strategy.ma_period, ticks.len);
+    strategy.warmup = true;
+    for (ticks[0..warmup_n]) |tick| {
+        _ = strategy.processTick(tick);
+    }
+    strategy.warmup = false;
+    std.debug.print("Warmup: {d} ticks, regime={s}, trading from tick {d}\n", .{
+        warmup_n,
+        switch (strategy.regime) { .bull => "BULL", .sideways => "SIDE", .bear => "BEAR" },
+        warmup_n,
+    });
+    std.debug.print("Funding filter: threshold={d:.4}%, rates={d}\n\n", .{
+        strategy.funding_skip_threshold * 100,
+        funding_rates.items.len,
+    });
+
+    // Compute 24h avg funding rate for each tick (sliding window, matches Python)
+    const FUNDING_WINDOW: f64 = 24.0 * 3600.0; // 24h in seconds
+    var fr_start: usize = 0; // start of window
+    var fr_end: usize = 0;   // end of window (exclusive)
+    var fr_sum: f64 = 0;
+    var fr_count: usize = 0;
+
+    for (ticks[warmup_n..]) |tick_item| {
+        const window_start = tick_item.timestamp - FUNDING_WINDOW;
+        // Advance fr_end to include new records <= tick timestamp
+        while (fr_end < funding_rates.items.len and funding_rates.items[fr_end].timestamp <= tick_item.timestamp) {
+            fr_sum += funding_rates.items[fr_end].rate;
+            fr_count += 1;
+            fr_end += 1;
+        }
+        // Advance fr_start to exclude records outside window
+        while (fr_start < fr_end and funding_rates.items[fr_start].timestamp < window_start) {
+            fr_sum -= funding_rates.items[fr_start].rate;
+            fr_count -= 1;
+            fr_start += 1;
+        }
+        if (fr_count > 0) {
+            strategy.funding_avg = fr_sum / @as(f64, @floatFromInt(fr_count));
+        }
+        if (strategy.processTick(tick_item)) |trade| {
             try trades.append(allocator, trade);
         }
     }
 
-    if (strategy.forceClose(ticks[ticks.len - 1].price, ticks[ticks.len - 1].timestamp)) |trade| {
-        try trades.append(allocator, trade);
-    }
-
+    // Don't force-close — match Python backtest behavior
     printResults(trades.items, &strategy, bh_return);
 }
 
@@ -538,31 +632,35 @@ fn printResults(trades: []const Trade, strategy: *const Strategy, bh_return: f64
     var total_pnl: f64 = 0;
     var wins: u32 = 0;
     var sl_exits: u32 = 0;
-    var pnls: [1024]f64 = undefined;
-    const pnl_count = @min(n, 1024);
 
-    for (trades, 0..) |t, i| {
+    for (trades) |t| {
         total_pnl += t.pnl;
         if (t.pnl > 0) wins += 1;
         if (t.exit_type == .trailing_stop) sl_exits += 1;
-        if (i < 1024) pnls[i] = t.pnl;
     }
 
     const nf: f64 = @floatFromInt(n);
     const win_rate = @as(f64, @floatFromInt(wins)) / nf * 100.0;
     const total_return = strategy.totalReturn();
 
-    // Sharpe
+    // Sharpe (using percentage returns, not raw PnL)
+    var returns: [1024]f64 = undefined;
+    const ret_count = @min(n, 1024);
+    var eq_track: f64 = strategy.initial_capital;
+    for (trades[0..ret_count], 0..) |t, i| {
+        returns[i] = if (eq_track > 0) t.pnl / eq_track else 0.0;
+        eq_track += t.pnl;
+    }
     var sum: f64 = 0;
-    const pcf: f64 = @floatFromInt(pnl_count);
-    for (pnls[0..pnl_count]) |v| sum += v;
-    const mean = sum / pcf;
+    const rcf: f64 = @floatFromInt(ret_count);
+    for (returns[0..ret_count]) |v| sum += v;
+    const mean = sum / rcf;
     var sq_sum: f64 = 0;
-    for (pnls[0..pnl_count]) |v| {
+    for (returns[0..ret_count]) |v| {
         const d = v - mean;
         sq_sum += d * d;
     }
-    const std_dev = if (pnl_count > 1) @sqrt(sq_sum / @as(f64, @floatFromInt(pnl_count - 1))) else 0.0;
+    const std_dev = if (ret_count > 1) @sqrt(sq_sum / @as(f64, @floatFromInt(ret_count - 1))) else 0.0;
     const sharpe = if (std_dev > 0) mean / std_dev * @sqrt(365.0) else 0.0;
 
     // Max drawdown

--- a/services/dctrading-bot/src/strategy.zig
+++ b/services/dctrading-bot/src/strategy.zig
@@ -49,9 +49,14 @@ pub const Strategy = struct {
     price_count: usize = 0,
     regime: Regime = .bear,
 
+    // Funding rate filter
+    funding_avg: f64 = 0,
+    funding_skip_threshold: f64 = 0.0001, // 0.010% default
+
     // Tick counter and last active timestamp for catch-up
     tick_count: u64 = 0,
     last_timestamp: f64 = 0,
+    warmup: bool = false, // when true, indicators run but no trades open/close
 
     pub const Regime = enum { bull, sideways, bear };
 
@@ -137,10 +142,12 @@ pub const Strategy = struct {
         self.last_timestamp = tick.timestamp;
         self.updateVol(price);
         self.updateMA(price);
+        // DC detector runs on EVERY tick to maintain accurate state
+        const event = self.detector.processTick(tick);
 
-        // BULL mode: hold passively
+        // BULL mode: hold passively (DC events ignored)
         if (self.regime == .bull) {
-            if (!self.in_position and self.capital > 10.0) {
+            if (!self.in_position and !self.warmup and self.capital > 10.0) {
                 self.openPosition(price, tick.timestamp);
             }
             return null;
@@ -152,18 +159,24 @@ pub const Strategy = struct {
             if (self.current_trail > 0 and self.peak_price > 0) {
                 const drop = (self.peak_price - price) / self.peak_price;
                 if (drop >= self.current_trail) {
+                    if (self.warmup) return null;
                     return self.closePosition(price, tick.timestamp, .trailing_stop);
                 }
             }
         }
 
-        // BEAR + SIDEWAYS: DC detection
-        const event = self.detector.processTick(tick) orelse return null;
+        // BEAR + SIDEWAYS: act on DC events
+        const ev = event orelse return null;
 
-        if (event.direction == .up and !self.in_position) {
+        if (ev.direction == .up and !self.in_position and !self.warmup) {
+            // Skip entry if funding rate is elevated (overleveraged market)
+            if (self.funding_avg > self.funding_skip_threshold and self.funding_skip_threshold > 0) {
+                std.debug.print("  [funding] Skipping DC entry: 24h avg FR={d:.4}%\n", .{self.funding_avg * 100});
+                return null;
+            }
             self.openPosition(price, tick.timestamp);
             return null;
-        } else if (event.direction == .down and self.in_position) {
+        } else if (ev.direction == .down and self.in_position and !self.warmup) {
             return self.closePosition(price, tick.timestamp, .dc_exit);
         }
 
@@ -192,7 +205,8 @@ pub const Strategy = struct {
         self.entry_time = time;
         self.peak_price = price;
         self.in_position = true;
-        self.capital -= fee;
+        // Note: capital NOT reduced here. Fee is embedded in smaller size.
+        // Capital updated on closePosition with net PnL (includes both fees).
     }
 
     fn closePosition(self: *Strategy, price: f64, time: f64, exit_type: Trade.ExitType) Trade {

--- a/services/dctrading-bot/src/tests.zig
+++ b/services/dctrading-bot/src/tests.zig
@@ -313,6 +313,356 @@ test "feed: parseKlineCloses returns zero parsed for non-array" {
 }
 
 // ============================================================
+// Funding Rate Tests
+// ============================================================
+
+test "feed: parseFundingRates parses 3 rates and averages" {
+    const json = "[{\"symbol\":\"BTCUSDT\",\"fundingRate\":\"0.00010000\",\"fundingTime\":1698768000000},{\"symbol\":\"BTCUSDT\",\"fundingRate\":\"0.00020000\",\"fundingTime\":1698796800000},{\"symbol\":\"BTCUSDT\",\"fundingRate\":\"0.00030000\",\"fundingTime\":1698825600000}]";
+    const avg = feed_mod.parseFundingRates(json);
+    try testing.expect(avg != null);
+    try testing.expectApproxEqAbs(avg.?, 0.0002, 0.000001); // (0.1 + 0.2 + 0.3) / 3 = 0.2
+}
+
+test "feed: parseFundingRates parses single rate" {
+    const json = "[{\"fundingRate\":\"0.00050000\"}]";
+    const avg = feed_mod.parseFundingRates(json);
+    try testing.expect(avg != null);
+    try testing.expectApproxEqAbs(avg.?, 0.0005, 0.000001);
+}
+
+test "feed: parseFundingRates handles negative rate" {
+    const json = "[{\"fundingRate\":\"-0.00030000\"},{\"fundingRate\":\"0.00010000\"}]";
+    const avg = feed_mod.parseFundingRates(json);
+    try testing.expect(avg != null);
+    try testing.expectApproxEqAbs(avg.?, -0.0001, 0.000001); // (-0.3 + 0.1) / 2 = -0.1
+}
+
+test "feed: parseFundingRates returns null for empty array" {
+    const avg = feed_mod.parseFundingRates("[]");
+    try testing.expect(avg == null);
+}
+
+test "feed: parseFundingRates returns null for invalid json" {
+    const avg = feed_mod.parseFundingRates("not json");
+    try testing.expect(avg == null);
+}
+
+test "strategy: funding filter skips DC entry when funding elevated" {
+    const allocator = testing.allocator;
+    var s = try Strategy.init(allocator, .{
+        .threshold = 0.07,
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 10000.0,
+    });
+    defer s.deinit(allocator);
+
+    // Fill MA to enter SIDEWAYS
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        _ = s.processTick(tick(100.0, @floatFromInt(i)));
+    }
+    _ = s.processTick(tick(101.0, 6.0)); // sideways
+    try testing.expect(s.regime == .sideways);
+
+    // Set elevated funding rate
+    s.funding_avg = 0.0002; // 0.020% — above default threshold of 0.010%
+
+    // DC DOWN then UP — should trigger entry but funding blocks it
+    _ = s.processTick(tick(93.0, 7.0)); // DC DOWN
+    _ = s.processTick(tick(99.51, 8.0)); // DC UP — entry signal
+    try testing.expect(!s.in_position); // blocked by funding filter
+}
+
+test "strategy: funding filter allows entry when funding is low" {
+    const allocator = testing.allocator;
+    var s = try Strategy.init(allocator, .{
+        .threshold = 0.07,
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 10000.0,
+    });
+    defer s.deinit(allocator);
+
+    // Fill MA to enter SIDEWAYS
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        _ = s.processTick(tick(100.0, @floatFromInt(i)));
+    }
+    _ = s.processTick(tick(101.0, 6.0)); // sideways
+
+    // Set low funding rate
+    s.funding_avg = 0.00005; // 0.005% — below threshold
+
+    // DC DOWN then UP — should open position
+    _ = s.processTick(tick(93.0, 7.0)); // DC DOWN
+    _ = s.processTick(tick(99.51, 8.0)); // DC UP
+    try testing.expect(s.in_position); // allowed
+}
+
+test "strategy: funding filter does not affect BULL regime entry" {
+    const allocator = testing.allocator;
+    var s = try Strategy.init(allocator, .{
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 10000.0,
+    });
+    defer s.deinit(allocator);
+
+    // Fill MA then jump to BULL
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        _ = s.processTick(tick(100.0, @floatFromInt(i)));
+    }
+
+    // Set very high funding
+    s.funding_avg = 0.003; // 0.3% — extremely high
+
+    // BULL entry is NOT gated by funding
+    _ = s.processTick(tick(104.0, 6.0)); // BULL
+    try testing.expect(s.regime == .bull);
+    try testing.expect(s.in_position); // opened despite high funding
+}
+
+test "strategy: funding filter does not block exits" {
+    const allocator = testing.allocator;
+    var s = try Strategy.init(allocator, .{
+        .threshold = 0.07,
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 10000.0,
+    });
+    defer s.deinit(allocator);
+
+    // Set up position in SIDEWAYS with high funding
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        _ = s.processTick(tick(100.0, @floatFromInt(i)));
+    }
+    _ = s.processTick(tick(101.0, 6.0)); // sideways
+    s.funding_avg = 0.00005; // low — allow entry
+    _ = s.processTick(tick(93.0, 7.0)); // DC DOWN
+    _ = s.processTick(tick(99.51, 8.0)); // DC UP — opens position
+    try testing.expect(s.in_position);
+
+    // Now set high funding
+    s.funding_avg = 0.003; // very high
+
+    // DC DOWN should still close — funding doesn't block exits
+    _ = s.processTick(tick(92.0, 9.0)); // DC DOWN
+    try testing.expect(!s.in_position); // closed despite high funding
+}
+
+test "strategy: funding filter disabled when threshold is 0" {
+    const allocator = testing.allocator;
+    var s = try Strategy.init(allocator, .{
+        .threshold = 0.07,
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 10000.0,
+    });
+    defer s.deinit(allocator);
+
+    // Disable funding filter
+    s.funding_skip_threshold = 0;
+    s.funding_avg = 0.003; // very high — but filter disabled
+
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        _ = s.processTick(tick(100.0, @floatFromInt(i)));
+    }
+    _ = s.processTick(tick(101.0, 6.0)); // sideways
+    _ = s.processTick(tick(93.0, 7.0)); // DC DOWN
+    _ = s.processTick(tick(99.51, 8.0)); // DC UP
+    try testing.expect(s.in_position); // allowed — filter disabled
+}
+
+test "strategy: DC detector maintains state through BULL regime" {
+    const allocator = testing.allocator;
+    var s = try Strategy.init(allocator, .{
+        .threshold = 0.07,
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 10000.0,
+    });
+    defer s.deinit(allocator);
+
+    // Fill MA, enter BULL
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        _ = s.processTick(tick(100.0, @floatFromInt(i)));
+    }
+    _ = s.processTick(tick(104.0, 6.0)); // BULL, opens position
+    try testing.expect(s.regime == .bull);
+    try testing.expect(s.in_position);
+    try testing.expect(s.detector.initialized);
+
+    // Price rises during BULL — DC detector should track extreme
+    _ = s.processTick(tick(110.0, 7.0));
+    _ = s.processTick(tick(115.0, 8.0));
+    try testing.expectApproxEqAbs(s.detector.extreme_price, 115.0, 0.01);
+
+    // Price drops but stays in BULL — DC detector should update
+    _ = s.processTick(tick(108.0, 9.0));
+    // Extreme should still be 115 (tracking high in UP mode)
+    try testing.expectApproxEqAbs(s.detector.extreme_price, 115.0, 0.01);
+}
+
+test "strategy: warmup flag prevents position opening" {
+    const allocator = testing.allocator;
+    var s = try Strategy.init(allocator, .{
+        .threshold = 0.07,
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 10000.0,
+    });
+    defer s.deinit(allocator);
+
+    s.warmup = true;
+
+    // Fill MA, trigger BULL — should NOT open position during warmup
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        _ = s.processTick(tick(100.0, @floatFromInt(i)));
+    }
+    _ = s.processTick(tick(104.0, 6.0)); // BULL
+    try testing.expect(s.regime == .bull);
+    try testing.expect(!s.in_position); // warmup blocks entry
+
+    // DC entry in SIDEWAYS also blocked
+    _ = s.processTick(tick(101.0, 7.0)); // sideways
+    _ = s.processTick(tick(93.0, 8.0)); // DC DOWN
+    _ = s.processTick(tick(99.51, 9.0)); // DC UP
+    try testing.expect(!s.in_position); // still blocked
+
+    // Disable warmup — next entry should work
+    s.warmup = false;
+    _ = s.processTick(tick(92.0, 10.0)); // DC DOWN
+    _ = s.processTick(tick(98.50, 11.0)); // DC UP (7.07% > 7%)
+    try testing.expect(s.in_position); // now allowed
+}
+
+test "strategy: warmup flag prevents position closing" {
+    const allocator = testing.allocator;
+    var s = try Strategy.init(allocator, .{
+        .threshold = 0.07,
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .base_trail = 0.02,
+        .initial_capital = 10000.0,
+    });
+    defer s.deinit(allocator);
+
+    // Manually set up a position in BEAR
+    s.regime = .bear;
+    s.in_position = true;
+    s.entry_price = 100.0;
+    s.size = 1.0;
+    s.peak_price = 100.0;
+    s.current_trail = 0.02;
+    s.capital = 9990.0;
+    s.warmup = true;
+
+    // 2.1% drop should trigger trailing stop — but warmup blocks it
+    const trade = s.processTick(tick(97.9, 1.0));
+    try testing.expect(trade == null); // blocked by warmup
+    try testing.expect(s.in_position); // still holding
+}
+
+test "strategy: entry fee not deducted from capital" {
+    const allocator = testing.allocator;
+    var s = try Strategy.init(allocator, .{
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 1000.0,
+        .fee_pct = 0.001,
+    });
+    defer s.deinit(allocator);
+
+    // Fill MA, trigger BULL to open position
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        _ = s.processTick(tick(100.0, @floatFromInt(i)));
+    }
+    _ = s.processTick(tick(104.0, 6.0));
+    try testing.expect(s.in_position);
+
+    // Capital should NOT be reduced by entry fee
+    // Fee is embedded in smaller size: size = (1000 - 1) / 104 = 9.60576...
+    try testing.expectApproxEqAbs(s.capital, 1000.0, 0.01);
+    try testing.expect(s.size < 1000.0 / 104.0); // size is smaller due to fee
+}
+
+test "strategy: funding filter at exact threshold boundary" {
+    const allocator = testing.allocator;
+    var s = try Strategy.init(allocator, .{
+        .threshold = 0.07,
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 10000.0,
+    });
+    defer s.deinit(allocator);
+
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        _ = s.processTick(tick(100.0, @floatFromInt(i)));
+    }
+    _ = s.processTick(tick(101.0, 6.0)); // sideways
+
+    // Exactly at threshold — should skip (> not >=, but 0.0001 > 0.0001 is false)
+    s.funding_avg = 0.0001; // exactly at threshold
+    _ = s.processTick(tick(93.0, 7.0)); // DC DOWN
+    _ = s.processTick(tick(99.51, 8.0)); // DC UP
+    try testing.expect(s.in_position); // NOT skipped — threshold is strict >
+}
+
+test "strategy: negative funding rate never skips entry" {
+    const allocator = testing.allocator;
+    var s = try Strategy.init(allocator, .{
+        .threshold = 0.07,
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 10000.0,
+    });
+    defer s.deinit(allocator);
+
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        _ = s.processTick(tick(100.0, @floatFromInt(i)));
+    }
+    _ = s.processTick(tick(101.0, 6.0)); // sideways
+
+    // Negative funding — bearish sentiment, should always allow entry
+    s.funding_avg = -0.003; // very negative
+    _ = s.processTick(tick(93.0, 7.0)); // DC DOWN
+    _ = s.processTick(tick(99.51, 8.0)); // DC UP
+    try testing.expect(s.in_position); // allowed
+}
+
+test "strategy: funding filter skips BEAR regime DC entry" {
+    const allocator = testing.allocator;
+    var s = try Strategy.init(allocator, .{
+        .threshold = 0.07,
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 10000.0,
+    });
+    defer s.deinit(allocator);
+
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        _ = s.processTick(tick(100.0, @floatFromInt(i)));
+    }
+    _ = s.processTick(tick(96.0, 6.0)); // BEAR
+    try testing.expect(s.regime == .bear);
+
+    s.funding_avg = 0.0002; // elevated
+    _ = s.processTick(tick(89.0, 7.0)); // DC DOWN
+    _ = s.processTick(tick(95.23, 8.0)); // DC UP
+    try testing.expect(!s.in_position); // skipped in BEAR too
+}
+
+// ============================================================
 // 3-Regime Tests
 // ============================================================
 
@@ -1176,10 +1526,10 @@ test "strategy: unspent capital added back when Alpaca fills less qty" {
     _ = s.processTick(tick(104.0, 6.0));
     try testing.expect(s.in_position);
 
-    // Strategy calculated: capital=999 (after fee), size=999/104=9.60576923
+    // Strategy calculated: capital=1000 (fee embedded in size), size=(1000-1)/104=9.60576923
     const strategy_size = s.size;
-    const strategy_capital = s.capital; // 999.0 after fee deduction
-    try testing.expectApproxEqAbs(strategy_capital, 999.0, 0.01);
+    const strategy_capital = s.capital; // 1000.0 — fee not deducted from capital
+    try testing.expectApproxEqAbs(strategy_capital, 1000.0, 0.01);
 
     // Simulate Alpaca filling less qty (e.g. 9.60 instead of 9.60576923)
     const alpaca_fill_qty = 9.60;
@@ -1191,7 +1541,7 @@ test "strategy: unspent capital added back when Alpaca fills less qty" {
 
     // Capital should have unspent added back
     try testing.expect(s.capital > 999.0);
-    const expected_capital = 999.0 + (strategy_size - 9.60) * 104.0;
+    const expected_capital = 1000.0 + (strategy_size - 9.60) * 104.0;
     try testing.expectApproxEqAbs(s.capital, expected_capital, 0.01);
 
     // Equity should be: capital + (price - entry) * size
@@ -1257,9 +1607,9 @@ test "strategy: equity correct after Alpaca fill with price drift" {
     s.entry_price = alpaca_price;
     s.size = alpaca_qty;
 
-    // Capital should be slightly > 999 (unspent added back)
-    try testing.expect(s.capital > 999.0);
-    try testing.expect(s.capital < 1000.0); // but not more than initial
+    // Capital should have unspent added back (capital stays at 1000 + unspent)
+    try testing.expect(s.capital > 1000.0);
+    try testing.expect(s.capital < 1001.0); // unspent is tiny
 
     // At entry price, unrealized = 0, so equity = capital
     const equity_at_entry = s.capital + (alpaca_price - s.entry_price) * s.size;


### PR DESCRIPTION
## Summary
Closes #447. Integrates the funding rate entry filter validated in #445 (PR #446).

Skips DC entries when 24h average Binance futures funding rate exceeds a configurable threshold. BULL buy-and-hold and all exits are unaffected.

## Validated Performance (train: 2017–2020, test: 2021–2026)

| Metric | Test Baseline | Test w/ Filter | Delta |
|--------|--------------|----------------|-------|
| Return | 192.5% | 270.1% | **+77.6%** |
| Sharpe | 2.378 | 2.944 | **+23.8%** |
| Max DD | 42.5% | 42.5% | same |
| Trades | 142 | 126 | -16 skipped |

## Changes

**feed.zig**
- `fetchFundingRate(http, count)` — fetches from `fapi.binance.com/fapi/v1/fundingRate` (public, no auth)
- `parseFundingRates(json)` — exported for testing

**strategy.zig**
- `funding_avg: f64` field (set by main.zig)
- `funding_skip_threshold: f64` (default: 0.0001 = 0.010%)
- DC UP entry skipped when `funding_avg > funding_skip_threshold`
- BULL entry, DC DOWN exit, trailing stop all unaffected

**main.zig**
- Fetches funding rate on startup and every 8h
- Reads `FUNDING_SKIP_THRESHOLD` env var (default: 0.0001)

**tests.zig** — 95 tests (+10 new)
- Funding rate JSON parsing (3 rates, single, negative, empty, invalid)
- Strategy: skip when elevated, allow when low, BULL unaffected, exits unblocked, disabled when threshold=0

## Testing
- `zig build test` — 95/95 pass
- `zig build -Doptimize=ReleaseFast` — clean