### PR TITLE
Add checkpoint backup recovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,10 @@ NTFY_TOPIC=
 # Funding Rate Filter (optional, default: 0.0001 = 0.010%)
 # Skip DC entries when 24h avg funding rate exceeds threshold
 # FUNDING_SKIP_THRESHOLD=0.0001
+
+# Checkpoint backups (optional, default: 5 local rotated backups)
+# Set to 0 to disable backup rotation.
+# CHECKPOINT_BACKUP_RETENTION=5
+# Turso remote checkpoint backup interval in seconds (optional, default: 3600)
+# Set to 0 to disable remote checkpoint backup.
+# CHECKPOINT_REMOTE_BACKUP_INTERVAL=3600

--- a/apps/neko-trade/Sources/DCTradingViewer/Models/Models.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Models/Models.swift
@@ -205,6 +205,8 @@ struct BotStatus {
     let baseAsset: String
     let quoteAsset: String
     let markSymbol: String
+    let checkpointHealth: String
+    let checkpointError: String
 
     var symbolMetadata: SymbolMetadata {
         SymbolMetadata(
@@ -217,6 +219,10 @@ struct BotStatus {
 
     var isLive: Bool {
         status == "RUNNING" && Date().timeIntervalSince1970 - lastTick < 120
+    }
+
+    var checkpointNeedsAttention: Bool {
+        !checkpointHealth.isEmpty && checkpointHealth != "OK"
     }
 
     var uptimeDuration: TimeInterval {

--- a/apps/neko-trade/Sources/DCTradingViewer/Services/TursoClient.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Services/TursoClient.swift
@@ -277,7 +277,9 @@ final class TursoClient {
             tradingSymbol: getOptionalString(row, result.cols, "trading_symbol") ?? "",
             baseAsset: getOptionalString(row, result.cols, "base_asset") ?? "",
             quoteAsset: getOptionalString(row, result.cols, "quote_asset") ?? "",
-            markSymbol: getOptionalString(row, result.cols, "mark_symbol") ?? ""
+            markSymbol: getOptionalString(row, result.cols, "mark_symbol") ?? "",
+            checkpointHealth: getOptionalString(row, result.cols, "checkpoint_health") ?? "OK",
+            checkpointError: getOptionalString(row, result.cols, "checkpoint_error") ?? ""
         )
     }
 

--- a/apps/neko-trade/Sources/DCTradingViewer/Views/DashboardView.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Views/DashboardView.swift
@@ -222,6 +222,29 @@ struct DashboardView: View {
             }
             .padding(.horizontal)
             .padding(.vertical, 10)
+
+            if bs.checkpointNeedsAttention {
+                Divider()
+                    .overlay(Color.orange.opacity(0.25))
+
+                HStack(spacing: 8) {
+                    Image(systemName: "externaldrive.trianglebadge.exclamationmark")
+                        .font(.system(.caption, design: .monospaced, weight: .semibold))
+                        .foregroundStyle(.orange)
+                    Text(bs.checkpointHealth)
+                        .font(.system(.caption, design: .monospaced, weight: .semibold))
+                        .foregroundStyle(.orange)
+                    if !bs.checkpointError.isEmpty {
+                        Text(bs.checkpointError)
+                            .font(.system(.caption2, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    Spacer()
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 10)
+            }
         }
         .background {
             RoundedRectangle(cornerRadius: 12, style: .continuous)

--- a/apps/neko-trade/Sources/DCTradingViewer/Views/SettingsView.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Views/SettingsView.swift
@@ -81,6 +81,29 @@ struct SettingsView: View {
                         .padding(.horizontal)
                         .padding(.vertical, 10)
 
+                        if bs.checkpointNeedsAttention {
+                            Divider()
+                                .overlay(Color.orange.opacity(0.25))
+
+                            HStack(spacing: 8) {
+                                Image(systemName: "externaldrive.trianglebadge.exclamationmark")
+                                    .font(.system(.caption, design: .monospaced, weight: .semibold))
+                                    .foregroundStyle(.orange)
+                                Text(bs.checkpointHealth)
+                                    .font(.system(.caption, design: .monospaced, weight: .semibold))
+                                    .foregroundStyle(.orange)
+                                if !bs.checkpointError.isEmpty {
+                                    Text(bs.checkpointError)
+                                        .font(.system(.caption2, design: .monospaced))
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(1)
+                                }
+                                Spacer()
+                            }
+                            .padding(.horizontal)
+                            .padding(.vertical, 10)
+                        }
+
                         Divider()
                             .overlay(statusColor.opacity(0.2))
 

--- a/apps/neko-trade/Tests/DCTradingViewerAccountingTests/AccountingTests.swift
+++ b/apps/neko-trade/Tests/DCTradingViewerAccountingTests/AccountingTests.swift
@@ -127,7 +127,9 @@ final class AccountingTests: XCTestCase {
             tradingSymbol: tradingSymbol,
             baseAsset: baseAsset,
             quoteAsset: quoteAsset,
-            markSymbol: markSymbol
+            markSymbol: markSymbol,
+            checkpointHealth: "OK",
+            checkpointError: ""
         )
     }
 }

--- a/services/dctrading-bot/.gitignore
+++ b/services/dctrading-bot/.gitignore
@@ -1,4 +1,5 @@
 *.csv
 *.checkpoint
+*.checkpoint.*
 zig-out/
 .zig-cache/

--- a/services/dctrading-bot/AGENTS.md
+++ b/services/dctrading-bot/AGENTS.md
@@ -23,14 +23,15 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 - `tests.zig` — 166 tests covering DC detector, strategy, checkpoint, regime transitions, JSON parsing, capital accounting, double-entry transfers, exchange interface, funding rate filter, non-blocking order flow, capital_reserved, integration scenarios.
 
 ### Scripts (`scripts/`)
-- `switch-to-gcp.sh` — Stop local bot, start GCP Tokyo instance + systemd service.
-- `switch-to-local.sh` — Stop GCP bot + instance, start local bot in tmux.
+- `switch-to-gcp.sh` — Stop local bot, start GCP Tokyo instance + systemd service. Copies binary plus checkpoint primary/local backups, excluding temp files.
+- `switch-to-local.sh` — Stop GCP bot + instance, download checkpoint primary/local backups, start local bot in tmux.
+- `nuke.sh` — Destructive reset for Turso state, local checkpoint primary/backups, and Alpaca positions.
 
 ### Key Patterns
 - **HTTP calls**: All modules use shared `HttpClient` (native `std.http.Client`). Exception: `feed.zig` bootstrap uses `popen("curl")` for Binance REST, and `telegram.zig` shutdown uses curl fallback.
 - **Async writes**: Turso and Telegram fire-and-forget via `std.Thread.spawn` + `detach()`. Context struct heap-allocated, freed in worker.
 - **Sync reads**: Startup queries (capital, position, trade count) are blocking HTTP calls.
-- **Checkpoint**: Binary file with magic number validation. 24 f64 scalars + two ring buffers (vol, MA). Saved every minute.
+- **Checkpoint**: Binary file with magic number validation. 24 f64 scalars + two ring buffers (vol, MA). Saved every minute through an atomic temp-file swap. Live mode keeps rotated local backups (`dctrading.checkpoint.bak.N`) and falls back to the newest valid backup if the primary checkpoint cannot be loaded.
 - **Regime**: `enum { bull, sideways, bear }`. Encoded as 0/1/2 in checkpoint scalar[8].
 
 ### Environment Variables
@@ -48,13 +49,16 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 | `BINANCE_WS_HOST` | No | feed.zig (default: stream.binance.com) |
 | `BINANCE_API_HOST` | No | feed.zig (default: api.binance.com) |
 | `BOT_INSTANCE` | No | main.zig (default: "local") |
+| `CHECKPOINT_BACKUP_RETENTION` | No | main.zig (default: 5 local rotated backups; 0 disables) |
+| `CHECKPOINT_REMOTE_BACKUP_INTERVAL` | No | main.zig/Turso (default: 3600 seconds; 0 disables) |
 
 ### Database Schema (Turso)
 - `accounts` — Double-entry accounts (TigerBeetle-inspired): cash, btc_position, fees, equity, pnl, bnb. 4 balance fields: debits_pending, debits_posted, credits_pending, credits_posted.
 - `transfers` — Immutable append-only transfer log. Two-phase (pending/posted/voided). Codes: 1=deposit, 2=buy, 3=sell, 4=fee, 5=pnl. Atomic BEGIN/COMMIT pipelines.
 - Fee routing: adapter-provided `commission_asset` routes fees to the paying asset account (`USD`/`USDT` → cash, `BTC` → btc_position, `BNB` → bnb), even when commission is zero. Transfer `amount` is historical quote-currency value at fill time; native fee quantity is stored in transfer `size`, with the fill-time asset quote valuation rate in `price`. `strategy.size` remains whatever the exchange adapter reports as fill quantity. `fee_pct` is for backtest/simulation estimates and legacy fills with no commission metadata, not for Alpaca paper fills.
 - `equity_log` — Periodic snapshots (every 5 min + on trades): capital, equity, unrealized, regime, price.
-- `bot_status` — Single row (id=1): regime, position, equity, version (DCTRADE4@instance).
+- `bot_status` — Single row (id=1): regime, position, equity, version (DCTRADE4@instance), active symbol metadata, and checkpoint health/error.
+- `checkpoint_backups` — Single remote checkpoint snapshot (id=1): base64-encoded DCTRADE4 checkpoint, byte length, checksum, tick count, and update time. Used only if local primary/backups cannot be loaded.
 ### Build
 ```bash
 zig build -Doptimize=ReleaseFast              # macOS arm64
@@ -70,7 +74,7 @@ zig build test                                 # 166 tests
 5. On SELL signal: cancel pending buys → `submitOrder()` sell → pending transfer → fill → post transfer + PnL
 6. Every 5 min: log equity to Turso, upsert bot_status, check deposits
 7. Every 8h: refresh funding rate from Binance
-8. Shutdown (SIGINT/SIGTERM): save checkpoint, log to Turso, notify via curl fallback
+8. Shutdown (SIGINT/SIGTERM): save checkpoint with backup rotation, log to Turso, notify via curl fallback
 
 ### Companion Projects
 - **Neko Trade** — SwiftUI dashboard app (macOS + iOS). Separate repo.

--- a/services/dctrading-bot/README.md
+++ b/services/dctrading-bot/README.md
@@ -84,6 +84,12 @@ export BINANCE_API_HOST=api.binance.com
 # Funding filter (default: 0.0001 = 0.010%; 0 disables)
 export FUNDING_SKIP_THRESHOLD=0.0001
 
+# Local checkpoint backups (default: 5; 0 disables)
+export CHECKPOINT_BACKUP_RETENTION=5
+
+# Turso remote checkpoint backup interval in seconds (default: 3600; 0 disables)
+export CHECKPOINT_REMOTE_BACKUP_INTERVAL=3600
+
 # Instance tracking
 export BOT_INSTANCE=local
 ```
@@ -123,6 +129,11 @@ Known-good historical simulation outputs are recorded in
 ./scripts/switch-to-local.sh
 ```
 
+The switch scripts move the checkpoint primary plus local backup files between
+hosts and intentionally ignore `dctrading.checkpoint.tmp`. If no local files are
+available, startup can still restore from Turso when remote checkpoint backup is
+configured.
+
 ## Account Ledger
 
 Every capital movement is tracked in `account_ledger`:
@@ -146,6 +157,18 @@ Binary checkpoint (DCTRADE4) saves full strategy state every minute:
 - Position, capital, regime, MA buffer, vol buffer, DC detector state
 - Survives restarts without re-bootstrapping
 - Old DCTRADE3 checkpoints rejected (fresh bootstrap on upgrade)
+- Live mode writes via `dctrading.checkpoint.tmp` and atomically swaps it into place
+- Before each live save, the previous checkpoint is copied into rotated local backups:
+  `dctrading.checkpoint.bak.1`, `.bak.2`, and so on
+- `CHECKPOINT_BACKUP_RETENTION` controls how many local backups are kept; default is `5`, `0` disables rotation
+- Startup tries the primary checkpoint first, then falls back to the newest valid backup
+- When Turso is configured, live mode also stores the latest checkpoint in
+  `checkpoint_backups` every `CHECKPOINT_REMOTE_BACKUP_INTERVAL` seconds and on clean shutdown
+- Turso snapshots include a checksum; restore refuses snapshots whose decoded bytes do not match it
+- If all local checkpoint files are missing or corrupt, startup restores the Turso snapshot to
+  `dctrading.checkpoint` and loads it before falling back to a fresh bootstrap
+- Checkpoint problems are surfaced in `bot_status.checkpoint_health` and
+  `bot_status.checkpoint_error`; Telegram/ntfy sends a warning when health first enters a degraded state
 
 ## Companion Projects
 

--- a/services/dctrading-bot/scripts/nuke.sh
+++ b/services/dctrading-bot/scripts/nuke.sh
@@ -20,14 +20,17 @@ curl -s "https://$TURSO_HOST/v2/pipeline" \
     {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS account_ledger"}},
     {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS trade_events"}},
     {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS positions"}},
+    {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS transfers"}},
+    {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS accounts"}},
     {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS equity_log"}},
+    {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS checkpoint_backups"}},
     {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS bot_status"}}
   ]}' > /dev/null
 echo "  ✓ Tables dropped"
 
-echo "  Deleting checkpoint..."
-rm -f "$PROJECT_DIR/dctrading.checkpoint"
-echo "  ✓ Checkpoint deleted"
+echo "  Deleting checkpoint state..."
+rm -f "$PROJECT_DIR"/dctrading.checkpoint "$PROJECT_DIR"/dctrading.checkpoint.tmp "$PROJECT_DIR"/dctrading.checkpoint.bak.*
+echo "  ✓ Checkpoint state deleted"
 
 echo "  Closing Alpaca positions..."
 curl -s -X DELETE "https://paper-api.alpaca.markets/v2/positions" \

--- a/services/dctrading-bot/scripts/switch-to-gcp.sh
+++ b/services/dctrading-bot/scripts/switch-to-gcp.sh
@@ -30,14 +30,19 @@ gcloud compute instances start $INSTANCE --zone=$ZONE --quiet
 echo "  Waiting for instance..."
 sleep 20
 
-# Upload binary + checkpoint
+# Upload binary + checkpoint state
 echo "  Uploading binary..."
 gcloud compute ssh $INSTANCE --zone=$ZONE --command="sudo systemctl stop dctrading 2>/dev/null; chmod +w ~/dctrading 2>/dev/null" 2>/dev/null || true
 gcloud compute scp zig-out/bin/dctrading $INSTANCE:~/dctrading --zone=$ZONE
 gcloud compute ssh $INSTANCE --zone=$ZONE --command="chmod +x ~/dctrading"
-if [ -f dctrading.checkpoint ]; then
-    echo "  Uploading checkpoint..."
-    gcloud compute scp dctrading.checkpoint $INSTANCE:~/dctrading.checkpoint --zone=$ZONE
+shopt -s nullglob
+checkpoint_files=(dctrading.checkpoint dctrading.checkpoint.bak.*)
+if [ ${#checkpoint_files[@]} -gt 0 ]; then
+    echo "  Uploading checkpoint state..."
+    gcloud compute ssh $INSTANCE --zone=$ZONE --command="rm -f ~/dctrading.checkpoint.tmp ~/dctrading.checkpoint.bak.*" 2>/dev/null || true
+    gcloud compute scp "${checkpoint_files[@]}" $INSTANCE:~/ --zone=$ZONE
+else
+    echo "  No local checkpoint state to upload; bot can restore from Turso if configured."
 fi
 echo "  Upload complete."
 

--- a/services/dctrading-bot/scripts/switch-to-local.sh
+++ b/services/dctrading-bot/scripts/switch-to-local.sh
@@ -12,12 +12,16 @@ cd "$PROJECT_DIR"
 
 echo "🔄 Switching to local..."
 
-# Stop bot on GCP + download checkpoint
+# Stop bot on GCP + download checkpoint state
 echo "  Stopping GCP bot..."
 gcloud compute ssh $INSTANCE --zone=$ZONE --command="sudo systemctl stop dctrading" 2>/dev/null || true
 sleep 2
-echo "  Downloading checkpoint from GCP..."
-gcloud compute scp $INSTANCE:~/dctrading.checkpoint dctrading.checkpoint --zone=$ZONE 2>/dev/null && echo "  Checkpoint downloaded." || echo "  No checkpoint on GCP (fresh start)."
+echo "  Downloading checkpoint state from GCP..."
+rm -f dctrading.checkpoint.tmp dctrading.checkpoint.bak.*
+gcloud compute scp "$INSTANCE:~/dctrading.checkpoint*" . --zone=$ZONE 2>/dev/null && {
+    rm -f dctrading.checkpoint.tmp
+    echo "  Checkpoint state downloaded."
+} || echo "  No checkpoint state on GCP; bot can restore from Turso if configured."
 
 # Stop GCP instance
 echo "  Stopping GCP instance..."

--- a/services/dctrading-bot/src/main.zig
+++ b/services/dctrading-bot/src/main.zig
@@ -67,6 +67,16 @@ fn upperCopy(dst: []u8, src: []const u8) usize {
     return len;
 }
 
+fn parseEnvU8(name: [*:0]const u8, default_value: u8) u8 {
+    const raw = getenv(name) orelse return default_value;
+    return std.fmt.parseInt(u8, std.mem.sliceTo(raw, 0), 10) catch default_value;
+}
+
+fn parseEnvU32(name: [*:0]const u8, default_value: u32) u32 {
+    const raw = getenv(name) orelse return default_value;
+    return std.fmt.parseInt(u32, std.mem.sliceTo(raw, 0), 10) catch default_value;
+}
+
 fn parseSymbolInfo(symbol: []const u8) SymbolInfo {
     var info: SymbolInfo = undefined;
     info.trading_symbol_len = upperCopy(&info.trading_symbol, symbol);
@@ -134,6 +144,12 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
     // turso_mod imported at file scope
     const checkpoint_path: [*:0]const u8 = "dctrading.checkpoint";
     const checkpoint_interval: u64 = 60; // ~1 hour with 1-min downsampling
+    const checkpoint_backup_retention = parseEnvU8("CHECKPOINT_BACKUP_RETENTION", 5);
+    const checkpoint_remote_interval = parseEnvU32("CHECKPOINT_REMOTE_BACKUP_INTERVAL", 3600);
+    var last_remote_checkpoint_ts: f64 = 0;
+    var checkpoint_health: []const u8 = "OK";
+    var checkpoint_error: []const u8 = "";
+    var last_checkpoint_alert: []const u8 = "";
     const symbol_info = parseSymbolInfo(if (getenv("TRADING_SYMBOL")) |ptr| std.mem.sliceTo(ptr, 0) else "BTC/USD");
     const trading_symbol = symbol_info.tradingSymbol();
 
@@ -141,7 +157,7 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
     std.debug.print("  lambda={d:.3}, capital=${d:.0}\n", .{ threshold, capital });
     std.debug.print("  symbol={s} quote={s} mark={s}\n", .{ trading_symbol, symbol_info.quoteAsset(), symbol_info.markSymbol() });
     std.debug.print("  Strategy: ZI-DCT0 long-only + vol-trail 2%/72h + 60d MA buf=3%\n", .{});
-    std.debug.print("  Checkpoint: every {d} ticks\n\n", .{checkpoint_interval});
+    std.debug.print("  Checkpoint: every {d} ticks, backups={d}, remote={d}s\n\n", .{ checkpoint_interval, checkpoint_backup_retention, checkpoint_remote_interval });
 
     // Register signal handlers for clean shutdown (SIGINT=2, SIGTERM=15)
     _ = signal(2, &handleSigint); // Ctrl-C / local
@@ -155,9 +171,24 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
     });
     defer strategy.deinit(allocator);
 
+    // Init shared HTTP client
+    var http = http_mod.HttpClient.init(allocator, io);
+    defer http.deinit();
+
+    // Init Turso DB logging (optional — disabled if env vars not set)
+    var turso = turso_mod.Turso.init(allocator, &http);
+    if (turso != null) turso.?.createTables();
+
     var loaded_checkpoint = false;
-    if (strategy.loadCheckpoint(checkpoint_path)) {
+    if (strategy.loadCheckpointWithBackups(checkpoint_path, checkpoint_backup_retention)) {
         loaded_checkpoint = true;
+    } else if (turso != null and turso.?.restoreCheckpointBackupToFile(checkpoint_path) and strategy.loadCheckpoint(checkpoint_path)) {
+        loaded_checkpoint = true;
+        checkpoint_health = "RESTORED_REMOTE";
+        checkpoint_error = "local_checkpoint_unavailable";
+        std.debug.print("  Restored checkpoint from Turso remote backup.\n", .{});
+    }
+    if (loaded_checkpoint) {
         std.debug.print("  Resumed from checkpoint: capital=${d:.2} regime={s} ticks={d}\n", .{
             strategy.capital,
             switch (strategy.regime) {
@@ -175,16 +206,14 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
         std.debug.print("\n", .{});
     }
 
-    // Init shared HTTP client
-    var http = http_mod.HttpClient.init(allocator, io);
-    defer http.deinit();
-
-    // Init Turso DB logging (optional — disabled if env vars not set)
-    var turso = turso_mod.Turso.init(allocator, &http);
-    if (turso != null) turso.?.createTables();
-
     // Init Telegram notifications (optional)
     const tg = telegram_mod.Telegram.init(allocator, &http);
+    if (!std.mem.eql(u8, checkpoint_health, "OK")) {
+        if (tg) |tl| {
+            tl.notifyCheckpointWarning(checkpoint_health, checkpoint_error, if (getenv("BOT_INSTANCE")) |ptr| std.mem.sliceTo(ptr, 0) else "local");
+            last_checkpoint_alert = checkpoint_health;
+        }
+    }
 
     // Init exchange (Alpaca paper trading)
     const alpaca = alpaca_mod.Alpaca.init(&http) orelse {
@@ -495,17 +524,51 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
             // Log equity + checkpoint
             const traded = (was_in_pos != strategy.in_position);
             const equity_interval = t.timestamp - last_equity_ts >= 300.0;
-            _ = strategy.saveCheckpoint(checkpoint_path);
+            const checkpoint_saved = strategy.saveCheckpointWithBackups(checkpoint_path, checkpoint_backup_retention);
+            if (!checkpoint_saved) {
+                checkpoint_health = "CHECKPOINT_SAVE_FAILED";
+                checkpoint_error = "local_checkpoint_write_failed";
+                std.debug.print("  [checkpoint] ERROR: local checkpoint save failed.\n", .{});
+                if (!std.mem.eql(u8, last_checkpoint_alert, checkpoint_health)) {
+                    if (tg) |tl| tl.notifyCheckpointWarning(checkpoint_health, checkpoint_error, instance);
+                    last_checkpoint_alert = checkpoint_health;
+                }
+            } else if (std.mem.eql(u8, checkpoint_health, "CHECKPOINT_SAVE_FAILED")) {
+                checkpoint_health = "OK";
+                checkpoint_error = "";
+                last_checkpoint_alert = "";
+            }
             if (turso != null) {
-                turso.?.upsertStatus(t.timestamp, strategy.tick_count, regime_str, strategy.in_position, strategy.entry_price, equity, strategy.capital, unrealized, t.price, uptime_start, instance, symbol_info.tradingSymbol(), symbol_info.baseAsset(), symbol_info.quoteAsset(), symbol_info.markSymbol());
+                if (checkpoint_saved and checkpoint_remote_interval > 0) {
+                    const remote_now_ts: f64 = @floatFromInt(time(null));
+                    if (remote_now_ts - last_remote_checkpoint_ts >= @as(f64, @floatFromInt(checkpoint_remote_interval))) {
+                        if (turso.?.backupCheckpointFile(checkpoint_path, strategy.tick_count, false)) {
+                            last_remote_checkpoint_ts = remote_now_ts;
+                            if (std.mem.eql(u8, checkpoint_health, "REMOTE_BACKUP_FAILED")) {
+                                checkpoint_health = "OK";
+                                checkpoint_error = "";
+                                last_checkpoint_alert = "";
+                            }
+                        } else {
+                            checkpoint_health = "REMOTE_BACKUP_FAILED";
+                            checkpoint_error = "turso_checkpoint_backup_failed";
+                            std.debug.print("  [checkpoint] WARNING: Turso checkpoint backup failed.\n", .{});
+                            if (!std.mem.eql(u8, last_checkpoint_alert, checkpoint_health)) {
+                                if (tg) |tl| tl.notifyCheckpointWarning(checkpoint_health, checkpoint_error, instance);
+                                last_checkpoint_alert = checkpoint_health;
+                            }
+                        }
+                    }
+                }
+                turso.?.upsertStatus(t.timestamp, strategy.tick_count, regime_str, strategy.in_position, strategy.entry_price, equity, strategy.capital, unrealized, t.price, uptime_start, instance, symbol_info.tradingSymbol(), symbol_info.baseAsset(), symbol_info.quoteAsset(), symbol_info.markSymbol(), checkpoint_health, checkpoint_error);
                 if (equity_interval or traded) {
                     turso.?.logEquity(t.timestamp, strategy.tick_count, strategy.capital, equity, unrealized, regime_str, t.price);
                     last_equity_ts = t.timestamp;
                 }
                 // Refresh funding rate every 8h
-                const now_ts: f64 = @floatFromInt(time(null));
-                if (now_ts - last_funding_check >= 28800.0) {
-                    last_funding_check = now_ts;
+                const funding_now_ts: f64 = @floatFromInt(time(null));
+                if (funding_now_ts - last_funding_check >= 28800.0) {
+                    last_funding_check = funding_now_ts;
                     if (feed_mod.fetchFundingRate(&http, trading_symbol, 3)) |avg| {
                         strategy.funding_avg = avg;
                     }
@@ -540,7 +603,19 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
 
     // Clean shutdown — save state, keep position open
     std.debug.print("\n  Shutting down...\n", .{});
-    _ = strategy.saveCheckpoint(checkpoint_path);
+    const final_checkpoint_saved = strategy.saveCheckpointWithBackups(checkpoint_path, checkpoint_backup_retention);
+    if (!final_checkpoint_saved) {
+        checkpoint_health = "CHECKPOINT_SAVE_FAILED";
+        checkpoint_error = "shutdown_checkpoint_write_failed";
+        if (tg) |tl| tl.notifyCheckpointWarning(checkpoint_health, checkpoint_error, instance);
+    }
+    if (final_checkpoint_saved and checkpoint_remote_interval > 0 and turso != null) {
+        if (!turso.?.backupCheckpointFile(checkpoint_path, strategy.tick_count, true)) {
+            checkpoint_health = "REMOTE_BACKUP_FAILED";
+            checkpoint_error = "shutdown_turso_checkpoint_backup_failed";
+            if (tg) |tl| tl.notifyCheckpointWarning(checkpoint_health, checkpoint_error, instance);
+        }
+    }
     const final_unrealized = if (strategy.in_position) (loop.last_price - strategy.entry_price) * strategy.size else 0.0;
     const eq = strategy.capital + final_unrealized;
     // Log final equity to Turso on shutdown

--- a/services/dctrading-bot/src/strategy.zig
+++ b/services/dctrading-bot/src/strategy.zig
@@ -14,6 +14,8 @@ pub extern "c" fn fopen(path: [*:0]const u8, mode: [*:0]const u8) ?*anyopaque;
 pub extern "c" fn fclose(fp: *anyopaque) c_int;
 pub extern "c" fn fread(buf: [*]u8, size: usize, count: usize, fp: *anyopaque) usize;
 pub extern "c" fn fwrite(buf: [*]const u8, size: usize, count: usize, fp: *anyopaque) usize;
+extern "c" fn rename(old: [*:0]const u8, new: [*:0]const u8) c_int;
+extern "c" fn remove(path: [*:0]const u8) c_int;
 
 pub const Strategy = struct {
     detector: DCDetector,
@@ -314,7 +316,7 @@ pub const Strategy = struct {
     const CHECKPOINT_MAGIC: u64 = 0x4443_5452_4144_4534; // "DCTRADE4"
     const SCALAR_COUNT = 24;
 
-    pub fn saveCheckpoint(self: *const Strategy, path: [*:0]const u8) bool {
+    fn writeCheckpointFile(self: *const Strategy, path: [*:0]const u8) bool {
         const fp = fopen(path, "wb") orelse return false;
         defer _ = fclose(fp);
 
@@ -348,6 +350,25 @@ pub const Strategy = struct {
         _ = fwrite(@ptrCast(self.returns_buf.ptr), @sizeOf(f64), self.vol_window, fp);
         _ = fwrite(@ptrCast(self.price_buf.ptr), @sizeOf(f64), self.ma_period, fp);
 
+        return true;
+    }
+
+    pub fn saveCheckpoint(self: *const Strategy, path: [*:0]const u8) bool {
+        return self.writeCheckpointFile(path);
+    }
+
+    pub fn saveCheckpointWithBackups(self: *const Strategy, path: [*:0]const u8, retention: u8) bool {
+        var tmp_buf: [4096]u8 = undefined;
+        const path_slice = std.mem.sliceTo(path, 0);
+        const tmp_path = std.fmt.bufPrintZ(&tmp_buf, "{s}.tmp", .{path_slice}) catch return false;
+
+        if (!self.writeCheckpointFile(tmp_path)) return false;
+        if (retention > 0) rotateCheckpointBackups(path, retention);
+
+        if (rename(tmp_path, path) != 0) {
+            _ = remove(tmp_path);
+            return false;
+        }
         return true;
     }
 
@@ -388,7 +409,58 @@ pub const Strategy = struct {
 
         return true;
     }
+
+    pub fn loadCheckpointWithBackups(self: *Strategy, path: [*:0]const u8, retention: u8) bool {
+        if (self.loadCheckpoint(path)) return true;
+
+        var backup_buf: [4096]u8 = undefined;
+        var index: u8 = 1;
+        while (index <= retention) : (index += 1) {
+            const backup_path = backupPath(&backup_buf, path, index) orelse return false;
+            if (self.loadCheckpoint(backup_path)) return true;
+        }
+        return false;
+    }
 };
+
+fn backupPath(buf: []u8, path: [*:0]const u8, index: u8) ?[:0]u8 {
+    return std.fmt.bufPrintZ(buf, "{s}.bak.{d}", .{ std.mem.sliceTo(path, 0), index }) catch null;
+}
+
+fn copyFile(src: [*:0]const u8, dst: [*:0]const u8) bool {
+    const in = fopen(src, "rb") orelse return false;
+    defer _ = fclose(in);
+
+    const out = fopen(dst, "wb") orelse return false;
+    defer _ = fclose(out);
+
+    var buf: [8192]u8 = undefined;
+    while (true) {
+        const read_count = fread(&buf, 1, buf.len, in);
+        if (read_count == 0) break;
+        if (fwrite(&buf, 1, read_count, out) != read_count) return false;
+    }
+    return true;
+}
+
+fn rotateCheckpointBackups(path: [*:0]const u8, retention: u8) void {
+    if (retention == 0) return;
+
+    var old_buf: [4096]u8 = undefined;
+    var new_buf: [4096]u8 = undefined;
+
+    var index = retention;
+    while (index > 1) : (index -= 1) {
+        const old_path = backupPath(&old_buf, path, index - 1) orelse return;
+        const new_path = backupPath(&new_buf, path, index) orelse return;
+        _ = remove(new_path);
+        _ = rename(old_path, new_path);
+    }
+
+    const first_backup = backupPath(&new_buf, path, 1) orelse return;
+    _ = remove(first_backup);
+    _ = copyFile(path, first_backup);
+}
 
 fn ringStd(buf: []const f64, count: usize) f64 {
     if (count < 2) return 0;

--- a/services/dctrading-bot/src/telegram.zig
+++ b/services/dctrading-bot/src/telegram.zig
@@ -88,6 +88,15 @@ pub const Telegram = struct {
         self.sendSync(msg);
     }
 
+    pub fn notifyCheckpointWarning(self: *const Telegram, health: []const u8, detail: []const u8, instance: []const u8) void {
+        var buf: [512]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf,
+            "⚠️ Checkpoint warning\nHealth: {s}\nDetail: {s}\nInstance: {s}",
+            .{ health, detail, instance },
+        ) catch return;
+        self.send(msg);
+    }
+
     fn send(self: *const Telegram, text: []const u8) void {
         const Context = struct {
             tg: *const Telegram,

--- a/services/dctrading-bot/src/tests.zig
+++ b/services/dctrading-bot/src/tests.zig
@@ -879,6 +879,63 @@ test "strategy: old DCTRADE3 checkpoint rejected after upgrade" {
     try testing.expect(!s.loadCheckpoint(path));
 }
 
+test "strategy: checkpoint backups recover from corrupt primary" {
+    const allocator = testing.allocator;
+    const path: [*:0]const u8 = "/tmp/test_ckpt_backup.bin";
+
+    var s = try Strategy.init(allocator, .{ .ma_period = 10, .vol_window = 10 });
+    defer s.deinit(allocator);
+    s.capital = 1000.0;
+    s.tick_count = 10;
+    try testing.expect(s.saveCheckpointWithBackups(path, 3));
+
+    s.capital = 2000.0;
+    s.tick_count = 20;
+    try testing.expect(s.saveCheckpointWithBackups(path, 3));
+
+    const fp = strat_mod.fopen(path, "wb") orelse unreachable;
+    var junk: [4]u8 = .{ 'b', 'a', 'd', '\n' };
+    _ = strat_mod.fwrite(&junk, 1, junk.len, fp);
+    _ = strat_mod.fclose(fp);
+
+    var recovered = try Strategy.init(allocator, .{ .ma_period = 10, .vol_window = 10 });
+    defer recovered.deinit(allocator);
+    try testing.expect(recovered.loadCheckpointWithBackups(path, 3));
+    try testing.expectApproxEqAbs(recovered.capital, 1000.0, 0.001);
+    try testing.expectEqual(@as(u64, 10), recovered.tick_count);
+}
+
+test "strategy: checkpoint backup retention keeps older fallback slots" {
+    const allocator = testing.allocator;
+    const path: [*:0]const u8 = "/tmp/test_ckpt_backup_retention.bin";
+
+    var s = try Strategy.init(allocator, .{ .ma_period = 10, .vol_window = 10 });
+    defer s.deinit(allocator);
+
+    var i: u64 = 1;
+    while (i <= 4) : (i += 1) {
+        s.capital = @as(f64, @floatFromInt(i * 1000));
+        s.tick_count = i;
+        try testing.expect(s.saveCheckpointWithBackups(path, 2));
+    }
+
+    const primary = strat_mod.fopen(path, "wb") orelse unreachable;
+    var junk: [4]u8 = .{ 'b', 'a', 'd', '\n' };
+    _ = strat_mod.fwrite(&junk, 1, junk.len, primary);
+    _ = strat_mod.fclose(primary);
+
+    const bak1: [*:0]const u8 = "/tmp/test_ckpt_backup_retention.bin.bak.1";
+    const first_backup = strat_mod.fopen(bak1, "wb") orelse unreachable;
+    _ = strat_mod.fwrite(&junk, 1, junk.len, first_backup);
+    _ = strat_mod.fclose(first_backup);
+
+    var recovered = try Strategy.init(allocator, .{ .ma_period = 10, .vol_window = 10 });
+    defer recovered.deinit(allocator);
+    try testing.expect(recovered.loadCheckpointWithBackups(path, 2));
+    try testing.expectApproxEqAbs(recovered.capital, 2000.0, 0.001);
+    try testing.expectEqual(@as(u64, 2), recovered.tick_count);
+}
+
 // ============================================================
 // HTTP Client / Alpaca / Turso Parsing Tests
 // ============================================================
@@ -1263,6 +1320,23 @@ test "turso: parseTransferId handles unquoted integer" {
     const val = turso_mod.Turso.parseTransferId(json);
     try testing.expect(val != null);
     try testing.expectEqual(val.?, 42);
+}
+
+test "turso: parseValueStringAlloc parses selected value" {
+    const json = "{\"results\":[{\"response\":{\"result\":{\"rows\":[[{\"type\":\"integer\",\"value\":12},{\"type\":\"text\",\"value\":\"YWJj\"}]]}}}]}";
+    const value = turso_mod.Turso.parseValueStringAlloc(testing.allocator, json, 1).?;
+    defer testing.allocator.free(value);
+    try testing.expectEqualStrings("YWJj", value);
+}
+
+test "turso: checkpoint backup response parses checksum and payload" {
+    const json = "{\"results\":[{\"response\":{\"result\":{\"rows\":[[{\"type\":\"integer\",\"value\":3},{\"type\":\"text\",\"value\":\"2a4f1d7cb516c72\"},{\"type\":\"text\",\"value\":\"YWJj\"}]]}}}]}";
+    const checksum = turso_mod.Turso.parseValueStringAlloc(testing.allocator, json, 1).?;
+    defer testing.allocator.free(checksum);
+    const payload = turso_mod.Turso.parseValueStringAlloc(testing.allocator, json, 2).?;
+    defer testing.allocator.free(payload);
+    try testing.expectEqualStrings("2a4f1d7cb516c72", checksum);
+    try testing.expectEqualStrings("YWJj", payload);
 }
 
 test "turso: account constants are correct" {

--- a/services/dctrading-bot/src/turso.zig
+++ b/services/dctrading-bot/src/turso.zig
@@ -6,6 +6,12 @@ const HttpClient = http_mod.HttpClient;
 const Trade = types.Trade;
 
 extern "c" fn getenv(name: [*:0]const u8) ?[*:0]const u8;
+extern "c" fn fopen(path: [*:0]const u8, mode: [*:0]const u8) ?*anyopaque;
+extern "c" fn fclose(fp: *anyopaque) c_int;
+extern "c" fn fread(buf: [*]u8, size: usize, count: usize, fp: *anyopaque) usize;
+extern "c" fn fwrite(buf: [*]const u8, size: usize, count: usize, fp: *anyopaque) usize;
+extern "c" fn fseek(fp: *anyopaque, offset: c_long, whence: c_int) c_int;
+extern "c" fn ftell(fp: *anyopaque) c_long;
 
 pub const Turso = struct {
     url: []const u8, // full pipeline URL: https://host/v2/pipeline
@@ -63,7 +69,8 @@ pub const Turso = struct {
         const sql_core =
             \\{"requests": [
             \\  {"type": "execute", "stmt": {"sql": "CREATE TABLE IF NOT EXISTS equity_log (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, tick_count INTEGER, capital REAL, equity REAL, unrealized REAL, regime TEXT, price REAL, created_at TEXT DEFAULT (datetime('now')))"}},
-            \\  {"type": "execute", "stmt": {"sql": "CREATE TABLE IF NOT EXISTS bot_status (id INTEGER PRIMARY KEY CHECK (id = 1), status TEXT, last_tick REAL, tick_count INTEGER, regime TEXT, in_position INTEGER, entry_price REAL, equity REAL, capital REAL, unrealized REAL, price REAL, uptime_start REAL, version TEXT, trading_symbol TEXT DEFAULT 'BTC/USD', base_asset TEXT DEFAULT 'BTC', quote_asset TEXT DEFAULT 'USD', mark_symbol TEXT DEFAULT 'BTCUSDT', updated_at TEXT DEFAULT (datetime('now')))"}},
+            \\  {"type": "execute", "stmt": {"sql": "CREATE TABLE IF NOT EXISTS bot_status (id INTEGER PRIMARY KEY CHECK (id = 1), status TEXT, last_tick REAL, tick_count INTEGER, regime TEXT, in_position INTEGER, entry_price REAL, equity REAL, capital REAL, unrealized REAL, price REAL, uptime_start REAL, version TEXT, trading_symbol TEXT DEFAULT 'BTC/USD', base_asset TEXT DEFAULT 'BTC', quote_asset TEXT DEFAULT 'USD', mark_symbol TEXT DEFAULT 'BTCUSDT', checkpoint_health TEXT DEFAULT 'OK', checkpoint_error TEXT DEFAULT '', updated_at TEXT DEFAULT (datetime('now')))"}},
+            \\  {"type": "execute", "stmt": {"sql": "CREATE TABLE IF NOT EXISTS checkpoint_backups (id INTEGER PRIMARY KEY CHECK (id = 1), path TEXT NOT NULL, data_base64 TEXT NOT NULL, byte_len INTEGER NOT NULL, checksum TEXT NOT NULL DEFAULT '', tick_count INTEGER NOT NULL, updated_at TEXT DEFAULT (datetime('now')))"}},
             \\  {"type": "execute", "stmt": {"sql": "CREATE INDEX IF NOT EXISTS idx_equity_log_timestamp ON equity_log(timestamp)"}}
             \\]}
         ;
@@ -102,6 +109,15 @@ pub const Turso = struct {
         self.execSyncSilent(
             \\{"requests": [{"type": "execute", "stmt": {"sql": "ALTER TABLE bot_status ADD COLUMN mark_symbol TEXT DEFAULT 'BTCUSDT'"}}]}
         );
+        self.execSyncSilent(
+            \\{"requests": [{"type": "execute", "stmt": {"sql": "ALTER TABLE bot_status ADD COLUMN checkpoint_health TEXT DEFAULT 'OK'"}}]}
+        );
+        self.execSyncSilent(
+            \\{"requests": [{"type": "execute", "stmt": {"sql": "ALTER TABLE bot_status ADD COLUMN checkpoint_error TEXT DEFAULT ''"}}]}
+        );
+        self.execSyncSilent(
+            \\{"requests": [{"type": "execute", "stmt": {"sql": "ALTER TABLE checkpoint_backups ADD COLUMN checksum TEXT NOT NULL DEFAULT ''"}}]}
+        );
         if (core_ok and acct_ok) {
             std.debug.print("  [turso] Tables ready.\n", .{});
         } else {
@@ -129,12 +145,12 @@ pub const Turso = struct {
     }
 
     /// Upsert bot status (async, every tick).
-    pub fn upsertStatus(self: *const Turso, last_tick: f64, tick_count: u64, regime: []const u8, in_position: bool, entry_price: f64, equity: f64, capital: f64, unrealized: f64, price: f64, uptime_start: f64, instance: []const u8, trading_symbol: []const u8, base_asset: []const u8, quote_asset: []const u8, mark_symbol: []const u8) void {
-        var buf: [4096]u8 = undefined;
+    pub fn upsertStatus(self: *const Turso, last_tick: f64, tick_count: u64, regime: []const u8, in_position: bool, entry_price: f64, equity: f64, capital: f64, unrealized: f64, price: f64, uptime_start: f64, instance: []const u8, trading_symbol: []const u8, base_asset: []const u8, quote_asset: []const u8, mark_symbol: []const u8, checkpoint_health: []const u8, checkpoint_error: []const u8) void {
+        var buf: [8192]u8 = undefined;
         var ver_buf: [64]u8 = undefined;
         const ver = std.fmt.bufPrint(&ver_buf, "DCTRADE4@{s}", .{instance}) catch "DCTRADE4";
         const sql = std.fmt.bufPrint(&buf,
-            \\{{"requests": [{{"type": "execute", "stmt": {{"sql": "INSERT INTO bot_status (id, status, last_tick, tick_count, regime, in_position, entry_price, equity, capital, unrealized, price, uptime_start, version, trading_symbol, base_asset, quote_asset, mark_symbol) VALUES (1, 'RUNNING', {d:.6}, {d}, '{s}', {d}, {d:.8}, {d:.2}, {d:.2}, {d:.2}, {d:.2}, {d:.6}, '{s}', '{s}', '{s}', '{s}', '{s}') ON CONFLICT(id) DO UPDATE SET status='RUNNING', last_tick={d:.6}, tick_count={d}, regime='{s}', in_position={d}, entry_price={d:.8}, equity={d:.2}, capital={d:.2}, unrealized={d:.2}, price={d:.2}, version='{s}', trading_symbol='{s}', base_asset='{s}', quote_asset='{s}', mark_symbol='{s}', updated_at=datetime('now')"}}}}]}}
+            \\{{"requests": [{{"type": "execute", "stmt": {{"sql": "INSERT INTO bot_status (id, status, last_tick, tick_count, regime, in_position, entry_price, equity, capital, unrealized, price, uptime_start, version, trading_symbol, base_asset, quote_asset, mark_symbol, checkpoint_health, checkpoint_error) VALUES (1, 'RUNNING', {d:.6}, {d}, '{s}', {d}, {d:.8}, {d:.2}, {d:.2}, {d:.2}, {d:.2}, {d:.6}, '{s}', '{s}', '{s}', '{s}', '{s}', '{s}', '{s}') ON CONFLICT(id) DO UPDATE SET status=excluded.status, last_tick=excluded.last_tick, tick_count=excluded.tick_count, regime=excluded.regime, in_position=excluded.in_position, entry_price=excluded.entry_price, equity=excluded.equity, capital=excluded.capital, unrealized=excluded.unrealized, price=excluded.price, version=excluded.version, trading_symbol=excluded.trading_symbol, base_asset=excluded.base_asset, quote_asset=excluded.quote_asset, mark_symbol=excluded.mark_symbol, checkpoint_health=excluded.checkpoint_health, checkpoint_error=excluded.checkpoint_error, updated_at=datetime('now')"}}}}]}}
         , .{
             last_tick,
             tick_count,
@@ -151,20 +167,8 @@ pub const Turso = struct {
             base_asset,
             quote_asset,
             mark_symbol,
-            last_tick,
-            tick_count,
-            regime,
-            @as(u8, if (in_position) 1 else 0),
-            entry_price,
-            equity,
-            capital,
-            unrealized,
-            price,
-            ver,
-            trading_symbol,
-            base_asset,
-            quote_asset,
-            mark_symbol,
+            checkpoint_health,
+            checkpoint_error,
         }) catch return;
         self.execAsync(sql);
     }
@@ -176,6 +180,56 @@ pub const Turso = struct {
             \\]}
         ;
         _ = self.execSync(sql);
+    }
+
+    pub fn backupCheckpointFile(self: *const Turso, path: [*:0]const u8, tick_count: u64, wait: bool) bool {
+        const bytes = readFileAlloc(self.allocator, path) orelse return false;
+        defer self.allocator.free(bytes);
+
+        const encoded_len = std.base64.standard.Encoder.calcSize(bytes.len);
+        const encoded = self.allocator.alloc(u8, encoded_len) catch return false;
+        defer self.allocator.free(encoded);
+        _ = std.base64.standard.Encoder.encode(encoded, bytes);
+
+        const path_slice = std.mem.sliceTo(path, 0);
+        const checksum = std.hash.Wyhash.hash(0, bytes);
+        const sql = std.fmt.allocPrint(self.allocator,
+            \\{{"requests": [{{"type": "execute", "stmt": {{"sql": "INSERT INTO checkpoint_backups (id, path, data_base64, byte_len, checksum, tick_count, updated_at) VALUES (1, '{s}', '{s}', {d}, '{x}', {d}, datetime('now')) ON CONFLICT(id) DO UPDATE SET path='{s}', data_base64='{s}', byte_len={d}, checksum='{x}', tick_count={d}, updated_at=datetime('now')"}}}}]}}
+        , .{ path_slice, encoded, bytes.len, checksum, tick_count, path_slice, encoded, bytes.len, checksum, tick_count }) catch return false;
+        defer self.allocator.free(sql);
+
+        if (wait) return self.execSync(sql);
+        self.execAsync(sql);
+        return true;
+    }
+
+    pub fn restoreCheckpointBackupToFile(self: *const Turso, path: [*:0]const u8) bool {
+        const sql =
+            \\{"requests": [{"type": "execute", "stmt": {"sql": "SELECT byte_len, checksum, data_base64 FROM checkpoint_backups WHERE id = 1"}}]}
+        ;
+        const resp = self.execSyncRead(sql) orelse return false;
+        defer resp.deinit();
+        if (std.mem.indexOf(u8, resp.body, "\"rows\":[]") != null) return false;
+
+        const expected_len = parseFirstValueInt(resp.body) orelse return false;
+        if (expected_len == 0) return false;
+
+        const checksum_text = parseValueStringAlloc(self.allocator, resp.body, 1) orelse return false;
+        defer self.allocator.free(checksum_text);
+        const expected_checksum = std.fmt.parseInt(u64, checksum_text, 16) catch return false;
+
+        const encoded = parseValueStringAlloc(self.allocator, resp.body, 2) orelse return false;
+        defer self.allocator.free(encoded);
+
+        const decoded_len = std.base64.standard.Decoder.calcSizeForSlice(encoded) catch return false;
+        if (decoded_len != expected_len) return false;
+
+        const decoded = self.allocator.alloc(u8, decoded_len) catch return false;
+        defer self.allocator.free(decoded);
+        std.base64.standard.Decoder.decode(decoded, encoded) catch return false;
+        if (std.hash.Wyhash.hash(0, decoded) != expected_checksum) return false;
+
+        return writeFile(path, decoded);
     }
 
     // === Double-Entry Accounting (TigerBeetle-inspired) ===
@@ -469,6 +523,26 @@ pub const Turso = struct {
             return std.fmt.parseInt(u32, r[pos..end], 10) catch null;
         }
     }
+
+    pub fn parseValueStringAlloc(allocator: std.mem.Allocator, json: []const u8, value_index: usize) ?[]u8 {
+        const vkey = "\"value\":";
+        var search_pos: usize = 0;
+        var seen: usize = 0;
+        while (search_pos < json.len) {
+            const rel = std.mem.indexOf(u8, json[search_pos..], vkey) orelse return null;
+            var pos = search_pos + rel + vkey.len;
+            if (seen == value_index) {
+                if (pos >= json.len or json[pos] != '"') return null;
+                pos += 1;
+                const end = std.mem.indexOf(u8, json[pos..], "\"") orelse return null;
+                return allocator.dupe(u8, json[pos..][0..end]) catch null;
+            }
+            seen += 1;
+            search_pos = pos;
+        }
+        return null;
+    }
+
     // --- Internal helpers ---
 
     fn execSync(self: *const Turso, json_body: []const u8) bool {
@@ -496,16 +570,19 @@ pub const Turso = struct {
     fn execAsync(self: *const Turso, json_body: []const u8) void {
         const Context = struct {
             turso: *const Turso,
-            body: [4096]u8,
-            body_len: usize,
+            body: []u8,
         };
 
         var ctx = self.allocator.create(Context) catch return;
         ctx.turso = self;
-        ctx.body_len = json_body.len;
-        @memcpy(ctx.body[0..json_body.len], json_body);
+        ctx.body = self.allocator.alloc(u8, json_body.len) catch {
+            self.allocator.destroy(ctx);
+            return;
+        };
+        @memcpy(ctx.body, json_body);
 
         const thread = std.Thread.spawn(.{}, asyncWorker, .{ ctx, self.allocator }) catch {
+            self.allocator.free(ctx.body);
             self.allocator.destroy(ctx);
             return;
         };
@@ -513,10 +590,12 @@ pub const Turso = struct {
     }
 
     fn asyncWorker(ctx: anytype, allocator: std.mem.Allocator) void {
-        defer allocator.destroy(ctx);
+        defer {
+            allocator.free(ctx.body);
+            allocator.destroy(ctx);
+        }
         const turso: *const Turso = ctx.turso;
-        const body = ctx.body[0..ctx.body_len];
-        _ = turso.execSync(body);
+        _ = turso.execSync(ctx.body);
     }
 
     pub fn parseFirstValueFloat(r: []const u8) ?f64 {
@@ -551,3 +630,25 @@ pub const Turso = struct {
         }
     }
 };
+
+fn readFileAlloc(allocator: std.mem.Allocator, path: [*:0]const u8) ?[]u8 {
+    const fp = fopen(path, "rb") orelse return null;
+    defer _ = fclose(fp);
+
+    if (fseek(fp, 0, 2) != 0) return null;
+    const size_raw = ftell(fp);
+    if (size_raw < 0) return null;
+    if (fseek(fp, 0, 0) != 0) return null;
+
+    const size: usize = @intCast(size_raw);
+    const bytes = allocator.alloc(u8, size) catch return null;
+    errdefer allocator.free(bytes);
+    if (fread(bytes.ptr, 1, size, fp) != size) return null;
+    return bytes;
+}
+
+fn writeFile(path: [*:0]const u8, bytes: []const u8) bool {
+    const fp = fopen(path, "wb") orelse return false;
+    defer _ = fclose(fp);
+    return fwrite(bytes.ptr, 1, bytes.len, fp) == bytes.len;
+}


### PR DESCRIPTION
## Summary
- add atomic live checkpoint saves via `dctrading.checkpoint.tmp` before replacing `dctrading.checkpoint`
- keep rotated local checkpoint backups (`dctrading.checkpoint.bak.N`) with configurable `CHECKPOINT_BACKUP_RETENTION`
- add Turso remote checkpoint snapshots in `checkpoint_backups`, controlled by `CHECKPOINT_REMOTE_BACKUP_INTERVAL`
- store and verify a checksum for Turso checkpoint snapshots before restore
- restore startup state in order: primary checkpoint, local backups, Turso remote snapshot, then fresh bootstrap
- surface checkpoint health in `bot_status.checkpoint_health` and `bot_status.checkpoint_error`
- send Telegram/ntfy checkpoint warnings when checkpoint health enters a degraded state
- show checkpoint warnings in Neko Dashboard and Settings status cards
- update switch/nuke scripts so checkpoint primary, local backups, and Turso snapshots move/reset consistently

## Behavior
Live mode continues saving the local checkpoint at the existing cadence. Each save now writes a temporary checkpoint first, rotates the previous primary checkpoint into local backups, then atomically renames the temp file into place.

When Turso is configured, the bot also stores the latest checkpoint as a base64 snapshot in `checkpoint_backups` every `CHECKPOINT_REMOTE_BACKUP_INTERVAL` seconds, defaulting to one hour, and once more on clean shutdown. The snapshot includes byte length, tick count, and a checksum. Startup only restores a Turso snapshot if the decoded length and checksum match.

If local checkpoint save fails, remote backup fails, or startup has to restore from Turso, the bot updates checkpoint health in `bot_status` and sends a warning notification once per degraded state. Neko reads those fields and displays the warning inline in the bot status cards.

`switch-to-gcp.sh` and `switch-to-local.sh` now copy the checkpoint primary plus `dctrading.checkpoint.bak.*` files and ignore `dctrading.checkpoint.tmp`. `nuke.sh` now removes checkpoint primary/backups/temp files and drops current Turso state tables (`transfers`, `accounts`, `equity_log`, `bot_status`, `checkpoint_backups`) plus legacy tables.

## Config
- `CHECKPOINT_BACKUP_RETENTION=5` by default; set `0` to disable local backup rotation
- `CHECKPOINT_REMOTE_BACKUP_INTERVAL=3600` by default; set `0` to disable Turso checkpoint snapshots

## Tests
- `git diff --check`
- `bash -n services/dctrading-bot/scripts/switch-to-gcp.sh && bash -n services/dctrading-bot/scripts/switch-to-local.sh && bash -n services/dctrading-bot/scripts/nuke.sh`
- `zig build -Doptimize=ReleaseFast`
- `zig build test`
- direct dctrading test binary: all 170 tests passed
- `moon run dctrading-bot:test`
- `moon run neko-trade:build`
- `xcodebuild test -project DCTradingViewer.xcodeproj -scheme DCTradingViewerAccountingTests -destination 'platform=macOS'`
  - 8 tests passed

Closes #454


