### PR TITLE
Add resource monitoring and dashboard status for DCTrading

### DIFF
--- a/apps/neko-trade/AGENTS.md
+++ b/apps/neko-trade/AGENTS.md
@@ -10,7 +10,7 @@ SwiftUI dashboard app for the DCTrading bot. Displays bot status, equity, trades
 
 ### Views (`Views/`)
 - `ContentView.swift` — Tab container: Dashboard, Ledger, Equity, Trades, Settings.
-- `DashboardView.swift` — Bot status, regime (BULL=green, SIDE=orange, BEAR=red), managed equity from app-managed BTC/BNB quantities marked at Binance spot, realized P&L, unrealized P&L, active-symbol price from Binance. Auto-refreshes every 30s.
+- `DashboardView.swift` — Bot status, resource health, regime (BULL=green, SIDE=orange, BEAR=red), managed equity from app-managed BTC/BNB quantities marked at Binance spot, realized P&L, unrealized P&L, active-symbol price from Binance. Auto-refreshes every 30s.
 - `LedgerView.swift` — Transfer ledger with cash balance summary, BNB allocation top-up, and running balance per entry.
 - `EquityChartView.swift` — Equity over time using Swift Charts.
 - `TradeHistoryView.swift` — Buy/sell transfers from double-entry ledger, Alpaca position, active-symbol price chart with trade markers.
@@ -27,6 +27,7 @@ SwiftUI dashboard app for the DCTrading bot. Displays bot status, equity, trades
 ### Key Patterns
 - **Alpaca as position source of truth**: Open position qty and entry price come from Alpaca, not Turso.
 - **Active symbol from bot_status**: `trading_symbol`, `base_asset`, `quote_asset`, and `mark_symbol` drive labels, quote-currency formatting, and Binance price lookups. Old databases fall back to `BTC/USD`.
+- **Resource status from bot_status**: `resource_health`, `resource_error`, and latest `resource_*` metrics are shown in the dashboard only when degraded. Resource issues are app-visible status, not Telegram/ntfy notifications.
 - **Price from Binance**: Free API, avoids unnecessary Turso reads. `BTC/USD` mode marks with `BTCUSDT`; BNB is marked with `BNBUSDT` and treated as USD-equivalent in USD mode.
 - **Realized PnL formula**: `(cash_balance + btc_balance + bnb_balance) - total_deposits`; transfer amounts are historical quote-currency values, while native BTC/BNB fee quantities live in transfer `size`.
 - **Estimated equity/PnL formula**: `cash_balance + managed_btc_qty * active mark price + managed_bnb_qty * BNBUSDT`; managed quantities are derived from posted transfer `size`, so exchange assets outside bot-managed transfers are ignored.

--- a/apps/neko-trade/Sources/DCTradingViewer/Models/Models.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Models/Models.swift
@@ -207,6 +207,15 @@ struct BotStatus {
     let markSymbol: String
     let checkpointHealth: String
     let checkpointError: String
+    let resourceHealth: String
+    let resourceError: String
+    let resourceRssMb: Double
+    let resourceDiskFreeMb: Double
+    let resourceDiskUsedPct: Double
+    let resourceFeedGapSec: Double
+    let resourceWsLagSec: Double
+    let resourceHttpErrors: Int
+    let resourceHttpMaxMs: Double
 
     var symbolMetadata: SymbolMetadata {
         SymbolMetadata(
@@ -223,6 +232,10 @@ struct BotStatus {
 
     var checkpointNeedsAttention: Bool {
         !checkpointHealth.isEmpty && checkpointHealth != "OK"
+    }
+
+    var resourceNeedsAttention: Bool {
+        !resourceHealth.isEmpty && resourceHealth != "OK"
     }
 
     var uptimeDuration: TimeInterval {

--- a/apps/neko-trade/Sources/DCTradingViewer/Services/TursoClient.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Services/TursoClient.swift
@@ -279,7 +279,16 @@ final class TursoClient {
             quoteAsset: getOptionalString(row, result.cols, "quote_asset") ?? "",
             markSymbol: getOptionalString(row, result.cols, "mark_symbol") ?? "",
             checkpointHealth: getOptionalString(row, result.cols, "checkpoint_health") ?? "OK",
-            checkpointError: getOptionalString(row, result.cols, "checkpoint_error") ?? ""
+            checkpointError: getOptionalString(row, result.cols, "checkpoint_error") ?? "",
+            resourceHealth: getOptionalString(row, result.cols, "resource_health") ?? "OK",
+            resourceError: getOptionalString(row, result.cols, "resource_error") ?? "",
+            resourceRssMb: getDouble(row, result.cols, "resource_rss_mb"),
+            resourceDiskFreeMb: getDouble(row, result.cols, "resource_disk_free_mb"),
+            resourceDiskUsedPct: getDouble(row, result.cols, "resource_disk_used_pct"),
+            resourceFeedGapSec: getDouble(row, result.cols, "resource_feed_gap_sec"),
+            resourceWsLagSec: getDouble(row, result.cols, "resource_ws_lag_sec"),
+            resourceHttpErrors: getInt(row, result.cols, "resource_http_errors"),
+            resourceHttpMaxMs: getDouble(row, result.cols, "resource_http_max_ms")
         )
     }
 

--- a/apps/neko-trade/Sources/DCTradingViewer/Views/ContentView.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Views/ContentView.swift
@@ -57,7 +57,9 @@ struct ContentView: View {
     private var iOSLayout: some View {
         TabView(selection: $selectedTab) {
             NavigationStack {
-                DashboardView(settings: settings)
+                DashboardView(settings: settings) {
+                    selectedTab = .settings
+                }
             }
             .tabItem {
                 Label(AppTab.dashboard.rawValue, systemImage: AppTab.dashboard.icon)
@@ -105,7 +107,9 @@ struct ContentView: View {
     private func detailView(for tab: AppTab) -> some View {
         switch tab {
         case .dashboard:
-            DashboardView(settings: settings)
+            DashboardView(settings: settings) {
+                selectedTab = .settings
+            }
         case .equity:
             EquityChartView(settings: settings)
         case .trades:

--- a/apps/neko-trade/Sources/DCTradingViewer/Views/DashboardView.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Views/DashboardView.swift
@@ -3,6 +3,7 @@ import Charts
 
 struct DashboardView: View {
     @ObservedObject var settings: AppSettings
+    var openSettings: () -> Void = {}
     @State private var openPosition: Position?
     @State private var latestEquity: EquityLog?
     @State private var botStatus: BotStatus?
@@ -53,7 +54,9 @@ struct DashboardView: View {
     @ViewBuilder
     private var dashboardContent: some View {
         LazyVStack(spacing: 16) {
-            // Bot status indicator
+            if let bs = botStatus, botNeedsAttention(bs) {
+                botWarningButton(bs)
+            }
 
             // Regime + Equity header
             if let eq = latestEquity {
@@ -158,138 +161,60 @@ struct DashboardView: View {
         }
     }
 
-    private func botStatusCard(_ bs: BotStatus) -> some View {
-        let statusColor: Color = bs.isLive ? .green : .red
-        let statusText = bs.isLive ? "LIVE" : "OFFLINE"
-
-        return VStack(spacing: 0) {
-            // Main status row
-            HStack(spacing: 14) {
-                // Pulsing status dot
-                ZStack {
-                    Circle()
-                        .fill(statusColor.opacity(0.25))
-                        .frame(width: 32, height: 32)
-                    Circle()
-                        .fill(statusColor)
-                        .frame(width: 14, height: 14)
-                        .shadow(color: statusColor.opacity(0.8), radius: 8)
-                }
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(statusText)
-                        .font(.system(.title2, design: .monospaced, weight: .heavy))
-                        .foregroundStyle(statusColor)
-                    Text("v\(bs.version)")
-                        .font(.system(.caption2, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer()
-
-                VStack(alignment: .trailing, spacing: 2) {
-                    Text("UPTIME")
-                        .font(.system(.caption2, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                    Text(bs.formattedUptime)
-                        .font(.system(.body, design: .monospaced, weight: .semibold))
-                }
-            }
-            .padding()
-
-            Divider()
-                .overlay(statusColor.opacity(0.2))
-
-            // Detail row
-            HStack {
-                HStack(spacing: 6) {
-                    Image(systemName: "clock.arrow.circlepath")
-                        .font(.system(.caption2, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                    Text("Last tick: \(bs.lastTickRelative)")
-                        .font(.system(.caption, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-                HStack(spacing: 6) {
-                    Image(systemName: "number")
-                        .font(.system(.caption2, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                    Text("\(bs.tickCount) ticks")
-                        .font(.system(.caption, design: .monospaced))
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .padding(.horizontal)
-            .padding(.vertical, 10)
-
-            if bs.checkpointNeedsAttention {
-                Divider()
-                    .overlay(Color.orange.opacity(0.25))
-
-                HStack(spacing: 8) {
-                    Image(systemName: "externaldrive.trianglebadge.exclamationmark")
-                        .font(.system(.caption, design: .monospaced, weight: .semibold))
-                        .foregroundStyle(.orange)
-                    Text(bs.checkpointHealth)
-                        .font(.system(.caption, design: .monospaced, weight: .semibold))
-                        .foregroundStyle(.orange)
-                    if !bs.checkpointError.isEmpty {
-                        Text(bs.checkpointError)
-                            .font(.system(.caption2, design: .monospaced))
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                    }
-                    Spacer()
-                }
-                .padding(.horizontal)
-                .padding(.vertical, 10)
-            }
-
-            resourceStatusRow(bs)
-        }
-        .background {
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(.ultraThinMaterial)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .strokeBorder(statusColor.opacity(0.4), lineWidth: 1.5)
-                )
-                .shadow(color: statusColor.opacity(0.15), radius: 12, y: 4)
-        }
+    private func botNeedsAttention(_ bs: BotStatus) -> Bool {
+        !bs.isLive || bs.checkpointNeedsAttention || bs.resourceNeedsAttention
     }
 
-    private func resourceStatusRow(_ bs: BotStatus) -> some View {
-        let resourceColor: Color = bs.resourceNeedsAttention ? .yellow : .green
-        let detail = bs.resourceError.isEmpty ? "OK" : bs.resourceError
+    private func botWarningButton(_ bs: BotStatus) -> some View {
+        let issues = botWarningIssues(bs)
 
-        return VStack(alignment: .leading, spacing: 6) {
-            Divider()
-                .overlay(resourceColor.opacity(0.25))
+        return Button(action: openSettings) {
+            HStack(spacing: 12) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(.title3, design: .monospaced, weight: .semibold))
+                    .foregroundStyle(.orange)
 
-            HStack(spacing: 8) {
-                Image(systemName: "gauge")
-                    .font(.system(.caption, design: .monospaced, weight: .semibold))
-                    .foregroundStyle(resourceColor)
-                Text("RESOURCE \(bs.resourceHealth.isEmpty ? "OK" : bs.resourceHealth)")
-                    .font(.system(.caption, design: .monospaced, weight: .semibold))
-                    .foregroundStyle(resourceColor)
-                Text(detail)
-                    .font(.system(.caption2, design: .monospaced))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Bot needs attention")
+                        .font(.system(.body, design: .monospaced, weight: .semibold))
+                        .foregroundStyle(.primary)
+                    Text(issues)
+                        .font(.system(.caption, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
                 Spacer()
-            }
-            .padding(.horizontal)
 
-            Text("disk \(Int(bs.resourceDiskFreeMb))MB free / \(String(format: "%.1f", bs.resourceDiskUsedPct))% used · rss \(String(format: "%.1f", bs.resourceRssMb))MB · gap \(Int(bs.resourceFeedGapSec))s · lag \(Int(bs.resourceWsLagSec))s · http \(bs.resourceHttpErrors) err / \(Int(bs.resourceHttpMaxMs))ms")
-                .font(.system(.caption2, design: .monospaced))
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
-                .padding(.horizontal)
+                Image(systemName: "gearshape")
+                    .font(.system(.body, design: .monospaced, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .padding()
+            .background {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(.orange.opacity(0.12))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .strokeBorder(.orange.opacity(0.35), lineWidth: 1)
+                    )
+            }
         }
-        .padding(.vertical, 10)
+        .buttonStyle(.plain)
+    }
+
+    private func botWarningIssues(_ bs: BotStatus) -> String {
+        var issues: [String] = []
+        if !bs.isLive {
+            issues.append("offline")
+        }
+        if bs.checkpointNeedsAttention {
+            issues.append("checkpoint \(bs.checkpointHealth)")
+        }
+        if bs.resourceNeedsAttention {
+            issues.append("resource \(bs.resourceHealth)")
+        }
+        return issues.joined(separator: " · ")
     }
 
     private func statCard(title: String, value: String, icon: String, color: Color) -> some View {

--- a/apps/neko-trade/Sources/DCTradingViewer/Views/DashboardView.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Views/DashboardView.swift
@@ -245,6 +245,8 @@ struct DashboardView: View {
                 .padding(.horizontal)
                 .padding(.vertical, 10)
             }
+
+            resourceStatusRow(bs)
         }
         .background {
             RoundedRectangle(cornerRadius: 12, style: .continuous)
@@ -255,6 +257,39 @@ struct DashboardView: View {
                 )
                 .shadow(color: statusColor.opacity(0.15), radius: 12, y: 4)
         }
+    }
+
+    private func resourceStatusRow(_ bs: BotStatus) -> some View {
+        let resourceColor: Color = bs.resourceNeedsAttention ? .yellow : .green
+        let detail = bs.resourceError.isEmpty ? "OK" : bs.resourceError
+
+        return VStack(alignment: .leading, spacing: 6) {
+            Divider()
+                .overlay(resourceColor.opacity(0.25))
+
+            HStack(spacing: 8) {
+                Image(systemName: "gauge")
+                    .font(.system(.caption, design: .monospaced, weight: .semibold))
+                    .foregroundStyle(resourceColor)
+                Text("RESOURCE \(bs.resourceHealth.isEmpty ? "OK" : bs.resourceHealth)")
+                    .font(.system(.caption, design: .monospaced, weight: .semibold))
+                    .foregroundStyle(resourceColor)
+                Text(detail)
+                    .font(.system(.caption2, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                Spacer()
+            }
+            .padding(.horizontal)
+
+            Text("disk \(Int(bs.resourceDiskFreeMb))MB free / \(String(format: "%.1f", bs.resourceDiskUsedPct))% used · rss \(String(format: "%.1f", bs.resourceRssMb))MB · gap \(Int(bs.resourceFeedGapSec))s · lag \(Int(bs.resourceWsLagSec))s · http \(bs.resourceHttpErrors) err / \(Int(bs.resourceHttpMaxMs))ms")
+                .font(.system(.caption2, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+                .padding(.horizontal)
+        }
+        .padding(.vertical, 10)
     }
 
     private func statCard(title: String, value: String, icon: String, color: Color) -> some View {

--- a/apps/neko-trade/Sources/DCTradingViewer/Views/SettingsView.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Views/SettingsView.swift
@@ -123,6 +123,8 @@ struct SettingsView: View {
                         }
                         .padding(.horizontal)
                         .padding(.vertical, 10)
+
+                        resourceStatusRow(bs)
                     }
                     .background {
                         RoundedRectangle(cornerRadius: 12, style: .continuous)
@@ -255,6 +257,66 @@ struct SettingsView: View {
             wasLive = isLive
         } catch {
             // Silently fail, status will remain nil or stale
+        }
+    }
+
+    private func resourceStatusRow(_ bs: BotStatus) -> some View {
+        let resourceColor: Color = bs.resourceNeedsAttention ? .yellow : .green
+        let detail = bs.resourceError.isEmpty ? "OK" : bs.resourceError
+
+        let columns = [GridItem(.adaptive(minimum: 130), alignment: .leading)]
+
+        return VStack(alignment: .leading, spacing: 10) {
+            Divider()
+                .overlay(resourceColor.opacity(0.25))
+
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "gauge")
+                    .font(.system(.body, design: .monospaced, weight: .semibold))
+                    .foregroundStyle(resourceColor)
+                Text("RESOURCE \(bs.resourceHealth.isEmpty ? "OK" : bs.resourceHealth)")
+                    .font(.system(.body, design: .monospaced, weight: .semibold))
+                    .foregroundStyle(resourceColor)
+                Spacer()
+            }
+            .padding(.horizontal)
+
+            Text(detail)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+                .padding(.horizontal)
+
+            LazyVGrid(columns: columns, alignment: .leading, spacing: 8) {
+                resourceMetric("Disk free", "\(Int(bs.resourceDiskFreeMb)) MB")
+                resourceMetric("Disk used", "\(String(format: "%.1f", bs.resourceDiskUsedPct))%")
+                resourceMetric("Memory", "\(String(format: "%.1f", bs.resourceRssMb)) MB")
+                resourceMetric("Feed gap", "\(Int(bs.resourceFeedGapSec))s")
+                resourceMetric("WS lag", "\(Int(bs.resourceWsLagSec))s")
+                resourceMetric("HTTP", "\(bs.resourceHttpErrors) err / \(Int(bs.resourceHttpMaxMs))ms")
+            }
+            .padding(.horizontal)
+        }
+        .padding(.vertical, 10)
+    }
+
+    private func resourceMetric(_ title: String, _ value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title.uppercased())
+                .font(.system(.caption2, design: .monospaced, weight: .medium))
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.system(.caption, design: .monospaced, weight: .semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 6)
+        .padding(.horizontal, 8)
+        .background {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(.secondary.opacity(0.08))
         }
     }
 

--- a/services/dctrading-bot/AGENTS.md
+++ b/services/dctrading-bot/AGENTS.md
@@ -12,15 +12,16 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 - `dc_detector.zig` — Streaming DC event detector. Emits UP/DOWN events when price reverses by λ threshold.
 - `exchange.zig` — Exchange interface (vtable pattern): sync `buy()`/`sell()`, async `submitOrder()`/`checkOrder()`/`cancelOrder()`, `getPosition()`. Shared types: `OrderFill`, `PendingOrder`, `OrderStatus`, `CancelResult`, `Position`, `Side`.
 - `alpaca.zig` — Alpaca paper trading, implements Exchange interface. Sync orders (buy/sell with fill polling), async orders (submitOrderAsync/checkOrderStatus/cancelOrderAsync), position queries. Uses `HttpClient`.
-- `turso.zig` — Turso/libsql HTTP client. Tables: `accounts`, `transfers` (with `order_id` column), `equity_log`, `bot_status`. Two-phase transfers (pending/posted/voided, append-only). Async writes via detached threads, sync reads for startup.
+- `turso.zig` — Turso/libsql HTTP client. Tables: `accounts`, `transfers` (with `order_id` column), `equity_log`, `bot_status`, `resource_log`. Two-phase transfers (pending/posted/voided, append-only). Async writes via detached threads, sync reads for startup.
 - `telegram.zig` — Telegram + ntfy notifications. Async sends via threads, curl fallback for shutdown reliability.
-- `http_client.zig` — Thread-safe wrapper around `std.http.Client`. Mutex-protected POST/GET/DELETE with auto-retry on stale connections.
+- `http_client.zig` — Thread-safe wrapper around `std.http.Client`. Mutex-protected POST/GET/DELETE with auto-retry on stale connections and per-window request/error/retry/latency metrics.
+- `resource_monitor.zig` — Resource health sampler/classifier. Tracks process RSS/CPU, disk free/used, WebSocket feed gaps/lag/reconnects, and HTTP metrics for app-visible status.
 - `types.zig` — Core types: `Tick`, `Trade`, `DCEvent`, `Direction`.
 - `live_loop.zig` — Extracted core order flow logic: pending order tracking, trailing stop, strategy signals, buy/sell submission, capital_reserved, and ledger vtable. Shared by `runLive()` and integration tests.
 - `tick_source.zig` — `TickSource` vtable interface + `SimFeed` (replays ticks from array). For testing.
 - `sim_exchange.zig` — `SimExchange` implementing Exchange vtable with configurable fill delay, slippage, partial fills, cancel races, failure injection, order log. For testing.
 - `integration_tests.zig` — 32 end-to-end scenarios using LiveLoop + SimExchange + mock ledger.
-- `tests.zig` — 179 tests covering DC detector, strategy, checkpoint, regime transitions, JSON parsing, capital accounting, double-entry transfers, exchange interface, funding rate filter, non-blocking order flow, capital_reserved, integration scenarios.
+- `tests.zig` — 182 tests covering DC detector, strategy, checkpoint, regime transitions, JSON parsing, capital accounting, double-entry transfers, exchange interface, funding rate filter, non-blocking order flow, capital_reserved, resource monitoring, integration scenarios.
 - CLI `checkpoint:migrate [path] [backups]` migrates checkpoint primary/backups offline to the current DCTRADE5 layout after writing `.pre-migrate` copies.
 
 ### Scripts (`scripts/`)
@@ -51,6 +52,14 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 | `CHECKPOINT_PATH` | No | main.zig (default: dctrading.checkpoint in cwd) |
 | `CHECKPOINT_BACKUP_RETENTION` | No | main.zig (default: 5) |
 | `CHECKPOINT_REMOTE_BACKUP_INTERVAL` | No | main.zig (default: 3600s, 0 disables) |
+| `RESOURCE_LOG_INTERVAL_SEC` | No | main.zig/resource_monitor.zig (default: 300s, 0 disables) |
+| `RESOURCE_DISK_PATH` | No | resource_monitor.zig (default: current working directory) |
+| `RESOURCE_RSS_WARN_MB` | No | resource_monitor.zig (default: 512) |
+| `RESOURCE_DISK_FREE_WARN_MB` | No | resource_monitor.zig (default: 1024) |
+| `RESOURCE_DISK_USED_WARN_PCT` | No | resource_monitor.zig (default: 90) |
+| `RESOURCE_FEED_GAP_WARN_SEC` | No | resource_monitor.zig (default: 180) |
+| `RESOURCE_WS_LAG_WARN_SEC` | No | resource_monitor.zig (default: 180) |
+| `RESOURCE_HTTP_LATENCY_WARN_MS` | No | resource_monitor.zig (default: 5000) |
 | `BINANCE_WS_HOST` | No | feed.zig (default: stream.binance.com) |
 | `BINANCE_API_HOST` | No | feed.zig (default: api.binance.com) |
 | `BOT_INSTANCE` | No | main.zig (default: "local") |
@@ -62,13 +71,14 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 - `transfers` — Immutable append-only transfer log. Two-phase (pending/posted/voided). Codes: 1=deposit, 2=buy, 3=sell, 4=fee, 5=pnl. Atomic BEGIN/COMMIT pipelines.
 - Fee routing: adapter-provided `commission_asset` routes fees to the paying asset account (`USD`/`USDT` → cash, `BTC` → btc_position, `BNB` → bnb), even when commission is zero. Transfer `amount` is historical quote-currency value at fill time; native fee quantity is stored in transfer `size`, with the fill-time asset quote valuation rate in `price`. `strategy.size` remains whatever the exchange adapter reports as fill quantity. `fee_pct` is for backtest/simulation estimates and legacy fills with no commission metadata, not for Alpaca paper fills.
 - `equity_log` — Periodic snapshots (every 5 min + on trades): capital, equity, unrealized, regime, price.
-- `bot_status` — Single row (id=1): regime, position, equity, version (DCTRADE5@instance), active symbol metadata, and checkpoint health/error.
+- `bot_status` — Single row (id=1): regime, position, equity, version (DCTRADE5@instance), active symbol metadata, checkpoint health/error, and latest resource health/metrics for Neko.
+- `resource_log` — Periodic process/feed/HTTP resource snapshots used for dashboard status and diagnostics. Resource degradation is app-visible only; Telegram/ntfy stays reserved for trading, checkpoint, funding, startup/shutdown events.
 - `checkpoint_backups` — Single remote checkpoint snapshot (id=1): base64-encoded DCTRADE5 checkpoint, byte length, checksum, tick count, and update time. Used only if local primary/backups cannot be loaded.
 ### Build
 ```bash
 zig build -Doptimize=ReleaseFast              # macOS arm64
 zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux  # GCP
-zig build test                                 # 179 tests
+zig build test                                 # 182 tests
 ./zig-out/bin/dctrading checkpoint:migrate dctrading.checkpoint 5
 ```
 
@@ -78,7 +88,7 @@ zig build test                                 # 179 tests
 3. Stream: Binance WebSocket → downsample to 1-min → `LiveLoop.processTick()`
 4. On BUY signal: `submitOrder()` (non-blocking) → pending transfer in Turso → `checkOrder()` each tick → fill → post transfer
 5. On SELL signal: cancel pending buys → `submitOrder()` sell → pending transfer → fill → post transfer + PnL
-6. Every 5 min: log equity to Turso, upsert bot_status, check deposits
+6. Every 5 min: log equity/resource snapshots to Turso, upsert bot_status, check deposits
 7. Hourly: refresh cached funding rate before strategy-minute processing; notify only when Binance publishes a new funding print
 8. Shutdown (SIGINT/SIGTERM): save checkpoint with backup rotation, log to Turso, notify via curl fallback
 

--- a/services/dctrading-bot/README.md
+++ b/services/dctrading-bot/README.md
@@ -44,9 +44,10 @@ Single static binary. No Python, no Docker, no runtime dependencies (except curl
 | `integration_tests.zig` | End-to-end LiveLoop scenarios using SimExchange and mock ledger |
 | `turso.zig` | Turso DB client (equity log, positions, bot status, two-phase ledger) |
 | `telegram.zig` | Telegram + ntfy push notifications |
-| `http_client.zig` | Shared HTTP client (std.http.Client wrapper) |
+| `http_client.zig` | Shared HTTP client (std.http.Client wrapper + request metrics) |
+| `resource_monitor.zig` | Process, disk, feed, and HTTP resource health snapshots |
 | `types.zig` | Tick, Trade, DC event types |
-| `tests.zig` | 179 tests |
+| `tests.zig` | 182 tests |
 
 ## Setup
 
@@ -93,6 +94,16 @@ export CHECKPOINT_PATH=dctrading.checkpoint
 
 # Turso remote checkpoint backup interval in seconds (default: 3600; 0 disables)
 export CHECKPOINT_REMOTE_BACKUP_INTERVAL=3600
+
+# App-visible resource monitoring (defaults shown; 0 interval disables)
+export RESOURCE_LOG_INTERVAL_SEC=300
+export RESOURCE_DISK_PATH=.
+export RESOURCE_RSS_WARN_MB=512
+export RESOURCE_DISK_FREE_WARN_MB=1024
+export RESOURCE_DISK_USED_WARN_PCT=90
+export RESOURCE_FEED_GAP_WARN_SEC=180
+export RESOURCE_WS_LAG_WARN_SEC=180
+export RESOURCE_HTTP_LATENCY_WARN_MS=5000
 
 # Instance tracking
 export BOT_INSTANCE=local
@@ -180,6 +191,14 @@ Binary checkpoint (DCTRADE5) saves full strategy state every minute:
 - If any local checkpoint file exists but none can be loaded and Turso restore also fails, live mode refuses to bootstrap so it cannot overwrite possibly recoverable checkpoint state
 - Checkpoint problems are surfaced in `bot_status.checkpoint_health` and
   `bot_status.checkpoint_error`; Telegram/ntfy sends a warning when health first enters a degraded state
+
+## Resource Monitoring
+
+Live mode writes resource snapshots to Turso every five minutes by default:
+- `resource_log` stores RSS, CPU seconds, disk free/used, ticks/min, feed gap, WebSocket lag, reconnect count, and HTTP request/error/retry/latency metrics
+- `bot_status.resource_*` columns expose the current classified health and latest key metrics for Neko Trade
+- Disk pressure is classified before secondary warnings (`DISK_LOW`, then `DISK_HIGH`)
+- Resource warnings are intentionally not sent to Telegram/ntfy; those channels stay reserved for trading, checkpoint, funding, startup, and shutdown events
 
 ## Companion Projects
 

--- a/services/dctrading-bot/src/http_client.zig
+++ b/services/dctrading-bot/src/http_client.zig
@@ -9,12 +9,19 @@ const Io = std.Io;
 pub const HttpClient = struct {
     client: http.Client,
     allocator: std.mem.Allocator,
+    io: Io,
     mutex: std.atomic.Mutex = .unlocked,
+    request_count: u64 = 0,
+    error_count: u64 = 0,
+    retry_count: u64 = 0,
+    last_latency_ms: f64 = 0,
+    max_latency_ms: f64 = 0,
 
     pub fn init(allocator: std.mem.Allocator, io: Io) HttpClient {
         return .{
             .client = .{ .allocator = allocator, .io = io },
             .allocator = allocator,
+            .io = io,
         };
     }
 
@@ -37,6 +44,14 @@ pub const HttpClient = struct {
         }
     };
 
+    pub const MetricsSnapshot = struct {
+        requests: u64 = 0,
+        errors: u64 = 0,
+        retries: u64 = 0,
+        last_ms: f64 = 0,
+        max_ms: f64 = 0,
+    };
+
     /// POST JSON to a URL with custom headers. Returns owned response body.
     pub fn post(self: *HttpClient, url: []const u8, headers: []const Header, body: []const u8) !Response {
         return self.doRequest(.POST, url, headers, body, 64 * 1024);
@@ -57,6 +72,27 @@ pub const HttpClient = struct {
         return self.doRequest(.GET, url, headers, null, max_response_bytes);
     }
 
+    pub fn snapshotAndResetMetrics(self: *HttpClient) MetricsSnapshot {
+        while (!self.mutex.tryLock()) {
+            std.atomic.spinLoopHint();
+        }
+        defer self.mutex.unlock();
+
+        const snapshot: MetricsSnapshot = .{
+            .requests = self.request_count,
+            .errors = self.error_count,
+            .retries = self.retry_count,
+            .last_ms = self.last_latency_ms,
+            .max_ms = self.max_latency_ms,
+        };
+        self.request_count = 0;
+        self.error_count = 0;
+        self.retry_count = 0;
+        self.last_latency_ms = 0;
+        self.max_latency_ms = 0;
+        return snapshot;
+    }
+
     fn doRequest(
         self: *HttpClient,
         method: http.Method,
@@ -65,6 +101,7 @@ pub const HttpClient = struct {
         body: ?[]const u8,
         max_response_bytes: usize,
     ) !Response {
+        const start_ms = self.nowMs();
         // Spin-lock: Zig 0.16 atomic.Mutex only has tryLock
         while (!self.mutex.tryLock()) {
             std.atomic.spinLoopHint();
@@ -85,15 +122,31 @@ pub const HttpClient = struct {
         while (attempt < 2) : (attempt += 1) {
             const result = self.doRequestInner(method, uri, extra_headers[0..header_count], body, max_response_bytes);
             if (result) |resp| {
+                self.recordMetrics(start_ms, false, attempt);
                 return resp;
             } else |err| {
                 if (attempt == 0 and err == error.HttpConnectionClosing) {
                     continue; // retry with fresh connection
                 }
+                self.recordMetrics(start_ms, true, attempt);
                 return err;
             }
         }
         unreachable;
+    }
+
+    fn recordMetrics(self: *HttpClient, start_ms: i64, failed: bool, attempt: u32) void {
+        const elapsed_ms = @max(0, self.nowMs() - start_ms);
+        const latency: f64 = @floatFromInt(elapsed_ms);
+        self.request_count += 1;
+        if (failed) self.error_count += 1;
+        if (attempt > 0) self.retry_count += attempt;
+        self.last_latency_ms = latency;
+        if (latency > self.max_latency_ms) self.max_latency_ms = latency;
+    }
+
+    fn nowMs(self: *HttpClient) i64 {
+        return Io.Timestamp.now(self.io, .awake).toMilliseconds();
     }
 
     fn doRequestInner(

--- a/services/dctrading-bot/src/main.zig
+++ b/services/dctrading-bot/src/main.zig
@@ -9,6 +9,7 @@ const http_mod = @import("http_client.zig");
 const turso_mod = @import("turso.zig");
 const live_loop_mod = @import("live_loop.zig");
 const sim_exchange_mod = @import("sim_exchange.zig");
+const resource_monitor = @import("resource_monitor.zig");
 
 const Tick = types.Tick;
 const Trade = types.Trade;
@@ -77,6 +78,11 @@ fn parseEnvU8(name: [*:0]const u8, default_value: u8) u8 {
 fn parseEnvU32(name: [*:0]const u8, default_value: u32) u32 {
     const raw = getenv(name) orelse return default_value;
     return std.fmt.parseInt(u32, std.mem.sliceTo(raw, 0), 10) catch default_value;
+}
+
+fn parseEnvF64(name: [*:0]const u8, default_value: f64) f64 {
+    const raw = getenv(name) orelse return default_value;
+    return std.fmt.parseFloat(f64, std.mem.sliceTo(raw, 0)) catch default_value;
 }
 
 fn parseSymbolInfo(symbol: []const u8) SymbolInfo {
@@ -157,6 +163,16 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
     const checkpoint_interval: u64 = 60; // ~1 hour with 1-min downsampling
     const checkpoint_backup_retention = parseEnvU8("CHECKPOINT_BACKUP_RETENTION", 5);
     const checkpoint_remote_interval = parseEnvU32("CHECKPOINT_REMOTE_BACKUP_INTERVAL", 3600);
+    const resource_interval_sec = parseEnvF64("RESOURCE_LOG_INTERVAL_SEC", 300.0);
+    const resource_disk_path: []const u8 = if (getenv("RESOURCE_DISK_PATH")) |ptr| std.mem.sliceTo(ptr, 0) else ".";
+    const resource_thresholds: resource_monitor.Thresholds = .{
+        .rss_warn_mb = parseEnvF64("RESOURCE_RSS_WARN_MB", 512.0),
+        .disk_free_warn_mb = parseEnvF64("RESOURCE_DISK_FREE_WARN_MB", 1024.0),
+        .disk_used_warn_pct = parseEnvF64("RESOURCE_DISK_USED_WARN_PCT", 90.0),
+        .feed_gap_warn_sec = parseEnvF64("RESOURCE_FEED_GAP_WARN_SEC", 180.0),
+        .ws_lag_warn_sec = parseEnvF64("RESOURCE_WS_LAG_WARN_SEC", 180.0),
+        .http_latency_warn_ms = parseEnvF64("RESOURCE_HTTP_LATENCY_WARN_MS", 5000.0),
+    };
     var last_remote_checkpoint_ts: f64 = 0;
     var checkpoint_health: []const u8 = "OK";
     var checkpoint_error: []const u8 = "";
@@ -170,6 +186,7 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
     std.debug.print("  Strategy: ZI-DCT0 long-only + vol-trail 2%/72h + 60d MA buf=3%\n", .{});
     printCheckpointLocation(checkpoint_path);
     std.debug.print("  Checkpoint: every {d} ticks, backups={d}, remote={d}s\n\n", .{ checkpoint_interval, checkpoint_backup_retention, checkpoint_remote_interval });
+    std.debug.print("  Resource monitor: every {d:.0}s disk={s} warn free<{d:.0}MB used>{d:.0}% rss>{d:.0}MB\n\n", .{ resource_interval_sec, resource_disk_path, resource_thresholds.disk_free_warn_mb, resource_thresholds.disk_used_warn_pct, resource_thresholds.rss_warn_mb });
 
     // Register signal handlers for clean shutdown (SIGINT=2, SIGTERM=15)
     _ = signal(2, &handleSigint); // Ctrl-C / local
@@ -439,6 +456,9 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
     }
     var last_equity_ts: f64 = 0;
     var last_deposit_check: f64 = 0;
+    var last_resource_ts: f64 = 0;
+    var last_resource_tick_ts: f64 = 0;
+    var resource_window: resource_monitor.FeedWindow = .{};
     var known_total_deposits: f64 = if (turso != null) (turso.?.queryTotalDepositsNew() orelse capital) else capital;
     var last_funding_check: f64 = if (initial_funding_fetch_ok) initial_funding_now else 0;
     const uptime_start: f64 = @floatFromInt(time(null));
@@ -480,6 +500,7 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
     while (!shutdown_requested) {
         const tick = feed.nextTick() catch |err| {
             std.debug.print("\n  FEED ERROR: {s}. Reconnecting...\n", .{@errorName(err)});
+            resource_window.reconnect_count += 1;
             _ = usleep(3_000_000); // 3s
             feed.deinit();
             feed = feed_mod.Feed.init(allocator, io, trading_symbol) catch |e| {
@@ -490,6 +511,15 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
         };
         if (tick == null) continue;
         const t = tick.?;
+        resource_window.ticks += 1;
+        if (last_resource_tick_ts > 0) {
+            const feed_gap = t.timestamp - last_resource_tick_ts;
+            if (feed_gap > resource_window.max_gap_sec) resource_window.max_gap_sec = feed_gap;
+        }
+        last_resource_tick_ts = t.timestamp;
+        const tick_wall_now: f64 = @floatFromInt(time(null));
+        const ws_lag = tick_wall_now - t.timestamp;
+        if (ws_lag > resource_window.max_ws_lag_sec) resource_window.max_ws_lag_sec = ws_lag;
 
         // Refresh funding rate before strategy-minute ticks so DC entries use the latest filter value.
         const is_strategy_tick = t.timestamp - loop.last_feed_ts >= 60.0;
@@ -590,6 +620,30 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
                 checkpoint_health = "OK";
                 checkpoint_error = "";
                 last_checkpoint_alert = "";
+            }
+            if (resource_interval_sec > 0 and t.timestamp - last_resource_ts >= resource_interval_sec) {
+                const http_metrics = http.snapshotAndResetMetrics();
+                const resource_sample = resource_monitor.sample(tick_wall_now, uptime_start, resource_interval_sec, resource_disk_path, resource_window, http_metrics);
+                const resource_health = resource_monitor.classify(resource_sample, resource_thresholds);
+                std.debug.print("  [resource] health={s} rss={d:.1}MB disk_free={d:.0}MB disk_used={d:.1}% ticks/min={d:.1} gap={d:.0}s lag={d:.0}s reconnects={d} http={d}/{d} retry={d} max={d:.0}ms\n", .{
+                    resource_health.status,
+                    resource_sample.rss_mb,
+                    resource_sample.disk_free_mb,
+                    resource_sample.disk_used_pct,
+                    resource_sample.ticks_per_min,
+                    resource_sample.feed_gap_sec,
+                    resource_sample.ws_lag_sec,
+                    resource_sample.reconnect_count,
+                    resource_sample.http_errors,
+                    resource_sample.http_requests,
+                    resource_sample.http_retries,
+                    resource_sample.http_max_ms,
+                });
+                if (turso != null) {
+                    turso.?.logResource(resource_sample, resource_health.status, resource_health.detail);
+                }
+                last_resource_ts = t.timestamp;
+                resource_window = .{};
             }
             if (turso != null) {
                 if (checkpoint_saved and checkpoint_remote_interval > 0) {

--- a/services/dctrading-bot/src/resource_monitor.zig
+++ b/services/dctrading-bot/src/resource_monitor.zig
@@ -1,0 +1,156 @@
+const std = @import("std");
+const http_mod = @import("http_client.zig");
+
+extern "c" fn popen(cmd: [*:0]const u8, mode: [*:0]const u8) ?*anyopaque;
+extern "c" fn pclose(fp: *anyopaque) c_int;
+extern "c" fn fread(buf: [*]u8, size: usize, count: usize, fp: *anyopaque) usize;
+extern "c" fn clock() c_long;
+extern "c" fn getpid() c_int;
+
+const CLOCKS_PER_SEC: f64 = 1_000_000.0;
+
+pub const ResourceSample = struct {
+    timestamp: f64,
+    uptime_sec: f64,
+    rss_mb: f64,
+    cpu_sec: f64,
+    disk_free_mb: f64,
+    disk_used_pct: f64,
+    disk_path: []const u8,
+    ticks_per_min: f64,
+    feed_gap_sec: f64,
+    ws_lag_sec: f64,
+    reconnect_count: u32,
+    http_requests: u64,
+    http_errors: u64,
+    http_retries: u64,
+    http_last_ms: f64,
+    http_max_ms: f64,
+};
+
+pub const Thresholds = struct {
+    rss_warn_mb: f64 = 512.0,
+    disk_free_warn_mb: f64 = 1024.0,
+    disk_used_warn_pct: f64 = 90.0,
+    feed_gap_warn_sec: f64 = 180.0,
+    ws_lag_warn_sec: f64 = 180.0,
+    http_latency_warn_ms: f64 = 5000.0,
+};
+
+pub const Health = struct {
+    status: []const u8,
+    detail: []const u8,
+};
+
+pub const FeedWindow = struct {
+    ticks: u32 = 0,
+    max_gap_sec: f64 = 0,
+    max_ws_lag_sec: f64 = 0,
+    reconnect_count: u32 = 0,
+};
+
+pub fn sample(now: f64, uptime_start: f64, interval_sec: f64, disk_path: []const u8, feed: FeedWindow, http: http_mod.HttpClient.MetricsSnapshot) ResourceSample {
+    const disk = sampleDisk(disk_path);
+    const interval_min = if (interval_sec > 0) interval_sec / 60.0 else 5.0;
+    return .{
+        .timestamp = now,
+        .uptime_sec = @max(0, now - uptime_start),
+        .rss_mb = sampleRssMb(),
+        .cpu_sec = sampleCpuSec(),
+        .disk_free_mb = disk.free_mb,
+        .disk_used_pct = disk.used_pct,
+        .disk_path = disk_path,
+        .ticks_per_min = @as(f64, @floatFromInt(feed.ticks)) / interval_min,
+        .feed_gap_sec = feed.max_gap_sec,
+        .ws_lag_sec = feed.max_ws_lag_sec,
+        .reconnect_count = feed.reconnect_count,
+        .http_requests = http.requests,
+        .http_errors = http.errors,
+        .http_retries = http.retries,
+        .http_last_ms = http.last_ms,
+        .http_max_ms = http.max_ms,
+    };
+}
+
+pub fn classify(s: ResourceSample, t: Thresholds) Health {
+    if (s.disk_free_mb > 0 and s.disk_free_mb < t.disk_free_warn_mb) return .{ .status = "DISK_LOW", .detail = "disk_free_mb_below_threshold" };
+    if (s.disk_used_pct >= t.disk_used_warn_pct) return .{ .status = "DISK_HIGH", .detail = "disk_used_pct_above_threshold" };
+    if (s.rss_mb >= t.rss_warn_mb) return .{ .status = "MEMORY_HIGH", .detail = "rss_mb_above_threshold" };
+    if (s.feed_gap_sec >= t.feed_gap_warn_sec) return .{ .status = "FEED_GAP", .detail = "feed_gap_sec_above_threshold" };
+    if (s.ws_lag_sec >= t.ws_lag_warn_sec) return .{ .status = "WS_LAG", .detail = "ws_lag_sec_above_threshold" };
+    if (s.http_max_ms >= t.http_latency_warn_ms) return .{ .status = "HTTP_SLOW", .detail = "http_max_ms_above_threshold" };
+    if (s.http_errors > 0) return .{ .status = "HTTP_ERRORS", .detail = "http_errors_observed" };
+    return .{ .status = "OK", .detail = "" };
+}
+
+fn sampleCpuSec() f64 {
+    const ticks = clock();
+    if (ticks <= 0) return 0;
+    return @as(f64, @floatFromInt(ticks)) / CLOCKS_PER_SEC;
+}
+
+fn sampleRssMb() f64 {
+    if (readProcStatmRssMb()) |rss| return rss;
+    if (readPsRssMb()) |rss| return rss;
+    return 0;
+}
+
+fn readProcStatmRssMb() ?f64 {
+    var cmd_buf: [128]u8 = undefined;
+    const cmd = std.fmt.bufPrintZ(&cmd_buf, "cat /proc/{d}/statm 2>/dev/null", .{getpid()}) catch return null;
+    const fp = popen(cmd, "r") orelse return null;
+    defer _ = pclose(fp);
+    var buf: [128]u8 = undefined;
+    const n = fread(&buf, 1, buf.len - 1, fp);
+    var fields = std.mem.tokenizeScalar(u8, buf[0..n], ' ');
+    _ = fields.next() orelse return null;
+    const rss_pages_txt = fields.next() orelse return null;
+    const rss_pages = std.fmt.parseFloat(f64, rss_pages_txt) catch return null;
+    return rss_pages * 4096.0 / (1024.0 * 1024.0);
+}
+
+fn readPsRssMb() ?f64 {
+    var cmd_buf: [128]u8 = undefined;
+    const cmd = std.fmt.bufPrintZ(&cmd_buf, "ps -o rss= -p {d}", .{getpid()}) catch return null;
+    const fp = popen(cmd, "r") orelse return null;
+    defer _ = pclose(fp);
+
+    var out: [128]u8 = undefined;
+    const n = fread(&out, 1, out.len - 1, fp);
+    const txt = std.mem.trim(u8, out[0..n], " \t\r\n");
+    if (txt.len == 0) return null;
+    const rss_kb = std.fmt.parseFloat(f64, txt) catch return null;
+    return rss_kb / 1024.0;
+}
+
+const DiskSample = struct {
+    free_mb: f64,
+    used_pct: f64,
+};
+
+fn sampleDisk(path: []const u8) DiskSample {
+    var cmd_buf: [512]u8 = undefined;
+    const cmd = std.fmt.bufPrintZ(&cmd_buf, "df -k '{s}'", .{path}) catch return .{ .free_mb = 0, .used_pct = 0 };
+    const fp = popen(cmd, "r") orelse return .{ .free_mb = 0, .used_pct = 0 };
+    defer _ = pclose(fp);
+
+    var out: [1024]u8 = undefined;
+    const n = fread(&out, 1, out.len - 1, fp);
+    return parseDf(out[0..n]) orelse .{ .free_mb = 0, .used_pct = 0 };
+}
+
+pub fn parseDf(output: []const u8) ?DiskSample {
+    var lines = std.mem.splitScalar(u8, output, '\n');
+    _ = lines.next() orelse return null;
+    const data = lines.next() orelse return null;
+    var fields = std.mem.tokenizeAny(u8, data, " \t");
+    _ = fields.next() orelse return null; // filesystem
+    _ = fields.next() orelse return null; // 1K-blocks
+    _ = fields.next() orelse return null; // used
+    const avail_txt = fields.next() orelse return null;
+    const use_pct_txt = fields.next() orelse return null;
+    const avail_kb = std.fmt.parseFloat(f64, avail_txt) catch return null;
+    const pct_txt = std.mem.trim(u8, use_pct_txt, "%");
+    const used_pct = std.fmt.parseFloat(f64, pct_txt) catch return null;
+    return .{ .free_mb = avail_kb / 1024.0, .used_pct = used_pct };
+}

--- a/services/dctrading-bot/src/tests.zig
+++ b/services/dctrading-bot/src/tests.zig
@@ -3,6 +3,7 @@ const testing = std.testing;
 const types = @import("types.zig");
 const dc_mod = @import("dc_detector.zig");
 const strat_mod = @import("strategy.zig");
+const resource_monitor = @import("resource_monitor.zig");
 
 const Tick = types.Tick;
 const DCDetector = dc_mod.DCDetector;
@@ -3363,6 +3364,56 @@ test "capital_reserved: recomputed from pending array on startup" {
     try testing.expectApproxEqAbs(reserved, expected, 0.01);
     // Sell not counted
     try testing.expect(reserved < 95000.0 * 0.1 + 96000.0 * 0.01 + 94000.0 * 0.1);
+}
+
+test "resource_monitor: parses df output" {
+    const output =
+        \\Filesystem     1K-blocks     Used Available Use% Mounted on
+        \\/dev/disk3s1s1 488245288 12345678 123904000 73% /
+        \\
+    ;
+    const sample = resource_monitor.parseDf(output) orelse return error.ExpectedDiskSample;
+    try testing.expectApproxEqAbs(@as(f64, 123904000.0 / 1024.0), sample.free_mb, 0.001);
+    try testing.expectApproxEqAbs(@as(f64, 73.0), sample.used_pct, 0.001);
+}
+
+test "resource_monitor: classifies disk pressure before secondary warnings" {
+    const sample: resource_monitor.ResourceSample = .{
+        .timestamp = 1,
+        .uptime_sec = 1,
+        .rss_mb = 2048,
+        .cpu_sec = 1,
+        .disk_free_mb = 100,
+        .disk_used_pct = 95,
+        .disk_path = ".",
+        .ticks_per_min = 60,
+        .feed_gap_sec = 0,
+        .ws_lag_sec = 0,
+        .reconnect_count = 0,
+        .http_requests = 0,
+        .http_errors = 0,
+        .http_retries = 0,
+        .http_last_ms = 0,
+        .http_max_ms = 0,
+    };
+    const health = resource_monitor.classify(sample, .{});
+    try testing.expectEqualStrings("DISK_LOW", health.status);
+    try testing.expectEqualStrings("disk_free_mb_below_threshold", health.detail);
+}
+
+test "resource_monitor: computes ticks per minute from configured interval" {
+    const sample = resource_monitor.sample(
+        1200,
+        900,
+        120,
+        ".",
+        .{ .ticks = 180 },
+        .{ .requests = 3, .errors = 1, .retries = 1, .last_ms = 25, .max_ms = 50 },
+    );
+    try testing.expectApproxEqAbs(@as(f64, 90.0), sample.ticks_per_min, 0.001);
+    try testing.expectApproxEqAbs(@as(f64, 300.0), sample.uptime_sec, 0.001);
+    try testing.expectEqual(@as(u64, 3), sample.http_requests);
+    try testing.expectEqual(@as(u64, 1), sample.http_errors);
 }
 
 // Integration tests (LiveLoop + SimExchange + SimFeed)

--- a/services/dctrading-bot/src/turso.zig
+++ b/services/dctrading-bot/src/turso.zig
@@ -2,6 +2,7 @@
 const std = @import("std");
 const types = @import("types.zig");
 const http_mod = @import("http_client.zig");
+const resource_monitor = @import("resource_monitor.zig");
 const HttpClient = http_mod.HttpClient;
 const Trade = types.Trade;
 
@@ -69,8 +70,10 @@ pub const Turso = struct {
         const sql_core =
             \\{"requests": [
             \\  {"type": "execute", "stmt": {"sql": "CREATE TABLE IF NOT EXISTS equity_log (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL, tick_count INTEGER, capital REAL, equity REAL, unrealized REAL, regime TEXT, price REAL, created_at TEXT DEFAULT (datetime('now')))"}},
-            \\  {"type": "execute", "stmt": {"sql": "CREATE TABLE IF NOT EXISTS bot_status (id INTEGER PRIMARY KEY CHECK (id = 1), status TEXT, last_tick REAL, tick_count INTEGER, regime TEXT, in_position INTEGER, entry_price REAL, equity REAL, capital REAL, unrealized REAL, price REAL, uptime_start REAL, version TEXT, trading_symbol TEXT DEFAULT 'BTC/USD', base_asset TEXT DEFAULT 'BTC', quote_asset TEXT DEFAULT 'USD', mark_symbol TEXT DEFAULT 'BTCUSDT', checkpoint_health TEXT DEFAULT 'OK', checkpoint_error TEXT DEFAULT '', updated_at TEXT DEFAULT (datetime('now')))"}},
+            \\  {"type": "execute", "stmt": {"sql": "CREATE TABLE IF NOT EXISTS bot_status (id INTEGER PRIMARY KEY CHECK (id = 1), status TEXT, last_tick REAL, tick_count INTEGER, regime TEXT, in_position INTEGER, entry_price REAL, equity REAL, capital REAL, unrealized REAL, price REAL, uptime_start REAL, version TEXT, trading_symbol TEXT DEFAULT 'BTC/USD', base_asset TEXT DEFAULT 'BTC', quote_asset TEXT DEFAULT 'USD', mark_symbol TEXT DEFAULT 'BTCUSDT', checkpoint_health TEXT DEFAULT 'OK', checkpoint_error TEXT DEFAULT '', resource_health TEXT DEFAULT 'OK', resource_error TEXT DEFAULT '', resource_rss_mb REAL DEFAULT 0, resource_disk_free_mb REAL DEFAULT 0, resource_disk_used_pct REAL DEFAULT 0, resource_feed_gap_sec REAL DEFAULT 0, resource_ws_lag_sec REAL DEFAULT 0, resource_http_errors INTEGER DEFAULT 0, resource_http_max_ms REAL DEFAULT 0, updated_at TEXT DEFAULT (datetime('now')))"}},
             \\  {"type": "execute", "stmt": {"sql": "CREATE TABLE IF NOT EXISTS checkpoint_backups (id INTEGER PRIMARY KEY CHECK (id = 1), path TEXT NOT NULL, data_base64 TEXT NOT NULL, byte_len INTEGER NOT NULL, checksum TEXT NOT NULL DEFAULT '', tick_count INTEGER NOT NULL, updated_at TEXT DEFAULT (datetime('now')))"}},
+            \\  {"type": "execute", "stmt": {"sql": "CREATE TABLE IF NOT EXISTS resource_log (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp REAL NOT NULL, uptime_sec REAL NOT NULL, rss_mb REAL NOT NULL, cpu_sec REAL NOT NULL, disk_path TEXT NOT NULL, disk_free_mb REAL NOT NULL, disk_used_pct REAL NOT NULL, ticks_per_min REAL NOT NULL, feed_gap_sec REAL NOT NULL, ws_lag_sec REAL NOT NULL, reconnect_count INTEGER NOT NULL, http_requests INTEGER NOT NULL, http_errors INTEGER NOT NULL, http_retries INTEGER NOT NULL, http_last_ms REAL NOT NULL, http_max_ms REAL NOT NULL, resource_health TEXT NOT NULL, resource_error TEXT NOT NULL, created_at TEXT DEFAULT (datetime('now')))"}},
+            \\  {"type": "execute", "stmt": {"sql": "CREATE INDEX IF NOT EXISTS idx_resource_log_timestamp ON resource_log(timestamp)"}},
             \\  {"type": "execute", "stmt": {"sql": "CREATE INDEX IF NOT EXISTS idx_equity_log_timestamp ON equity_log(timestamp)"}}
             \\]}
         ;
@@ -116,6 +119,33 @@ pub const Turso = struct {
             \\{"requests": [{"type": "execute", "stmt": {"sql": "ALTER TABLE bot_status ADD COLUMN checkpoint_error TEXT DEFAULT ''"}}]}
         );
         self.execSyncSilent(
+            \\{"requests": [{"type": "execute", "stmt": {"sql": "ALTER TABLE bot_status ADD COLUMN resource_health TEXT DEFAULT 'OK'"}}]}
+        );
+        self.execSyncSilent(
+            \\{"requests": [{"type": "execute", "stmt": {"sql": "ALTER TABLE bot_status ADD COLUMN resource_error TEXT DEFAULT ''"}}]}
+        );
+        self.execSyncSilent(
+            \\{"requests": [{"type": "execute", "stmt": {"sql": "ALTER TABLE bot_status ADD COLUMN resource_rss_mb REAL DEFAULT 0"}}]}
+        );
+        self.execSyncSilent(
+            \\{"requests": [{"type": "execute", "stmt": {"sql": "ALTER TABLE bot_status ADD COLUMN resource_disk_free_mb REAL DEFAULT 0"}}]}
+        );
+        self.execSyncSilent(
+            \\{"requests": [{"type": "execute", "stmt": {"sql": "ALTER TABLE bot_status ADD COLUMN resource_disk_used_pct REAL DEFAULT 0"}}]}
+        );
+        self.execSyncSilent(
+            \\{"requests": [{"type": "execute", "stmt": {"sql": "ALTER TABLE bot_status ADD COLUMN resource_feed_gap_sec REAL DEFAULT 0"}}]}
+        );
+        self.execSyncSilent(
+            \\{"requests": [{"type": "execute", "stmt": {"sql": "ALTER TABLE bot_status ADD COLUMN resource_ws_lag_sec REAL DEFAULT 0"}}]}
+        );
+        self.execSyncSilent(
+            \\{"requests": [{"type": "execute", "stmt": {"sql": "ALTER TABLE bot_status ADD COLUMN resource_http_errors INTEGER DEFAULT 0"}}]}
+        );
+        self.execSyncSilent(
+            \\{"requests": [{"type": "execute", "stmt": {"sql": "ALTER TABLE bot_status ADD COLUMN resource_http_max_ms REAL DEFAULT 0"}}]}
+        );
+        self.execSyncSilent(
             \\{"requests": [{"type": "execute", "stmt": {"sql": "ALTER TABLE checkpoint_backups ADD COLUMN checksum TEXT NOT NULL DEFAULT ''"}}]}
         );
         if (core_ok and acct_ok) {
@@ -141,6 +171,46 @@ pub const Turso = struct {
         const sql = std.fmt.bufPrint(&buf,
             \\{{"requests": [{{"type": "execute", "stmt": {{"sql": "INSERT INTO equity_log (timestamp, tick_count, capital, equity, unrealized, regime, price) VALUES ({d:.6}, {d}, {d:.2}, {d:.2}, {d:.2}, '{s}', {d:.2})"}}}}]}}
         , .{ timestamp, tick_count, capital, equity, unrealized, regime, price }) catch return;
+        self.execAsync(sql);
+    }
+
+    /// Log process/feed/HTTP resource health (async).
+    pub fn logResource(self: *const Turso, sample: resource_monitor.ResourceSample, health: []const u8, detail: []const u8) void {
+        var buf: [4096]u8 = undefined;
+        const sql = std.fmt.bufPrint(&buf,
+            \\{{"requests": [
+            \\  {{"type": "execute", "stmt": {{"sql": "INSERT INTO resource_log (timestamp, uptime_sec, rss_mb, cpu_sec, disk_path, disk_free_mb, disk_used_pct, ticks_per_min, feed_gap_sec, ws_lag_sec, reconnect_count, http_requests, http_errors, http_retries, http_last_ms, http_max_ms, resource_health, resource_error) VALUES ({d:.6}, {d:.2}, {d:.2}, {d:.2}, '{s}', {d:.2}, {d:.2}, {d:.2}, {d:.2}, {d:.2}, {d}, {d}, {d}, {d}, {d:.2}, {d:.2}, '{s}', '{s}')"}}}},
+            \\  {{"type": "execute", "stmt": {{"sql": "UPDATE bot_status SET resource_health='{s}', resource_error='{s}', resource_rss_mb={d:.2}, resource_disk_free_mb={d:.2}, resource_disk_used_pct={d:.2}, resource_feed_gap_sec={d:.2}, resource_ws_lag_sec={d:.2}, resource_http_errors={d}, resource_http_max_ms={d:.2}, updated_at=datetime('now') WHERE id=1"}}}}
+            \\]}}
+        , .{
+            sample.timestamp,
+            sample.uptime_sec,
+            sample.rss_mb,
+            sample.cpu_sec,
+            sample.disk_path,
+            sample.disk_free_mb,
+            sample.disk_used_pct,
+            sample.ticks_per_min,
+            sample.feed_gap_sec,
+            sample.ws_lag_sec,
+            sample.reconnect_count,
+            sample.http_requests,
+            sample.http_errors,
+            sample.http_retries,
+            sample.http_last_ms,
+            sample.http_max_ms,
+            health,
+            detail,
+            health,
+            detail,
+            sample.rss_mb,
+            sample.disk_free_mb,
+            sample.disk_used_pct,
+            sample.feed_gap_sec,
+            sample.ws_lag_sec,
+            sample.http_errors,
+            sample.http_max_ms,
+        }) catch return;
         self.execAsync(sql);
     }
 


### PR DESCRIPTION
## Summary
- Add periodic resource sampling in the bot for RSS, CPU, disk free/used, feed gaps, WebSocket lag, reconnects, and HTTP latency/error metrics.
- Persist resource snapshots in Turso via `resource_log` and expose the latest resource health/metrics through `bot_status`.
- Show resource state in the Neko dashboard status card with a healthy green state and a degraded warning state.
- Keep Telegram/ntfy notifications reserved for trading, checkpoint, funding, startup, and shutdown events.
- Add focused Zig tests for resource parsing and classification.
- Update bot and dashboard docs for the new monitoring fields and env vars.

## Testing
- `zig build test`
- `zig build -Doptimize=ReleaseFast`
- `moon run neko-trade:build`