### PR TITLE
Use actual exchange fill fees in LiveLoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ maneki-monorepo/
 
 | Service | Stack | Description |
 |---|---|---|
-| `dctrading-bot` | Zig 0.16 | BTC algorithmic trading bot. Directional Change theory, 3-regime strategy (BULL/SIDEWAYS/BEAR), Binance WebSocket, Alpaca paper trading, Turso DB, Telegram/ntfy notifications. Non-blocking order flow, two-phase transfers. 158 tests. |
+| `dctrading-bot` | Zig 0.16 | BTC algorithmic trading bot. Directional Change theory, 3-regime strategy (BULL/SIDEWAYS/BEAR), Binance WebSocket, Alpaca paper trading, Turso DB, Telegram/ntfy notifications. Non-blocking order flow, two-phase transfers. 160 tests. |
 
 ### Labs
 

--- a/services/dctrading-bot/AGENTS.md
+++ b/services/dctrading-bot/AGENTS.md
@@ -19,8 +19,8 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 - `live_loop.zig` — Extracted core order flow logic: pending order tracking, trailing stop, strategy signals, buy/sell submission, capital_reserved, and ledger vtable. Shared by `runLive()` and integration tests.
 - `tick_source.zig` — `TickSource` vtable interface + `SimFeed` (replays ticks from array). For testing.
 - `sim_exchange.zig` — `SimExchange` implementing Exchange vtable with configurable fill delay, slippage, partial fills, cancel races, failure injection, order log. For testing.
-- `integration_tests.zig` — 27 end-to-end scenarios using LiveLoop + SimExchange + mock ledger.
-- `tests.zig` — 158 tests covering DC detector, strategy, checkpoint, regime transitions, JSON parsing, capital accounting, double-entry transfers, exchange interface, funding rate filter, non-blocking order flow, capital_reserved, integration scenarios.
+- `integration_tests.zig` — 29 end-to-end scenarios using LiveLoop + SimExchange + mock ledger.
+- `tests.zig` — 160 tests covering DC detector, strategy, checkpoint, regime transitions, JSON parsing, capital accounting, double-entry transfers, exchange interface, funding rate filter, non-blocking order flow, capital_reserved, integration scenarios.
 
 ### Scripts (`scripts/`)
 - `switch-to-gcp.sh` — Stop local bot, start GCP Tokyo instance + systemd service.
@@ -57,7 +57,7 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 ```bash
 zig build -Doptimize=ReleaseFast              # macOS arm64
 zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux  # GCP
-zig build test                                 # 158 tests
+zig build test                                 # 160 tests
 ```
 
 ### Trading Flow

--- a/services/dctrading-bot/README.md
+++ b/services/dctrading-bot/README.md
@@ -46,7 +46,7 @@ Single static binary. No Python, no Docker, no runtime dependencies (except curl
 | `telegram.zig` | Telegram + ntfy push notifications |
 | `http_client.zig` | Shared HTTP client (std.http.Client wrapper) |
 | `types.zig` | Tick, Trade, DC event types |
-| `tests.zig` | 158 tests |
+| `tests.zig` | 160 tests |
 
 ## Setup
 

--- a/services/dctrading-bot/src/integration_tests.zig
+++ b/services/dctrading-bot/src/integration_tests.zig
@@ -1047,6 +1047,73 @@ test "integration: ledger records buy pending and actual fill settlement" {
     try testing.expectApproxEqAbs(420.0, ledger.posted[0].timestamp, 0.001);
 }
 
+test "integration: ledger uses actual exchange commission for buy fee" {
+    const allocator = testing.allocator;
+    var strategy = try Strategy.init(allocator, .{
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 1000.0,
+        .fee_pct = 0.001,
+    });
+    defer strategy.deinit(allocator);
+    strategy.suppress_entry = true;
+
+    var sim = SimExchange{ .fill_delay = 1, .fill_commission = 0.25 };
+    @memcpy(sim.fill_commission_asset[0..3], "USD");
+    sim.fill_commission_asset_len = 3;
+    sim.last_price = 104.0;
+    const ex = sim.exchange();
+    var ledger = MockLedger{};
+    var loop = LiveLoop.init(&strategy, ex, ledger.ledger());
+
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        loop.processTick(makeTick(100.0, @as(f64, @floatFromInt(i)) * 60.0));
+    }
+
+    loop.processTick(makeTick(104.0, 360.0));
+    sim.advanceTick();
+    loop.processTick(makeTick(104.0, 420.0));
+
+    try testing.expectEqual(@as(u32, 1), ledger.posted_count);
+    try testing.expectEqual(turso_mod.Turso.CODE_FEE, ledger.posted[0].code);
+    try testing.expectApproxEqAbs(0.25, ledger.posted[0].amount, 0.001);
+}
+
+test "integration: ledger falls back to configured fee when exchange commission is zero" {
+    const allocator = testing.allocator;
+    var strategy = try Strategy.init(allocator, .{
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 1000.0,
+        .fee_pct = 0.001,
+    });
+    defer strategy.deinit(allocator);
+    strategy.suppress_entry = true;
+
+    var sim = SimExchange{ .fill_delay = 1, .fill_commission = 0 };
+    @memcpy(sim.fill_commission_asset[0..3], "USD");
+    sim.fill_commission_asset_len = 3;
+    sim.last_price = 104.0;
+    const ex = sim.exchange();
+    var ledger = MockLedger{};
+    var loop = LiveLoop.init(&strategy, ex, ledger.ledger());
+
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        loop.processTick(makeTick(100.0, @as(f64, @floatFromInt(i)) * 60.0));
+    }
+
+    loop.processTick(makeTick(104.0, 360.0));
+    sim.advanceTick();
+    loop.processTick(makeTick(104.0, 420.0));
+
+    try testing.expectEqual(@as(u32, 1), ledger.post_fill_count);
+    try testing.expectEqual(@as(u32, 1), ledger.posted_count);
+    try testing.expectEqual(turso_mod.Turso.CODE_FEE, ledger.posted[0].code);
+    try testing.expectApproxEqAbs(104.0 * ledger.last_pending.qty * 0.001, ledger.posted[0].amount, 0.001);
+}
+
 test "integration: ledger records sell fill fee and realized pnl" {
     const allocator = testing.allocator;
     var strategy = try Strategy.init(allocator, .{

--- a/services/dctrading-bot/src/live_loop.zig
+++ b/services/dctrading-bot/src/live_loop.zig
@@ -211,7 +211,7 @@ pub const LiveLoop = struct {
         self.strategy.capital_reserved -= po.signal_price * po.size;
         const buy_price = if (fill.fill_price > 0) fill.fill_price else po.signal_price;
         const buy_size = if (fill.fill_qty > 0) fill.fill_qty else po.size;
-        const fee = if (fill.commission > 0) fill.commission else buy_price * buy_size * 0.001;
+        const fee = self.fillFee(fill, buy_price, buy_size);
 
         if (po.is_deposit_buy) {
             self.strategy.entry_price = (self.strategy.entry_price * self.strategy.size + buy_price * buy_size) / (self.strategy.size + buy_size);
@@ -240,7 +240,7 @@ pub const LiveLoop = struct {
 
     fn handleSellFill(self: *LiveLoop, po: PendingOrderEntry, fill: exchange_mod.OrderFill) void {
         const sell_price = if (fill.fill_price > 0) fill.fill_price else po.signal_price;
-        const sell_fee = if (fill.commission > 0) fill.commission else sell_price * po.size * 0.001;
+        const sell_fee = self.fillFee(fill, sell_price, po.size);
         const pnl = (sell_price - po.entry_price) * po.size - sell_fee;
         const price_diff_pnl = (sell_price - po.signal_price) * po.size;
         if (price_diff_pnl != 0) self.strategy.capital += price_diff_pnl;
@@ -265,6 +265,11 @@ pub const LiveLoop = struct {
                 self.ledger.?.createPostedTransfer(turso_mod.Turso.ACCT_PNL, turso_mod.Turso.ACCT_CASH, -pnl, turso_mod.Turso.CODE_PNL, "Realized loss", 0, 0, 0);
             }
         }
+    }
+
+    fn fillFee(self: *const LiveLoop, fill: exchange_mod.OrderFill, price: f64, qty: f64) f64 {
+        if (fill.commission > 0) return fill.commission;
+        return price * qty * self.strategy.fee_pct;
     }
 
     pub fn submitBuy(self: *LiveLoop, price: f64, size: f64, is_deposit: bool, timestamp: f64) void {

--- a/services/dctrading-bot/src/sim_exchange.zig
+++ b/services/dctrading-bot/src/sim_exchange.zig
@@ -15,6 +15,9 @@ pub const SimExchange = struct {
     fill_delay: u32 = 1, // ticks before order fills (0 = immediate)
     fill_price_offset: f64 = 0, // slippage: actual = signal + offset
     partial_fill_ratio: f64 = 1.0, // 1.0 = full fill, 0.5 = half
+    fill_commission: f64 = 0,
+    fill_commission_asset: [8]u8 = undefined,
+    fill_commission_asset_len: usize = 0,
     fail_next_submit: bool = false,
     fail_next_cancel: bool = false,
     cancel_fills_instead: bool = false, // simulate race: cancel returns .filled
@@ -113,7 +116,7 @@ pub const SimExchange = struct {
             const fq = order.qty * self.partial_fill_ratio;
             self.position_qty += fq;
             self.position_entry = fp;
-            return .{ .fill_price = fp, .fill_qty = fq, .status = .filled };
+            return self.makeFill(fp, fq);
         }
         return null;
     }
@@ -131,7 +134,7 @@ pub const SimExchange = struct {
                 self.position_qty = 0;
                 self.position_entry = 0;
             }
-            return .{ .fill_price = fp, .fill_qty = fq, .status = .filled };
+            return self.makeFill(fp, fq);
         }
         return null;
     }
@@ -179,7 +182,7 @@ pub const SimExchange = struct {
         if (order.filled) {
             const fp = order.price + self.fill_price_offset;
             const fq = order.qty * self.partial_fill_ratio;
-            var fill: OrderFill = .{ .fill_price = fp, .fill_qty = fq, .status = .filled };
+            var fill = self.makeFill(fp, fq);
             const id_str = std.fmt.bufPrint(&fill.order_id, "{d}", .{oid}) catch return .{ .failed = {} };
             fill.order_id_len = id_str.len;
             self.removeOrder(oid);
@@ -206,7 +209,7 @@ pub const SimExchange = struct {
                 }
             }
             self.appendLog(.{ .tick = self.tick_count, .kind = .fill, .order_id = oid, .side = order.side, .qty = fq, .price = fp });
-            var fill: OrderFill = .{ .fill_price = fp, .fill_qty = fq, .status = .filled };
+            var fill = self.makeFill(fp, fq);
             const id_str = std.fmt.bufPrint(&fill.order_id, "{d}", .{oid}) catch return .{ .failed = {} };
             fill.order_id_len = id_str.len;
             self.removeOrder(oid);
@@ -233,7 +236,7 @@ pub const SimExchange = struct {
             order.filled = true;
             const fp = order.price + self.fill_price_offset;
             const fq = order.qty * self.partial_fill_ratio;
-            return .{ .filled = .{ .fill_price = fp, .fill_qty = fq, .status = .filled } };
+            return .{ .filled = self.makeFill(fp, fq) };
         }
 
         order.cancelled = true;
@@ -250,6 +253,17 @@ pub const SimExchange = struct {
             .market_value = self.position_qty * self.position_entry,
             .unrealized_pnl = 0,
         };
+    }
+
+    fn makeFill(self: *const SimExchange, fill_price: f64, fill_qty: f64) OrderFill {
+        var fill: OrderFill = .{ .fill_price = fill_price, .fill_qty = fill_qty, .status = .filled };
+        if (self.fill_commission > 0 or self.fill_commission_asset_len > 0) {
+            fill.commission = self.fill_commission;
+            const len = @min(self.fill_commission_asset_len, fill.commission_asset.len);
+            @memcpy(fill.commission_asset[0..len], self.fill_commission_asset[0..len]);
+            fill.commission_asset_len = len;
+        }
+        return fill;
     }
 
     const vtable = Exchange.VTable{


### PR DESCRIPTION
## Summary

Fixes the live-order fee handling slice of #425.

LiveLoop previously used a hardcoded 0.1% estimate whenever `OrderFill.commission` was zero. This PR keeps fee transfers for accounting and makes the fee source explicit: nonzero exchange-provided commission wins, while zero or missing commission falls back to the configured `strategy.fee_pct` estimate.

## Changes

- Add `LiveLoop.fillFee()` to centralize fee selection:
  - use exchange-provided `fill.commission` when `commission > 0`
  - fall back to `strategy.fee_pct` when commission is zero or missing
- Replace the remaining live settlement hardcoded `0.001` fallback with `strategy.fee_pct`
- Extend `SimExchange` so tests can return explicit commission amount + commission asset
- Add integration coverage for:
  - nonzero exchange commission overriding estimated fees
  - zero exchange commission preserving the configured fallback fee transfer
- Update dctrading test counts from 158 to 160

## Out of scope

This does not add the BNB account or multi-asset fee routing. That belongs to #442 and should handle:

- `BNB` fees routed to the BNB account
- `USD`/`USDT` fees routed to cash
- `BTC` fees routed to btc_position
- Neko Trade PnL updates in #444

## Verification

- `zig build test --summary all`
  - `160/160` tests passed
- Historical Zig backtest on `labs/dctrading/data/cache/backtest_2019_2024.csv`
  - PnL: `$40390.77`
  - Return: `4039.08%`
  - Trades: `136`
  - Capital: `$41390.77`
- LiveLoop simulation on the same CSV
  - PnL: `$40390.77`
  - Return: `4039.08%`
  - Trades: `136`
  - Capital: `$41390.77`
  - Pending: `0`

The simulation and legacy backtest remain exactly matched after the fee-handling change.
