### PR TITLE
Make Neko accounting and estimated equity fee-asset aware

### DIFF
--- a/apps/neko-trade/AGENTS.md
+++ b/apps/neko-trade/AGENTS.md
@@ -10,7 +10,7 @@ SwiftUI dashboard app for the DCTrading bot. Displays bot status, equity, trades
 
 ### Views (`Views/`)
 - `ContentView.swift` — Tab container: Dashboard, Ledger, Equity, Trades, Settings.
-- `DashboardView.swift` — Bot status, regime (BULL=green, SIDE=orange, BEAR=red), equity, BTC price from Binance, open position with unrealized PnL. Auto-refreshes every 30s.
+- `DashboardView.swift` — Bot status, regime (BULL=green, SIDE=orange, BEAR=red), managed equity from app-managed BTC/BNB quantities marked at Binance spot, realized P&L, unrealized P&L, BTC price from Binance. Auto-refreshes every 30s.
 - `LedgerView.swift` — Transfer ledger with cash balance summary + running balance per entry.
 - `EquityChartView.swift` — Equity over time using Swift Charts.
 - `TradeHistoryView.swift` — Buy/sell transfers from double-entry ledger, Alpaca position, BTC price chart with trade markers.
@@ -27,6 +27,9 @@ SwiftUI dashboard app for the DCTrading bot. Displays bot status, equity, trades
 ### Key Patterns
 - **Alpaca as position source of truth**: Open position qty and entry price come from Alpaca, not Turso.
 - **BTC price from Binance**: Free API, avoids unnecessary Turso reads.
+- **Realized PnL formula**: `(cash_balance + btc_balance + bnb_balance) - total_deposits`; transfer amounts are historical USD values, while native BTC/BNB fee quantities live in transfer `size`.
+- **Estimated equity/PnL formula**: `cash_balance + managed_btc_qty * BTCUSDT + managed_bnb_qty * BNBUSDT`; managed quantities are derived from posted transfer `size`, so exchange assets outside bot-managed transfers are ignored.
+- **Account-aware ledger balances**: Running cash balance uses the transfer debit/credit accounts, so BTC/BNB fee transfers do not change displayed cash.
 - **UserDefaults for credentials**: `AppSettings` singleton persists Turso URL/token and Alpaca key/secret.
 - **Auto-refresh**: Dashboard polls every 30s via `Timer.publish`.
 - **Regime colors**: BULL=green, SIDEWAYS=orange, BEAR=red throughout the UI.

--- a/apps/neko-trade/README.md
+++ b/apps/neko-trade/README.md
@@ -4,8 +4,8 @@ SwiftUI dashboard for the DCTrading bot. macOS + iOS.
 
 ## Features
 
-- **Dashboard** — Bot status, regime, equity, BTC price (Binance), open position with unrealized PnL
-- **Ledger** — Account ledger with cash balance summary (DEPOSIT, ENTRY_FEE, BUY, SELL, EXIT_FEE)
+- **Dashboard** — Bot status, regime, managed equity from app-managed BTC/BNB marked at Binance spot, realized P&L, unrealized P&L, BTC price
+- **Ledger** — Account ledger with cash balance summary and account-aware running cash balance
 - **Equity** — Equity chart over time from Turso snapshots
 - **Trades** — Trade history with entry/exit prices, PnL, signal vs fill price drift
 - **Settings** — Turso + Alpaca credential management with persistent status indicators
@@ -15,7 +15,8 @@ SwiftUI dashboard for the DCTrading bot. macOS + iOS.
 | Data | Source | Notes |
 |------|--------|-------|
 | BTC price | Binance API | Free, no auth needed |
-| Bot status, equity, trades, ledger | Turso DB | Requires URL + token |
+| Bot status, equity, trades, ledger | Turso DB | Requires URL + token; transfer amounts are historical USD values, native asset quantities live in transfer size |
+| Estimated equity prices | Binance API | Marks app-managed BTC/BNB quantities at current BTCUSDT/BNBUSDT spot |
 | Open position (qty, entry price) | Alpaca API | Source of truth for position |
 
 ## Setup

--- a/apps/neko-trade/Sources/DCTradingViewer/Models/Models.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Models/Models.swift
@@ -39,6 +39,10 @@ struct Position: Identifiable, Codable {
 // MARK: - Transfer (double-entry)
 
 struct Transfer: Identifiable, Codable {
+    static let cashAccountId = 1
+    static let btcAccountId = 2
+    static let bnbAccountId = 6
+
     let id: Int
     let debitAccountId: Int
     let creditAccountId: Int
@@ -64,9 +68,19 @@ struct Transfer: Identifiable, Codable {
         }
     }
 
-    /// Deposit and sell are positive for cash account
+    /// Display sign for the transfer amount. Account balances use `effect(on:)`.
     var isPositive: Bool {
         code == 1 || code == 3
+    }
+
+    func effect(on accountId: Int) -> Double {
+        if debitAccountId == accountId { return amount }
+        if creditAccountId == accountId { return -amount }
+        return 0
+    }
+
+    var cashEffect: Double {
+        effect(on: Self.cashAccountId)
     }
 
     var typeColor: Color {
@@ -97,6 +111,14 @@ struct Transfer: Identifiable, Codable {
         if let ts = Double(timestamp) { return Date(timeIntervalSince1970: ts) }
         return Date()
     }
+}
+
+// MARK: - Managed Balances
+
+struct ManagedBalances {
+    let cash: Double
+    let btcQuantity: Double
+    let bnbQuantity: Double
 }
 
 // MARK: - Equity Log

--- a/apps/neko-trade/Sources/DCTradingViewer/Services/BinanceClient.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Services/BinanceClient.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-/// Lightweight Binance public API client for BTC price data.
+/// Lightweight Binance public API client for public spot price data.
 /// No API key needed — uses public endpoints.
 struct BinanceClient {
     static let baseURL = "https://api.binance.com/api/v3"
 
-    /// Fetch current BTC/USDT price.
-    static func fetchPrice() async throws -> Double {
-        let url = URL(string: "\(baseURL)/ticker/price?symbol=BTCUSDT")!
+    /// Fetch current spot price for a Binance symbol.
+    static func fetchPrice(symbol: String = "BTCUSDT") async throws -> Double {
+        let url = URL(string: "\(baseURL)/ticker/price?symbol=\(symbol)")!
         let (data, _) = try await URLSession.shared.data(from: url)
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         guard let priceStr = json?["price"] as? String,

--- a/apps/neko-trade/Sources/DCTradingViewer/Services/TursoClient.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Services/TursoClient.swift
@@ -37,6 +37,9 @@ final class AppSettings: ObservableObject {
 // MARK: - Turso Client
 
 final class TursoClient {
+    static let totalRealizedPnLSQL = "SELECT (SELECT COALESCE(credits_posted - debits_posted, 0) FROM accounts WHERE id = 1) + (SELECT COALESCE(credits_posted - debits_posted, 0) FROM accounts WHERE id = 2) + (SELECT COALESCE(credits_posted - debits_posted, 0) FROM accounts WHERE id = 6) - (SELECT COALESCE(SUM(amount), 0) FROM transfers WHERE code = 1 AND status = 'posted') as total"
+    static let managedBalancesSQL = "SELECT (SELECT COALESCE(credits_posted - debits_posted, 0) FROM accounts WHERE id = 1) as cash, COALESCE(SUM(CASE WHEN debit_account_id = 2 THEN size WHEN credit_account_id = 2 THEN -size ELSE 0 END), 0) as btc_qty, COALESCE(SUM(CASE WHEN debit_account_id = 6 THEN size WHEN credit_account_id = 6 THEN -size ELSE 0 END), 0) as bnb_qty FROM transfers WHERE status = 'posted'"
+
     private let settings: AppSettings
 
     init(settings: AppSettings = .shared) {
@@ -227,10 +230,9 @@ final class TursoClient {
     }
 
     func fetchTotalRealizedPnL() async throws -> Double {
-        // Net return = (cash_balance + btc_balance) - total_deposits
-        // Includes fees as cost, BTC cost basis as unrealized allocation
-        let sql = "SELECT (SELECT credits_posted - debits_posted FROM accounts WHERE id = 1) + (SELECT credits_posted - debits_posted FROM accounts WHERE id = 2) - (SELECT COALESCE(SUM(amount), 0) FROM transfers WHERE code = 1 AND status = 'posted') as total"
-        let result = try await executeSQL(sql)
+        // Net return = USD-denominated ledger value - total deposits. Native
+        // fee quantity is stored in transfer size, while amount remains USD.
+        let result = try await executeSQL(Self.totalRealizedPnLSQL)
         guard let row = result.rows.first else { return 0 }
         return getDouble(row, result.cols, "total")
     }
@@ -240,6 +242,18 @@ final class TursoClient {
         let result = try await executeSQL(sql)
         guard let row = result.rows.first else { return 0 }
         return getDouble(row, result.cols, "total")
+    }
+
+    func fetchManagedBalances() async throws -> ManagedBalances {
+        let result = try await executeSQL(Self.managedBalancesSQL)
+        guard let row = result.rows.first else {
+            return ManagedBalances(cash: 0, btcQuantity: 0, bnbQuantity: 0)
+        }
+        return ManagedBalances(
+            cash: getDouble(row, result.cols, "cash"),
+            btcQuantity: getDouble(row, result.cols, "btc_qty"),
+            bnbQuantity: getDouble(row, result.cols, "bnb_qty")
+        )
     }
 
     func fetchBotStatus() async throws -> BotStatus? {

--- a/apps/neko-trade/Sources/DCTradingViewer/Views/DashboardView.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Views/DashboardView.swift
@@ -5,13 +5,13 @@ struct DashboardView: View {
     @ObservedObject var settings: AppSettings
     @State private var openPosition: Position?
     @State private var latestEquity: EquityLog?
-    @State private var totalPnL: Double = 0
-    @State private var totalDeposits: Double = 0
+    @State private var realizedPnL: Double?
     @State private var isLoading = false
     @State private var errorMessage: String?
     @State private var lastRefresh: Date?
     @State private var equityHistory: [EquityLog] = []
     @State private var btcPrice: Double = 0
+    @State private var estimatedEquity: Double?
     @State private var btcPriceHistory: [(Date, Double)] = []
 
     private let client = TursoClient()
@@ -59,32 +59,31 @@ struct DashboardView: View {
                 regimeCard(eq)
             }
 
-            // Stats grid — derive from position if no equity log
-            let equity = latestEquity?.equity ?? 0
-            let unrealized = latestEquity?.unrealized ?? 0
+            // Stats grid — keep top-level metrics focused on current account value.
+            let unrealized = openPosition?.pnl ?? latestEquity?.unrealized
             let price = btcPrice > 0 ? btcPrice : latestEquity?.price ?? openPosition?.entryPrice ?? 0
 
             HStack(spacing: 12) {
                 statCard(
                     title: "EQUITY",
-                    value: equity > 0 ? formatCurrency(equity) : "—",
-                    icon: "chart.line.uptrend.xyaxis",
-                    color: .cyan
+                    value: estimatedEquity.map { formatCurrency($0) } ?? "—",
+                    icon: "chart.bar.xaxis",
+                    color: .mint
                 )
                 statCard(
                     title: "REALIZED P&L",
-                    value: formatCurrency(totalPnL),
+                    value: realizedPnL.map { formatCurrency($0) } ?? "—",
                     icon: "banknote",
-                    color: totalPnL >= 0 ? .green : .red
+                    color: (realizedPnL ?? 0) >= 0 ? .green : .red
                 )
             }
 
             HStack(spacing: 12) {
                 statCard(
-                    title: "UNREALIZED",
-                    value: equity > 0 ? formatCurrency(unrealized) : "—",
+                    title: "UNREALIZED P&L",
+                    value: unrealized.map { formatCurrency($0) } ?? "—",
                     icon: "clock.arrow.circlepath",
-                    color: unrealized >= 0 ? .green : .red
+                    color: (unrealized ?? 0) >= 0 ? .green : .red
                 )
                 statCard(
                     title: "BTC PRICE",
@@ -93,7 +92,6 @@ struct DashboardView: View {
                     color: .orange
                 )
             }
-
 
             // Sparklines
             if equityHistory.count >= 2 || btcPriceHistory.count >= 2 {
@@ -357,10 +355,11 @@ struct DashboardView: View {
         errorMessage = nil
         do {
             async let equityTask = client.fetchLatestEquity()
-            async let pnlTask = client.fetchTotalRealizedPnL()
-            async let depositsTask = client.fetchTotalDeposits()
+            async let realizedPnLTask = client.fetchTotalRealizedPnL()
+            async let managedBalancesTask = client.fetchManagedBalances()
             async let historyTask = client.fetchRecentEquity(limit: 50)
             async let priceTask = BinanceClient.fetchPrice()
+            async let bnbPriceTask = BinanceClient.fetchPrice(symbol: "BNBUSDT")
             async let klinesTask = BinanceClient.fetchKlines(interval: "5m", limit: 60)
 
             // Fetch Alpaca position (source of truth)
@@ -371,9 +370,16 @@ struct DashboardView: View {
                 )
             }
 
-            let (equity, pnl, history, deposits) = try await (equityTask, pnlTask, historyTask, depositsTask)
+            let (equity, realized, history, managedBalances) = try await (equityTask, realizedPnLTask, historyTask, managedBalancesTask)
             let price = try? await priceTask
+            let bnb = try? await bnbPriceTask
             let klines = (try? await klinesTask) ?? []
+            let currentBtcPrice = price ?? equity?.price ?? 0
+            let bnbPriceRequired = abs(managedBalances.bnbQuantity) > 0.00000001
+            let canMarkEquity = currentBtcPrice > 0 && (!bnbPriceRequired || bnb != nil)
+            let markedEquity: Double? = canMarkEquity
+                ? managedBalances.cash + managedBalances.btcQuantity * currentBtcPrice + managedBalances.bnbQuantity * (bnb ?? 0)
+                : nil
 
             await MainActor.run {
                 // Use Alpaca position if available, fall back to Turso
@@ -393,10 +399,10 @@ struct DashboardView: View {
                     openPosition = nil
                 }
                 latestEquity = equity
-                totalPnL = pnl
-                totalDeposits = deposits
+                realizedPnL = realized
                 equityHistory = history
                 if let price { btcPrice = price }
+                estimatedEquity = markedEquity
                 btcPriceHistory = klines
                 lastRefresh = Date()
                 isLoading = false
@@ -470,4 +476,3 @@ struct DashboardView: View {
         }
 }
 }
-

--- a/apps/neko-trade/Sources/DCTradingViewer/Views/LedgerView.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Views/LedgerView.swift
@@ -121,11 +121,7 @@ struct LedgerView: View {
         for t in transfers {
             result.append((t, bal))
             // Reverse the effect to get balance before this transfer
-            if t.isPositive {
-                bal -= t.amount
-            } else {
-                bal += t.amount
-            }
+            bal -= t.cashEffect
         }
         return result
     }

--- a/apps/neko-trade/Tests/DCTradingViewerAccountingTests/AccountingTests.swift
+++ b/apps/neko-trade/Tests/DCTradingViewerAccountingTests/AccountingTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import Neko_Trade
+
+final class AccountingTests: XCTestCase {
+    func testCashEffectUsesTransferAccounts() {
+        let deposit = transfer(debitAccountId: Transfer.cashAccountId, creditAccountId: 4, amount: 1000, code: 1)
+        let buy = transfer(debitAccountId: Transfer.btcAccountId, creditAccountId: Transfer.cashAccountId, amount: 250, code: 2)
+        let cashFee = transfer(debitAccountId: 3, creditAccountId: Transfer.cashAccountId, amount: 0.25, code: 4)
+        let bnbFee = transfer(debitAccountId: 3, creditAccountId: Transfer.bnbAccountId, amount: 0.00123, code: 4)
+        let btcFee = transfer(debitAccountId: 3, creditAccountId: Transfer.btcAccountId, amount: 0.0000025, code: 4)
+
+        XCTAssertEqual(deposit.cashEffect, 1000)
+        XCTAssertEqual(buy.cashEffect, -250)
+        XCTAssertEqual(cashFee.cashEffect, -0.25)
+        XCTAssertEqual(bnbFee.cashEffect, 0)
+        XCTAssertEqual(btcFee.cashEffect, 0)
+    }
+
+    func testRealizedPnLQueryIncludesUsdValuedAssetAccounts() {
+        let sql = TursoClient.totalRealizedPnLSQL
+
+        XCTAssertTrue(sql.contains("WHERE id = 1"))
+        XCTAssertTrue(sql.contains("WHERE id = 2"))
+        XCTAssertTrue(sql.contains("WHERE id = 6"))
+        XCTAssertTrue(sql.contains("WHERE code = 1 AND status = 'posted'"))
+    }
+
+    func testManagedBalancesQueryUsesNativeTransferSizes() {
+        let sql = TursoClient.managedBalancesSQL
+
+        XCTAssertTrue(sql.contains("debit_account_id = 2 THEN size"))
+        XCTAssertTrue(sql.contains("credit_account_id = 2 THEN -size"))
+        XCTAssertTrue(sql.contains("debit_account_id = 6 THEN size"))
+        XCTAssertTrue(sql.contains("credit_account_id = 6 THEN -size"))
+        XCTAssertTrue(sql.contains("WHERE status = 'posted'"))
+    }
+
+    private func transfer(debitAccountId: Int, creditAccountId: Int, amount: Double, code: Int) -> Transfer {
+        Transfer(
+            id: 1,
+            debitAccountId: debitAccountId,
+            creditAccountId: creditAccountId,
+            amount: amount,
+            pendingId: nil,
+            code: code,
+            flags: 0,
+            status: "posted",
+            userData: nil,
+            price: 0,
+            size: 0,
+            timestamp: "0",
+            createdAt: ""
+        )
+    }
+}

--- a/apps/neko-trade/moon.yml
+++ b/apps/neko-trade/moon.yml
@@ -1,14 +1,12 @@
 $schema: 'https://moonrepo.dev/schemas/project.json'
 
 language: system
-type: application
+stack: systems
 
 tags: [trading, swift]
 
 tasks:
   generate:
     command: xcodegen
-    platform: system
   build:
-    command: xcodegen && xcodebuild -project DCTradingViewer.xcodeproj -scheme DCTradingViewer_macOS -destination 'platform=macOS' build
-    platform: system
+    script: xcodegen && xcodebuild -project DCTradingViewer.xcodeproj -scheme DCTradingViewer_macOS -destination 'platform=macOS' build

--- a/apps/neko-trade/project.yml
+++ b/apps/neko-trade/project.yml
@@ -20,3 +20,23 @@ targets:
       INFOPLIST_KEY_UILaunchScreen_Generation: YES
       GENERATE_INFOPLIST_FILE: YES
       ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+  DCTradingViewerAccountingTests:
+    type: bundle.unit-test
+    platform: macOS
+    sources:
+      - Tests/DCTradingViewerAccountingTests
+    dependencies:
+      - target: DCTradingViewer_macOS
+    settings:
+      PRODUCT_BUNDLE_IDENTIFIER: tech.maneki.nekotrade.accounting-tests
+      GENERATE_INFOPLIST_FILE: YES
+      TEST_HOST: "$(BUILT_PRODUCTS_DIR)/Neko Trade.app/Contents/MacOS/Neko Trade"
+      BUNDLE_LOADER: "$(TEST_HOST)"
+schemes:
+  DCTradingViewerAccountingTests:
+    build:
+      targets:
+        DCTradingViewerAccountingTests: all
+    test:
+      targets:
+        - DCTradingViewerAccountingTests

--- a/labs/dctrading/moon.yml
+++ b/labs/dctrading/moon.yml
@@ -1,21 +1,16 @@
 $schema: 'https://moonrepo.dev/schemas/project.json'
 
 language: python
-type: tool
+stack: data
 
 tags: [trading, python]
 
 tasks:
   test-sentiment:
     command: python scripts/test_sentiment.py --mock
-    platform: system
   news-monitor:
     command: python scripts/news_monitor.py
-    platform: system
-    local: true
   backtest-fast:
     command: python scripts/backtest_fast.py --capital 1000
-    platform: system
   backtest-regimes:
     command: python scripts/backtest_regimes.py --since 2023-01-01 --until 2025-12-31
-    platform: system

--- a/services/dctrading-bot/AGENTS.md
+++ b/services/dctrading-bot/AGENTS.md
@@ -51,7 +51,7 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 ### Database Schema (Turso)
 - `accounts` — Double-entry accounts (TigerBeetle-inspired): cash, btc_position, fees, equity, pnl, bnb. 4 balance fields: debits_pending, debits_posted, credits_pending, credits_posted.
 - `transfers` — Immutable append-only transfer log. Two-phase (pending/posted/voided). Codes: 1=deposit, 2=buy, 3=sell, 4=fee, 5=pnl. Atomic BEGIN/COMMIT pipelines.
-- Fee routing: nonzero `commission_asset` routes fees to the paying asset account (`USD`/`USDT` → cash, `BTC` → btc_position, `BNB` → bnb). This nets the ledger balance down, but `strategy.size` remains whatever the exchange adapter reports as fill quantity.
+- Fee routing: nonzero `commission_asset` routes fees to the paying asset account (`USD`/`USDT` → cash, `BTC` → btc_position, `BNB` → bnb). Transfer `amount` is historical USD value at fill time; native fee quantity is stored in transfer `size`, with the fill-time asset USD valuation rate in `price`. `strategy.size` remains whatever the exchange adapter reports as fill quantity.
 - `equity_log` — Periodic snapshots (every 5 min + on trades): capital, equity, unrealized, regime, price.
 - `bot_status` — Single row (id=1): regime, position, equity, version (DCTRADE4@instance).
 ### Build

--- a/services/dctrading-bot/moon.yml
+++ b/services/dctrading-bot/moon.yml
@@ -1,21 +1,16 @@
 $schema: 'https://moonrepo.dev/schemas/project.json'
 
 language: system
-type: application
+stack: systems
 
 tags: [trading, zig]
 
 tasks:
   build:
     command: zig build -Doptimize=ReleaseFast
-    platform: system
   build-linux:
     command: zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux
-    platform: system
   test:
     command: zig build test
-    platform: system
   run:
     command: ./zig-out/bin/dctrading -
-    platform: system
-    local: true

--- a/services/dctrading-bot/src/alpaca.zig
+++ b/services/dctrading-bot/src/alpaca.zig
@@ -151,6 +151,7 @@ pub const Alpaca = struct {
             fill.fill_price = parseJsonFloat(r, "\"filled_avg_price\":") orelse 0;
             fill.fill_qty = parseJsonFloat(r, "\"filled_qty\":") orelse 0;
             fill.commission = parseJsonFloat(r, "\"commission\":") orelse 0;
+            fill.commission_usd = fill.commission;
             @memcpy(fill.commission_asset[0..3], "USD");
             fill.commission_asset_len = 3;
             // Copy order ID
@@ -266,6 +267,7 @@ pub const Alpaca = struct {
                 fill.fill_price = parseJsonFloat(r, "\"filled_avg_price\":") orelse 0;
                 fill.fill_qty = parseJsonFloat(r, "\"filled_qty\":") orelse 0;
                 fill.commission = parseJsonFloat(r, "\"commission\":") orelse 0;
+                fill.commission_usd = fill.commission;
                 @memcpy(fill.commission_asset[0..3], "USD");
                 fill.commission_asset_len = 3;
                 std.debug.print("  [alpaca] Filled: price=${d:.2} qty={d:.8} fee=${d:.4}\n", .{ fill.fill_price, fill.fill_qty, fill.commission });
@@ -293,6 +295,7 @@ pub const Alpaca = struct {
                         fill.fill_price = parseJsonFloat(pr, "\"filled_avg_price\":") orelse 0;
                         fill.fill_qty = parseJsonFloat(pr, "\"filled_qty\":") orelse 0;
                         fill.commission = parseJsonFloat(pr, "\"commission\":") orelse 0;
+                        fill.commission_usd = fill.commission;
                         @memcpy(fill.commission_asset[0..3], "USD");
                         fill.commission_asset_len = 3;
                         std.debug.print("  [alpaca] Filled (poll {d}): price=${d:.2} qty={d:.8} fee=${d:.4}\n", .{ poll + 1, fill.fill_price, fill.fill_qty, fill.commission });

--- a/services/dctrading-bot/src/exchange.zig
+++ b/services/dctrading-bot/src/exchange.zig
@@ -13,7 +13,13 @@ pub const OrderFill = struct {
     order_id_len: usize = 0,
     fill_price: f64,
     fill_qty: f64,
+    /// Native commission quantity in `commission_asset` units.
     commission: f64 = 0,
+    /// Historical USD value of `commission` at fill time. Required when
+    /// commission_asset is non-USD and the adapter has a valuation rate.
+    /// If omitted, LiveLoop estimates BTC fees from fill_price and falls back
+    /// to configured fee_pct for assets it cannot value locally.
+    commission_usd: f64 = 0,
     commission_asset: [8]u8 = undefined,
     commission_asset_len: usize = 0,
     status: enum { filled, accepted, failed },

--- a/services/dctrading-bot/src/integration_tests.zig
+++ b/services/dctrading-bot/src/integration_tests.zig
@@ -1092,7 +1092,7 @@ test "integration: ledger routes BNB commission to BNB account" {
     defer strategy.deinit(allocator);
     strategy.suppress_entry = true;
 
-    var sim = SimExchange{ .fill_delay = 1, .fill_commission = 0.00123 };
+    var sim = SimExchange{ .fill_delay = 1, .fill_commission = 0.00123, .fill_commission_usd = 0.75 };
     @memcpy(sim.fill_commission_asset[0..3], "BNB");
     sim.fill_commission_asset_len = 3;
     sim.last_price = 104.0;
@@ -1113,7 +1113,9 @@ test "integration: ledger routes BNB commission to BNB account" {
     try testing.expectEqual(turso_mod.Turso.CODE_FEE, ledger.posted[0].code);
     try testing.expectEqual(turso_mod.Turso.ACCT_FEES, ledger.posted[0].debit_acct);
     try testing.expectEqual(turso_mod.Turso.ACCT_BNB, ledger.posted[0].credit_acct);
-    try testing.expectApproxEqAbs(0.00123, ledger.posted[0].amount, 0.000001);
+    try testing.expectApproxEqAbs(0.75, ledger.posted[0].amount, 0.000001);
+    try testing.expectApproxEqAbs(0.00123, ledger.posted[0].qty, 0.000001);
+    try testing.expectApproxEqAbs(0.75 / 0.00123, ledger.posted[0].price, 0.000001);
 }
 
 test "integration: ledger falls back to configured fee when exchange commission is zero" {
@@ -1185,7 +1187,9 @@ test "integration: ledger routes BTC commission to BTC account on sell" {
     try testing.expectEqual(turso_mod.Turso.CODE_FEE, ledger.posted[0].code);
     try testing.expectEqual(turso_mod.Turso.ACCT_FEES, ledger.posted[0].debit_acct);
     try testing.expectEqual(turso_mod.Turso.ACCT_BTC, ledger.posted[0].credit_acct);
-    try testing.expectApproxEqAbs(0.00042, ledger.posted[0].amount, 0.000001);
+    try testing.expectApproxEqAbs(0.00042 * 130.0, ledger.posted[0].amount, 0.000001);
+    try testing.expectApproxEqAbs(0.00042, ledger.posted[0].qty, 0.000001);
+    try testing.expectApproxEqAbs(130.0, ledger.posted[0].price, 0.000001);
     try testing.expectEqual(turso_mod.Turso.CODE_PNL, ledger.posted[1].code);
 }
 

--- a/services/dctrading-bot/src/live_loop.zig
+++ b/services/dctrading-bot/src/live_loop.zig
@@ -231,10 +231,11 @@ pub const LiveLoop = struct {
 
         if (po.transfer_id > 0 and self.ledger != null) {
             const buy_cost = buy_price * buy_size;
+            const fee_asset_price = self.feeAssetPrice(fill, buy_price);
             var ud_buf: [256]u8 = undefined;
             const ud = std.fmt.bufPrint(&ud_buf, "BUY oid={s}", .{po.order_id[0..po.order_id_len]}) catch "BUY";
             self.ledger.?.postTransferWithFill(po.transfer_id, buy_cost, buy_price, buy_size, ud);
-            self.ledger.?.createPostedTransfer(turso_mod.Turso.ACCT_FEES, feeCreditAccount(fill), fee, turso_mod.Turso.CODE_FEE, "BUY fee", t.timestamp, 0, 0);
+            self.ledger.?.createPostedTransfer(turso_mod.Turso.ACCT_FEES, feeCreditAccount(fill), fee, turso_mod.Turso.CODE_FEE, "BUY fee", t.timestamp, fee_asset_price, fill.commission);
         }
     }
 
@@ -249,6 +250,7 @@ pub const LiveLoop = struct {
 
         if (po.transfer_id > 0 and self.ledger != null) {
             const sell_amount = sell_price * po.size;
+            const fee_asset_price = self.feeAssetPrice(fill, sell_price);
             const exit_str = switch (po.exit_type) {
                 .dc_exit => "DC",
                 .trailing_stop => "SL",
@@ -258,7 +260,7 @@ pub const LiveLoop = struct {
             var ud_buf: [128]u8 = undefined;
             const ud = std.fmt.bufPrint(&ud_buf, "SELL exit={s}", .{exit_str}) catch "SELL";
             self.ledger.?.postTransferWithFill(po.transfer_id, sell_amount, sell_price, po.size, ud);
-            self.ledger.?.createPostedTransfer(turso_mod.Turso.ACCT_FEES, feeCreditAccount(fill), sell_fee, turso_mod.Turso.CODE_FEE, "SELL fee", 0, 0, 0);
+            self.ledger.?.createPostedTransfer(turso_mod.Turso.ACCT_FEES, feeCreditAccount(fill), sell_fee, turso_mod.Turso.CODE_FEE, "SELL fee", 0, fee_asset_price, fill.commission);
             if (pnl > 0) {
                 self.ledger.?.createPostedTransfer(turso_mod.Turso.ACCT_CASH, turso_mod.Turso.ACCT_PNL, pnl, turso_mod.Turso.CODE_PNL, "Realized PnL", 0, 0, 0);
             } else if (pnl < 0) {
@@ -268,13 +270,28 @@ pub const LiveLoop = struct {
     }
 
     fn fillFee(self: *const LiveLoop, fill: exchange_mod.OrderFill, price: f64, qty: f64) f64 {
-        if (fill.commission > 0) return fill.commission;
+        if (fill.commission_usd > 0) return fill.commission_usd;
+        if (fill.commission > 0) {
+            const asset = fill.commission_asset[0..fill.commission_asset_len];
+            if (std.mem.eql(u8, asset, "USD") or std.mem.eql(u8, asset, "USDT")) return fill.commission;
+            if (std.mem.eql(u8, asset, "BTC")) return fill.commission * price;
+        }
         return price * qty * self.strategy.fee_pct;
     }
 
-    // Routes the fee transfer to the asset that paid commission. For BTC fees,
-    // ledger balances net BTC down via this transfer; strategy.size still uses
-    // the fill quantity supplied by the exchange adapter.
+    fn feeAssetPrice(self: *const LiveLoop, fill: exchange_mod.OrderFill, trade_price: f64) f64 {
+        _ = self;
+        if (fill.commission <= 0) return 0;
+        if (fill.commission_usd > 0) return fill.commission_usd / fill.commission;
+        const asset = fill.commission_asset[0..fill.commission_asset_len];
+        if (std.mem.eql(u8, asset, "USD") or std.mem.eql(u8, asset, "USDT")) return 1;
+        if (std.mem.eql(u8, asset, "BTC")) return trade_price;
+        return 0;
+    }
+
+    // Routes the fee transfer to the asset that paid commission. Transfer
+    // amount is historical USD value at fill time; transfer size stores native
+    // commission qty and price stores the valuation rate.
     fn feeCreditAccount(fill: exchange_mod.OrderFill) u8 {
         if (fill.commission <= 0) return turso_mod.Turso.ACCT_CASH;
         const asset = fill.commission_asset[0..fill.commission_asset_len];

--- a/services/dctrading-bot/src/sim_exchange.zig
+++ b/services/dctrading-bot/src/sim_exchange.zig
@@ -16,6 +16,7 @@ pub const SimExchange = struct {
     fill_price_offset: f64 = 0, // slippage: actual = signal + offset
     partial_fill_ratio: f64 = 1.0, // 1.0 = full fill, 0.5 = half
     fill_commission: f64 = 0,
+    fill_commission_usd: f64 = 0,
     fill_commission_asset: [8]u8 = undefined,
     fill_commission_asset_len: usize = 0,
     fail_next_submit: bool = false,
@@ -259,6 +260,7 @@ pub const SimExchange = struct {
         var fill: OrderFill = .{ .fill_price = fill_price, .fill_qty = fill_qty, .status = .filled };
         if (self.fill_commission > 0 or self.fill_commission_asset_len > 0) {
             fill.commission = self.fill_commission;
+            fill.commission_usd = self.fill_commission_usd;
             const len = @min(self.fill_commission_asset_len, fill.commission_asset.len);
             @memcpy(fill.commission_asset[0..len], self.fill_commission_asset[0..len]);
             fill.commission_asset_len = len;

--- a/services/dctrading-bot/src/tests.zig
+++ b/services/dctrading-bot/src/tests.zig
@@ -1058,15 +1058,18 @@ test "exchange: OrderFill order_id storage" {
 test "exchange: OrderFill commission fields default to zero" {
     const fill = exchange_mod.OrderFill{ .fill_price = 80000.0, .fill_qty = 0.01, .status = .filled };
     try testing.expectApproxEqAbs(fill.commission, 0.0, 0.001);
+    try testing.expectApproxEqAbs(fill.commission_usd, 0.0, 0.001);
     try testing.expectEqual(fill.commission_asset_len, 0);
 }
 
 test "exchange: OrderFill commission_asset storage" {
     var fill = exchange_mod.OrderFill{ .fill_price = 80000.0, .fill_qty = 0.01, .status = .filled };
     fill.commission = 0.50;
+    fill.commission_usd = 0.50;
     @memcpy(fill.commission_asset[0..3], "USD");
     fill.commission_asset_len = 3;
     try testing.expectApproxEqAbs(fill.commission, 0.50, 0.001);
+    try testing.expectApproxEqAbs(fill.commission_usd, 0.50, 0.001);
     try testing.expectEqualStrings("USD", fill.commission_asset[0..fill.commission_asset_len]);
 }
 


### PR DESCRIPTION
## Summary
- keep ledger account amounts USD-denominated for historical accounting while preserving native BTC/BNB fee quantity in transfer size and fee valuation price in transfer price
- route BNB fee transfers to the BNB account and keep BTC/USDT fee handling asset-aware without mixing native balances into USD amount fields
- add Neko realized P&L over USD-valued cash/BTC/BNB account balances minus deposits
- show the main dashboard metrics: managed equity, realized P&L, unrealized P&L, and BTC price
- compute managed equity from app-managed native BTC/BNB transfer sizes marked with current Binance BTCUSDT/BNBUSDT spot prices
- document the split between historical realized accounting and mark-to-market managed equity

## Accounting model
Historical ledger accounting stays USD based: transfer amount is the USD value known at fill time, transfer size carries the native asset quantity, and transfer price carries the valuation rate. This keeps realized P&L queryable from account balances without adding BNB units to USD units.

Managed dashboard equity is separate: Neko derives only app-managed native quantities from posted ledger transfer sizes, then marks BTC with BTCUSDT and BNB with BNBUSDT. Assets elsewhere in the Binance account are ignored unless they were recorded by bot-managed transfers. If a required mark price is unavailable, Neko leaves the estimate blank instead of showing a partial estimate.

Dashboard P&L is split explicitly: realized P&L comes from the historical USD ledger query; unrealized P&L comes from the live Alpaca open position when available, falling back to the bot equity snapshot.

## Tests
- xcodebuild test -project DCTradingViewer.xcodeproj -scheme DCTradingViewerAccountingTests -destination platform=macOS
- moon run neko-trade:build
- git diff --check