### PR TITLE
feat(dctrading-bot): use actual exchange fees instead of hardcoded 0.1%

### DIFF
--- a/services/dctrading-bot/src/alpaca.zig
+++ b/services/dctrading-bot/src/alpaca.zig
@@ -136,7 +136,10 @@ pub const Alpaca = struct {
                 fill.status = .filled;
                 fill.fill_price = parseJsonFloat(r, "\"filled_avg_price\":") orelse 0;
                 fill.fill_qty = parseJsonFloat(r, "\"filled_qty\":") orelse 0;
-                std.debug.print("  [alpaca] Filled: price=${d:.2} qty={d:.8}\n", .{ fill.fill_price, fill.fill_qty });
+                fill.commission = parseJsonFloat(r, "\"commission\":") orelse 0;
+                @memcpy(fill.commission_asset[0..3], "USD");
+                fill.commission_asset_len = 3;
+                std.debug.print("  [alpaca] Filled: price=${d:.2} qty={d:.8} fee=${d:.4}\n", .{ fill.fill_price, fill.fill_qty, fill.commission });
                 return fill;
             }
 
@@ -160,7 +163,10 @@ pub const Alpaca = struct {
                         fill.status = .filled;
                         fill.fill_price = parseJsonFloat(pr, "\"filled_avg_price\":") orelse 0;
                         fill.fill_qty = parseJsonFloat(pr, "\"filled_qty\":") orelse 0;
-                        std.debug.print("  [alpaca] Filled (poll {d}): price=${d:.2} qty={d:.8}\n", .{ poll + 1, fill.fill_price, fill.fill_qty });
+                        fill.commission = parseJsonFloat(pr, "\"commission\":") orelse 0;
+                        @memcpy(fill.commission_asset[0..3], "USD");
+                        fill.commission_asset_len = 3;
+                        std.debug.print("  [alpaca] Filled (poll {d}): price=${d:.2} qty={d:.8} fee=${d:.4}\n", .{ poll + 1, fill.fill_price, fill.fill_qty, fill.commission });
                         return fill;
                     }
                     if (std.mem.indexOf(u8, pr, "\"status\":\"canceled\"") != null or

--- a/services/dctrading-bot/src/exchange.zig
+++ b/services/dctrading-bot/src/exchange.zig
@@ -7,6 +7,9 @@ pub const OrderFill = struct {
     order_id_len: usize = 0,
     fill_price: f64,
     fill_qty: f64,
+    commission: f64 = 0,
+    commission_asset: [8]u8 = undefined,
+    commission_asset_len: usize = 0,
     status: enum { filled, accepted, failed },
 };
 

--- a/services/dctrading-bot/src/main.zig
+++ b/services/dctrading-bot/src/main.zig
@@ -274,6 +274,7 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
             var buy_size = strategy.size;
             var alpaca_oid: []const u8 = "";
             var unspent_amt: f64 = 0;
+            var fill_commission: f64 = 0;
             if (exchange.buy(strategy.size)) |fill| {
                 if (fill.status == .filled and fill.fill_price > 0) {
                     buy_price = fill.fill_price;
@@ -283,6 +284,7 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
                     strategy.entry_price = buy_price;
                     strategy.size = buy_size;
                     alpaca_oid = fill.order_id[0..fill.order_id_len];
+                    fill_commission = fill.commission;
                 } else {
                     std.debug.print("  [exchange] Buy order not filled: status={s}\n", .{if (fill.status == .accepted) "accepted" else "failed"});
                 }
@@ -290,10 +292,10 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
                 std.debug.print("  [exchange] Buy order failed (null)\n", .{});
             }
             if (turso != null) {
-                const fee = buy_price * buy_size * 0.001;
+                const fee = if (fill_commission > 0) fill_commission else buy_price * buy_size * 0.001;
                 const buy_cost = buy_price * buy_size;
                 // Double-entry: fee transfer (cash → fees)
-                turso.?.createPostedTransfer(turso_mod.Turso.ACCT_FEES, turso_mod.Turso.ACCT_CASH, fee, turso_mod.Turso.CODE_FEE, "BUY fee 0.1%", t.timestamp, 0, 0);
+                turso.?.createPostedTransfer(turso_mod.Turso.ACCT_FEES, turso_mod.Turso.ACCT_CASH, fee, turso_mod.Turso.CODE_FEE, "BUY fee", t.timestamp, 0, 0);
                 // Double-entry: buy transfer (btc_position ← cash)
                 var ud_buf: [256]u8 = undefined;
                 const ud = std.fmt.bufPrint(&ud_buf, "BUY signal={d:.2} oid={s}", .{ signal_price, alpaca_oid }) catch "BUY";
@@ -362,17 +364,20 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
 
                         // If in BULL with open position, immediately buy with the deposit
                         if (strategy.regime == .bull and strategy.in_position and deposit > 10.0) {
-                            const fee = deposit * strategy.fee_pct;
-                            const usable = deposit - fee;
+                            const est_fee = deposit * strategy.fee_pct; // estimate for position sizing
+                            const usable = deposit - est_fee;
                             const add_size = usable / t.price;
                             var buy_price = t.price;
                             var buy_size = add_size;
+                            var dep_fill_commission: f64 = 0;
                             if (exchange.buy(add_size)) |fill| {
                                 if (fill.status == .filled and fill.fill_price > 0) {
                                     buy_price = fill.fill_price;
                                     buy_size = fill.fill_qty;
+                                    dep_fill_commission = fill.commission;
                                 }
                             }
+                            const fee = if (dep_fill_commission > 0) dep_fill_commission else est_fee;
                             strategy.entry_price = (strategy.entry_price * strategy.size + buy_price * buy_size) / (strategy.size + buy_size);
                             strategy.size += buy_size;
                             strategy.capital -= fee;
@@ -446,11 +451,15 @@ fn handleSell(trade: Trade, strategy: *const Strategy, closed_count: *u32, excha
     closed_count.* += 1;
     printLiveTrade(trade, closed_count.*, strategy);
     var sell_price = trade.exit_price;
+    var sell_commission: f64 = 0;
     if (exchange.sell(trade.size)) |fill| {
-        if (fill.status == .filled and fill.fill_price > 0) sell_price = fill.fill_price;
+        if (fill.status == .filled and fill.fill_price > 0) {
+            sell_price = fill.fill_price;
+            sell_commission = fill.commission;
+        }
     }
     if (turso) |t| {
-        const exit_fee = sell_price * trade.size * 0.001;
+        const exit_fee = if (sell_commission > 0) sell_commission else sell_price * trade.size * 0.001;
         const sell_proceeds = sell_price * trade.size;
         const pnl = trade.pnl;
         const exit_str = switch (trade.exit_type) { .dc_exit => "DC", .trailing_stop => "SL", .regime_close => "REG", .end_of_data => "END" };
@@ -459,7 +468,7 @@ fn handleSell(trade: Trade, strategy: *const Strategy, closed_count: *u32, excha
         const ud = std.fmt.bufPrint(&ud_buf, "SELL exit={s}", .{exit_str}) catch "SELL";
         t.createPostedTransfer(turso_mod.Turso.ACCT_CASH, turso_mod.Turso.ACCT_BTC, sell_proceeds, turso_mod.Turso.CODE_SELL, ud, timestamp, sell_price, trade.size);
         // Double-entry: fee transfer (fees ← cash)
-        t.createPostedTransfer(turso_mod.Turso.ACCT_FEES, turso_mod.Turso.ACCT_CASH, exit_fee, turso_mod.Turso.CODE_FEE, "SELL fee 0.1%", timestamp, 0, 0);
+        t.createPostedTransfer(turso_mod.Turso.ACCT_FEES, turso_mod.Turso.ACCT_CASH, exit_fee, turso_mod.Turso.CODE_FEE, "SELL fee", timestamp, 0, 0);
         // Double-entry: PnL transfer (if nonzero)
         if (pnl > 0) {
             t.createPostedTransfer(turso_mod.Turso.ACCT_CASH, turso_mod.Turso.ACCT_PNL, pnl, turso_mod.Turso.CODE_PNL, "Realized PnL", timestamp, 0, 0);

--- a/services/dctrading-bot/src/tests.zig
+++ b/services/dctrading-bot/src/tests.zig
@@ -1044,6 +1044,68 @@ test "exchange: OrderFill order_id storage" {
     try testing.expectEqualStrings(id, fill.order_id[0..fill.order_id_len]);
 }
 
+test "exchange: OrderFill commission fields default to zero" {
+    const fill = exchange_mod.OrderFill{ .fill_price = 80000.0, .fill_qty = 0.01, .status = .filled };
+    try testing.expectApproxEqAbs(fill.commission, 0.0, 0.001);
+    try testing.expectEqual(fill.commission_asset_len, 0);
+}
+
+test "exchange: OrderFill commission_asset storage" {
+    var fill = exchange_mod.OrderFill{ .fill_price = 80000.0, .fill_qty = 0.01, .status = .filled };
+    fill.commission = 0.50;
+    @memcpy(fill.commission_asset[0..3], "USD");
+    fill.commission_asset_len = 3;
+    try testing.expectApproxEqAbs(fill.commission, 0.50, 0.001);
+    try testing.expectEqualStrings("USD", fill.commission_asset[0..fill.commission_asset_len]);
+}
+
+test "exchange: OrderFill commission_asset supports BNB and BTC" {
+    var fill = exchange_mod.OrderFill{ .fill_price = 80000.0, .fill_qty = 0.01, .status = .filled };
+    // BNB fee (Binance discount)
+    fill.commission = 0.00123;
+    @memcpy(fill.commission_asset[0..3], "BNB");
+    fill.commission_asset_len = 3;
+    try testing.expectEqualStrings("BNB", fill.commission_asset[0..fill.commission_asset_len]);
+    // BTC fee (Binance default when buying)
+    @memcpy(fill.commission_asset[0..3], "BTC");
+    try testing.expectEqualStrings("BTC", fill.commission_asset[0..fill.commission_asset_len]);
+}
+
+test "exchange: mock exchange returns commission in fill" {
+    const CommissionExchange = struct {
+        fn buy(_: *const anyopaque, qty: f64) ?exchange_mod.OrderFill {
+            var fill = exchange_mod.OrderFill{ .fill_price = 95000.0, .fill_qty = qty, .status = .filled };
+            fill.commission = 0.95; // $0.95 fee
+            @memcpy(fill.commission_asset[0..3], "USD");
+            fill.commission_asset_len = 3;
+            return fill;
+        }
+        fn sell(_: *const anyopaque, qty: f64) ?exchange_mod.OrderFill {
+            var fill = exchange_mod.OrderFill{ .fill_price = 96000.0, .fill_qty = qty, .status = .filled };
+            fill.commission = 0.00000100; // BTC fee
+            @memcpy(fill.commission_asset[0..3], "BTC");
+            fill.commission_asset_len = 3;
+            return fill;
+        }
+        fn getPosition(_: *const anyopaque) ?exchange_mod.Position { return null; }
+        const vtable = exchange_mod.Exchange.VTable{
+            .buy = @ptrCast(&buy),
+            .sell = @ptrCast(&sell),
+            .getPosition = @ptrCast(&getPosition),
+        };
+    };
+    var dummy: u8 = 0;
+    const ex = exchange_mod.Exchange{ .ptr = @ptrCast(&dummy), .vtable = &CommissionExchange.vtable };
+
+    const buy_fill = ex.buy(0.01).?;
+    try testing.expectApproxEqAbs(buy_fill.commission, 0.95, 0.001);
+    try testing.expectEqualStrings("USD", buy_fill.commission_asset[0..buy_fill.commission_asset_len]);
+
+    const sell_fill = ex.sell(0.01).?;
+    try testing.expectApproxEqAbs(sell_fill.commission, 0.00000100, 0.00000001);
+    try testing.expectEqualStrings("BTC", sell_fill.commission_asset[0..sell_fill.commission_asset_len]);
+}
+
 test "exchange: two different implementations share the same interface" {
     // Simulates switching between Alpaca and a future Binance exchange
     const ExchangeA = struct {


### PR DESCRIPTION
## Summary
- Add `commission` and `commission_asset` fields to `OrderFill` so the bot can use actual exchange fees instead of hardcoded 0.1%
- Live trading path now prefers actual fill commission, falling back to 0.1% estimate when commission is 0 (Alpaca paper trading)
- Backtest path unchanged — still uses `fee_pct` parameter

## What changed

**exchange.zig** — `OrderFill` gains two new fields (with defaults, backward compatible):
- `commission: f64 = 0` — actual fee amount from exchange
- `commission_asset: [8]u8` + `commission_asset_len: usize = 0` — fee currency ("USD", "BNB", "BTC")

**alpaca.zig** — Both fill paths (immediate + poll) parse `commission` from Alpaca response, set `commission_asset = "USD"`

**main.zig** — All 3 hardcoded `* 0.001` fee spots replaced with:
```zig
const fee = if (fill_commission > 0) fill_commission else price * size * 0.001;
```
- Regular buy fee (was `buy_price * buy_size * 0.001`)
- Deposit buy fee (was `deposit * strategy.fee_pct`)
- Sell fee in handleSell (was `sell_price * trade.size * 0.001`)

**tests.zig** — 4 new tests (109 total):
- Commission fields default to zero
- USD/BNB/BTC asset storage
- Mock exchange returning commission in fills

## Design decisions
- **Fallback to estimate**: Alpaca paper trading returns commission=0. Rather than breaking the ledger, we fall back to the 0.1% estimate. When Binance is added with real fees, the actual commission flows through.
- **commission_asset for future routing**: #442 (BNB account) will use this field to route fee transfers to the correct account (cash, bnb, or btc_position).
- **Backtest unchanged**: Strategy.fee_pct still drives backtest fee calculations. Only the live Turso ledger entries use actual fees.

## Tests
109/109 pass (`zig build test`)

Closes #440, closes #443
Partial progress on #425
