### PR TITLE
Refine Neko Trade card surfaces and smooth equity charts

### DIFF
--- a/apps/neko-trade/AGENTS.md
+++ b/apps/neko-trade/AGENTS.md
@@ -10,6 +10,7 @@ SwiftUI dashboard app for the DCTrading bot. Displays bot status, equity, trades
 
 ### Views (`Views/`)
 - `ContentView.swift` — Tab container: Dashboard, Ledger, Equity, Trades, Settings.
+- `AppCardSurface.swift` — Shared material card surface used by dashboard, equity, and settings cards.
 - `DashboardView.swift` — Bot status, resource health, regime (BULL=green, SIDE=orange, BEAR=red), managed equity from app-managed BTC/BNB quantities marked at Binance spot, realized P&L, unrealized P&L, active-symbol price from Binance. Auto-refreshes every 30s.
 - `LedgerView.swift` — Transfer ledger with cash balance summary, BNB allocation top-up, and running balance per entry.
 - `EquityChartView.swift` — Equity over time using Swift Charts.

--- a/apps/neko-trade/ARCHITECTURE.md
+++ b/apps/neko-trade/ARCHITECTURE.md
@@ -20,6 +20,7 @@ apps/neko-trade/
 │   │   └── BinanceClient.swift     # Binance REST client (active-symbol price + klines)
 │   ├── Views/
 │   │   ├── ContentView.swift       # Tab container (5 tabs)
+│   │   ├── AppCardSurface.swift    # Shared material card surface
 │   │   ├── DashboardView.swift     # Bot status, regime, equity, active-symbol price, open position (~470 lines)
 │   │   ├── LedgerView.swift        # Account ledger with cash balance summary + BNB allocation
 │   │   ├── EquityChartView.swift   # Equity over time (Swift Charts)

--- a/apps/neko-trade/Sources/DCTradingViewer/Views/AppCardSurface.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Views/AppCardSurface.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct AppCardSurface: View {
+    var accent: Color?
+    var borderOpacity: Double = 0.18
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 12, style: .continuous)
+            .fill(.ultraThinMaterial)
+            .overlay {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .strokeBorder((accent ?? .secondary).opacity(accent == nil ? 0.10 : borderOpacity), lineWidth: 1)
+            }
+            .shadow(color: .black.opacity(0.04), radius: 8, y: 2)
+    }
+}

--- a/apps/neko-trade/Sources/DCTradingViewer/Views/DashboardView.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Views/DashboardView.swift
@@ -149,15 +149,7 @@ struct DashboardView: View {
         }
         .padding()
         .background {
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(.ultraThinMaterial)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .strokeBorder(
-                            (eq.isBull ? Color.green : Color.red).opacity(0.3),
-                            lineWidth: 1
-                        )
-                )
+            AppCardSurface(accent: eq.regimeColor, borderOpacity: 0.24)
         }
     }
 
@@ -192,12 +184,7 @@ struct DashboardView: View {
             }
             .padding()
             .background {
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(.orange.opacity(0.12))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12, style: .continuous)
-                            .strokeBorder(.orange.opacity(0.35), lineWidth: 1)
-                    )
+                AppCardSurface(accent: .orange, borderOpacity: 0.32)
             }
         }
         .buttonStyle(.plain)
@@ -236,8 +223,7 @@ struct DashboardView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .background {
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(.ultraThinMaterial)
+            AppCardSurface()
         }
     }
 
@@ -275,12 +261,7 @@ struct DashboardView: View {
         }
         .padding()
         .background {
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(.ultraThinMaterial)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .strokeBorder(Color.green.opacity(0.2), lineWidth: 1)
-                )
+            AppCardSurface(accent: .green, borderOpacity: 0.20)
         }
     }
 
@@ -295,8 +276,7 @@ struct DashboardView: View {
         .frame(maxWidth: .infinity)
         .padding()
         .background {
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(.ultraThinMaterial)
+            AppCardSurface()
         }
     }
 
@@ -448,7 +428,7 @@ struct DashboardView: View {
                     )
                     .foregroundStyle(color)
                     .lineStyle(StrokeStyle(lineWidth: 1.5))
-                    .interpolationMethod(.catmullRom)
+                    .interpolationMethod(.monotone)
                 }
             }
             .chartXAxis(.hidden)
@@ -460,8 +440,7 @@ struct DashboardView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding()
         .background {
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(.ultraThinMaterial)
+            AppCardSurface()
         }
-}
+    }
 }

--- a/apps/neko-trade/Sources/DCTradingViewer/Views/EquityChartView.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Views/EquityChartView.swift
@@ -118,8 +118,7 @@ struct EquityChartView: View {
         }
         .padding()
         .background {
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(.ultraThinMaterial)
+            AppCardSurface()
         }
     }
 
@@ -182,7 +181,7 @@ struct EquityChartView: View {
                     )
                 )
                 .lineStyle(StrokeStyle(lineWidth: 2))
-                .interpolationMethod(.catmullRom)
+                .interpolationMethod(.monotone)
 
                 AreaMark(
                     x: .value("Time", point.date),
@@ -195,7 +194,7 @@ struct EquityChartView: View {
                         endPoint: .bottom
                     )
                 )
-                .interpolationMethod(.catmullRom)
+                .interpolationMethod(.monotone)
             }
         }
         .chartYScale(domain: minEq...maxEq)

--- a/apps/neko-trade/Sources/DCTradingViewer/Views/SettingsView.swift
+++ b/apps/neko-trade/Sources/DCTradingViewer/Views/SettingsView.swift
@@ -8,222 +8,55 @@ struct SettingsView: View {
     @State private var isTesting = false
     @State private var botStatus: BotStatus?
     @State private var wasLive: Bool = false
-    
+
     private let client = TursoClient()
     private let statusTimer = Timer.publish(every: 30, on: .main, in: .common).autoconnect()
 
     var body: some View {
-        Form {
-            // Bot Status Section
-            if settings.isConfigured, let bs = botStatus {
-                let statusColor: Color = bs.isLive ? .green : .red
-                let statusText = bs.isLive ? "LIVE" : "OFFLINE"
-                
-                Section {
-                    VStack(spacing: 0) {
-                        // Main status row
-                        HStack(spacing: 14) {
-                            // Pulsing status dot
-                            ZStack {
-                                Circle()
-                                    .fill(statusColor.opacity(0.25))
-                                    .frame(width: 32, height: 32)
-                                Circle()
-                                    .fill(statusColor)
-                                    .frame(width: 14, height: 14)
-                                    .shadow(color: statusColor.opacity(0.8), radius: 8)
-                            }
-                            
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(statusText)
-                                    .font(.system(.title2, design: .monospaced, weight: .heavy))
-                                    .foregroundStyle(statusColor)
-                                Text("v\(bs.version)")
-                                    .font(.system(.caption2, design: .monospaced))
-                                    .foregroundStyle(.secondary)
-                            }
-                            
-                            Spacer()
-                            
-                            VStack(alignment: .trailing, spacing: 2) {
-                                Text("UPTIME")
-                                    .font(.system(.caption2, design: .monospaced))
-                                    .foregroundStyle(.secondary)
-                                Text(bs.formattedUptime)
-                                    .font(.system(.body, design: .monospaced, weight: .semibold))
-                            }
-                        }
-                        .padding()
-                        
-                        Divider()
-                            .overlay(statusColor.opacity(0.2))
-                        
-                        // Detail row
-                        HStack {
-                            HStack(spacing: 6) {
-                                Image(systemName: "clock.arrow.circlepath")
-                                    .font(.system(.caption2, design: .monospaced))
-                                    .foregroundStyle(.secondary)
-                                Text("Last tick: \(bs.lastTickRelative)")
-                                    .font(.system(.caption, design: .monospaced))
-                                    .foregroundStyle(.secondary)
-                            }
-                            Spacer()
-                            HStack(spacing: 6) {
-                                Image(systemName: "number")
-                                    .font(.system(.caption2, design: .monospaced))
-                                    .foregroundStyle(.secondary)
-                                Text("\(bs.tickCount) ticks")
-                                    .font(.system(.caption, design: .monospaced))
-                                    .foregroundStyle(.secondary)
-                            }
-                        }
-                        .padding(.horizontal)
-                        .padding(.vertical, 10)
-
-                        if bs.checkpointNeedsAttention {
-                            Divider()
-                                .overlay(Color.orange.opacity(0.25))
-
-                            HStack(spacing: 8) {
-                                Image(systemName: "externaldrive.trianglebadge.exclamationmark")
-                                    .font(.system(.caption, design: .monospaced, weight: .semibold))
-                                    .foregroundStyle(.orange)
-                                Text(bs.checkpointHealth)
-                                    .font(.system(.caption, design: .monospaced, weight: .semibold))
-                                    .foregroundStyle(.orange)
-                                if !bs.checkpointError.isEmpty {
-                                    Text(bs.checkpointError)
-                                        .font(.system(.caption2, design: .monospaced))
-                                        .foregroundStyle(.secondary)
-                                        .lineLimit(1)
-                                }
-                                Spacer()
-                            }
-                            .padding(.horizontal)
-                            .padding(.vertical, 10)
-                        }
-
-                        Divider()
-                            .overlay(statusColor.opacity(0.2))
-
-                        HStack {
-                            HStack(spacing: 6) {
-                                Image(systemName: "tag")
-                                    .font(.system(.caption2, design: .monospaced))
-                                    .foregroundStyle(.secondary)
-                                Text(bs.symbolMetadata.tradingSymbol)
-                                    .font(.system(.caption, design: .monospaced))
-                                    .foregroundStyle(.secondary)
-                            }
-                            Spacer()
-                            Text("QUOTE \(bs.symbolMetadata.quoteAsset)")
-                                .font(.system(.caption, design: .monospaced))
-                                .foregroundStyle(.secondary)
-                        }
-                        .padding(.horizontal)
-                        .padding(.vertical, 10)
-
-                        resourceStatusRow(bs)
-                    }
-                    .background {
-                        RoundedRectangle(cornerRadius: 12, style: .continuous)
-                            .fill(.ultraThinMaterial)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                    .strokeBorder(statusColor.opacity(0.4), lineWidth: 1.5)
-                            )
-                            .shadow(color: statusColor.opacity(0.15), radius: 12, y: 4)
-                    }
-                }
-            }
-            
-            Section {
-                HStack {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Label("Database Connection", systemImage: "server.rack")
-                            .font(.system(.title3, design: .monospaced, weight: .semibold))
-                            .foregroundStyle(.primary)
-                        Text("Connect to your Turso database to view live trading data.")
-                            .font(.system(.caption, design: .monospaced))
-                            .foregroundStyle(.secondary)
-                    }
-                    Spacer()
-                    Image(systemName: settings.isConfigured ? "checkmark.circle.fill" : "circle")
-                        .foregroundStyle(settings.isConfigured ? .green : .orange)
-                        .font(.title3)
-                }
-                .padding(.vertical, 4)
-            }
-
-            Section("Turso URL") {
-                TextField("libsql://your-db.turso.io", text: $settings.tursoURL)
-                    .font(.system(.body, design: .monospaced))
-                    .textFieldStyle(.roundedBorder)
-                    .autocorrectionDisabled()
-                    #if os(iOS)
-                    .textInputAutocapitalization(.never)
-                    .keyboardType(.URL)
-                    #endif
-            }
-
-            Section("Auth Token") {
-                SecureField("eyJhbGciOi...", text: $settings.tursoToken)
-                    .font(.system(.body, design: .monospaced))
-                    .textFieldStyle(.roundedBorder)
-                    .autocorrectionDisabled()
-                    #if os(iOS)
-                    .textInputAutocapitalization(.never)
-                    #endif
-            }
-
-
-            Section {
-                HStack {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Label("Alpaca Paper Trading", systemImage: "chart.bar.fill")
-                            .font(.system(.title3, design: .monospaced, weight: .semibold))
-                            .foregroundStyle(.primary)
-                        Text("Connect to Alpaca for live position data.")
-                            .font(.system(.caption, design: .monospaced))
-                            .foregroundStyle(.secondary)
-                    }
-                    Spacer()
-                    Image(systemName: settings.isAlpacaConfigured ? "checkmark.circle.fill" : "circle")
-                        .foregroundStyle(settings.isAlpacaConfigured ? .green : .orange)
-                        .font(.title3)
-                }
-                .padding(.vertical, 4)
-            }
-
-            Section("API Key") {
-                TextField("PK...", text: $settings.alpacaKey)
-                    .font(.system(.body, design: .monospaced))
-                    .textFieldStyle(.roundedBorder)
-                    .autocorrectionDisabled()
-                    #if os(iOS)
-                    .textInputAutocapitalization(.never)
-                    #endif
-            }
-
-            Section("API Secret") {
-                SecureField("Your Alpaca secret", text: $settings.alpacaSecret)
-                    .font(.system(.body, design: .monospaced))
-                    .textFieldStyle(.roundedBorder)
-                    .autocorrectionDisabled()
-                    #if os(iOS)
-                    .textInputAutocapitalization(.never)
-                    #endif
-            }
-
+        ScrollView {
+            settingsContent
         }
-        .formStyle(.grouped)
         .navigationTitle("Settings")
         .task { await loadStatus() }
         .onReceive(statusTimer) { _ in
             guard settings.isConfigured else { return }
             Task { await loadStatus() }
         }
+    }
+
+    private var settingsContent: some View {
+        LazyVStack(spacing: 16) {
+            if settings.isConfigured, let bs = botStatus {
+                botStatusCard(bs)
+            }
+
+            settingsGroup(accent: settings.isConfigured ? .green : .orange) {
+                connectionHeader(
+                    title: "Database Connection",
+                    subtitle: "Connect to your Turso database to view live trading data.",
+                    icon: "server.rack",
+                    isConnected: settings.isConfigured
+                )
+                cardDivider(.secondary)
+                settingsTextField("TURSO URL", placeholder: "libsql://your-db.turso.io", text: $settings.tursoURL, keyboardURL: true)
+                cardDivider(.secondary)
+                settingsSecureField("AUTH TOKEN", placeholder: "eyJhbGciOi...", text: $settings.tursoToken)
+            }
+
+            settingsGroup(accent: settings.isAlpacaConfigured ? .green : .orange) {
+                connectionHeader(
+                    title: "Alpaca Paper Trading",
+                    subtitle: "Connect to Alpaca for live position data.",
+                    icon: "chart.bar.fill",
+                    isConnected: settings.isAlpacaConfigured
+                )
+                cardDivider(.secondary)
+                settingsTextField("API KEY", placeholder: "PK...", text: $settings.alpacaKey)
+                cardDivider(.secondary)
+                settingsSecureField("API SECRET", placeholder: "Your Alpaca secret", text: $settings.alpacaSecret)
+            }
+        }
+        .padding()
     }
 
     private func testConnection() {
@@ -245,7 +78,177 @@ struct SettingsView: View {
             }
         }
     }
-    
+
+    private func botStatusCard(_ bs: BotStatus) -> some View {
+        let statusColor: Color = bs.isLive ? .green : .red
+        let statusText = bs.isLive ? "LIVE" : "OFFLINE"
+
+        return VStack(spacing: 0) {
+            HStack(spacing: 12) {
+                Circle()
+                    .fill(statusColor)
+                    .frame(width: 12, height: 12)
+                    .shadow(color: statusColor.opacity(0.55), radius: 6)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(statusText)
+                        .font(.system(.title2, design: .monospaced, weight: .bold))
+                        .foregroundStyle(statusColor)
+                    Text("v\(bs.version)")
+                        .font(.system(.caption2, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text("UPTIME")
+                        .font(.system(.caption2, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                    Text(bs.formattedUptime)
+                        .font(.system(.body, design: .monospaced, weight: .semibold))
+                }
+            }
+            .padding()
+
+            cardDivider(statusColor)
+
+            HStack {
+                metricLabel(icon: "clock.arrow.circlepath", text: "Last tick: \(bs.lastTickRelative)")
+                Spacer()
+                metricLabel(icon: "number", text: "\(bs.tickCount) ticks")
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 10)
+
+            if bs.checkpointNeedsAttention {
+                cardDivider(.orange)
+
+                HStack(spacing: 8) {
+                    Image(systemName: "externaldrive.trianglebadge.exclamationmark")
+                        .font(.system(.caption, design: .monospaced, weight: .semibold))
+                        .foregroundStyle(.orange)
+                    Text(bs.checkpointHealth)
+                        .font(.system(.caption, design: .monospaced, weight: .semibold))
+                        .foregroundStyle(.orange)
+                    if !bs.checkpointError.isEmpty {
+                        Text(bs.checkpointError)
+                            .font(.system(.caption2, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    Spacer()
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 10)
+            }
+
+            cardDivider(statusColor)
+
+            HStack {
+                metricLabel(icon: "tag", text: bs.symbolMetadata.tradingSymbol)
+                Spacer()
+                Text("QUOTE \(bs.symbolMetadata.quoteAsset)")
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 10)
+
+            resourceStatusRow(bs)
+        }
+        .background {
+            AppCardSurface(accent: statusColor, borderOpacity: 0.24)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private func settingsTextField(_ title: String, placeholder: String, text: Binding<String>, keyboardURL: Bool = false) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.system(.caption2, design: .monospaced, weight: .medium))
+                .foregroundStyle(.secondary)
+            TextField(placeholder, text: text)
+                .font(.system(.body, design: .monospaced))
+                .textFieldStyle(.plain)
+                .autocorrectionDisabled()
+                #if os(iOS)
+                .textInputAutocapitalization(.never)
+                .keyboardType(keyboardURL ? .URL : .default)
+                #endif
+        }
+        .padding()
+    }
+
+    private func settingsSecureField(_ title: String, placeholder: String, text: Binding<String>) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.system(.caption2, design: .monospaced, weight: .medium))
+                .foregroundStyle(.secondary)
+            SecureField(placeholder, text: text)
+                .font(.system(.body, design: .monospaced))
+                .textFieldStyle(.plain)
+                .autocorrectionDisabled()
+                #if os(iOS)
+                .textInputAutocapitalization(.never)
+                #endif
+        }
+        .padding()
+    }
+
+    private func settingsGroup<Content: View>(accent: Color, @ViewBuilder content: () -> Content) -> some View {
+        VStack(spacing: 0) {
+            content()
+        }
+        .background {
+            AppCardSurface(accent: accent, borderOpacity: accent == .green ? 0.18 : 0.24)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private func connectionHeader(title: String, subtitle: String, icon: String, isConnected: Bool) -> some View {
+        let color: Color = isConnected ? .green : .orange
+
+        return HStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.system(.body, design: .monospaced, weight: .semibold))
+                .foregroundStyle(color)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.system(.body, design: .monospaced, weight: .semibold))
+                    .foregroundStyle(.primary)
+                Text(subtitle)
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Image(systemName: isConnected ? "checkmark.circle.fill" : "circle")
+                .foregroundStyle(color)
+                .font(.system(.title3, design: .monospaced))
+        }
+        .padding()
+    }
+
+    private func metricLabel(icon: String, text: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(.caption2, design: .monospaced))
+                .foregroundStyle(.secondary)
+            Text(text)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func cardDivider(_ color: Color) -> some View {
+        Divider()
+            .overlay(color.opacity(0.18))
+    }
+
     private func loadStatus() async {
         guard settings.isConfigured else { return }
         do {


### PR DESCRIPTION
## Summary
- Introduce a shared `AppCardSurface` for consistent material cards across dashboard, equity, and settings screens.
- Rework the Settings view into card-based sections with clearer connection status, grouped fields, and cleaner layout hierarchy.
- Switch equity and dashboard charts to monotone interpolation for smoother, less overshot lines.
- Update Neko Trade docs to reflect the new shared view component.

## Testing
- Not run (not requested).