### PR TITLE
Fix LiveLoop ledger settlement coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ maneki-monorepo/
 
 | Service | Stack | Description |
 |---|---|---|
-| `dctrading-bot` | Zig 0.16 | BTC algorithmic trading bot. Directional Change theory, 3-regime strategy (BULL/SIDEWAYS/BEAR), Binance WebSocket, Alpaca paper trading, Turso DB, Telegram/ntfy notifications. Non-blocking order flow, two-phase transfers. 155 tests. |
+| `dctrading-bot` | Zig 0.16 | BTC algorithmic trading bot. Directional Change theory, 3-regime strategy (BULL/SIDEWAYS/BEAR), Binance WebSocket, Alpaca paper trading, Turso DB, Telegram/ntfy notifications. Non-blocking order flow, two-phase transfers. 158 tests. |
 
 ### Labs
 

--- a/services/dctrading-bot/AGENTS.md
+++ b/services/dctrading-bot/AGENTS.md
@@ -16,11 +16,11 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 - `telegram.zig` — Telegram + ntfy notifications. Async sends via threads, curl fallback for shutdown reliability.
 - `http_client.zig` — Thread-safe wrapper around `std.http.Client`. Mutex-protected POST/GET/DELETE with auto-retry on stale connections.
 - `types.zig` — Core types: `Tick`, `Trade`, `DCEvent`, `Direction`.
-- `live_loop.zig` — Extracted core order flow logic: pending order tracking, trailing stop, strategy signals, buy/sell submission, capital_reserved. Shared by `runLive()` and integration tests.
+- `live_loop.zig` — Extracted core order flow logic: pending order tracking, trailing stop, strategy signals, buy/sell submission, capital_reserved, and ledger vtable. Shared by `runLive()` and integration tests.
 - `tick_source.zig` — `TickSource` vtable interface + `SimFeed` (replays ticks from array). For testing.
 - `sim_exchange.zig` — `SimExchange` implementing Exchange vtable with configurable fill delay, slippage, partial fills, cancel races, failure injection, order log. For testing.
-- `integration_tests.zig` — 24 end-to-end scenarios using LiveLoop + SimExchange.
-- `tests.zig` — 155 tests covering DC detector, strategy, checkpoint, regime transitions, JSON parsing, capital accounting, double-entry transfers, exchange interface, funding rate filter, non-blocking order flow, capital_reserved, integration scenarios.
+- `integration_tests.zig` — 27 end-to-end scenarios using LiveLoop + SimExchange + mock ledger.
+- `tests.zig` — 158 tests covering DC detector, strategy, checkpoint, regime transitions, JSON parsing, capital accounting, double-entry transfers, exchange interface, funding rate filter, non-blocking order flow, capital_reserved, integration scenarios.
 
 ### Scripts (`scripts/`)
 - `switch-to-gcp.sh` — Stop local bot, start GCP Tokyo instance + systemd service.
@@ -57,7 +57,7 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 ```bash
 zig build -Doptimize=ReleaseFast              # macOS arm64
 zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux  # GCP
-zig build test                                 # 155 tests
+zig build test                                 # 158 tests
 ```
 
 ### Trading Flow

--- a/services/dctrading-bot/README.md
+++ b/services/dctrading-bot/README.md
@@ -38,15 +38,15 @@ Single static binary. No Python, no Docker, no runtime dependencies (except curl
 | `dc_detector.zig` | Streaming DC event detector |
 | `exchange.zig` | Exchange vtable interface for sync and async order flow |
 | `alpaca.zig` | Alpaca paper trading (sync/async orders, position queries) |
-| `live_loop.zig` | Shared live order-flow engine used by production and simulation tests |
+| `live_loop.zig` | Shared live order-flow engine and ledger interface used by production and simulation tests |
 | `sim_exchange.zig` | Configurable simulated exchange for integration tests |
 | `tick_source.zig` | Tick source interface and simulated feed |
-| `integration_tests.zig` | End-to-end LiveLoop scenarios using SimExchange |
+| `integration_tests.zig` | End-to-end LiveLoop scenarios using SimExchange and mock ledger |
 | `turso.zig` | Turso DB client (equity log, positions, bot status, two-phase ledger) |
 | `telegram.zig` | Telegram + ntfy push notifications |
 | `http_client.zig` | Shared HTTP client (std.http.Client wrapper) |
 | `types.zig` | Tick, Trade, DC event types |
-| `tests.zig` | 155 tests |
+| `tests.zig` | 158 tests |
 
 ## Setup
 

--- a/services/dctrading-bot/src/integration_tests.zig
+++ b/services/dctrading-bot/src/integration_tests.zig
@@ -5,6 +5,7 @@ const testing = std.testing;
 const types = @import("types.zig");
 const strat_mod = @import("strategy.zig");
 const exchange_mod = @import("exchange.zig");
+const turso_mod = @import("turso.zig");
 const sim_exchange_mod = @import("sim_exchange.zig");
 const tick_source_mod = @import("tick_source.zig");
 const live_loop_mod = @import("live_loop.zig");
@@ -14,6 +15,112 @@ const Strategy = strat_mod.Strategy;
 const SimExchange = sim_exchange_mod.SimExchange;
 const SimFeed = tick_source_mod.SimFeed;
 const LiveLoop = live_loop_mod.LiveLoop;
+const Ledger = live_loop_mod.Ledger;
+
+const MockLedger = struct {
+    next_id: u32 = 100,
+    pending_count: u32 = 0,
+    post_fill_count: u32 = 0,
+    posted_count: u32 = 0,
+    void_count: u32 = 0,
+    last_pending: PendingCall = .{},
+    last_post_fill: PostFillCall = .{},
+    posted: [8]PostedCall = undefined,
+    voided_id: u32 = 0,
+
+    const PendingCall = struct {
+        debit_acct: u8 = 0,
+        credit_acct: u8 = 0,
+        amount: f64 = 0,
+        code: u8 = 0,
+        timestamp: f64 = 0,
+        price: f64 = 0,
+        qty: f64 = 0,
+        order_id_len: usize = 0,
+    };
+
+    const PostFillCall = struct {
+        pending_id: u32 = 0,
+        actual_amount: f64 = 0,
+        actual_price: f64 = 0,
+        actual_size: f64 = 0,
+    };
+
+    const PostedCall = struct {
+        debit_acct: u8 = 0,
+        credit_acct: u8 = 0,
+        amount: f64 = 0,
+        code: u8 = 0,
+        timestamp: f64 = 0,
+        price: f64 = 0,
+        qty: f64 = 0,
+    };
+
+    fn ledger(self: *MockLedger) Ledger {
+        return .{
+            .ptr = @ptrCast(self),
+            .vtable = &vtable,
+        };
+    }
+
+    fn createPendingTransfer(ptr: *const anyopaque, debit_acct: u8, credit_acct: u8, amount: f64, code: u8, _: []const u8, timestamp: f64, price: f64, qty: f64, order_id: []const u8) ?u32 {
+        const self: *MockLedger = @ptrCast(@alignCast(@constCast(ptr)));
+        self.pending_count += 1;
+        self.last_pending = .{
+            .debit_acct = debit_acct,
+            .credit_acct = credit_acct,
+            .amount = amount,
+            .code = code,
+            .timestamp = timestamp,
+            .price = price,
+            .qty = qty,
+            .order_id_len = order_id.len,
+        };
+        const id = self.next_id;
+        self.next_id += 1;
+        return id;
+    }
+
+    fn postTransferWithFill(ptr: *const anyopaque, pending_id: u32, actual_amount: f64, actual_price: f64, actual_size: f64, _: []const u8) void {
+        const self: *MockLedger = @ptrCast(@alignCast(@constCast(ptr)));
+        self.post_fill_count += 1;
+        self.last_post_fill = .{
+            .pending_id = pending_id,
+            .actual_amount = actual_amount,
+            .actual_price = actual_price,
+            .actual_size = actual_size,
+        };
+    }
+
+    fn createPostedTransfer(ptr: *const anyopaque, debit_acct: u8, credit_acct: u8, amount: f64, code: u8, _: []const u8, timestamp: f64, price: f64, qty: f64) void {
+        const self: *MockLedger = @ptrCast(@alignCast(@constCast(ptr)));
+        if (self.posted_count < self.posted.len) {
+            self.posted[self.posted_count] = .{
+                .debit_acct = debit_acct,
+                .credit_acct = credit_acct,
+                .amount = amount,
+                .code = code,
+                .timestamp = timestamp,
+                .price = price,
+                .qty = qty,
+            };
+        }
+        self.posted_count += 1;
+    }
+
+    fn voidTransfer(ptr: *const anyopaque, pending_id: u32) void {
+        const self: *MockLedger = @ptrCast(@alignCast(@constCast(ptr)));
+        self.void_count += 1;
+        self.voided_id = pending_id;
+    }
+
+    const vtable = Ledger.VTable{
+        .createPendingTransfer = &createPendingTransfer,
+        .postTransferWithFill = &postTransferWithFill,
+        .createPostedTransfer = &createPostedTransfer,
+        .voidTransfer = &voidTransfer,
+    };
+};
 
 fn makeTick(price: f64, ts: f64) Tick {
     return .{ .timestamp = ts, .price = price };
@@ -486,7 +593,8 @@ test "integration: cancel race — buy fills despite cancel" {
     var sim = SimExchange{ .fill_delay = 100, .cancel_fills_instead = true };
     sim.last_price = 100.0;
     const ex = sim.exchange();
-    var loop = LiveLoop.init(&strategy, ex, null);
+    var ledger = MockLedger{};
+    var loop = LiveLoop.init(&strategy, ex, ledger.ledger());
 
     // Setup: BEAR with position + pending deposit buy
     strategy.regime = .bear;
@@ -498,6 +606,8 @@ test "integration: cancel race — buy fills despite cancel" {
 
     loop.submitBuy(104.0, 0.5, true, 0.0);
     try testing.expect(loop.pending_count == 1);
+    try testing.expectEqual(@as(u32, 1), ledger.pending_count);
+    try testing.expectEqual(@as(u32, 100), loop.pending_orders[0].transfer_id);
 
     // Trailing stop fires: cancel buy, but it fills instead
     loop.processTick(makeTick(101.0, 60.0));
@@ -506,6 +616,15 @@ test "integration: cancel race — buy fills despite cancel" {
     try testing.expect(loop.buys_filled == 1);
     // Sell also submitted
     try testing.expect(loop.sells_submitted == 1);
+    try testing.expectEqual(@as(u32, 2), ledger.pending_count);
+    try testing.expectEqual(@as(u32, 1), ledger.post_fill_count);
+    try testing.expectEqual(@as(u32, 100), ledger.last_post_fill.pending_id);
+    try testing.expectApproxEqAbs(100.0 * 0.5, ledger.last_post_fill.actual_amount, 0.001);
+    try testing.expectApproxEqAbs(100.0, ledger.last_post_fill.actual_price, 0.001);
+    try testing.expectApproxEqAbs(0.5, ledger.last_post_fill.actual_size, 0.001);
+    try testing.expectEqual(@as(u32, 1), ledger.posted_count);
+    try testing.expectEqual(turso_mod.Turso.CODE_FEE, ledger.posted[0].code);
+    try testing.expectEqual(@as(u32, 0), ledger.void_count);
 }
 
 // ============================================================
@@ -881,6 +1000,136 @@ test "integration: one-minute tick uses fresh strategy state before realtime sto
     try testing.expect(!loop.was_downsampled);
     try testing.expect(loop.sells_submitted == 1);
     try testing.expect(!strategy.in_position);
+}
+
+test "integration: ledger records buy pending and actual fill settlement" {
+    const allocator = testing.allocator;
+    var strategy = try Strategy.init(allocator, .{
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 1000.0,
+        .fee_pct = 0.001,
+    });
+    defer strategy.deinit(allocator);
+    strategy.suppress_entry = true;
+
+    var sim = SimExchange{ .fill_delay = 1, .fill_price_offset = 2.0 };
+    sim.last_price = 104.0;
+    const ex = sim.exchange();
+    var ledger = MockLedger{};
+    var loop = LiveLoop.init(&strategy, ex, ledger.ledger());
+
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        loop.processTick(makeTick(100.0, @as(f64, @floatFromInt(i)) * 60.0));
+    }
+
+    loop.processTick(makeTick(104.0, 360.0));
+    try testing.expectEqual(@as(u32, 1), ledger.pending_count);
+    try testing.expectEqual(turso_mod.Turso.ACCT_BTC, ledger.last_pending.debit_acct);
+    try testing.expectEqual(turso_mod.Turso.ACCT_CASH, ledger.last_pending.credit_acct);
+    try testing.expectEqual(turso_mod.Turso.CODE_BUY, ledger.last_pending.code);
+    try testing.expectApproxEqAbs(104.0, ledger.last_pending.price, 0.001);
+    try testing.expect(ledger.last_pending.order_id_len > 0);
+    try testing.expectEqual(@as(u32, 100), loop.pending_orders[0].transfer_id);
+
+    sim.advanceTick();
+    loop.processTick(makeTick(104.0, 420.0));
+    const fill_price = 106.0;
+    const fill_size = ledger.last_pending.qty;
+    try testing.expectEqual(@as(u32, 1), ledger.post_fill_count);
+    try testing.expectEqual(@as(u32, 100), ledger.last_post_fill.pending_id);
+    try testing.expectApproxEqAbs(fill_price * fill_size, ledger.last_post_fill.actual_amount, 0.001);
+    try testing.expectApproxEqAbs(fill_price, ledger.last_post_fill.actual_price, 0.001);
+    try testing.expectApproxEqAbs(fill_size, ledger.last_post_fill.actual_size, 0.001);
+    try testing.expectEqual(@as(u32, 1), ledger.posted_count);
+    try testing.expectEqual(turso_mod.Turso.CODE_FEE, ledger.posted[0].code);
+    try testing.expectApproxEqAbs(420.0, ledger.posted[0].timestamp, 0.001);
+}
+
+test "integration: ledger records sell fill fee and realized pnl" {
+    const allocator = testing.allocator;
+    var strategy = try Strategy.init(allocator, .{
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 10000.0,
+        .fee_pct = 0.001,
+    });
+    defer strategy.deinit(allocator);
+    strategy.suppress_entry = true;
+
+    var sim = SimExchange{ .fill_delay = 1, .fill_price_offset = 10.0 };
+    sim.last_price = 120.0;
+    const ex = sim.exchange();
+    var ledger = MockLedger{};
+    var loop = LiveLoop.init(&strategy, ex, ledger.ledger());
+
+    strategy.regime = .bear;
+    strategy.in_position = true;
+    strategy.entry_price = 100.0;
+    strategy.size = 2.0;
+    strategy.peak_price = 130.0;
+    strategy.current_trail = 0.02;
+
+    loop.processTick(makeTick(120.0, 60.0));
+    try testing.expectEqual(@as(u32, 1), ledger.pending_count);
+    try testing.expectEqual(turso_mod.Turso.ACCT_CASH, ledger.last_pending.debit_acct);
+    try testing.expectEqual(turso_mod.Turso.ACCT_BTC, ledger.last_pending.credit_acct);
+    try testing.expectEqual(turso_mod.Turso.CODE_SELL, ledger.last_pending.code);
+    try testing.expectEqual(@as(u32, 100), loop.pending_orders[0].transfer_id);
+
+    sim.advanceTick();
+    loop.processTick(makeTick(120.0, 61.0));
+    const sell_price = 130.0;
+    const sell_size = 2.0;
+    const sell_fee = sell_price * sell_size * 0.001;
+    const pnl = (sell_price - 100.0) * sell_size - sell_fee;
+    try testing.expectEqual(@as(u32, 1), ledger.post_fill_count);
+    try testing.expectApproxEqAbs(sell_price * sell_size, ledger.last_post_fill.actual_amount, 0.001);
+    try testing.expectApproxEqAbs(sell_price, ledger.last_post_fill.actual_price, 0.001);
+    try testing.expectApproxEqAbs(sell_size, ledger.last_post_fill.actual_size, 0.001);
+    try testing.expectEqual(@as(u32, 2), ledger.posted_count);
+    try testing.expectEqual(turso_mod.Turso.CODE_FEE, ledger.posted[0].code);
+    try testing.expectApproxEqAbs(sell_fee, ledger.posted[0].amount, 0.001);
+    try testing.expectEqual(turso_mod.Turso.CODE_PNL, ledger.posted[1].code);
+    try testing.expectEqual(turso_mod.Turso.ACCT_CASH, ledger.posted[1].debit_acct);
+    try testing.expectEqual(turso_mod.Turso.ACCT_PNL, ledger.posted[1].credit_acct);
+    try testing.expectApproxEqAbs(pnl, ledger.posted[1].amount, 0.001);
+}
+
+test "integration: ledger voids cancelled pending buy" {
+    const allocator = testing.allocator;
+    var strategy = try Strategy.init(allocator, .{
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 10000.0,
+        .fee_pct = 0.001,
+    });
+    defer strategy.deinit(allocator);
+    strategy.suppress_entry = true;
+
+    var sim = SimExchange{ .fill_delay = 100 };
+    sim.last_price = 100.0;
+    const ex = sim.exchange();
+    var ledger = MockLedger{};
+    var loop = LiveLoop.init(&strategy, ex, ledger.ledger());
+
+    loop.submitBuy(100.0, 1.0, true, 0.0);
+    try testing.expectEqual(@as(u32, 1), ledger.pending_count);
+    try testing.expectEqual(@as(u32, 100), loop.pending_orders[0].transfer_id);
+
+    strategy.regime = .bear;
+    strategy.in_position = true;
+    strategy.entry_price = 100.0;
+    strategy.size = 1.0;
+    strategy.peak_price = 105.0;
+    strategy.current_trail = 0.02;
+
+    loop.processTick(makeTick(101.0, 60.0));
+    try testing.expectEqual(@as(u32, 1), ledger.void_count);
+    try testing.expectEqual(@as(u32, 100), ledger.voided_id);
+    try testing.expectEqual(@as(u8, 1), loop.pending_count); // sell remains pending
+    try testing.expectEqual(exchange_mod.Side.sell, loop.pending_orders[0].side);
 }
 
 // ============================================================

--- a/services/dctrading-bot/src/live_loop.zig
+++ b/services/dctrading-bot/src/live_loop.zig
@@ -12,6 +12,72 @@ const Trade = types.Trade;
 const Strategy = strat_mod.Strategy;
 const Exchange = exchange_mod.Exchange;
 
+pub const Ledger = struct {
+    ptr: *const anyopaque,
+    vtable: *const VTable,
+
+    pub const VTable = struct {
+        createPendingTransfer: *const fn (ptr: *const anyopaque, debit_acct: u8, credit_acct: u8, amount: f64, code: u8, user_data: []const u8, timestamp: f64, price: f64, qty: f64, order_id: []const u8) ?u32,
+        postTransferWithFill: *const fn (ptr: *const anyopaque, pending_id: u32, actual_amount: f64, actual_price: f64, actual_size: f64, user_data: []const u8) void,
+        createPostedTransfer: *const fn (ptr: *const anyopaque, debit_acct: u8, credit_acct: u8, amount: f64, code: u8, user_data: []const u8, timestamp: f64, price: f64, qty: f64) void,
+        voidTransfer: *const fn (ptr: *const anyopaque, pending_id: u32) void,
+    };
+
+    pub fn createPendingTransfer(self: Ledger, debit_acct: u8, credit_acct: u8, amount: f64, code: u8, user_data: []const u8, timestamp: f64, price: f64, qty: f64, order_id: []const u8) ?u32 {
+        return self.vtable.createPendingTransfer(self.ptr, debit_acct, credit_acct, amount, code, user_data, timestamp, price, qty, order_id);
+    }
+
+    pub fn postTransferWithFill(self: Ledger, pending_id: u32, actual_amount: f64, actual_price: f64, actual_size: f64, user_data: []const u8) void {
+        self.vtable.postTransferWithFill(self.ptr, pending_id, actual_amount, actual_price, actual_size, user_data);
+    }
+
+    pub fn createPostedTransfer(self: Ledger, debit_acct: u8, credit_acct: u8, amount: f64, code: u8, user_data: []const u8, timestamp: f64, price: f64, qty: f64) void {
+        self.vtable.createPostedTransfer(self.ptr, debit_acct, credit_acct, amount, code, user_data, timestamp, price, qty);
+    }
+
+    pub fn voidTransfer(self: Ledger, pending_id: u32) void {
+        self.vtable.voidTransfer(self.ptr, pending_id);
+    }
+};
+
+pub const TursoLedger = struct {
+    turso: *const turso_mod.Turso,
+
+    pub fn ledger(self: *const TursoLedger) Ledger {
+        return .{
+            .ptr = @ptrCast(self),
+            .vtable = &vtable,
+        };
+    }
+
+    fn createPendingTransfer(ptr: *const anyopaque, debit_acct: u8, credit_acct: u8, amount: f64, code: u8, user_data: []const u8, timestamp: f64, price: f64, qty: f64, order_id: []const u8) ?u32 {
+        const self: *const TursoLedger = @ptrCast(@alignCast(ptr));
+        return self.turso.createPendingTransfer(debit_acct, credit_acct, amount, code, user_data, timestamp, price, qty, order_id);
+    }
+
+    fn postTransferWithFill(ptr: *const anyopaque, pending_id: u32, actual_amount: f64, actual_price: f64, actual_size: f64, user_data: []const u8) void {
+        const self: *const TursoLedger = @ptrCast(@alignCast(ptr));
+        self.turso.postTransferWithFill(pending_id, actual_amount, actual_price, actual_size, user_data);
+    }
+
+    fn createPostedTransfer(ptr: *const anyopaque, debit_acct: u8, credit_acct: u8, amount: f64, code: u8, user_data: []const u8, timestamp: f64, price: f64, qty: f64) void {
+        const self: *const TursoLedger = @ptrCast(@alignCast(ptr));
+        self.turso.createPostedTransfer(debit_acct, credit_acct, amount, code, user_data, timestamp, price, qty);
+    }
+
+    fn voidTransfer(ptr: *const anyopaque, pending_id: u32) void {
+        const self: *const TursoLedger = @ptrCast(@alignCast(ptr));
+        self.turso.voidTransfer(pending_id);
+    }
+
+    const vtable = Ledger.VTable{
+        .createPendingTransfer = &createPendingTransfer,
+        .postTransferWithFill = &postTransferWithFill,
+        .createPostedTransfer = &createPostedTransfer,
+        .voidTransfer = &voidTransfer,
+    };
+};
+
 pub const PendingOrderEntry = struct {
     order_id: [64]u8 = undefined,
     order_id_len: usize = 0,
@@ -30,7 +96,7 @@ pub const MAX_PENDING: usize = 4;
 pub const LiveLoop = struct {
     strategy: *Strategy,
     exchange: Exchange,
-    turso: ?*const turso_mod.Turso,
+    ledger: ?Ledger,
 
     pending_orders: [MAX_PENDING]PendingOrderEntry = undefined,
     pending_count: u8 = 0,
@@ -54,11 +120,11 @@ pub const LiveLoop = struct {
     last_buy_fill: ?struct { price: f64, size: f64, is_deposit: bool } = null,
     last_sell_fill: ?struct { price: f64, size: f64, pnl: f64, exit_type: types.Trade.ExitType } = null,
     last_sell_trade: ?types.Trade = null, // for printLiveTrade
-    pub fn init(strategy: *Strategy, exchange: Exchange, turso: ?*const turso_mod.Turso) LiveLoop {
+    pub fn init(strategy: *Strategy, exchange: Exchange, ledger: ?Ledger) LiveLoop {
         return .{
             .strategy = strategy,
             .exchange = exchange,
-            .turso = turso,
+            .ledger = ledger,
             .prev_regime = strategy.regime,
         };
     }
@@ -81,7 +147,7 @@ pub const LiveLoop = struct {
             // Realtime risk path between strategy ticks.
             if (self.strategy.regime == .bear) {
                 if (self.strategy.checkStop(t.price, t.timestamp)) |trade| {
-                    self.cancelPendingBuys();
+                    self.cancelPendingBuys(t.timestamp);
                     self.submitSell(trade, t.timestamp);
                 }
             }
@@ -93,7 +159,7 @@ pub const LiveLoop = struct {
         // --- Phase 2: Strategy tick ---
         self.strategy.buy_signal = false;
         if (self.strategy.processTick(t)) |trade| {
-            self.cancelPendingBuys();
+            self.cancelPendingBuys(t.timestamp);
             self.submitSell(trade, t.timestamp);
         }
 
@@ -131,7 +197,7 @@ pub const LiveLoop = struct {
                 },
                 .cancelled, .failed => {
                     if (po.side == .buy) self.strategy.capital_reserved -= po.signal_price * po.size;
-                    if (po.transfer_id > 0 and self.turso != null) self.turso.?.voidTransfer(po.transfer_id);
+                    if (po.transfer_id > 0 and self.ledger != null) self.ledger.?.voidTransfer(po.transfer_id);
                     self.removePending(i);
                     continue;
                 },
@@ -163,12 +229,12 @@ pub const LiveLoop = struct {
         self.buys_filled += 1;
         self.last_buy_fill = .{ .price = buy_price, .size = buy_size, .is_deposit = po.is_deposit_buy };
 
-        if (po.transfer_id > 0 and self.turso != null) {
+        if (po.transfer_id > 0 and self.ledger != null) {
             const buy_cost = buy_price * buy_size;
             var ud_buf: [256]u8 = undefined;
             const ud = std.fmt.bufPrint(&ud_buf, "BUY oid={s}", .{po.order_id[0..po.order_id_len]}) catch "BUY";
-            self.turso.?.postTransferWithFill(po.transfer_id, buy_cost, buy_price, buy_size, ud);
-            self.turso.?.createPostedTransfer(turso_mod.Turso.ACCT_FEES, turso_mod.Turso.ACCT_CASH, fee, turso_mod.Turso.CODE_FEE, "BUY fee", t.timestamp, 0, 0);
+            self.ledger.?.postTransferWithFill(po.transfer_id, buy_cost, buy_price, buy_size, ud);
+            self.ledger.?.createPostedTransfer(turso_mod.Turso.ACCT_FEES, turso_mod.Turso.ACCT_CASH, fee, turso_mod.Turso.CODE_FEE, "BUY fee", t.timestamp, 0, 0);
         }
     }
 
@@ -181,7 +247,7 @@ pub const LiveLoop = struct {
         self.sells_filled += 1;
         self.last_sell_fill = .{ .price = sell_price, .size = po.size, .pnl = pnl, .exit_type = po.exit_type };
 
-        if (po.transfer_id > 0 and self.turso != null) {
+        if (po.transfer_id > 0 and self.ledger != null) {
             const sell_amount = sell_price * po.size;
             const exit_str = switch (po.exit_type) {
                 .dc_exit => "DC",
@@ -191,12 +257,12 @@ pub const LiveLoop = struct {
             };
             var ud_buf: [128]u8 = undefined;
             const ud = std.fmt.bufPrint(&ud_buf, "SELL exit={s}", .{exit_str}) catch "SELL";
-            self.turso.?.postTransferWithFill(po.transfer_id, sell_amount, sell_price, po.size, ud);
-            self.turso.?.createPostedTransfer(turso_mod.Turso.ACCT_FEES, turso_mod.Turso.ACCT_CASH, sell_fee, turso_mod.Turso.CODE_FEE, "SELL fee", 0, 0, 0);
+            self.ledger.?.postTransferWithFill(po.transfer_id, sell_amount, sell_price, po.size, ud);
+            self.ledger.?.createPostedTransfer(turso_mod.Turso.ACCT_FEES, turso_mod.Turso.ACCT_CASH, sell_fee, turso_mod.Turso.CODE_FEE, "SELL fee", 0, 0, 0);
             if (pnl > 0) {
-                self.turso.?.createPostedTransfer(turso_mod.Turso.ACCT_CASH, turso_mod.Turso.ACCT_PNL, pnl, turso_mod.Turso.CODE_PNL, "Realized PnL", 0, 0, 0);
+                self.ledger.?.createPostedTransfer(turso_mod.Turso.ACCT_CASH, turso_mod.Turso.ACCT_PNL, pnl, turso_mod.Turso.CODE_PNL, "Realized PnL", 0, 0, 0);
             } else if (pnl < 0) {
-                self.turso.?.createPostedTransfer(turso_mod.Turso.ACCT_PNL, turso_mod.Turso.ACCT_CASH, -pnl, turso_mod.Turso.CODE_PNL, "Realized loss", 0, 0, 0);
+                self.ledger.?.createPostedTransfer(turso_mod.Turso.ACCT_PNL, turso_mod.Turso.ACCT_CASH, -pnl, turso_mod.Turso.CODE_PNL, "Realized loss", 0, 0, 0);
             }
         }
     }
@@ -206,9 +272,9 @@ pub const LiveLoop = struct {
             if (self.pending_count < MAX_PENDING) {
                 const oid_slice = pending.order_id[0..pending.order_id_len];
                 var tid: u32 = 0;
-                if (self.turso != null) {
+                if (self.ledger != null) {
                     const cost = price * size;
-                    tid = self.turso.?.createPendingTransfer(turso_mod.Turso.ACCT_BTC, turso_mod.Turso.ACCT_CASH, cost, turso_mod.Turso.CODE_BUY, "BUY pending", timestamp, price, size, oid_slice) orelse 0;
+                    tid = self.ledger.?.createPendingTransfer(turso_mod.Turso.ACCT_BTC, turso_mod.Turso.ACCT_CASH, cost, turso_mod.Turso.CODE_BUY, "BUY pending", timestamp, price, size, oid_slice) orelse 0;
                 }
                 self.pending_orders[self.pending_count] = .{
                     .side = .buy,
@@ -238,9 +304,9 @@ pub const LiveLoop = struct {
             if (self.pending_count < MAX_PENDING) {
                 const oid_slice = pending.order_id[0..pending.order_id_len];
                 var tid: u32 = 0;
-                if (self.turso != null) {
+                if (self.ledger != null) {
                     const sell_amt = trade.exit_price * trade.size;
-                    tid = self.turso.?.createPendingTransfer(turso_mod.Turso.ACCT_CASH, turso_mod.Turso.ACCT_BTC, sell_amt, turso_mod.Turso.CODE_SELL, "SELL pending", timestamp, trade.exit_price, trade.size, oid_slice) orelse 0;
+                    tid = self.ledger.?.createPendingTransfer(turso_mod.Turso.ACCT_CASH, turso_mod.Turso.ACCT_BTC, sell_amt, turso_mod.Turso.CODE_SELL, "SELL pending", timestamp, trade.exit_price, trade.size, oid_slice) orelse 0;
                 }
                 self.pending_orders[self.pending_count] = .{
                     .side = .sell,
@@ -260,7 +326,7 @@ pub const LiveLoop = struct {
         }
     }
 
-    fn cancelPendingBuys(self: *LiveLoop) void {
+    fn cancelPendingBuys(self: *LiveLoop, timestamp: f64) void {
         var i: u8 = 0;
         while (i < self.pending_count) {
             if (self.pending_orders[i].side == .buy) {
@@ -268,27 +334,18 @@ pub const LiveLoop = struct {
                 const result = self.exchange.cancelOrder(cancel_oid);
                 switch (result) {
                     .filled => |fill| {
-                        const bp = if (fill.fill_price > 0) fill.fill_price else self.pending_orders[i].signal_price;
-                        const bs = if (fill.fill_qty > 0) fill.fill_qty else self.pending_orders[i].size;
-                        if (self.pending_orders[i].is_deposit_buy) {
-                            self.strategy.entry_price = (self.strategy.entry_price * self.strategy.size + bp * bs) / (self.strategy.size + bs);
-                            self.strategy.size += bs;
-                            if (bp > self.strategy.peak_price) self.strategy.peak_price = bp;
-                        } else {
-                            self.strategy.entry_price = bp;
-                            self.strategy.size = bs;
-                            self.strategy.peak_price = bp;
-                            self.strategy.in_position = true;
-                        }
-                        self.buys_filled += 1;
+                        self.handleBuyFill(self.pending_orders[i], fill, .{
+                            .timestamp = timestamp,
+                            .price = if (fill.fill_price > 0) fill.fill_price else self.pending_orders[i].signal_price,
+                        });
                     },
                     .cancelled, .failed => {
-                        if (self.pending_orders[i].transfer_id > 0 and self.turso != null) {
-                            self.turso.?.voidTransfer(self.pending_orders[i].transfer_id);
+                        if (self.pending_orders[i].transfer_id > 0 and self.ledger != null) {
+                            self.ledger.?.voidTransfer(self.pending_orders[i].transfer_id);
                         }
+                        self.strategy.capital_reserved -= self.pending_orders[i].signal_price * self.pending_orders[i].size;
                     },
                 }
-                self.strategy.capital_reserved -= self.pending_orders[i].signal_price * self.pending_orders[i].size;
                 self.cancels_issued += 1;
                 self.removePending(i);
                 continue;

--- a/services/dctrading-bot/src/main.zig
+++ b/services/dctrading-bot/src/main.zig
@@ -326,7 +326,9 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
     }
 
     // Initialize LiveLoop — core order flow logic (shared with integration tests)
-    var loop = live_loop_mod.LiveLoop.init(&strategy, exchange, if (turso != null) &turso.? else null);
+    var turso_ledger = if (turso != null) live_loop_mod.TursoLedger{ .turso = &turso.? } else null;
+    const ledger = if (turso_ledger) |*tl| tl.ledger() else null;
+    var loop = live_loop_mod.LiveLoop.init(&strategy, exchange, ledger);
     loop.closed_count = closed_count;
     // Copy reconciled pending orders into LiveLoop
     var pi: u8 = 0;


### PR DESCRIPTION
## Summary
- add a LiveLoop ledger interface and Turso adapter so ledger calls can be mocked in integration tests
- cover buy fill, sell fill, cancelled pending buy, and cancel-filled buy race paths with MockLedger assertions
- add sell-side funding research script and update dctrading test-count docs

## Verification
- zig build test --summary all: 158/158 tests passed
- Zig backtest, Zig LiveLoop sim, and Python cross-validation all match on labs/dctrading/data/cache/backtest_2019_2024.csv with funding filter: 136 trades, PnL .77, return 4039.08%, capital .77