### PR TITLE
Route dctrading fees by commission asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ maneki-monorepo/
 
 | Service | Stack | Description |
 |---|---|---|
-| `dctrading-bot` | Zig 0.16 | BTC algorithmic trading bot. Directional Change theory, 3-regime strategy (BULL/SIDEWAYS/BEAR), Binance WebSocket, Alpaca paper trading, Turso DB, Telegram/ntfy notifications. Non-blocking order flow, two-phase transfers. 160 tests. |
+| `dctrading-bot` | Zig 0.16 | BTC algorithmic trading bot. Directional Change theory, 3-regime strategy (BULL/SIDEWAYS/BEAR), Binance WebSocket, Alpaca paper trading, Turso DB, Telegram/ntfy notifications. Non-blocking order flow, two-phase transfers. 162 tests. |
 
 ### Labs
 

--- a/services/dctrading-bot/AGENTS.md
+++ b/services/dctrading-bot/AGENTS.md
@@ -19,8 +19,8 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 - `live_loop.zig` — Extracted core order flow logic: pending order tracking, trailing stop, strategy signals, buy/sell submission, capital_reserved, and ledger vtable. Shared by `runLive()` and integration tests.
 - `tick_source.zig` — `TickSource` vtable interface + `SimFeed` (replays ticks from array). For testing.
 - `sim_exchange.zig` — `SimExchange` implementing Exchange vtable with configurable fill delay, slippage, partial fills, cancel races, failure injection, order log. For testing.
-- `integration_tests.zig` — 29 end-to-end scenarios using LiveLoop + SimExchange + mock ledger.
-- `tests.zig` — 160 tests covering DC detector, strategy, checkpoint, regime transitions, JSON parsing, capital accounting, double-entry transfers, exchange interface, funding rate filter, non-blocking order flow, capital_reserved, integration scenarios.
+- `integration_tests.zig` — 31 end-to-end scenarios using LiveLoop + SimExchange + mock ledger.
+- `tests.zig` — 162 tests covering DC detector, strategy, checkpoint, regime transitions, JSON parsing, capital accounting, double-entry transfers, exchange interface, funding rate filter, non-blocking order flow, capital_reserved, integration scenarios.
 
 ### Scripts (`scripts/`)
 - `switch-to-gcp.sh` — Stop local bot, start GCP Tokyo instance + systemd service.
@@ -49,15 +49,16 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 | `BOT_INSTANCE` | No | main.zig (default: "local") |
 
 ### Database Schema (Turso)
-- `accounts` — Double-entry accounts (TigerBeetle-inspired): cash, btc_position, fees, equity, pnl. 4 balance fields: debits_pending, debits_posted, credits_pending, credits_posted.
+- `accounts` — Double-entry accounts (TigerBeetle-inspired): cash, btc_position, fees, equity, pnl, bnb. 4 balance fields: debits_pending, debits_posted, credits_pending, credits_posted.
 - `transfers` — Immutable append-only transfer log. Two-phase (pending/posted/voided). Codes: 1=deposit, 2=buy, 3=sell, 4=fee, 5=pnl. Atomic BEGIN/COMMIT pipelines.
+- Fee routing: nonzero `commission_asset` routes fees to the paying asset account (`USD`/`USDT` → cash, `BTC` → btc_position, `BNB` → bnb). This nets the ledger balance down, but `strategy.size` remains whatever the exchange adapter reports as fill quantity.
 - `equity_log` — Periodic snapshots (every 5 min + on trades): capital, equity, unrealized, regime, price.
 - `bot_status` — Single row (id=1): regime, position, equity, version (DCTRADE4@instance).
 ### Build
 ```bash
 zig build -Doptimize=ReleaseFast              # macOS arm64
 zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux  # GCP
-zig build test                                 # 160 tests
+zig build test                                 # 162 tests
 ```
 
 ### Trading Flow

--- a/services/dctrading-bot/README.md
+++ b/services/dctrading-bot/README.md
@@ -46,7 +46,7 @@ Single static binary. No Python, no Docker, no runtime dependencies (except curl
 | `telegram.zig` | Telegram + ntfy push notifications |
 | `http_client.zig` | Shared HTTP client (std.http.Client wrapper) |
 | `types.zig` | Tick, Trade, DC event types |
-| `tests.zig` | 160 tests |
+| `tests.zig` | 162 tests |
 
 ## Setup
 
@@ -130,6 +130,8 @@ EXIT_FEE      -1.05     bal=1050.02   "SELL fee 0.1%"
 ```
 
 PnL = current balance - total deposits. No double-counting.
+
+Fee transfers are routed by `commission_asset`: `USD`/`USDT` fees reduce `cash`, `BTC` fees reduce `btc_position`, and `BNB` fees reduce `bnb`. The ledger therefore nets a BTC-paid fee out of the BTC account. The in-memory `strategy.size` still uses the fill quantity supplied by the exchange adapter; if a Binance adapter reports gross executed quantity while charging fees in BTC, that adapter must normalize the fill quantity or the strategy must subtract the base-asset commission in a follow-up.
 
 ## Checkpoint
 

--- a/services/dctrading-bot/src/integration_tests.zig
+++ b/services/dctrading-bot/src/integration_tests.zig
@@ -1077,7 +1077,43 @@ test "integration: ledger uses actual exchange commission for buy fee" {
 
     try testing.expectEqual(@as(u32, 1), ledger.posted_count);
     try testing.expectEqual(turso_mod.Turso.CODE_FEE, ledger.posted[0].code);
+    try testing.expectEqual(turso_mod.Turso.ACCT_CASH, ledger.posted[0].credit_acct);
     try testing.expectApproxEqAbs(0.25, ledger.posted[0].amount, 0.001);
+}
+
+test "integration: ledger routes BNB commission to BNB account" {
+    const allocator = testing.allocator;
+    var strategy = try Strategy.init(allocator, .{
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 1000.0,
+        .fee_pct = 0.001,
+    });
+    defer strategy.deinit(allocator);
+    strategy.suppress_entry = true;
+
+    var sim = SimExchange{ .fill_delay = 1, .fill_commission = 0.00123 };
+    @memcpy(sim.fill_commission_asset[0..3], "BNB");
+    sim.fill_commission_asset_len = 3;
+    sim.last_price = 104.0;
+    const ex = sim.exchange();
+    var ledger = MockLedger{};
+    var loop = LiveLoop.init(&strategy, ex, ledger.ledger());
+
+    var i: usize = 0;
+    while (i < 5) : (i += 1) {
+        loop.processTick(makeTick(100.0, @as(f64, @floatFromInt(i)) * 60.0));
+    }
+
+    loop.processTick(makeTick(104.0, 360.0));
+    sim.advanceTick();
+    loop.processTick(makeTick(104.0, 420.0));
+
+    try testing.expectEqual(@as(u32, 1), ledger.posted_count);
+    try testing.expectEqual(turso_mod.Turso.CODE_FEE, ledger.posted[0].code);
+    try testing.expectEqual(turso_mod.Turso.ACCT_FEES, ledger.posted[0].debit_acct);
+    try testing.expectEqual(turso_mod.Turso.ACCT_BNB, ledger.posted[0].credit_acct);
+    try testing.expectApproxEqAbs(0.00123, ledger.posted[0].amount, 0.000001);
 }
 
 test "integration: ledger falls back to configured fee when exchange commission is zero" {
@@ -1111,7 +1147,46 @@ test "integration: ledger falls back to configured fee when exchange commission 
     try testing.expectEqual(@as(u32, 1), ledger.post_fill_count);
     try testing.expectEqual(@as(u32, 1), ledger.posted_count);
     try testing.expectEqual(turso_mod.Turso.CODE_FEE, ledger.posted[0].code);
+    try testing.expectEqual(turso_mod.Turso.ACCT_CASH, ledger.posted[0].credit_acct);
     try testing.expectApproxEqAbs(104.0 * ledger.last_pending.qty * 0.001, ledger.posted[0].amount, 0.001);
+}
+
+test "integration: ledger routes BTC commission to BTC account on sell" {
+    const allocator = testing.allocator;
+    var strategy = try Strategy.init(allocator, .{
+        .ma_period = 5,
+        .ma_buffer = 0.03,
+        .initial_capital = 10000.0,
+        .fee_pct = 0.001,
+    });
+    defer strategy.deinit(allocator);
+    strategy.suppress_entry = true;
+
+    var sim = SimExchange{ .fill_delay = 1, .fill_price_offset = 10.0, .fill_commission = 0.00042 };
+    @memcpy(sim.fill_commission_asset[0..3], "BTC");
+    sim.fill_commission_asset_len = 3;
+    sim.last_price = 120.0;
+    const ex = sim.exchange();
+    var ledger = MockLedger{};
+    var loop = LiveLoop.init(&strategy, ex, ledger.ledger());
+
+    strategy.regime = .bear;
+    strategy.in_position = true;
+    strategy.entry_price = 100.0;
+    strategy.size = 2.0;
+    strategy.peak_price = 130.0;
+    strategy.current_trail = 0.02;
+
+    loop.processTick(makeTick(120.0, 60.0));
+    sim.advanceTick();
+    loop.processTick(makeTick(120.0, 61.0));
+
+    try testing.expectEqual(@as(u32, 2), ledger.posted_count);
+    try testing.expectEqual(turso_mod.Turso.CODE_FEE, ledger.posted[0].code);
+    try testing.expectEqual(turso_mod.Turso.ACCT_FEES, ledger.posted[0].debit_acct);
+    try testing.expectEqual(turso_mod.Turso.ACCT_BTC, ledger.posted[0].credit_acct);
+    try testing.expectApproxEqAbs(0.00042, ledger.posted[0].amount, 0.000001);
+    try testing.expectEqual(turso_mod.Turso.CODE_PNL, ledger.posted[1].code);
 }
 
 test "integration: ledger records sell fill fee and realized pnl" {

--- a/services/dctrading-bot/src/live_loop.zig
+++ b/services/dctrading-bot/src/live_loop.zig
@@ -234,7 +234,7 @@ pub const LiveLoop = struct {
             var ud_buf: [256]u8 = undefined;
             const ud = std.fmt.bufPrint(&ud_buf, "BUY oid={s}", .{po.order_id[0..po.order_id_len]}) catch "BUY";
             self.ledger.?.postTransferWithFill(po.transfer_id, buy_cost, buy_price, buy_size, ud);
-            self.ledger.?.createPostedTransfer(turso_mod.Turso.ACCT_FEES, turso_mod.Turso.ACCT_CASH, fee, turso_mod.Turso.CODE_FEE, "BUY fee", t.timestamp, 0, 0);
+            self.ledger.?.createPostedTransfer(turso_mod.Turso.ACCT_FEES, feeCreditAccount(fill), fee, turso_mod.Turso.CODE_FEE, "BUY fee", t.timestamp, 0, 0);
         }
     }
 
@@ -258,7 +258,7 @@ pub const LiveLoop = struct {
             var ud_buf: [128]u8 = undefined;
             const ud = std.fmt.bufPrint(&ud_buf, "SELL exit={s}", .{exit_str}) catch "SELL";
             self.ledger.?.postTransferWithFill(po.transfer_id, sell_amount, sell_price, po.size, ud);
-            self.ledger.?.createPostedTransfer(turso_mod.Turso.ACCT_FEES, turso_mod.Turso.ACCT_CASH, sell_fee, turso_mod.Turso.CODE_FEE, "SELL fee", 0, 0, 0);
+            self.ledger.?.createPostedTransfer(turso_mod.Turso.ACCT_FEES, feeCreditAccount(fill), sell_fee, turso_mod.Turso.CODE_FEE, "SELL fee", 0, 0, 0);
             if (pnl > 0) {
                 self.ledger.?.createPostedTransfer(turso_mod.Turso.ACCT_CASH, turso_mod.Turso.ACCT_PNL, pnl, turso_mod.Turso.CODE_PNL, "Realized PnL", 0, 0, 0);
             } else if (pnl < 0) {
@@ -270,6 +270,17 @@ pub const LiveLoop = struct {
     fn fillFee(self: *const LiveLoop, fill: exchange_mod.OrderFill, price: f64, qty: f64) f64 {
         if (fill.commission > 0) return fill.commission;
         return price * qty * self.strategy.fee_pct;
+    }
+
+    // Routes the fee transfer to the asset that paid commission. For BTC fees,
+    // ledger balances net BTC down via this transfer; strategy.size still uses
+    // the fill quantity supplied by the exchange adapter.
+    fn feeCreditAccount(fill: exchange_mod.OrderFill) u8 {
+        if (fill.commission <= 0) return turso_mod.Turso.ACCT_CASH;
+        const asset = fill.commission_asset[0..fill.commission_asset_len];
+        if (std.mem.eql(u8, asset, "BNB")) return turso_mod.Turso.ACCT_BNB;
+        if (std.mem.eql(u8, asset, "BTC")) return turso_mod.Turso.ACCT_BTC;
+        return turso_mod.Turso.ACCT_CASH;
     }
 
     pub fn submitBuy(self: *LiveLoop, price: f64, size: f64, is_deposit: bool, timestamp: f64) void {

--- a/services/dctrading-bot/src/tests.zig
+++ b/services/dctrading-bot/src/tests.zig
@@ -1247,6 +1247,7 @@ test "turso: account constants are correct" {
     try testing.expectEqual(turso_mod.Turso.ACCT_FEES, 3);
     try testing.expectEqual(turso_mod.Turso.ACCT_EQUITY, 4);
     try testing.expectEqual(turso_mod.Turso.ACCT_PNL, 5);
+    try testing.expectEqual(turso_mod.Turso.ACCT_BNB, 6);
     try testing.expectEqual(turso_mod.Turso.CODE_DEPOSIT, 1);
     try testing.expectEqual(turso_mod.Turso.CODE_BUY, 2);
     try testing.expectEqual(turso_mod.Turso.CODE_SELL, 3);

--- a/services/dctrading-bot/src/turso.zig
+++ b/services/dctrading-bot/src/turso.zig
@@ -79,7 +79,8 @@ pub const Turso = struct {
             \\  {"type": "execute", "stmt": {"sql": "INSERT OR IGNORE INTO accounts (id, name, ledger, code) VALUES (2, 'btc_position', 2, 1002)"}},
             \\  {"type": "execute", "stmt": {"sql": "INSERT OR IGNORE INTO accounts (id, name, ledger, code) VALUES (3, 'fees', 1, 2001)"}},
             \\  {"type": "execute", "stmt": {"sql": "INSERT OR IGNORE INTO accounts (id, name, ledger, code) VALUES (4, 'equity', 1, 3001)"}},
-            \\  {"type": "execute", "stmt": {"sql": "INSERT OR IGNORE INTO accounts (id, name, ledger, code) VALUES (5, 'pnl', 1, 4001)"}}
+            \\  {"type": "execute", "stmt": {"sql": "INSERT OR IGNORE INTO accounts (id, name, ledger, code) VALUES (5, 'pnl', 1, 4001)"}},
+            \\  {"type": "execute", "stmt": {"sql": "INSERT OR IGNORE INTO accounts (id, name, ledger, code) VALUES (6, 'bnb', 3, 1003)"}}
             \\]}
         ;
         const core_ok = self.execSync(sql_core);
@@ -147,6 +148,7 @@ pub const Turso = struct {
     pub const ACCT_FEES: u8 = 3;
     pub const ACCT_EQUITY: u8 = 4;
     pub const ACCT_PNL: u8 = 5;
+    pub const ACCT_BNB: u8 = 6;
 
     // Transfer codes
     pub const CODE_DEPOSIT: u8 = 1;


### PR DESCRIPTION
## Summary

Implements the dctrading-bot side of BNB/multi-asset fee routing from #442.

The bot already stores `OrderFill.commission` and `commission_asset`; this PR uses that asset to route fee ledger transfers to the account that actually paid the fee. This keeps the existing fallback behavior from #461: if commission is zero or missing, the bot estimates the configured fee rate and routes it to cash for accounting.

## Changes

- Add Turso account `ACCT_BNB = 6`, seeded as `bnb`
- Route fee transfers by nonzero `commission_asset`:
  - `BNB` -> `fees` / `bnb`
  - `BTC` -> `fees` / `btc_position`
  - `USD`, `USDT`, missing, or fallback estimate -> `fees` / `cash`
- Keep fee amount behavior unchanged:
  - nonzero exchange commission is used as the actual amount
  - zero/missing commission falls back to `strategy.fee_pct`
- Add integration coverage for:
  - USD commission routing to cash
  - BNB commission routing to BNB
  - BTC commission routing to BTC
  - zero commission fallback routing to cash
- Update dctrading docs/test counts to `162`

## Notes

This PR does not implement low-BNB notifications or Neko Trade PnL/formula changes. Those remain follow-up work, especially #444 for app-side display/accounting changes.

For Binance-style base-asset fees, the ledger now nets the asset balance down via a separate fee transfer. Example: a BTC-paid fee routes `fees` / `btc_position`, reducing the ledger BTC account. The in-memory `strategy.size` still uses the fill quantity reported by the exchange adapter. If a future Binance adapter reports gross executed quantity while charging fees in BTC, that adapter must normalize the fill quantity or strategy handling must subtract the base-asset commission in a follow-up.

## Verification

- `zig build test --summary all`
  - `162/162` tests passed
- Built optimized dctrading binary:
  - `zig build -Doptimize=ReleaseFast`
- Historical Zig backtest on `labs/dctrading/data/cache/backtest_2019_2024.csv`
  - PnL: `$40390.77`
  - Return: `4039.08%`
  - Trades: `136`
  - Capital: `$41390.77`
- LiveLoop simulation on the same CSV
  - PnL: `$40390.77`
  - Return: `4039.08%`
  - Trades: `136`
  - Capital: `$41390.77`
  - Pending: `0`

The legacy backtest and LiveLoop simulation still match exactly after the fee-routing change.
