### PR TITLE
Add managed BNB low-balance alerts

### DIFF
--- a/services/dctrading-bot/AGENTS.md
+++ b/services/dctrading-bot/AGENTS.md
@@ -8,7 +8,7 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 ### Source Files (`src/`)
 - `main.zig` — Entry point. CLI parsing, `runLive()` (WebSocket trading loop), `runBacktest()` (CSV backtest), `runSimulate()` (LiveLoop CSV simulation). Wires all modules together via shared `HttpClient`.
 - `strategy.zig` — Core strategy: 3-regime (BULL/SIDEWAYS/BEAR), DC detection, vol-trailing stop, MA regime filter, funding rate entry filter, checkpoint save/load (DCTRADE5 format, 27 scalars + ring buffers; DCTRADE4 and earlier DCTRADE5 funding-cache layout migration).
-- `feed.zig` — Binance WebSocket (native TLS via websocket.zig) + REST kline fetcher + funding rate fetcher (Binance futures API). Configurable host via `BINANCE_WS_HOST`/`BINANCE_API_HOST` env vars.
+- `feed.zig` — Binance WebSocket (native TLS via websocket.zig) + REST kline/ticker fetcher + funding rate fetcher (Binance futures API). Configurable host via `BINANCE_WS_HOST`/`BINANCE_API_HOST` env vars.
 - `dc_detector.zig` — Streaming DC event detector. Emits UP/DOWN events when price reverses by λ threshold.
 - `exchange.zig` — Exchange interface (vtable pattern): sync `buy()`/`sell()`, async `submitOrder()`/`checkOrder()`/`cancelOrder()`, `getPosition()`. Shared types: `OrderFill`, `PendingOrder`, `OrderStatus`, `CancelResult`, `Position`, `Side`.
 - `alpaca.zig` — Alpaca paper trading, implements Exchange interface. Sync orders (buy/sell with fill polling), async orders (submitOrderAsync/checkOrderStatus/cancelOrderAsync), position queries. Uses `HttpClient`.
@@ -16,12 +16,13 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 - `telegram.zig` — Telegram + ntfy notifications. Async sends via threads, curl fallback for shutdown reliability.
 - `http_client.zig` — Thread-safe wrapper around `std.http.Client`. Mutex-protected POST/GET/DELETE with auto-retry on stale connections and per-window request/error/retry/latency metrics.
 - `resource_monitor.zig` — Resource health sampler/classifier. Tracks process RSS/CPU, disk free/used, WebSocket feed gaps/lag/reconnects, and HTTP metrics for app-visible status.
+- `bnb_monitor.zig` — Managed BNB low-balance alert state machine. Computes quote value, low/healthy state, and Telegram/ntfy cooldown eligibility.
 - `types.zig` — Core types: `Tick`, `Trade`, `DCEvent`, `Direction`.
 - `live_loop.zig` — Extracted core order flow logic: pending order tracking, trailing stop, strategy signals, buy/sell submission, capital_reserved, and ledger vtable. Shared by `runLive()` and integration tests.
 - `tick_source.zig` — `TickSource` vtable interface + `SimFeed` (replays ticks from array). For testing.
 - `sim_exchange.zig` — `SimExchange` implementing Exchange vtable with configurable fill delay, slippage, partial fills, cancel races, failure injection, order log. For testing.
 - `integration_tests.zig` — 32 end-to-end scenarios using LiveLoop + SimExchange + mock ledger.
-- `tests.zig` — 182 tests covering DC detector, strategy, checkpoint, regime transitions, JSON parsing, capital accounting, double-entry transfers, exchange interface, funding rate filter, non-blocking order flow, capital_reserved, resource monitoring, integration scenarios.
+- `tests.zig` — 194 tests covering DC detector, strategy, checkpoint, regime transitions, JSON parsing, capital accounting, double-entry transfers, exchange interface, funding rate filter, managed BNB low-balance alerts, non-blocking order flow, capital_reserved, resource monitoring, integration scenarios.
 - CLI `checkpoint:migrate [path] [backups]` migrates checkpoint primary/backups offline to the current DCTRADE5 layout after writing `.pre-migrate` copies.
 
 ### Scripts (`scripts/`)
@@ -49,6 +50,10 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 | `TELEGRAM_CHAT_ID` | No | telegram.zig |
 | `NTFY_TOPIC` | No | telegram.zig |
 | `FUNDING_SKIP_THRESHOLD` | No | main.zig (default: 0.0001 = 0.010%) |
+| `BNB_LOW_ALERT` | No | main.zig/bnb_monitor.zig (auto/on/off; default: auto) |
+| `BNB_LOW_THRESHOLD_QUOTE` | No | main.zig/bnb_monitor.zig (default: 5 quote units; 0 disables) |
+| `BNB_LOW_CHECK_INTERVAL_SEC` | No | main.zig (default: 300s) |
+| `BNB_LOW_ALERT_COOLDOWN_SEC` | No | main.zig/bnb_monitor.zig (default: 86400s) |
 | `CHECKPOINT_PATH` | No | main.zig (default: dctrading.checkpoint in cwd) |
 | `CHECKPOINT_BACKUP_RETENTION` | No | main.zig (default: 5) |
 | `CHECKPOINT_REMOTE_BACKUP_INTERVAL` | No | main.zig (default: 3600s, 0 disables) |
@@ -70,6 +75,7 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 - `accounts` — Double-entry accounts (TigerBeetle-inspired): cash, btc_position, fees, equity, pnl, bnb. 4 balance fields: debits_pending, debits_posted, credits_pending, credits_posted.
 - `transfers` — Immutable append-only transfer log. Two-phase (pending/posted/voided). Codes: 1=deposit, 2=buy, 3=sell, 4=fee, 5=pnl. Atomic BEGIN/COMMIT pipelines.
 - Fee routing: adapter-provided `commission_asset` routes fees to the paying asset account (`USD`/`USDT` → cash, `BTC` → btc_position, `BNB` → bnb), even when commission is zero. Transfer `amount` is historical quote-currency value at fill time; native fee quantity is stored in transfer `size`, with the fill-time asset quote valuation rate in `price`. `strategy.size` remains whatever the exchange adapter reports as fill quantity. `fee_pct` is for backtest/simulation estimates and legacy fills with no commission metadata, not for Alpaca paper fills.
+- Managed BNB quantity is derived from posted transfer `size`: rows debiting account 6 add native BNB, rows crediting account 6 subtract native BNB. Live mode marks that quantity at `BNBUSDT` and sends low-BNB Telegram/ntfy alerts with cooldown. In `BNB_LOW_ALERT=auto`, monitoring activates only after a posted BNB fee transfer exists.
 - `equity_log` — Periodic snapshots (every 5 min + on trades): capital, equity, unrealized, regime, price.
 - `bot_status` — Single row (id=1): regime, position, equity, version (DCTRADE5@instance), active symbol metadata, checkpoint health/error, and latest resource health/metrics for Neko.
 - `resource_log` — Periodic process/feed/HTTP resource snapshots used for dashboard status and diagnostics. Resource degradation is app-visible only; Telegram/ntfy stays reserved for trading, checkpoint, funding, startup/shutdown events.
@@ -78,7 +84,7 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 ```bash
 zig build -Doptimize=ReleaseFast              # macOS arm64
 zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux  # GCP
-zig build test                                 # 182 tests
+zig build test                                 # 194 tests
 ./zig-out/bin/dctrading checkpoint:migrate dctrading.checkpoint 5
 ```
 
@@ -88,7 +94,7 @@ zig build test                                 # 182 tests
 3. Stream: Binance WebSocket → downsample to 1-min → `LiveLoop.processTick()`
 4. On BUY signal: `submitOrder()` (non-blocking) → pending transfer in Turso → `checkOrder()` each tick → fill → post transfer
 5. On SELL signal: cancel pending buys → `submitOrder()` sell → pending transfer → fill → post transfer + PnL
-6. Every 5 min: log equity/resource snapshots to Turso, upsert bot_status, check deposits
+6. Every 5 min: log equity/resource snapshots to Turso, upsert bot_status, check deposits, and check managed BNB quote value
 7. Hourly: refresh cached funding rate before strategy-minute processing; notify only when Binance publishes a new funding print
 8. Shutdown (SIGINT/SIGTERM): save checkpoint with backup rotation, log to Turso, notify via curl fallback
 

--- a/services/dctrading-bot/README.md
+++ b/services/dctrading-bot/README.md
@@ -47,7 +47,7 @@ Single static binary. No Python, no Docker, no runtime dependencies (except curl
 | `http_client.zig` | Shared HTTP client (std.http.Client wrapper + request metrics) |
 | `resource_monitor.zig` | Process, disk, feed, and HTTP resource health snapshots |
 | `types.zig` | Tick, Trade, DC event types |
-| `tests.zig` | 182 tests |
+| `tests.zig` | 194 tests |
 
 ## Setup
 
@@ -85,6 +85,13 @@ export BINANCE_API_HOST=api.binance.com
 # Funding filter (default: 0.0001 = 0.010%; 0 disables)
 # Funding updates are cached, checkpointed, checked hourly, and sent to Telegram/ntfy when Binance publishes a new funding print.
 export FUNDING_SKIP_THRESHOLD=0.0001
+
+# Managed BNB low-balance alert.
+# auto monitors only after posted BNB fee transfers exist; on forces monitoring; off disables.
+export BNB_LOW_ALERT=auto
+export BNB_LOW_THRESHOLD_QUOTE=5
+export BNB_LOW_CHECK_INTERVAL_SEC=300
+export BNB_LOW_ALERT_COOLDOWN_SEC=86400
 
 # Local checkpoint backups (default: 5; 0 disables)
 export CHECKPOINT_BACKUP_RETENTION=5
@@ -168,6 +175,8 @@ EXIT_FEE      -1.05     bal=1050.02   "SELL fee from exchange fill"
 PnL = current balance - total deposits. No double-counting.
 
 Fee transfers are routed by `commission_asset`: `USD`/`USDT` fees reduce `cash`, `BTC` fees reduce `btc_position`, and `BNB` fees reduce `bnb`. Adapter-provided zero commission is treated as an actual zero-fee fill, which is required for Alpaca paper trading. The configured `fee_pct` remains a backtest/simulation estimate and a legacy fallback when an adapter provides no commission metadata. The ledger therefore nets a BTC-paid fee out of the BTC account. The in-memory `strategy.size` still uses the fill quantity supplied by the exchange adapter; if a Binance adapter reports gross executed quantity while charging fees in BTC, that adapter must normalize the fill quantity or the strategy must subtract the base-asset commission in a follow-up.
+
+With `BNB_LOW_ALERT=auto`, live mode checks bot-managed BNB only after the ledger has observed a posted BNB-paid fee transfer (`code = fee`, `credit_account_id = bnb`). This keeps Alpaca and BTC/USDT-fee setups quiet without manual exchange flags. `BNB_LOW_ALERT=on` forces monitoring before the first BNB fee, and `off` disables it. The quantity comes from posted Turso transfers (`debit_account_id = bnb` adds native `size`, `credit_account_id = bnb` subtracts native `size`) and is marked at Binance `BNBUSDT`. If its quote value falls below `BNB_LOW_THRESHOLD_QUOTE`, Telegram/ntfy sends a low-BNB alert with `BNB_LOW_ALERT_COOLDOWN_SEC` no-spam cooldown.
 
 ## Checkpoint
 

--- a/services/dctrading-bot/src/bnb_monitor.zig
+++ b/services/dctrading-bot/src/bnb_monitor.zig
@@ -1,0 +1,79 @@
+const std = @import("std");
+
+pub const AlertState = struct {
+    was_low: bool = false,
+    last_alert_ts: f64 = 0,
+};
+
+pub const CheckResult = struct {
+    enabled: bool,
+    quantity: f64,
+    price: f64,
+    value_quote: f64,
+    threshold_quote: f64,
+    is_low: bool,
+    should_alert: bool,
+};
+
+pub const AlertMode = enum { auto, on, off };
+
+pub fn parseAlertMode(raw: []const u8) AlertMode {
+    if (std.ascii.eqlIgnoreCase(raw, "on") or std.ascii.eqlIgnoreCase(raw, "true") or std.ascii.eqlIgnoreCase(raw, "1")) return .on;
+    if (std.ascii.eqlIgnoreCase(raw, "off") or std.ascii.eqlIgnoreCase(raw, "false") or std.ascii.eqlIgnoreCase(raw, "0")) return .off;
+    return .auto;
+}
+
+pub fn alertModeLabel(mode: AlertMode) []const u8 {
+    return switch (mode) {
+        .auto => "auto",
+        .on => "on",
+        .off => "off",
+    };
+}
+
+pub fn shouldMonitor(mode: AlertMode, has_bnb_fee: bool) bool {
+    return switch (mode) {
+        .auto => has_bnb_fee,
+        .on => true,
+        .off => false,
+    };
+}
+
+pub fn evaluate(quantity: f64, price: f64, threshold_quote: f64, now: f64, cooldown_sec: f64, state: *AlertState) CheckResult {
+    const enabled = threshold_quote > 0 and price > 0;
+    const qty = @max(quantity, 0);
+    const value_quote = qty * @max(price, 0);
+
+    if (!enabled) {
+        return .{
+            .enabled = false,
+            .quantity = qty,
+            .price = price,
+            .value_quote = value_quote,
+            .threshold_quote = threshold_quote,
+            .is_low = false,
+            .should_alert = false,
+        };
+    }
+
+    const is_low = value_quote < threshold_quote;
+    var should_alert = false;
+    if (is_low) {
+        const cooldown_elapsed = state.last_alert_ts <= 0 or now - state.last_alert_ts >= cooldown_sec;
+        should_alert = !state.was_low or cooldown_elapsed;
+        state.was_low = true;
+        if (should_alert) state.last_alert_ts = now;
+    } else {
+        state.was_low = false;
+    }
+
+    return .{
+        .enabled = true,
+        .quantity = qty,
+        .price = price,
+        .value_quote = value_quote,
+        .threshold_quote = threshold_quote,
+        .is_low = is_low,
+        .should_alert = should_alert,
+    };
+}

--- a/services/dctrading-bot/src/feed.zig
+++ b/services/dctrading-bot/src/feed.zig
@@ -361,6 +361,23 @@ pub fn fetchFundingRate(http: *HttpClient, symbol: []const u8, count: usize) ?f6
     return snapshot.avg;
 }
 
+/// Fetch the latest Binance spot ticker price for a symbol.
+pub fn fetchSpotPrice(http: *HttpClient, symbol: []const u8) ?f64 {
+    var url_buf: [256]u8 = undefined;
+    const sym = normalizeSymbol(symbol);
+    const url = std.fmt.bufPrint(&url_buf, "https://{s}/api/v3/ticker/price?symbol={s}", .{ apiHost(), sym.slice() }) catch return null;
+
+    const resp = http.get(url, &.{}) catch return null;
+    defer resp.deinit();
+
+    return parseTickerPrice(resp.body);
+}
+
+/// Parse Binance ticker/price JSON, e.g. {"symbol":"BNBUSDT","price":"600.12"}.
+pub fn parseTickerPrice(json: []const u8) ?f64 {
+    return parseJsonFieldFloat(json, "\"price\":");
+}
+
 /// Parse funding rate from JSON for testing.
 pub fn parseFundingRates(json: []const u8) ?f64 {
     const snapshot = parseFundingSnapshot(json) orelse return null;

--- a/services/dctrading-bot/src/main.zig
+++ b/services/dctrading-bot/src/main.zig
@@ -10,6 +10,7 @@ const turso_mod = @import("turso.zig");
 const live_loop_mod = @import("live_loop.zig");
 const sim_exchange_mod = @import("sim_exchange.zig");
 const resource_monitor = @import("resource_monitor.zig");
+const bnb_monitor = @import("bnb_monitor.zig");
 
 const Tick = types.Tick;
 const Trade = types.Trade;
@@ -163,6 +164,10 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
     const checkpoint_interval: u64 = 60; // ~1 hour with 1-min downsampling
     const checkpoint_backup_retention = parseEnvU8("CHECKPOINT_BACKUP_RETENTION", 5);
     const checkpoint_remote_interval = parseEnvU32("CHECKPOINT_REMOTE_BACKUP_INTERVAL", 3600);
+    const bnb_low_alert_mode = bnb_monitor.parseAlertMode(if (getenv("BNB_LOW_ALERT")) |ptr| std.mem.sliceTo(ptr, 0) else "auto");
+    const bnb_low_threshold_quote = parseEnvF64("BNB_LOW_THRESHOLD_QUOTE", 5.0);
+    const bnb_low_check_interval = parseEnvF64("BNB_LOW_CHECK_INTERVAL_SEC", 300.0);
+    const bnb_low_alert_cooldown = parseEnvF64("BNB_LOW_ALERT_COOLDOWN_SEC", 86400.0);
     const resource_interval_sec = parseEnvF64("RESOURCE_LOG_INTERVAL_SEC", 300.0);
     const resource_disk_path: []const u8 = if (getenv("RESOURCE_DISK_PATH")) |ptr| std.mem.sliceTo(ptr, 0) else ".";
     const resource_thresholds: resource_monitor.Thresholds = .{
@@ -186,6 +191,7 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
     std.debug.print("  Strategy: ZI-DCT0 long-only + vol-trail 2%/72h + 60d MA buf=3%\n", .{});
     printCheckpointLocation(checkpoint_path);
     std.debug.print("  Checkpoint: every {d} ticks, backups={d}, remote={d}s\n\n", .{ checkpoint_interval, checkpoint_backup_retention, checkpoint_remote_interval });
+    std.debug.print("  BNB alert: mode={s} threshold=${d:.2}, check={d:.0}s, cooldown={d:.0}s\n", .{ bnb_monitor.alertModeLabel(bnb_low_alert_mode), bnb_low_threshold_quote, bnb_low_check_interval, bnb_low_alert_cooldown });
     std.debug.print("  Resource monitor: every {d:.0}s disk={s} warn free<{d:.0}MB used>{d:.0}% rss>{d:.0}MB\n\n", .{ resource_interval_sec, resource_disk_path, resource_thresholds.disk_free_warn_mb, resource_thresholds.disk_used_warn_pct, resource_thresholds.rss_warn_mb });
 
     // Register signal handlers for clean shutdown (SIGINT=2, SIGTERM=15)
@@ -458,6 +464,8 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
     var last_deposit_check: f64 = 0;
     var last_resource_ts: f64 = 0;
     var last_resource_tick_ts: f64 = 0;
+    var last_bnb_low_check_ts: f64 = 0;
+    var bnb_low_state: bnb_monitor.AlertState = .{};
     var resource_window: resource_monitor.FeedWindow = .{};
     var known_total_deposits: f64 = if (turso != null) (turso.?.queryTotalDepositsNew() orelse capital) else capital;
     var last_funding_check: f64 = if (initial_funding_fetch_ok) initial_funding_now else 0;
@@ -671,6 +679,27 @@ fn runLive(allocator: std.mem.Allocator, io: std.Io, threshold: f64, capital: f6
                 if (equity_interval or traded) {
                     turso.?.logEquity(t.timestamp, strategy.tick_count, strategy.capital, equity, unrealized, regime_str, t.price);
                     last_equity_ts = t.timestamp;
+                }
+                if (bnb_low_threshold_quote > 0 and bnb_low_check_interval > 0 and t.timestamp - last_bnb_low_check_ts >= bnb_low_check_interval) {
+                    last_bnb_low_check_ts = t.timestamp;
+                    const has_bnb_fee = if (bnb_low_alert_mode == .auto) (turso.?.hasPostedBnbFees() orelse false) else false;
+                    if (bnb_monitor.shouldMonitor(bnb_low_alert_mode, has_bnb_fee)) {
+                        if (turso.?.queryManagedBnbQuantity()) |managed_bnb_qty| {
+                            if (feed_mod.fetchSpotPrice(&http, "BNBUSDT")) |bnb_price| {
+                                const bnb_check = bnb_monitor.evaluate(managed_bnb_qty, bnb_price, bnb_low_threshold_quote, tick_wall_now, bnb_low_alert_cooldown, &bnb_low_state);
+                                if (bnb_check.is_low) {
+                                    std.debug.print("  [bnb] WARNING: managed={d:.8} BNB value=${d:.2} threshold=${d:.2}\n", .{ bnb_check.quantity, bnb_check.value_quote, bnb_check.threshold_quote });
+                                }
+                                if (bnb_check.should_alert) {
+                                    if (tg) |tl| tl.notifyLowBnb(bnb_check.quantity, bnb_check.price, bnb_check.value_quote, bnb_check.threshold_quote, instance);
+                                }
+                            } else {
+                                std.debug.print("  [bnb] WARNING: failed to fetch BNBUSDT spot price.\n", .{});
+                            }
+                        } else {
+                            std.debug.print("  [bnb] WARNING: failed to query managed BNB quantity.\n", .{});
+                        }
+                    }
                 }
                 // Check for new deposits every 5 min
                 if (t.timestamp - last_deposit_check >= 300.0) {

--- a/services/dctrading-bot/src/telegram.zig
+++ b/services/dctrading-bot/src/telegram.zig
@@ -104,6 +104,16 @@ pub const Telegram = struct {
         self.send(msg);
     }
 
+    pub fn notifyLowBnb(self: *const Telegram, quantity: f64, price: f64, value_quote: f64, threshold_quote: f64, instance: []const u8) void {
+        var buf: [512]u8 = undefined;
+        const msg = std.fmt.bufPrint(
+            &buf,
+            "Low Managed BNB\nBalance: {d:.8} BNB\nPrice: ${d:.2}\nValue: ${d:.2}\nThreshold: ${d:.2}\nInstance: {s}",
+            .{ quantity, price, value_quote, threshold_quote, instance },
+        ) catch return;
+        self.send(msg);
+    }
+
     pub fn notifyFundingRate(self: *const Telegram, symbol: []const u8, avg: f64, threshold: f64, updated_at: f64, latest_time: f64, now: f64, instance: []const u8) void {
         var buf: [512]u8 = undefined;
         const msg = formatFundingRateMessage(&buf, symbol, avg, threshold, updated_at, latest_time, now, instance) catch return;

--- a/services/dctrading-bot/src/tests.zig
+++ b/services/dctrading-bot/src/tests.zig
@@ -4,6 +4,7 @@ const types = @import("types.zig");
 const dc_mod = @import("dc_detector.zig");
 const strat_mod = @import("strategy.zig");
 const resource_monitor = @import("resource_monitor.zig");
+const bnb_monitor = @import("bnb_monitor.zig");
 
 const Tick = types.Tick;
 const DCDetector = dc_mod.DCDetector;
@@ -319,9 +320,93 @@ test "feed: parseKlineCloses returns zero parsed for non-array" {
     try testing.expectEqual(result.parsed, 0);
 }
 
+test "feed: parseTickerPrice parses quoted Binance ticker price" {
+    const price = feed_mod.parseTickerPrice("{\"symbol\":\"BNBUSDT\",\"price\":\"612.34000000\"}");
+    try testing.expect(price != null);
+    try testing.expectApproxEqAbs(price.?, 612.34, 0.000001);
+}
+
+test "feed: parseTickerPrice parses unquoted ticker price" {
+    const price = feed_mod.parseTickerPrice("{\"symbol\":\"BNBUSDT\",\"price\":612.34}");
+    try testing.expect(price != null);
+    try testing.expectApproxEqAbs(price.?, 612.34, 0.000001);
+}
+
+test "feed: parseTickerPrice returns null for missing price" {
+    try testing.expect(feed_mod.parseTickerPrice("{\"symbol\":\"BNBUSDT\"}") == null);
+}
+
 // ============================================================
 // Funding Rate Tests
 // ============================================================
+
+test "bnb_monitor: low managed BNB alerts first time" {
+    var state: bnb_monitor.AlertState = .{};
+    const result = bnb_monitor.evaluate(0.005, 600.0, 5.0, 1000.0, 86400.0, &state);
+    try testing.expect(result.enabled);
+    try testing.expect(result.is_low);
+    try testing.expect(result.should_alert);
+    try testing.expect(state.was_low);
+    try testing.expectApproxEqAbs(state.last_alert_ts, 1000.0, 0.001);
+    try testing.expectApproxEqAbs(result.value_quote, 3.0, 0.001);
+}
+
+test "bnb_monitor: low managed BNB suppresses repeated alert before cooldown" {
+    var state: bnb_monitor.AlertState = .{};
+    _ = bnb_monitor.evaluate(0.005, 600.0, 5.0, 1000.0, 86400.0, &state);
+    const repeated = bnb_monitor.evaluate(0.004, 600.0, 5.0, 2000.0, 86400.0, &state);
+    try testing.expect(repeated.is_low);
+    try testing.expect(!repeated.should_alert);
+    try testing.expectApproxEqAbs(state.last_alert_ts, 1000.0, 0.001);
+}
+
+test "bnb_monitor: low managed BNB alerts again after cooldown" {
+    var state: bnb_monitor.AlertState = .{};
+    _ = bnb_monitor.evaluate(0.005, 600.0, 5.0, 1000.0, 3600.0, &state);
+    const repeated = bnb_monitor.evaluate(0.004, 600.0, 5.0, 4600.0, 3600.0, &state);
+    try testing.expect(repeated.is_low);
+    try testing.expect(repeated.should_alert);
+    try testing.expectApproxEqAbs(state.last_alert_ts, 4600.0, 0.001);
+}
+
+test "bnb_monitor: healthy managed BNB clears low state" {
+    var state: bnb_monitor.AlertState = .{};
+    _ = bnb_monitor.evaluate(0.005, 600.0, 5.0, 1000.0, 86400.0, &state);
+    const healthy = bnb_monitor.evaluate(0.02, 600.0, 5.0, 2000.0, 86400.0, &state);
+    try testing.expect(!healthy.is_low);
+    try testing.expect(!healthy.should_alert);
+    try testing.expect(!state.was_low);
+
+    const low_again = bnb_monitor.evaluate(0.005, 600.0, 5.0, 3000.0, 86400.0, &state);
+    try testing.expect(low_again.is_low);
+    try testing.expect(low_again.should_alert);
+}
+
+test "bnb_monitor: threshold disables alert" {
+    var state: bnb_monitor.AlertState = .{};
+    const result = bnb_monitor.evaluate(0, 600.0, 0, 1000.0, 86400.0, &state);
+    try testing.expect(!result.enabled);
+    try testing.expect(!result.is_low);
+    try testing.expect(!result.should_alert);
+}
+
+test "bnb_monitor: alert mode parser accepts explicit modes" {
+    try testing.expectEqual(bnb_monitor.AlertMode.auto, bnb_monitor.parseAlertMode(""));
+    try testing.expectEqual(bnb_monitor.AlertMode.auto, bnb_monitor.parseAlertMode("auto"));
+    try testing.expectEqual(bnb_monitor.AlertMode.on, bnb_monitor.parseAlertMode("on"));
+    try testing.expectEqual(bnb_monitor.AlertMode.on, bnb_monitor.parseAlertMode("true"));
+    try testing.expectEqual(bnb_monitor.AlertMode.on, bnb_monitor.parseAlertMode("1"));
+    try testing.expectEqual(bnb_monitor.AlertMode.off, bnb_monitor.parseAlertMode("off"));
+    try testing.expectEqual(bnb_monitor.AlertMode.off, bnb_monitor.parseAlertMode("false"));
+    try testing.expectEqual(bnb_monitor.AlertMode.off, bnb_monitor.parseAlertMode("0"));
+}
+
+test "bnb_monitor: auto mode follows observed BNB fee state" {
+    try testing.expect(!bnb_monitor.shouldMonitor(.auto, false));
+    try testing.expect(bnb_monitor.shouldMonitor(.auto, true));
+    try testing.expect(bnb_monitor.shouldMonitor(.on, false));
+    try testing.expect(!bnb_monitor.shouldMonitor(.off, true));
+}
 
 test "feed: parseFundingRates parses 3 rates and averages" {
     const json = "[{\"symbol\":\"BTCUSDT\",\"fundingRate\":\"0.00010000\",\"fundingTime\":1698768000000},{\"symbol\":\"BTCUSDT\",\"fundingRate\":\"0.00020000\",\"fundingTime\":1698796800000},{\"symbol\":\"BTCUSDT\",\"fundingRate\":\"0.00030000\",\"fundingTime\":1698825600000}]";
@@ -1496,6 +1581,50 @@ test "turso: account constants are correct" {
     try testing.expectEqual(turso_mod.Turso.CODE_SELL, 3);
     try testing.expectEqual(turso_mod.Turso.CODE_FEE, 4);
     try testing.expectEqual(turso_mod.Turso.CODE_PNL, 5);
+}
+
+test "turso: managed BNB quantity derives from native transfer size" {
+    const BnbRow = struct {
+        debit_account_id: u8,
+        credit_account_id: u8,
+        size: f64,
+        posted: bool,
+    };
+    const rows = [_]BnbRow{
+        .{ .debit_account_id = turso_mod.Turso.ACCT_BNB, .credit_account_id = turso_mod.Turso.ACCT_EQUITY, .size = 0.010, .posted = true },
+        .{ .debit_account_id = turso_mod.Turso.ACCT_FEES, .credit_account_id = turso_mod.Turso.ACCT_BNB, .size = 0.0015, .posted = true },
+        .{ .debit_account_id = turso_mod.Turso.ACCT_BNB, .credit_account_id = turso_mod.Turso.ACCT_EQUITY, .size = 0.020, .posted = false },
+    };
+
+    var qty: f64 = 0;
+    for (rows) |row| {
+        if (!row.posted) continue;
+        if (row.debit_account_id == turso_mod.Turso.ACCT_BNB) qty += row.size;
+        if (row.credit_account_id == turso_mod.Turso.ACCT_BNB) qty -= row.size;
+    }
+    try testing.expectApproxEqAbs(qty, 0.0085, 0.0000001);
+}
+
+test "turso: BNB fee detection only counts posted BNB fee transfers" {
+    const Row = struct {
+        credit_account_id: u8,
+        code: u8,
+        posted: bool,
+    };
+    const rows = [_]Row{
+        .{ .credit_account_id = turso_mod.Turso.ACCT_BNB, .code = turso_mod.Turso.CODE_DEPOSIT, .posted = true },
+        .{ .credit_account_id = turso_mod.Turso.ACCT_BNB, .code = turso_mod.Turso.CODE_FEE, .posted = false },
+        .{ .credit_account_id = turso_mod.Turso.ACCT_CASH, .code = turso_mod.Turso.CODE_FEE, .posted = true },
+        .{ .credit_account_id = turso_mod.Turso.ACCT_BNB, .code = turso_mod.Turso.CODE_FEE, .posted = true },
+    };
+
+    var has_bnb_fee = false;
+    for (rows) |row| {
+        if (row.posted and row.code == turso_mod.Turso.CODE_FEE and row.credit_account_id == turso_mod.Turso.ACCT_BNB) {
+            has_bnb_fee = true;
+        }
+    }
+    try testing.expect(has_bnb_fee);
 }
 
 test "turso: transfer flags are correct" {

--- a/services/dctrading-bot/src/turso.zig
+++ b/services/dctrading-bot/src/turso.zig
@@ -483,6 +483,28 @@ pub const Turso = struct {
         return parseFirstValueFloat(resp.body);
     }
 
+    /// Query bot-managed native BNB quantity from posted transfers.
+    /// BNB top-ups debit ACCT_BNB and BNB-paid fees credit ACCT_BNB.
+    pub fn queryManagedBnbQuantity(self: *const Turso) ?f64 {
+        const sql =
+            \\{"requests": [{"type": "execute", "stmt": {"sql": "SELECT COALESCE(SUM(CASE WHEN debit_account_id = 6 THEN size WHEN credit_account_id = 6 THEN -size ELSE 0 END), 0) FROM transfers WHERE status = 'posted'"}}]}
+        ;
+        const resp = self.execSyncRead(sql) orelse return null;
+        defer resp.deinit();
+        return parseFirstValueFloat(resp.body);
+    }
+
+    /// True when the ledger has observed posted fees paid from the BNB account.
+    pub fn hasPostedBnbFees(self: *const Turso) ?bool {
+        const sql =
+            \\{"requests": [{"type": "execute", "stmt": {"sql": "SELECT COUNT(*) FROM transfers WHERE status = 'posted' AND code = 4 AND credit_account_id = 6"}}]}
+        ;
+        const resp = self.execSyncRead(sql) orelse return null;
+        defer resp.deinit();
+        const count = parseFirstValueInt(resp.body) orelse return null;
+        return count > 0;
+    }
+
     /// Query account debits_posted (blocking). Used for deposit detection on equity account.
     pub fn queryAccountDebitsPosted(self: *const Turso, account_id: u8) ?f64 {
         var buf: [256]u8 = undefined;


### PR DESCRIPTION
## Summary
- Add a managed-BNB monitor that values bot-controlled BNB at `BNBUSDT` and alerts when its quote value drops below a threshold.
- Gate monitoring with `BNB_LOW_ALERT=auto|on|off`; `auto` only enables checks after the ledger has observed a posted BNB fee transfer.
- Add Telegram/ntfy notification plumbing, Turso queries for managed BNB quantity and posted BNB-fee detection, and supporting docs.

## Testing
- Added unit coverage for BNB alert mode parsing, alert cooldown behavior, and managed-BNB valuation.
- Added coverage for Binance ticker-price parsing and Turso-side BNB quantity / fee-detection logic.
- `zig build test --summary all` passed.
- `zig build -Doptimize=ReleaseFast` passed.
- `git diff --check` passed.