### PR TITLE
Deploy the DCTrading bot to AWS Tokyo and keep the GCP fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,16 @@ NTFY_TOPIC=
 # Instance tracking
 # BOT_INSTANCE=local
 
+# Cloud deployment switch scripts (AWS Tokyo by default)
+# CLOUD_TARGET=aws
+# AWS_REGION=ap-northeast-1
+# AWS_INSTANCE_ID=i-...
+# AWS_SSH_USER=ec2-user
+# AWS_SSH_KEY=~/.ssh/dctrading-aws.pem
+# AWS_SSH_HOST=ec2-...ap-northeast-1.compute.amazonaws.com
+# AWS_REMOTE_DIR=.
+# AWS_SERVICE_NAME=dctrading
+
 # Funding Rate Filter (optional, default: 0.0001 = 0.010%)
 # Skip DC entries when 24h avg funding rate exceeds threshold
 # FUNDING_SKIP_THRESHOLD=0.0001

--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,7 @@ NTFY_TOPIC=
 
 # Cloud deployment switch scripts (AWS Tokyo by default)
 # CLOUD_TARGET=aws
+# AWS_PROFILE=AdministratorAccess-118740508718
 # AWS_REGION=ap-northeast-1
 # AWS_INSTANCE_ID=i-...
 # AWS_SSH_USER=ec2-user

--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,12 @@ NTFY_TOPIC=
 # AWS_REMOTE_DIR=.
 # AWS_SERVICE_NAME=dctrading
 
+# Legacy GCP deployment variables (used when CLOUD_TARGET=gcp)
+# GCP_ZONE=asia-northeast1-b
+# GCP_INSTANCE=dctrading-asia
+# GCP_REMOTE_DIR=.
+# GCP_SERVICE_NAME=dctrading
+
 # Funding Rate Filter (optional, default: 0.0001 = 0.010%)
 # Skip DC entries when 24h avg funding rate exceeds threshold
 # FUNDING_SKIP_THRESHOLD=0.0001

--- a/services/dctrading-bot/.gitignore
+++ b/services/dctrading-bot/.gitignore
@@ -3,3 +3,4 @@
 *.checkpoint.*
 zig-out/
 .zig-cache/
+*.pem

--- a/services/dctrading-bot/AGENTS.md
+++ b/services/dctrading-bot/AGENTS.md
@@ -28,7 +28,7 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 - `switch-to-aws.sh` — Stop local bot, start AWS Tokyo EC2 instance + systemd service. Copies binary plus checkpoint primary/local backups, excluding temp files.
 - `switch-to-gcp.sh` — Stop local bot, start GCP Tokyo instance + systemd service. Copies binary plus checkpoint primary/local backups, excluding temp files.
 - `switch-to-local.sh` — Stop cloud bot + instance, download checkpoint primary/local backups, start local bot in tmux. Defaults to AWS; use `CLOUD_TARGET=gcp` for the legacy GCP path.
-- `nuke.sh` — Destructive reset for Turso state, local checkpoint primary/backups, and Alpaca positions.
+- `nuke.sh` — Destructive reset for Turso state, local + remote checkpoint primary/backups, and Alpaca positions. Uses `CLOUD_TARGET` to stop and clear remote state.
 
 ### Key Patterns
 - **HTTP calls**: All modules use shared `HttpClient` (native `std.http.Client`). Exception: `feed.zig` bootstrap uses `popen("curl")` for Binance REST, and `telegram.zig` shutdown uses curl fallback.
@@ -74,6 +74,11 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 | `AWS_SSH_HOST` | No | switch-to-aws.sh/switch-to-local.sh; overrides AWS CLI DNS lookup |
 | `AWS_REMOTE_DIR` | No | switch-to-aws.sh/switch-to-local.sh (default: remote home via `.`) |
 | `AWS_SERVICE_NAME` | No | switch-to-aws.sh/switch-to-local.sh (default: dctrading) |
+| `CLOUD_TARGET` | No | nuke.sh/switch-to-local.sh (default: aws; set gcp or local) |
+| `GCP_ZONE` | No | switch-to-gcp.sh/switch-to-local.sh (default: asia-northeast1-b) |
+| `GCP_INSTANCE` | No | switch-to-gcp.sh/switch-to-local.sh (default: dctrading-asia) |
+| `GCP_REMOTE_DIR` | No | switch-to-gcp.sh (default: remote home via `.`) |
+| `GCP_SERVICE_NAME` | No | switch-to-gcp.sh (default: dctrading) |
 
 ### Database Schema (Turso)
 - `accounts` — Double-entry accounts (TigerBeetle-inspired): cash, btc_position, fees, equity, pnl, bnb. 4 balance fields: debits_pending, debits_posted, credits_pending, credits_posted.

--- a/services/dctrading-bot/AGENTS.md
+++ b/services/dctrading-bot/AGENTS.md
@@ -25,6 +25,7 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 - CLI `checkpoint:migrate [path] [backups]` migrates checkpoint primary/backups offline to the current DCTRADE5 layout after writing `.pre-migrate` copies.
 
 ### Scripts (`scripts/`)
+- `create-aws-instance.sh` — One-time AWS infrastructure setup: security group, key pair, EC2 instance, and systemd service.
 - `switch-to-aws.sh` — Stop local bot, start AWS Tokyo EC2 instance + systemd service. Copies binary plus checkpoint primary/local backups, excluding temp files.
 - `switch-to-gcp.sh` — Stop local bot, start GCP Tokyo instance + systemd service. Copies binary plus checkpoint primary/local backups, excluding temp files.
 - `switch-to-local.sh` — Stop cloud bot + instance, download checkpoint primary/local backups, start local bot in tmux. Defaults to AWS; use `CLOUD_TARGET=gcp` for the legacy GCP path.

--- a/services/dctrading-bot/AGENTS.md
+++ b/services/dctrading-bot/AGENTS.md
@@ -75,6 +75,7 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 | `AWS_SSH_HOST` | No | switch-to-aws.sh/switch-to-local.sh; overrides AWS CLI DNS lookup |
 | `AWS_REMOTE_DIR` | No | switch-to-aws.sh/switch-to-local.sh (default: remote home via `.`) |
 | `AWS_SERVICE_NAME` | No | switch-to-aws.sh/switch-to-local.sh (default: dctrading) |
+| `AWS_PROFILE` | No | All AWS scripts (default: AdministratorAccess-118740508718) |
 | `CLOUD_TARGET` | No | nuke.sh/switch-to-local.sh (default: aws; set gcp or local) |
 | `GCP_ZONE` | No | switch-to-gcp.sh/switch-to-local.sh (default: asia-northeast1-b) |
 | `GCP_INSTANCE` | No | switch-to-gcp.sh/switch-to-local.sh (default: dctrading-asia) |

--- a/services/dctrading-bot/AGENTS.md
+++ b/services/dctrading-bot/AGENTS.md
@@ -25,8 +25,9 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 - CLI `checkpoint:migrate [path] [backups]` migrates checkpoint primary/backups offline to the current DCTRADE5 layout after writing `.pre-migrate` copies.
 
 ### Scripts (`scripts/`)
+- `switch-to-aws.sh` — Stop local bot, start AWS Tokyo EC2 instance + systemd service. Copies binary plus checkpoint primary/local backups, excluding temp files.
 - `switch-to-gcp.sh` — Stop local bot, start GCP Tokyo instance + systemd service. Copies binary plus checkpoint primary/local backups, excluding temp files.
-- `switch-to-local.sh` — Stop GCP bot + instance, download checkpoint primary/local backups, start local bot in tmux.
+- `switch-to-local.sh` — Stop cloud bot + instance, download checkpoint primary/local backups, start local bot in tmux. Defaults to AWS; use `CLOUD_TARGET=gcp` for the legacy GCP path.
 - `nuke.sh` — Destructive reset for Turso state, local checkpoint primary/backups, and Alpaca positions.
 
 ### Key Patterns
@@ -65,6 +66,14 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 | `BOT_INSTANCE` | No | main.zig (default: "local") |
 | `CHECKPOINT_BACKUP_RETENTION` | No | main.zig (default: 5 local rotated backups; 0 disables) |
 | `CHECKPOINT_REMOTE_BACKUP_INTERVAL` | No | main.zig/Turso (default: 3600 seconds; 0 disables) |
+| `CLOUD_TARGET` | No | switch-to-local.sh (default: aws; set gcp for legacy GCP) |
+| `AWS_REGION` | No | switch-to-aws.sh/switch-to-local.sh (default: ap-northeast-1) |
+| `AWS_INSTANCE_ID` | Yes for AWS scripts | switch-to-aws.sh/switch-to-local.sh |
+| `AWS_SSH_USER` | No | switch-to-aws.sh/switch-to-local.sh (default: ec2-user) |
+| `AWS_SSH_KEY` | No | switch-to-aws.sh/switch-to-local.sh |
+| `AWS_SSH_HOST` | No | switch-to-aws.sh/switch-to-local.sh; overrides AWS CLI DNS lookup |
+| `AWS_REMOTE_DIR` | No | switch-to-aws.sh/switch-to-local.sh (default: remote home via `.`) |
+| `AWS_SERVICE_NAME` | No | switch-to-aws.sh/switch-to-local.sh (default: dctrading) |
 
 ### Database Schema (Turso)
 - `accounts` — Double-entry accounts (TigerBeetle-inspired): cash, btc_position, fees, equity, pnl, bnb. 4 balance fields: debits_pending, debits_posted, credits_pending, credits_posted.
@@ -77,7 +86,7 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 ### Build
 ```bash
 zig build -Doptimize=ReleaseFast              # macOS arm64
-zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux  # GCP
+zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux  # cloud Linux
 zig build test                                 # 182 tests
 ./zig-out/bin/dctrading checkpoint:migrate dctrading.checkpoint 5
 ```

--- a/services/dctrading-bot/ARCHITECTURE.md
+++ b/services/dctrading-bot/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-BTC algorithmic trading bot using Directional Change (DC) theory. Single Zig 0.16 static binary (~4MB), runs 24/7 on GCP e2-micro (Tokyo) or local macOS. Processes real-time Binance WebSocket ticks, executes Alpaca paper trades, persists to Turso DB, notifies via Telegram/ntfy.
+BTC algorithmic trading bot using Directional Change (DC) theory. Single Zig 0.16 static binary (~4MB), runs 24/7 on AWS EC2 free-tier-compatible Linux in Tokyo or local macOS. The legacy GCP Tokyo script remains available during migration. Processes real-time Binance WebSocket ticks, executes Alpaca paper trades, persists to Turso DB, notifies via Telegram/ntfy.
 
 ## Structure
 
@@ -22,8 +22,9 @@ services/dctrading-bot/
 │   ├── types.zig          # Core types: Tick, Trade, DCEvent, Direction
 │   └── tests.zig          # 39 unit tests
 ├── scripts/
+│   ├── switch-to-aws.sh   # Build Linux binary, upload, start AWS Tokyo instance
 │   ├── switch-to-gcp.sh   # Build Linux binary, upload, start GCP instance
-│   └── switch-to-local.sh # Build macOS binary, start local in tmux
+│   └── switch-to-local.sh # Stop cloud instance, build macOS binary, start local in tmux
 ├── build.zig              # Zig build config
 └── build.zig.zon          # Dependencies (websocket.zig)
 ```
@@ -113,10 +114,11 @@ Two deployment targets, switched via scripts:
 
 | Target | Instance | Binary | Script |
 |--------|----------|--------|--------|
+| AWS Tokyo | Free-tier-compatible EC2, ap-northeast-1 | x86_64-linux | `switch-to-aws.sh` |
 | GCP Tokyo | e2-micro, asia-northeast1-b | x86_64-linux | `switch-to-gcp.sh` |
 | Local macOS | M-series Mac | aarch64-macos | `switch-to-local.sh` |
 
-Only one instance runs at a time. Scripts handle build, upload (GCP), and process management. GCP instance is STOPPED when local is running (billing).
+Only one instance runs at a time. Scripts handle build, upload, checkpoint transfer, and process management. AWS is the default cloud target for `switch-to-local.sh`; set `CLOUD_TARGET=gcp` to use the legacy GCP shutdown path.
 
 ## Key Design Decisions
 

--- a/services/dctrading-bot/README.md
+++ b/services/dctrading-bot/README.md
@@ -140,6 +140,9 @@ Known-good historical simulation outputs are recorded in
 ### AWS Tokyo Deployment
 
 ```bash
+# One-time: create the EC2 instance, security group, and key pair
+./scripts/create-aws-instance.sh
+
 # Required once in your shell or .env
 export AWS_REGION=ap-northeast-1
 export AWS_INSTANCE_ID=i-...

--- a/services/dctrading-bot/README.md
+++ b/services/dctrading-bot/README.md
@@ -171,12 +171,17 @@ configured.
 
 Expected AWS instance setup:
 - Tokyo region (`ap-northeast-1`) with a free-tier-compatible Linux EC2 instance
+  (`t2.micro` by default, 8GB gp3 root volume to stay within free-tier limits)
 - Security group allowing SSH from your IP and outbound HTTPS
 - AWS CLI authenticated locally with permission to start, stop, wait, and
   describe the instance
 - SSH access through `AWS_SSH_USER` and `AWS_SSH_KEY`
 - `~/dctrading`, `~/.env`, and a systemd service named `dctrading` that runs
   the binary from the same remote directory
+
+> **Billing warning:** Data transfer out is not free-tier. Monitor your AWS
+> bill and set up billing alerts. The bot only needs outbound HTTPS so costs
+> are typically negligible, but not zero.
 
 The previous GCP flow remains available while AWS is verified:
 

--- a/services/dctrading-bot/README.md
+++ b/services/dctrading-bot/README.md
@@ -182,6 +182,16 @@ The previous GCP flow remains available while AWS is verified:
 CLOUD_TARGET=gcp ./scripts/switch-to-local.sh
 ```
 
+### Nuke
+
+```bash
+# Nuke everything — stops remote bot, drops Turso tables, deletes checkpoints, closes Alpaca positions
+CLOUD_TARGET=aws ./scripts/nuke.sh
+
+# Or skip remote cleanup and only nuke local state + Turso + Alpaca
+CLOUD_TARGET=local ./scripts/nuke.sh
+```
+
 ## Account Ledger
 
 Every capital movement is tracked in `account_ledger`:

--- a/services/dctrading-bot/README.md
+++ b/services/dctrading-bot/README.md
@@ -130,27 +130,57 @@ source .env && ./zig-out/bin/dctrading -
 # Run tests
 zig build test
 
-# Cross-compile for Linux (GCP deployment)
+# Cross-compile for Linux (cloud deployment)
 zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux
 ```
 
 Known-good historical simulation outputs are recorded in
 [`docs/DCTRADING_SIMULATION_BASELINES.md`](../../docs/DCTRADING_SIMULATION_BASELINES.md).
 
-### GCP Deployment
+### AWS Tokyo Deployment
 
 ```bash
-# Switch to GCP Tokyo
-./scripts/switch-to-gcp.sh
+# Required once in your shell or .env
+export AWS_REGION=ap-northeast-1
+export AWS_INSTANCE_ID=i-...
+export AWS_SSH_USER=ec2-user
+export AWS_SSH_KEY=~/.ssh/dctrading-aws.pem
+
+# Optional when the instance DNS cannot be derived from AWS CLI
+export AWS_SSH_HOST=ec2-...ap-northeast-1.compute.amazonaws.com
+
+# Switch to AWS Tokyo
+./scripts/switch-to-aws.sh
 
 # Switch back to local
 ./scripts/switch-to-local.sh
 ```
 
+`switch-to-aws.sh` starts the EC2 instance, waits for SSH, uploads the Linux
+binary and checkpoint state, then starts the `dctrading` systemd service.
+`switch-to-local.sh` defaults to AWS, stops the remote service, downloads
+checkpoint state, stops the EC2 instance, then starts the local tmux process.
+
 The switch scripts move the checkpoint primary plus local backup files between
 hosts and intentionally ignore `dctrading.checkpoint.tmp`. If no local files are
 available, startup can still restore from Turso when remote checkpoint backup is
 configured.
+
+Expected AWS instance setup:
+- Tokyo region (`ap-northeast-1`) with a free-tier-compatible Linux EC2 instance
+- Security group allowing SSH from your IP and outbound HTTPS
+- AWS CLI authenticated locally with permission to start, stop, wait, and
+  describe the instance
+- SSH access through `AWS_SSH_USER` and `AWS_SSH_KEY`
+- `~/dctrading`, `~/.env`, and a systemd service named `dctrading` that runs
+  the binary from the same remote directory
+
+The previous GCP flow remains available while AWS is verified:
+
+```bash
+./scripts/switch-to-gcp.sh
+CLOUD_TARGET=gcp ./scripts/switch-to-local.sh
+```
 
 ## Account Ledger
 

--- a/services/dctrading-bot/REQUIREMENTS.md
+++ b/services/dctrading-bot/REQUIREMENTS.md
@@ -95,6 +95,7 @@
 | FR-8.2 | Cross-compile for target deployment platform | ✅ |
 | FR-8.3 | Auto-restart on crash in cloud deployment | ✅ |
 | FR-8.4 | Prevent host sleep during local execution | ✅ |
+| FR-8.5 | Support AWS Tokyo free-tier-compatible deployment while preserving the legacy GCP path | ✅ |
 
 ---
 

--- a/services/dctrading-bot/scripts/create-aws-instance.sh
+++ b/services/dctrading-bot/scripts/create-aws-instance.sh
@@ -152,8 +152,7 @@ After=network.target
 Type=simple
 User=$AWS_SSH_USER
 WorkingDirectory=/home/$AWS_SSH_USER
-EnvironmentFile=/home/$AWS_SSH_USER/.env
-ExecStart=/home/$AWS_SSH_USER/$AWS_REMOTE_DIR/dctrading -
+ExecStart=/bin/bash -lc 'source /home/$AWS_SSH_USER/.env && /home/$AWS_SSH_USER/$AWS_REMOTE_DIR/dctrading -'
 Restart=on-failure
 RestartSec=5
 

--- a/services/dctrading-bot/scripts/create-aws-instance.sh
+++ b/services/dctrading-bot/scripts/create-aws-instance.sh
@@ -105,9 +105,33 @@ AMI_ID=$(echo "$AMI_JSON" | jq -r '.ImageId')
 ROOT_DEVICE=$(echo "$AMI_JSON" | jq -r '.RootDeviceName')
 echo "  AMI: $AMI_ID (root: $ROOT_DEVICE)"
 
-# --- Launch Instance ---
-echo "  Launching EC2 instance ($AWS_INSTANCE_TYPE)..."
-INSTANCE_ID=$(aws ec2 run-instances \
+# --- Check for existing instance ---
+EXISTING=$(aws ec2 describe-instances \
+    --region "$AWS_REGION" \
+    --filters "Name=tag:Name,Values=dctrading" "Name=instance-state-name,Values=running,stopped" \
+    --query 'Reservations[0].Instances[0].InstanceId' \
+    --output text 2>/dev/null || true)
+
+if [ -n "$EXISTING" ] && [ "$EXISTING" != "None" ]; then
+    echo "  Existing dctrading instance found: $EXISTING"
+    INSTANCE_ID="$EXISTING"
+
+    STATE=$(aws ec2 describe-instances \
+        --region "$AWS_REGION" \
+        --instance-ids "$INSTANCE_ID" \
+        --query 'Reservations[0].Instances[0].State.Name' \
+        --output text)
+
+    if [ "$STATE" = "stopped" ]; then
+        echo "  Instance is stopped. Starting it..."
+        aws ec2 start-instances --region "$AWS_REGION" --instance-ids "$INSTANCE_ID" >/dev/null
+        aws ec2 wait instance-running --region "$AWS_REGION" --instance-ids "$INSTANCE_ID"
+    else
+        echo "  Instance is already running."
+    fi
+else
+    echo "  Launching EC2 instance ($AWS_INSTANCE_TYPE)..."
+    INSTANCE_ID=$(aws ec2 run-instances \
     --region "$AWS_REGION" \
     --image-id "$AMI_ID" \
     --instance-type "$AWS_INSTANCE_TYPE" \
@@ -142,8 +166,9 @@ EOF
 )" \
     --query 'Instances[0].InstanceId' \
     --output text)
+fi
 
-echo "  Instance launched: $INSTANCE_ID"
+echo "  Instance ready: $INSTANCE_ID"
 
 aws ec2 wait instance-running --region "$AWS_REGION" --instance-ids "$INSTANCE_ID"
 

--- a/services/dctrading-bot/scripts/create-aws-instance.sh
+++ b/services/dctrading-bot/scripts/create-aws-instance.sh
@@ -15,12 +15,21 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
 AWS_REGION="${AWS_REGION:-ap-northeast-1}"
-AWS_INSTANCE_TYPE="${AWS_INSTANCE_TYPE:-t2.micro}"
+AWS_INSTANCE_TYPE="${AWS_INSTANCE_TYPE:-t3.micro}"
 AWS_KEY_NAME="${AWS_KEY_NAME:-dctrading-aws}"
 AWS_SERVICE_NAME="${AWS_SERVICE_NAME:-dctrading}"
 AWS_REMOTE_DIR="${AWS_REMOTE_DIR:-.}"
 AWS_SSH_USER="${AWS_SSH_USER:-ec2-user}"
 export AWS_PROFILE="${AWS_PROFILE:-AdministratorAccess-118740508718}"
+
+if ! aws sts get-caller-identity >/dev/null 2>&1; then
+    echo "AWS SSO token expired or invalid. Launching login..."
+    aws sso login --profile "$AWS_PROFILE"
+    if ! aws sts get-caller-identity >/dev/null 2>&1; then
+        echo "AWS authentication failed after login." >&2
+        exit 1
+    fi
+fi
 
 for cmd in aws jq curl; do
     if ! command -v "$cmd" >/dev/null 2>&1; then

--- a/services/dctrading-bot/scripts/create-aws-instance.sh
+++ b/services/dctrading-bot/scripts/create-aws-instance.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# One-time AWS infrastructure setup for DCTrading bot.
+# Provisions: security group, key pair, EC2 instance, systemd service.
+# Run this once, then use switch-to-aws.sh for deployments.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+AWS_REGION="${AWS_REGION:-ap-northeast-1}"
+AWS_INSTANCE_TYPE="${AWS_INSTANCE_TYPE:-t2.micro}"
+AWS_KEY_NAME="${AWS_KEY_NAME:-dctrading-aws}"
+AWS_SERVICE_NAME="${AWS_SERVICE_NAME:-dctrading}"
+AWS_REMOTE_DIR="${AWS_REMOTE_DIR:-.}"
+AWS_SSH_USER="${AWS_SSH_USER:-ec2-user}"
+
+for cmd in aws jq curl; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "$cmd is required but not installed." >&2
+        exit 1
+    fi
+done
+
+echo "Creating AWS resources in $AWS_REGION..."
+
+# --- Security Group ---
+SG_NAME="dctrading-sg"
+SG_ID=$(aws ec2 describe-security-groups \
+    --region "$AWS_REGION" \
+    --filters "Name=group-name,Values=$SG_NAME" \
+    --query 'SecurityGroups[0].GroupId' \
+    --output text 2>/dev/null || true)
+
+if [ -z "$SG_ID" ] || [ "$SG_ID" = "None" ]; then
+    echo "  Creating security group $SG_NAME..."
+    VPC_ID=$(aws ec2 describe-vpcs \
+        --region "$AWS_REGION" \
+        --filters "Name=is-default,Values=true" \
+        --query 'Vpcs[0].VpcId' \
+        --output text)
+    SG_ID=$(aws ec2 create-security-group \
+        --region "$AWS_REGION" \
+        --group-name "$SG_NAME" \
+        --description "DCTrading bot SSH access" \
+        --vpc-id "$VPC_ID" \
+        --query 'GroupId' \
+        --output text)
+    MY_IP=$(curl -s https://checkip.amazonaws.com)
+    aws ec2 authorize-security-group-ingress \
+        --region "$AWS_REGION" \
+        --group-id "$SG_ID" \
+        --protocol tcp \
+        --port 22 \
+        --cidr "${MY_IP}/32" >/dev/null
+    echo "  Security group created: $SG_ID (SSH from $MY_IP)"
+else
+    echo "  Using existing security group: $SG_ID"
+fi
+
+# --- Key Pair ---
+KEY_PATH="$PROJECT_DIR/${AWS_KEY_NAME}.pem"
+if aws ec2 describe-key-pairs --region "$AWS_REGION" --key-names "$AWS_KEY_NAME" >/dev/null 2>&1; then
+    echo "  Using existing key pair: $AWS_KEY_NAME"
+    if [ ! -f "$KEY_PATH" ]; then
+        echo "  Warning: private key not found at $KEY_PATH" >&2
+        echo "  You will need the matching private key to SSH." >&2
+    fi
+else
+    echo "  Creating key pair: $AWS_KEY_NAME..."
+    aws ec2 create-key-pair \
+        --region "$AWS_REGION" \
+        --key-name "$AWS_KEY_NAME" \
+        --query 'KeyMaterial' \
+        --output text > "$KEY_PATH"
+    chmod 600 "$KEY_PATH"
+    echo "  Private key saved to: $KEY_PATH"
+fi
+
+# --- AMI ---
+echo "  Finding latest Amazon Linux 2023 AMI..."
+AMI_ID=$(aws ec2 describe-images \
+    --region "$AWS_REGION" \
+    --owners amazon \
+    --filters "Name=name,Values=al2023-ami-*-x86_64" "Name=state,Values=available" \
+    --query 'Images | sort_by(@, &CreationDate) | [-1].ImageId' \
+    --output text)
+echo "  AMI: $AMI_ID"
+
+# --- Launch Instance ---
+echo "  Launching EC2 instance ($AWS_INSTANCE_TYPE)..."
+INSTANCE_ID=$(aws ec2 run-instances \
+    --region "$AWS_REGION" \
+    --image-id "$AMI_ID" \
+    --instance-type "$AWS_INSTANCE_TYPE" \
+    --key-name "$AWS_KEY_NAME" \
+    --security-group-ids "$SG_ID" \
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=dctrading}]" \
+    --user-data "$(cat <<EOF
+#!/bin/bash
+set -e
+mkdir -p /home/$AWS_SSH_USER/$AWS_REMOTE_DIR
+cat > /etc/systemd/system/$AWS_SERVICE_NAME.service <<'UNIT'
+[Unit]
+Description=DCTrading Bot
+After=network.target
+
+[Service]
+Type=simple
+User=$AWS_SSH_USER
+WorkingDirectory=/home/$AWS_SSH_USER
+EnvironmentFile=/home/$AWS_SSH_USER/.env
+ExecStart=/home/$AWS_SSH_USER/$AWS_REMOTE_DIR/dctrading -
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+systemctl daemon-reload
+systemctl enable $AWS_SERVICE_NAME
+EOF
+)" \
+    --query 'Instances[0].InstanceId' \
+    --output text)
+
+echo "  Instance launched: $INSTANCE_ID"
+
+aws ec2 wait instance-running --region "$AWS_REGION" --instance-ids "$INSTANCE_ID"
+
+HOST=$(aws ec2 describe-instances \
+    --region "$AWS_REGION" \
+    --instance-ids "$INSTANCE_ID" \
+    --query 'Reservations[0].Instances[0].PublicDnsName' \
+    --output text)
+
+if [ -z "$HOST" ] || [ "$HOST" = "None" ]; then
+    echo "Instance has no public DNS yet. Waiting..."
+    sleep 10
+    HOST=$(aws ec2 describe-instances \
+        --region "$AWS_REGION" \
+        --instance-ids "$INSTANCE_ID" \
+        --query 'Reservations[0].Instances[0].PublicDnsName' \
+        --output text)
+fi
+
+echo "  Waiting for SSH at $HOST..."
+for attempt in {1..30}; do
+    if ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=5 \
+        -i "$KEY_PATH" "$AWS_SSH_USER@$HOST" "true" 2>/dev/null; then
+        break
+    fi
+    if [ "$attempt" -eq 30 ]; then
+        echo "Timed out waiting for SSH." >&2
+        exit 1
+    fi
+    sleep 5
+done
+
+echo ""
+echo "✅ AWS instance ready!"
+echo ""
+echo "Add these to your .env:"
+echo "  AWS_REGION=$AWS_REGION"
+echo "  AWS_INSTANCE_ID=$INSTANCE_ID"
+echo "  AWS_SSH_USER=$AWS_SSH_USER"
+echo "  AWS_SSH_KEY=$KEY_PATH"
+echo "  AWS_SSH_HOST=$HOST"
+echo "  AWS_REMOTE_DIR=$AWS_REMOTE_DIR"
+echo "  AWS_SERVICE_NAME=$AWS_SERVICE_NAME"
+echo ""
+echo "Then deploy with:"
+echo "  ./scripts/switch-to-aws.sh"

--- a/services/dctrading-bot/scripts/create-aws-instance.sh
+++ b/services/dctrading-bot/scripts/create-aws-instance.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 # One-time AWS infrastructure setup for DCTrading bot.
-# Provisions: security group, key pair, EC2 instance, systemd service.
+# Provisions: security group, key pair, EC2 instance (free-tier by default),
+#             8GB gp3 root volume, systemd service.
 # Run this once, then use switch-to-aws.sh for deployments.
+#
+# Free-tier notes:
+#   - t2.micro is free for 12 months (750 hrs/mo).
+#   - 8GB gp3 stays within the 30GB EBS free-tier allowance.
+#   - An Elastic IP is free while attached to a running instance.
+#   - Monitor your bill; data-transfer out is not free-tier.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -79,13 +86,15 @@ fi
 
 # --- AMI ---
 echo "  Finding latest Amazon Linux 2023 AMI..."
-AMI_ID=$(aws ec2 describe-images \
+AMI_JSON=$(aws ec2 describe-images \
     --region "$AWS_REGION" \
     --owners amazon \
     --filters "Name=name,Values=al2023-ami-*-x86_64" "Name=state,Values=available" \
-    --query 'Images | sort_by(@, &CreationDate) | [-1].ImageId' \
-    --output text)
-echo "  AMI: $AMI_ID"
+    --query 'Images | sort_by(@, &CreationDate) | [-1]' \
+    --output json)
+AMI_ID=$(echo "$AMI_JSON" | jq -r '.ImageId')
+ROOT_DEVICE=$(echo "$AMI_JSON" | jq -r '.RootDeviceName')
+echo "  AMI: $AMI_ID (root: $ROOT_DEVICE)"
 
 # --- Launch Instance ---
 echo "  Launching EC2 instance ($AWS_INSTANCE_TYPE)..."
@@ -95,6 +104,7 @@ INSTANCE_ID=$(aws ec2 run-instances \
     --instance-type "$AWS_INSTANCE_TYPE" \
     --key-name "$AWS_KEY_NAME" \
     --security-group-ids "$SG_ID" \
+    --block-device-mappings "[{\"DeviceName\":\"$ROOT_DEVICE\",\"Ebs\":{\"VolumeSize\":8,\"VolumeType\":\"gp3\",\"DeleteOnTermination\":true}}]" \
     --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=dctrading}]" \
     --user-data "$(cat <<EOF
 #!/bin/bash

--- a/services/dctrading-bot/scripts/create-aws-instance.sh
+++ b/services/dctrading-bot/scripts/create-aws-instance.sh
@@ -13,6 +13,7 @@ AWS_KEY_NAME="${AWS_KEY_NAME:-dctrading-aws}"
 AWS_SERVICE_NAME="${AWS_SERVICE_NAME:-dctrading}"
 AWS_REMOTE_DIR="${AWS_REMOTE_DIR:-.}"
 AWS_SSH_USER="${AWS_SSH_USER:-ec2-user}"
+export AWS_PROFILE="${AWS_PROFILE:-AdministratorAccess-118740508718}"
 
 for cmd in aws jq curl; do
     if ! command -v "$cmd" >/dev/null 2>&1; then

--- a/services/dctrading-bot/scripts/nuke.sh
+++ b/services/dctrading-bot/scripts/nuke.sh
@@ -13,6 +13,7 @@ AWS_SSH_USER="${AWS_SSH_USER:-ec2-user}"
 AWS_SSH_KEY="${AWS_SSH_KEY:-}"
 AWS_REMOTE_DIR="${AWS_REMOTE_DIR:-.}"
 AWS_SERVICE_NAME="${AWS_SERVICE_NAME:-dctrading}"
+export AWS_PROFILE="${AWS_PROFILE:-AdministratorAccess-118740508718}"
 
 GCP_ZONE="${GCP_ZONE:-asia-northeast1-b}"
 GCP_INSTANCE="${GCP_INSTANCE:-dctrading-asia}"

--- a/services/dctrading-bot/scripts/nuke.sh
+++ b/services/dctrading-bot/scripts/nuke.sh
@@ -15,6 +15,15 @@ AWS_REMOTE_DIR="${AWS_REMOTE_DIR:-.}"
 AWS_SERVICE_NAME="${AWS_SERVICE_NAME:-dctrading}"
 export AWS_PROFILE="${AWS_PROFILE:-AdministratorAccess-118740508718}"
 
+if ! aws sts get-caller-identity >/dev/null 2>&1; then
+    echo "AWS SSO token expired or invalid. Launching login..."
+    aws sso login --profile "$AWS_PROFILE"
+    if ! aws sts get-caller-identity >/dev/null 2>&1; then
+        echo "AWS authentication failed after login." >&2
+        exit 1
+    fi
+fi
+
 GCP_ZONE="${GCP_ZONE:-asia-northeast1-b}"
 GCP_INSTANCE="${GCP_INSTANCE:-dctrading-asia}"
 GCP_REMOTE_DIR="${GCP_REMOTE_DIR:-.}"

--- a/services/dctrading-bot/scripts/nuke.sh
+++ b/services/dctrading-bot/scripts/nuke.sh
@@ -1,36 +1,117 @@
 #!/bin/bash
-# Nuke all trading state: Turso tables, checkpoint, Alpaca positions
-set -e
+# Nuke all trading state: Turso tables, local + remote checkpoint, Alpaca positions.
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+CLOUD_TARGET="${CLOUD_TARGET:-aws}"
+
+AWS_REGION="${AWS_REGION:-ap-northeast-1}"
+AWS_INSTANCE_ID="${AWS_INSTANCE_ID:-}"
+AWS_SSH_USER="${AWS_SSH_USER:-ec2-user}"
+AWS_SSH_KEY="${AWS_SSH_KEY:-}"
+AWS_REMOTE_DIR="${AWS_REMOTE_DIR:-.}"
+AWS_SERVICE_NAME="${AWS_SERVICE_NAME:-dctrading}"
+
+GCP_ZONE="${GCP_ZONE:-asia-northeast1-b}"
+GCP_INSTANCE="${GCP_INSTANCE:-dctrading-asia}"
+GCP_REMOTE_DIR="${GCP_REMOTE_DIR:-.}"
+GCP_SERVICE_NAME="${GCP_SERVICE_NAME:-dctrading}"
 
 source "$PROJECT_DIR/.env"
 
 TURSO_HOST=$(echo "$TURSO_URL" | sed 's|libsql://||; s|https://||')
 
-echo "⚠️  This will destroy ALL trading data. Press Ctrl-C to cancel."
+ssh_opts=(-o StrictHostKeyChecking=accept-new)
+if [ -n "$AWS_SSH_KEY" ]; then
+    ssh_opts+=(-i "$AWS_SSH_KEY")
+fi
+
+aws_host() {
+    if [ -n "${AWS_SSH_HOST:-}" ]; then
+        printf "%s\n" "$AWS_SSH_HOST"
+        return
+    fi
+    if [ -z "$AWS_INSTANCE_ID" ]; then
+        echo ""
+        return
+    fi
+    aws ec2 describe-instances \
+        --region "$AWS_REGION" \
+        --instance-ids "$AWS_INSTANCE_ID" \
+        --query "Reservations[0].Instances[0].PublicDnsName" \
+        --output text
+}
+
+stop_remote() {
+    case "$CLOUD_TARGET" in
+        local)
+            echo "  Skipping remote cleanup (CLOUD_TARGET=local)."
+            ;;
+        aws)
+            local host
+            host="$(aws_host)"
+            if [ -z "$host" ] || [ "$host" = "None" ]; then
+                echo "  Could not resolve AWS host. Set AWS_SSH_HOST or AWS_INSTANCE_ID. Skipping remote cleanup." >&2
+                return
+            fi
+
+            echo "  Stopping AWS bot..."
+            ssh "${ssh_opts[@]}" "$AWS_SSH_USER@$host" "sudo systemctl stop '$AWS_SERVICE_NAME' 2>/dev/null || true" 2>/dev/null || true
+            sleep 2
+
+            echo "  Removing AWS checkpoint state..."
+            ssh "${ssh_opts[@]}" "$AWS_SSH_USER@$host" "rm -f '$AWS_REMOTE_DIR'/dctrading.checkpoint '$AWS_REMOTE_DIR'/dctrading.checkpoint.tmp '$AWS_REMOTE_DIR'/dctrading.checkpoint.bak.*" 2>/dev/null || true
+
+            if [ -n "$AWS_INSTANCE_ID" ]; then
+                echo "  Stopping AWS instance..."
+                aws ec2 stop-instances \
+                    --region "$AWS_REGION" \
+                    --instance-ids "$AWS_INSTANCE_ID" \
+                    >/dev/null || true
+            fi
+            ;;
+        gcp)
+            echo "  Stopping GCP bot..."
+            gcloud compute ssh "$GCP_INSTANCE" --zone="$GCP_ZONE" --command="sudo systemctl stop '$GCP_SERVICE_NAME'" 2>/dev/null || true
+            sleep 2
+
+            echo "  Removing GCP checkpoint state..."
+            gcloud compute ssh "$GCP_INSTANCE" --zone="$GCP_ZONE" --command="rm -f '$GCP_REMOTE_DIR'/dctrading.checkpoint '$GCP_REMOTE_DIR'/dctrading.checkpoint.tmp '$GCP_REMOTE_DIR'/dctrading.checkpoint.bak.*" 2>/dev/null || true
+
+            echo "  Stopping GCP instance..."
+            gcloud compute instances stop "$GCP_INSTANCE" --zone="$GCP_ZONE" --quiet >/dev/null || true
+            ;;
+        *)
+            echo "Unsupported CLOUD_TARGET=$CLOUD_TARGET. Use aws, gcp, or local." >&2
+            exit 1
+            ;;
+    esac
+}
+
+echo "⚠️  This will destroy ALL trading data (local + remote). Press Ctrl-C to cancel."
 sleep 3
+
+stop_remote
 
 echo "  Dropping Turso tables..."
 curl -s "https://$TURSO_HOST/v2/pipeline" \
   -H "Authorization: Bearer $TURSO_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"requests": [
-    {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS account_ledger"}},
-    {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS trade_events"}},
-    {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS positions"}},
     {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS transfers"}},
     {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS accounts"}},
     {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS equity_log"}},
+    {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS resource_log"}},
     {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS checkpoint_backups"}},
     {"type": "execute", "stmt": {"sql": "DROP TABLE IF EXISTS bot_status"}}
   ]}' > /dev/null
 echo "  ✓ Tables dropped"
 
-echo "  Deleting checkpoint state..."
+echo "  Deleting local checkpoint state..."
 rm -f "$PROJECT_DIR"/dctrading.checkpoint "$PROJECT_DIR"/dctrading.checkpoint.tmp "$PROJECT_DIR"/dctrading.checkpoint.bak.*
-echo "  ✓ Checkpoint state deleted"
+echo "  ✓ Local checkpoint state deleted"
 
 echo "  Closing Alpaca positions..."
 curl -s -X DELETE "https://paper-api.alpaca.markets/v2/positions" \

--- a/services/dctrading-bot/scripts/switch-to-aws.sh
+++ b/services/dctrading-bot/scripts/switch-to-aws.sh
@@ -112,6 +112,11 @@ aws_remote "$HOST" "sudo systemctl stop '$AWS_SERVICE_NAME' 2>/dev/null || true;
 upload "$HOST" zig-out/bin/dctrading
 aws_remote "$HOST" "chmod +x '$AWS_REMOTE_DIR/dctrading'"
 
+if [ -f "$PROJECT_DIR/.env" ]; then
+    echo "  Uploading .env..."
+    upload "$HOST" "$PROJECT_DIR/.env"
+fi
+
 shopt -s nullglob
 checkpoint_files=(dctrading.checkpoint dctrading.checkpoint.bak.*)
 if [ ${#checkpoint_files[@]} -gt 0 ]; then

--- a/services/dctrading-bot/scripts/switch-to-aws.sh
+++ b/services/dctrading-bot/scripts/switch-to-aws.sh
@@ -82,7 +82,7 @@ stop_local_bot() {
 
     echo "  Waiting for graceful shutdown (checkpoint save + Turso flush)..."
     for i in {1..30}; do
-        if ! ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {exit 1}'; then
+        if ! ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {found=1; exit} END {exit !found}'; then
             echo "  Local bot stopped gracefully."
             return
         fi

--- a/services/dctrading-bot/scripts/switch-to-aws.sh
+++ b/services/dctrading-bot/scripts/switch-to-aws.sh
@@ -71,33 +71,34 @@ echo "Switching to AWS Tokyo..."
 
 stop_local_bot() {
     local pid
-    pid=$(pgrep -f "dctrading\s+-" | head -1)
+    pid=$(ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {print $2; exit}')
     if [ -z "$pid" ]; then
         echo "  Local bot not running."
         return
     fi
 
     if tmux has-session -t trading 2>/dev/null; then
-        echo "  Stopping local bot via tmux..."
+        echo "  Stopping local bot via tmux (Ctrl-C)..."
         tmux send-keys -t trading C-c
     else
-        echo "  Stopping local bot (PID $pid)..."
-        kill -TERM "$pid" 2>/dev/null || true
+        echo "  Stopping local bot (PID $pid, SIGINT)..."
+        kill -INT "$pid" 2>/dev/null || true
     fi
 
-    for i in {1..10}; do
-        if ! pgrep -f "dctrading\s+-" >/dev/null; then
-            echo "  Local bot stopped."
+    echo "  Waiting for graceful shutdown (checkpoint save + Turso flush)..."
+    for i in {1..30}; do
+        if ! ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {exit 1}'; then
+            echo "  Local bot stopped gracefully."
             return
         fi
         sleep 1
     done
 
-    pid=$(pgrep -f "dctrading\s+-" | head -1)
+    pid=$(ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {print $2; exit}')
     if [ -n "$pid" ]; then
-        echo "  Force killing local bot (PID $pid)..."
+        echo "  WARNING: Bot still running after 30s. Force-killing (checkpoint may be lost)..." >&2
         kill -KILL "$pid" 2>/dev/null || true
-        sleep 1
+        sleep 2
     fi
 }
 

--- a/services/dctrading-bot/scripts/switch-to-aws.sh
+++ b/services/dctrading-bot/scripts/switch-to-aws.sh
@@ -77,13 +77,8 @@ stop_local_bot() {
         return
     fi
 
-    if tmux has-session -t trading 2>/dev/null; then
-        echo "  Stopping local bot via tmux (Ctrl-C)..."
-        tmux send-keys -t trading C-c
-    else
-        echo "  Stopping local bot (PID $pid, SIGINT)..."
-        kill -INT "$pid" 2>/dev/null || true
-    fi
+    echo "  Stopping local bot (PID $pid, SIGINT)..."
+    kill -INT "$pid" 2>/dev/null || true
 
     echo "  Waiting for graceful shutdown (checkpoint save + Turso flush)..."
     for i in {1..30}; do

--- a/services/dctrading-bot/scripts/switch-to-aws.sh
+++ b/services/dctrading-bot/scripts/switch-to-aws.sh
@@ -41,16 +41,24 @@ if [ -n "$AWS_SSH_KEY" ]; then
 fi
 
 aws_host() {
+    local live_host
+    live_host=$(aws ec2 describe-instances \
+        --region "$AWS_REGION" \
+        --instance-ids "$AWS_INSTANCE_ID" \
+        --query "Reservations[0].Instances[0].PublicDnsName" \
+        --output text)
+
+    if [ -n "$live_host" ] && [ "$live_host" != "None" ]; then
+        printf "%s\n" "$live_host"
+        return
+    fi
+
     if [ -n "${AWS_SSH_HOST:-}" ]; then
         printf "%s\n" "$AWS_SSH_HOST"
         return
     fi
 
-    aws ec2 describe-instances \
-        --region "$AWS_REGION" \
-        --instance-ids "$AWS_INSTANCE_ID" \
-        --query "Reservations[0].Instances[0].PublicDnsName" \
-        --output text
+    echo ""
 }
 
 aws_remote() {

--- a/services/dctrading-bot/scripts/switch-to-aws.sh
+++ b/services/dctrading-bot/scripts/switch-to-aws.sh
@@ -118,6 +118,13 @@ if [ -z "$HOST" ] || [ "$HOST" = "None" ]; then
     exit 1
 fi
 
+PUBLIC_IP=$(aws ec2 describe-instances \
+    --region "$AWS_REGION" \
+    --instance-ids "$AWS_INSTANCE_ID" \
+    --query 'Reservations[0].Instances[0].PublicIpAddress' \
+    --output text)
+echo "  Public IP: $PUBLIC_IP"
+
 # Ensure security group allows SSH from current IP
 MY_IP=$(curl -s https://checkip.amazonaws.com)
 SG_IDS=$(aws ec2 describe-instances \
@@ -125,8 +132,9 @@ SG_IDS=$(aws ec2 describe-instances \
     --instance-ids "$AWS_INSTANCE_ID" \
     --query 'Reservations[0].Instances[0].SecurityGroups[*].GroupId' \
     --output text)
+echo "  Security groups: $SG_IDS"
 for sg in $SG_IDS; do
-    echo "  Ensuring security group $sg allows SSH from $MY_IP..."
+    echo "  Ensuring SG $sg allows SSH from $MY_IP..."
     aws ec2 authorize-security-group-ingress \
         --region "$AWS_REGION" \
         --group-id "$sg" \
@@ -137,11 +145,16 @@ done
 
 echo "  Waiting for SSH at $HOST..."
 for attempt in {1..30}; do
-    if aws_remote "$HOST" "true" 2>/dev/null; then
+    printf "    attempt %d/30...\r" "$attempt"
+    if ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=5 -o BatchMode=yes \
+        "${ssh_opts[@]}" "$AWS_SSH_USER@$HOST" "true" 2>/dev/null; then
+        echo ""
         break
     fi
     if [ "$attempt" -eq 30 ]; then
+        echo ""
         echo "Timed out waiting for SSH." >&2
+        echo "Check AWS console: ensure the instance has a public IP and security group allows port 22 from ${MY_IP}/32." >&2
         exit 1
     fi
     sleep 5

--- a/services/dctrading-bot/scripts/switch-to-aws.sh
+++ b/services/dctrading-bot/scripts/switch-to-aws.sh
@@ -19,6 +19,15 @@ if ! command -v aws >/dev/null 2>&1; then
     exit 1
 fi
 
+if ! aws sts get-caller-identity >/dev/null 2>&1; then
+    echo "AWS SSO token expired or invalid. Launching login..."
+    aws sso login --profile "$AWS_PROFILE"
+    if ! aws sts get-caller-identity >/dev/null 2>&1; then
+        echo "AWS authentication failed after login." >&2
+        exit 1
+    fi
+fi
+
 # Verify instance exists before starting
 if ! aws ec2 describe-instances --region "$AWS_REGION" --instance-ids "$AWS_INSTANCE_ID" >/dev/null 2>&1; then
     echo "Instance $AWS_INSTANCE_ID not found in $AWS_REGION." >&2

--- a/services/dctrading-bot/scripts/switch-to-aws.sh
+++ b/services/dctrading-bot/scripts/switch-to-aws.sh
@@ -69,9 +69,39 @@ cd "$PROJECT_DIR"
 
 echo "Switching to AWS Tokyo..."
 
-echo "  Stopping local bot..."
-tmux send-keys -t trading C-c 2>/dev/null || true
-sleep 3
+stop_local_bot() {
+    local pid
+    pid=$(pgrep -f "dctrading\s+-" | head -1)
+    if [ -z "$pid" ]; then
+        echo "  Local bot not running."
+        return
+    fi
+
+    if tmux has-session -t trading 2>/dev/null; then
+        echo "  Stopping local bot via tmux..."
+        tmux send-keys -t trading C-c
+    else
+        echo "  Stopping local bot (PID $pid)..."
+        kill -TERM "$pid" 2>/dev/null || true
+    fi
+
+    for i in {1..10}; do
+        if ! pgrep -f "dctrading\s+-" >/dev/null; then
+            echo "  Local bot stopped."
+            return
+        fi
+        sleep 1
+    done
+
+    pid=$(pgrep -f "dctrading\s+-" | head -1)
+    if [ -n "$pid" ]; then
+        echo "  Force killing local bot (PID $pid)..."
+        kill -KILL "$pid" 2>/dev/null || true
+        sleep 1
+    fi
+}
+
+stop_local_bot
 
 echo "  Building Linux binary..."
 zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux

--- a/services/dctrading-bot/scripts/switch-to-aws.sh
+++ b/services/dctrading-bot/scripts/switch-to-aws.sh
@@ -201,7 +201,7 @@ After=network.target
 Type=simple
 User=$AWS_SSH_USER
 WorkingDirectory=/home/$AWS_SSH_USER
-ExecStart=/bin/bash -lc 'source /home/$AWS_SSH_USER/.env && /home/$AWS_SSH_USER/$AWS_REMOTE_DIR/dctrading -'
+ExecStart=/bin/bash -lc 'export BOT_INSTANCE=aws-tokyo && source /home/$AWS_SSH_USER/.env && /home/$AWS_SSH_USER/$AWS_REMOTE_DIR/dctrading -'
 Restart=on-failure
 RestartSec=5
 

--- a/services/dctrading-bot/scripts/switch-to-aws.sh
+++ b/services/dctrading-bot/scripts/switch-to-aws.sh
@@ -12,6 +12,7 @@ AWS_SSH_USER="${AWS_SSH_USER:-ec2-user}"
 AWS_SSH_KEY="${AWS_SSH_KEY:-}"
 AWS_REMOTE_DIR="${AWS_REMOTE_DIR:-.}"
 AWS_SERVICE_NAME="${AWS_SERVICE_NAME:-dctrading}"
+export AWS_PROFILE="${AWS_PROFILE:-AdministratorAccess-118740508718}"
 
 if ! command -v aws >/dev/null 2>&1; then
     echo "aws CLI not found. Install it and authenticate first." >&2

--- a/services/dctrading-bot/scripts/switch-to-aws.sh
+++ b/services/dctrading-bot/scripts/switch-to-aws.sh
@@ -13,6 +13,11 @@ AWS_SSH_KEY="${AWS_SSH_KEY:-}"
 AWS_REMOTE_DIR="${AWS_REMOTE_DIR:-.}"
 AWS_SERVICE_NAME="${AWS_SERVICE_NAME:-dctrading}"
 
+if ! command -v aws >/dev/null 2>&1; then
+    echo "aws CLI not found. Install it and authenticate first." >&2
+    exit 1
+fi
+
 ssh_opts=(-o StrictHostKeyChecking=accept-new)
 if [ -n "$AWS_SSH_KEY" ]; then
     ssh_opts+=(-i "$AWS_SSH_KEY")
@@ -31,7 +36,7 @@ aws_host() {
         --output text
 }
 
-remote() {
+aws_remote() {
     local host="$1"
     shift
     ssh "${ssh_opts[@]}" "$AWS_SSH_USER@$host" "$@"
@@ -72,7 +77,7 @@ fi
 
 echo "  Waiting for SSH at $HOST..."
 for attempt in {1..30}; do
-    if remote "$HOST" "true" 2>/dev/null; then
+    if aws_remote "$HOST" "true" 2>/dev/null; then
         break
     fi
     if [ "$attempt" -eq 30 ]; then
@@ -82,26 +87,29 @@ for attempt in {1..30}; do
     sleep 5
 done
 
+echo "  Ensuring remote directory exists..."
+aws_remote "$HOST" "mkdir -p '$AWS_REMOTE_DIR'"
+
 echo "  Uploading binary..."
-remote "$HOST" "sudo systemctl stop '$AWS_SERVICE_NAME' 2>/dev/null || true; chmod +w '$AWS_REMOTE_DIR/dctrading' 2>/dev/null || true"
+aws_remote "$HOST" "sudo systemctl stop '$AWS_SERVICE_NAME' 2>/dev/null || true; chmod +w '$AWS_REMOTE_DIR/dctrading' 2>/dev/null || true"
 upload "$HOST" zig-out/bin/dctrading
-remote "$HOST" "chmod +x '$AWS_REMOTE_DIR/dctrading'"
+aws_remote "$HOST" "chmod +x '$AWS_REMOTE_DIR/dctrading'"
 
 shopt -s nullglob
 checkpoint_files=(dctrading.checkpoint dctrading.checkpoint.bak.*)
 if [ ${#checkpoint_files[@]} -gt 0 ]; then
     echo "  Uploading checkpoint state..."
-    remote "$HOST" "rm -f '$AWS_REMOTE_DIR/dctrading.checkpoint.tmp' '$AWS_REMOTE_DIR'/dctrading.checkpoint.bak.*"
+    aws_remote "$HOST" "rm -f '$AWS_REMOTE_DIR/dctrading.checkpoint.tmp' '$AWS_REMOTE_DIR'/dctrading.checkpoint.bak.*"
     upload "$HOST" "${checkpoint_files[@]}"
 else
     echo "  No local checkpoint state to upload; bot can restore from Turso if configured."
 fi
 
 echo "  Starting bot on AWS..."
-remote "$HOST" "sudo systemctl start '$AWS_SERVICE_NAME'"
+aws_remote "$HOST" "sudo systemctl start '$AWS_SERVICE_NAME'"
 
 sleep 5
 echo "  Checking AWS bot..."
-remote "$HOST" "sudo journalctl -u '$AWS_SERVICE_NAME' -n 5 --no-pager"
+aws_remote "$HOST" "sudo journalctl -u '$AWS_SERVICE_NAME' -n 5 --no-pager"
 
 echo "Bot running on AWS Tokyo"

--- a/services/dctrading-bot/scripts/switch-to-aws.sh
+++ b/services/dctrading-bot/scripts/switch-to-aws.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Switch trading bot from local to AWS Tokyo.
+# Builds Linux binary, uploads it with checkpoint state, and starts systemd.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+AWS_REGION="${AWS_REGION:-ap-northeast-1}"
+AWS_INSTANCE_ID="${AWS_INSTANCE_ID:?Set AWS_INSTANCE_ID to the EC2 instance id}"
+AWS_SSH_USER="${AWS_SSH_USER:-ec2-user}"
+AWS_SSH_KEY="${AWS_SSH_KEY:-}"
+AWS_REMOTE_DIR="${AWS_REMOTE_DIR:-.}"
+AWS_SERVICE_NAME="${AWS_SERVICE_NAME:-dctrading}"
+
+ssh_opts=(-o StrictHostKeyChecking=accept-new)
+if [ -n "$AWS_SSH_KEY" ]; then
+    ssh_opts+=(-i "$AWS_SSH_KEY")
+fi
+
+aws_host() {
+    if [ -n "${AWS_SSH_HOST:-}" ]; then
+        printf "%s\n" "$AWS_SSH_HOST"
+        return
+    fi
+
+    aws ec2 describe-instances \
+        --region "$AWS_REGION" \
+        --instance-ids "$AWS_INSTANCE_ID" \
+        --query "Reservations[0].Instances[0].PublicDnsName" \
+        --output text
+}
+
+remote() {
+    local host="$1"
+    shift
+    ssh "${ssh_opts[@]}" "$AWS_SSH_USER@$host" "$@"
+}
+
+upload() {
+    local host="$1"
+    shift
+    scp "${ssh_opts[@]}" "$@" "$AWS_SSH_USER@$host:$AWS_REMOTE_DIR/"
+}
+
+cd "$PROJECT_DIR"
+
+echo "Switching to AWS Tokyo..."
+
+echo "  Stopping local bot..."
+tmux send-keys -t trading C-c 2>/dev/null || true
+sleep 3
+
+echo "  Building Linux binary..."
+zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux
+echo "  Linux binary ready."
+
+echo "  Starting AWS instance..."
+aws ec2 start-instances \
+    --region "$AWS_REGION" \
+    --instance-ids "$AWS_INSTANCE_ID" \
+    >/dev/null
+aws ec2 wait instance-running \
+    --region "$AWS_REGION" \
+    --instance-ids "$AWS_INSTANCE_ID"
+
+HOST="$(aws_host)"
+if [ -z "$HOST" ] || [ "$HOST" = "None" ]; then
+    echo "Could not resolve AWS instance public DNS. Set AWS_SSH_HOST manually." >&2
+    exit 1
+fi
+
+echo "  Waiting for SSH at $HOST..."
+for attempt in {1..30}; do
+    if remote "$HOST" "true" 2>/dev/null; then
+        break
+    fi
+    if [ "$attempt" -eq 30 ]; then
+        echo "Timed out waiting for SSH." >&2
+        exit 1
+    fi
+    sleep 5
+done
+
+echo "  Uploading binary..."
+remote "$HOST" "sudo systemctl stop '$AWS_SERVICE_NAME' 2>/dev/null || true; chmod +w '$AWS_REMOTE_DIR/dctrading' 2>/dev/null || true"
+upload "$HOST" zig-out/bin/dctrading
+remote "$HOST" "chmod +x '$AWS_REMOTE_DIR/dctrading'"
+
+shopt -s nullglob
+checkpoint_files=(dctrading.checkpoint dctrading.checkpoint.bak.*)
+if [ ${#checkpoint_files[@]} -gt 0 ]; then
+    echo "  Uploading checkpoint state..."
+    remote "$HOST" "rm -f '$AWS_REMOTE_DIR/dctrading.checkpoint.tmp' '$AWS_REMOTE_DIR'/dctrading.checkpoint.bak.*"
+    upload "$HOST" "${checkpoint_files[@]}"
+else
+    echo "  No local checkpoint state to upload; bot can restore from Turso if configured."
+fi
+
+echo "  Starting bot on AWS..."
+remote "$HOST" "sudo systemctl start '$AWS_SERVICE_NAME'"
+
+sleep 5
+echo "  Checking AWS bot..."
+remote "$HOST" "sudo journalctl -u '$AWS_SERVICE_NAME' -n 5 --no-pager"
+
+echo "Bot running on AWS Tokyo"

--- a/services/dctrading-bot/scripts/switch-to-aws.sh
+++ b/services/dctrading-bot/scripts/switch-to-aws.sh
@@ -191,6 +191,25 @@ else
     echo "  No local checkpoint state to upload; bot can restore from Turso if configured."
 fi
 
+echo "  Updating systemd service..."
+aws_remote "$HOST" "sudo tee /etc/systemd/system/$AWS_SERVICE_NAME.service > /dev/null <<'EOF'
+[Unit]
+Description=DCTrading Bot
+After=network.target
+
+[Service]
+Type=simple
+User=$AWS_SSH_USER
+WorkingDirectory=/home/$AWS_SSH_USER
+ExecStart=/bin/bash -lc 'source /home/$AWS_SSH_USER/.env && /home/$AWS_SSH_USER/$AWS_REMOTE_DIR/dctrading -'
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+sudo systemctl daemon-reload"
+
 echo "  Starting bot on AWS..."
 aws_remote "$HOST" "sudo systemctl start '$AWS_SERVICE_NAME'"
 

--- a/services/dctrading-bot/scripts/switch-to-aws.sh
+++ b/services/dctrading-bot/scripts/switch-to-aws.sh
@@ -18,6 +18,13 @@ if ! command -v aws >/dev/null 2>&1; then
     exit 1
 fi
 
+# Verify instance exists before starting
+if ! aws ec2 describe-instances --region "$AWS_REGION" --instance-ids "$AWS_INSTANCE_ID" >/dev/null 2>&1; then
+    echo "Instance $AWS_INSTANCE_ID not found in $AWS_REGION." >&2
+    echo "Run ./scripts/create-aws-instance.sh to provision it first." >&2
+    exit 1
+fi
+
 ssh_opts=(-o StrictHostKeyChecking=accept-new)
 if [ -n "$AWS_SSH_KEY" ]; then
     ssh_opts+=(-i "$AWS_SSH_KEY")

--- a/services/dctrading-bot/scripts/switch-to-aws.sh
+++ b/services/dctrading-bot/scripts/switch-to-aws.sh
@@ -118,6 +118,30 @@ if [ -z "$HOST" ] || [ "$HOST" = "None" ]; then
     exit 1
 fi
 
+# Ensure security group allows SSH from current IP
+MY_IP=$(curl -s https://checkip.amazonaws.com)
+SG_IDS=$(aws ec2 describe-instances \
+    --region "$AWS_REGION" \
+    --instance-ids "$AWS_INSTANCE_ID" \
+    --query 'Reservations[0].Instances[0].SecurityGroups[*].GroupId' \
+    --output text)
+for sg in $SG_IDS; do
+    HAS_RULE=$(aws ec2 describe-security-groups \
+        --region "$AWS_REGION" \
+        --group-ids "$sg" \
+        --query "SecurityGroups[0].IpPermissions[?FromPort==\`22\` && ToPort==\`22\` && IpRanges[?CidrIp==\`${MY_IP}/32\`]]" \
+        --output text)
+    if [ -z "$HAS_RULE" ] || [ "$HAS_RULE" = "None" ]; then
+        echo "  Updating security group $sg to allow SSH from $MY_IP..."
+        aws ec2 authorize-security-group-ingress \
+            --region "$AWS_REGION" \
+            --group-id "$sg" \
+            --protocol tcp \
+            --port 22 \
+            --cidr "${MY_IP}/32" >/dev/null 2>&1 || true
+    fi
+done
+
 echo "  Waiting for SSH at $HOST..."
 for attempt in {1..30}; do
     if aws_remote "$HOST" "true" 2>/dev/null; then

--- a/services/dctrading-bot/scripts/switch-to-aws.sh
+++ b/services/dctrading-bot/scripts/switch-to-aws.sh
@@ -126,20 +126,13 @@ SG_IDS=$(aws ec2 describe-instances \
     --query 'Reservations[0].Instances[0].SecurityGroups[*].GroupId' \
     --output text)
 for sg in $SG_IDS; do
-    HAS_RULE=$(aws ec2 describe-security-groups \
+    echo "  Ensuring security group $sg allows SSH from $MY_IP..."
+    aws ec2 authorize-security-group-ingress \
         --region "$AWS_REGION" \
-        --group-ids "$sg" \
-        --query "SecurityGroups[0].IpPermissions[?FromPort==\`22\` && ToPort==\`22\` && IpRanges[?CidrIp==\`${MY_IP}/32\`]]" \
-        --output text)
-    if [ -z "$HAS_RULE" ] || [ "$HAS_RULE" = "None" ]; then
-        echo "  Updating security group $sg to allow SSH from $MY_IP..."
-        aws ec2 authorize-security-group-ingress \
-            --region "$AWS_REGION" \
-            --group-id "$sg" \
-            --protocol tcp \
-            --port 22 \
-            --cidr "${MY_IP}/32" >/dev/null 2>&1 || true
-    fi
+        --group-id "$sg" \
+        --protocol tcp \
+        --port 22 \
+        --cidr "${MY_IP}/32" >/dev/null 2>&1 || true
 done
 
 echo "  Waiting for SSH at $HOST..."

--- a/services/dctrading-bot/scripts/switch-to-aws.sh
+++ b/services/dctrading-bot/scripts/switch-to-aws.sh
@@ -71,7 +71,7 @@ echo "Switching to AWS Tokyo..."
 
 stop_local_bot() {
     local pid
-    pid=$(ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {print $2; exit}')
+    pid=$(ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {print $2}' | head -1)
     if [ -z "$pid" ]; then
         echo "  Local bot not running."
         return
@@ -82,14 +82,14 @@ stop_local_bot() {
 
     echo "  Waiting for graceful shutdown (checkpoint save + Turso flush)..."
     for i in {1..30}; do
-        if ! ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {found=1; exit} END {exit !found}'; then
+        if ! ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {found=1} END {exit !found}'; then
             echo "  Local bot stopped gracefully."
             return
         fi
         sleep 1
     done
 
-    pid=$(ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {print $2; exit}')
+    pid=$(ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {print $2}' | head -1)
     if [ -n "$pid" ]; then
         echo "  WARNING: Bot still running after 30s. Force-killing (checkpoint may be lost)..." >&2
         kill -KILL "$pid" 2>/dev/null || true

--- a/services/dctrading-bot/scripts/switch-to-gcp.sh
+++ b/services/dctrading-bot/scripts/switch-to-gcp.sh
@@ -56,6 +56,11 @@ gcloud compute ssh "$GCP_INSTANCE" --zone="$GCP_ZONE" --command="sudo systemctl 
 gcloud compute scp zig-out/bin/dctrading "$GCP_INSTANCE:$GCP_REMOTE_DIR/dctrading" --zone="$GCP_ZONE"
 gcloud compute ssh "$GCP_INSTANCE" --zone="$GCP_ZONE" --command="chmod +x '$GCP_REMOTE_DIR/dctrading'"
 
+if [ -f "$PROJECT_DIR/.env" ]; then
+    echo "  Uploading .env..."
+    gcloud compute scp "$PROJECT_DIR/.env" "$GCP_INSTANCE:$GCP_REMOTE_DIR/.env" --zone="$GCP_ZONE" 2>/dev/null || true
+fi
+
 shopt -s nullglob
 checkpoint_files=(dctrading.checkpoint dctrading.checkpoint.bak.*)
 if [ ${#checkpoint_files[@]} -gt 0 ]; then

--- a/services/dctrading-bot/scripts/switch-to-gcp.sh
+++ b/services/dctrading-bot/scripts/switch-to-gcp.sh
@@ -97,6 +97,26 @@ else
 fi
 echo "  Upload complete."
 
+# Update systemd service
+echo "  Updating systemd service..."
+gcloud compute ssh "$GCP_INSTANCE" --zone="$GCP_ZONE" --command="sudo tee /etc/systemd/system/$GCP_SERVICE_NAME.service > /dev/null <<'EOF'
+[Unit]
+Description=DCTrading Bot
+After=network.target
+
+[Service]
+Type=simple
+User=\$USER
+WorkingDirectory=\$HOME
+ExecStart=/bin/bash -lc 'source \$HOME/.env && \$HOME/$GCP_REMOTE_DIR/dctrading -'
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+sudo systemctl daemon-reload" 2>/dev/null
+
 # Start bot on GCP
 echo "  Starting bot on GCP..."
 gcloud compute ssh "$GCP_INSTANCE" --zone="$GCP_ZONE" --command="sudo systemctl start '$GCP_SERVICE_NAME'" 2>/dev/null

--- a/services/dctrading-bot/scripts/switch-to-gcp.sh
+++ b/services/dctrading-bot/scripts/switch-to-gcp.sh
@@ -22,7 +22,7 @@ echo "🔄 Switching to GCP Tokyo..."
 
 stop_local_bot() {
     local pid
-    pid=$(ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {print $2; exit}')
+    pid=$(ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {print $2}' | head -1)
     if [ -z "$pid" ]; then
         echo "  Local bot not running."
         return
@@ -33,14 +33,14 @@ stop_local_bot() {
 
     echo "  Waiting for graceful shutdown (checkpoint save + Turso flush)..."
     for i in {1..30}; do
-        if ! ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {found=1; exit} END {exit !found}'; then
+        if ! ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {found=1} END {exit !found}'; then
             echo "  Local bot stopped gracefully."
             return
         fi
         sleep 1
     done
 
-    pid=$(ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {print $2; exit}')
+    pid=$(ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {print $2}' | head -1)
     if [ -n "$pid" ]; then
         echo "  WARNING: Bot still running after 30s. Force-killing (checkpoint may be lost)..." >&2
         kill -KILL "$pid" 2>/dev/null || true

--- a/services/dctrading-bot/scripts/switch-to-gcp.sh
+++ b/services/dctrading-bot/scripts/switch-to-gcp.sh
@@ -20,10 +20,39 @@ cd "$PROJECT_DIR"
 
 echo "🔄 Switching to GCP Tokyo..."
 
-# Stop local bot
-echo "  Stopping local bot..."
-tmux send-keys -t trading C-c 2>/dev/null || true
-sleep 3
+stop_local_bot() {
+    local pid
+    pid=$(pgrep -f "dctrading\s+-" | head -1)
+    if [ -z "$pid" ]; then
+        echo "  Local bot not running."
+        return
+    fi
+
+    if tmux has-session -t trading 2>/dev/null; then
+        echo "  Stopping local bot via tmux..."
+        tmux send-keys -t trading C-c
+    else
+        echo "  Stopping local bot (PID $pid)..."
+        kill -TERM "$pid" 2>/dev/null || true
+    fi
+
+    for i in {1..10}; do
+        if ! pgrep -f "dctrading\s+-" >/dev/null; then
+            echo "  Local bot stopped."
+            return
+        fi
+        sleep 1
+    done
+
+    pid=$(pgrep -f "dctrading\s+-" | head -1)
+    if [ -n "$pid" ]; then
+        echo "  Force killing local bot (PID $pid)..."
+        kill -KILL "$pid" 2>/dev/null || true
+        sleep 1
+    fi
+}
+
+stop_local_bot
 
 # Build Linux binary
 echo "  Building Linux binary..."

--- a/services/dctrading-bot/scripts/switch-to-gcp.sh
+++ b/services/dctrading-bot/scripts/switch-to-gcp.sh
@@ -33,7 +33,7 @@ stop_local_bot() {
 
     echo "  Waiting for graceful shutdown (checkpoint save + Turso flush)..."
     for i in {1..30}; do
-        if ! ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {exit 1}'; then
+        if ! ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {found=1; exit} END {exit !found}'; then
             echo "  Local bot stopped gracefully."
             return
         fi

--- a/services/dctrading-bot/scripts/switch-to-gcp.sh
+++ b/services/dctrading-bot/scripts/switch-to-gcp.sh
@@ -108,7 +108,7 @@ After=network.target
 Type=simple
 User=\$USER
 WorkingDirectory=\$HOME
-ExecStart=/bin/bash -lc 'source \$HOME/.env && \$HOME/$GCP_REMOTE_DIR/dctrading -'
+ExecStart=/bin/bash -lc 'export BOT_INSTANCE=gcp-tokyo && source \$HOME/.env && \$HOME/$GCP_REMOTE_DIR/dctrading -'
 Restart=on-failure
 RestartSec=5
 

--- a/services/dctrading-bot/scripts/switch-to-gcp.sh
+++ b/services/dctrading-bot/scripts/switch-to-gcp.sh
@@ -22,33 +22,34 @@ echo "🔄 Switching to GCP Tokyo..."
 
 stop_local_bot() {
     local pid
-    pid=$(pgrep -f "dctrading\s+-" | head -1)
+    pid=$(ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {print $2; exit}')
     if [ -z "$pid" ]; then
         echo "  Local bot not running."
         return
     fi
 
     if tmux has-session -t trading 2>/dev/null; then
-        echo "  Stopping local bot via tmux..."
+        echo "  Stopping local bot via tmux (Ctrl-C)..."
         tmux send-keys -t trading C-c
     else
-        echo "  Stopping local bot (PID $pid)..."
-        kill -TERM "$pid" 2>/dev/null || true
+        echo "  Stopping local bot (PID $pid, SIGINT)..."
+        kill -INT "$pid" 2>/dev/null || true
     fi
 
-    for i in {1..10}; do
-        if ! pgrep -f "dctrading\s+-" >/dev/null; then
-            echo "  Local bot stopped."
+    echo "  Waiting for graceful shutdown (checkpoint save + Turso flush)..."
+    for i in {1..30}; do
+        if ! ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {exit 1}'; then
+            echo "  Local bot stopped gracefully."
             return
         fi
         sleep 1
     done
 
-    pid=$(pgrep -f "dctrading\s+-" | head -1)
+    pid=$(ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {print $2; exit}')
     if [ -n "$pid" ]; then
-        echo "  Force killing local bot (PID $pid)..."
+        echo "  WARNING: Bot still running after 30s. Force-killing (checkpoint may be lost)..." >&2
         kill -KILL "$pid" 2>/dev/null || true
-        sleep 1
+        sleep 2
     fi
 }
 

--- a/services/dctrading-bot/scripts/switch-to-gcp.sh
+++ b/services/dctrading-bot/scripts/switch-to-gcp.sh
@@ -28,13 +28,8 @@ stop_local_bot() {
         return
     fi
 
-    if tmux has-session -t trading 2>/dev/null; then
-        echo "  Stopping local bot via tmux (Ctrl-C)..."
-        tmux send-keys -t trading C-c
-    else
-        echo "  Stopping local bot (PID $pid, SIGINT)..."
-        kill -INT "$pid" 2>/dev/null || true
-    fi
+    echo "  Stopping local bot (PID $pid, SIGINT)..."
+    kill -INT "$pid" 2>/dev/null || true
 
     echo "  Waiting for graceful shutdown (checkpoint save + Turso flush)..."
     for i in {1..30}; do

--- a/services/dctrading-bot/scripts/switch-to-gcp.sh
+++ b/services/dctrading-bot/scripts/switch-to-gcp.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
-# Switch trading bot from local to GCP Tokyo
-# Builds Linux binary, uploads, and starts on GCP
-set -e
+# Switch trading bot from local to GCP Tokyo.
+# Builds Linux binary, uploads, and starts on GCP.
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-ZONE="asia-northeast1-b"
-INSTANCE="dctrading-asia"
+
+GCP_ZONE="${GCP_ZONE:-asia-northeast1-b}"
+GCP_INSTANCE="${GCP_INSTANCE:-dctrading-asia}"
+GCP_REMOTE_DIR="${GCP_REMOTE_DIR:-.}"
+GCP_SERVICE_NAME="${GCP_SERVICE_NAME:-dctrading}"
+
+if ! command -v gcloud >/dev/null 2>&1; then
+    echo "gcloud CLI not found. Install it and authenticate first." >&2
+    exit 1
+fi
 
 cd "$PROJECT_DIR"
 
@@ -24,23 +32,36 @@ echo "  Linux binary ready."
 
 # Start GCP instance
 echo "  Starting GCP instance..."
-gcloud compute instances start $INSTANCE --zone=$ZONE --quiet
+gcloud compute instances start "$GCP_INSTANCE" --zone="$GCP_ZONE" --quiet
 
 # Wait for SSH
 echo "  Waiting for instance..."
-sleep 20
+for attempt in {1..30}; do
+    if gcloud compute ssh "$GCP_INSTANCE" --zone="$GCP_ZONE" --command="true" 2>/dev/null; then
+        break
+    fi
+    if [ "$attempt" -eq 30 ]; then
+        echo "Timed out waiting for SSH." >&2
+        exit 1
+    fi
+    sleep 5
+done
 
 # Upload binary + checkpoint state
+echo "  Ensuring remote directory exists..."
+gcloud compute ssh "$GCP_INSTANCE" --zone="$GCP_ZONE" --command="mkdir -p '$GCP_REMOTE_DIR'" 2>/dev/null || true
+
 echo "  Uploading binary..."
-gcloud compute ssh $INSTANCE --zone=$ZONE --command="sudo systemctl stop dctrading 2>/dev/null; chmod +w ~/dctrading 2>/dev/null" 2>/dev/null || true
-gcloud compute scp zig-out/bin/dctrading $INSTANCE:~/dctrading --zone=$ZONE
-gcloud compute ssh $INSTANCE --zone=$ZONE --command="chmod +x ~/dctrading"
+gcloud compute ssh "$GCP_INSTANCE" --zone="$GCP_ZONE" --command="sudo systemctl stop '$GCP_SERVICE_NAME' 2>/dev/null; chmod +w '$GCP_REMOTE_DIR/dctrading' 2>/dev/null" 2>/dev/null || true
+gcloud compute scp zig-out/bin/dctrading "$GCP_INSTANCE:$GCP_REMOTE_DIR/dctrading" --zone="$GCP_ZONE"
+gcloud compute ssh "$GCP_INSTANCE" --zone="$GCP_ZONE" --command="chmod +x '$GCP_REMOTE_DIR/dctrading'"
+
 shopt -s nullglob
 checkpoint_files=(dctrading.checkpoint dctrading.checkpoint.bak.*)
 if [ ${#checkpoint_files[@]} -gt 0 ]; then
     echo "  Uploading checkpoint state..."
-    gcloud compute ssh $INSTANCE --zone=$ZONE --command="rm -f ~/dctrading.checkpoint.tmp ~/dctrading.checkpoint.bak.*" 2>/dev/null || true
-    gcloud compute scp "${checkpoint_files[@]}" $INSTANCE:~/ --zone=$ZONE
+    gcloud compute ssh "$GCP_INSTANCE" --zone="$GCP_ZONE" --command="rm -f '$GCP_REMOTE_DIR'/dctrading.checkpoint.tmp '$GCP_REMOTE_DIR'/dctrading.checkpoint.bak.*" 2>/dev/null || true
+    gcloud compute scp "${checkpoint_files[@]}" "$GCP_INSTANCE:$GCP_REMOTE_DIR/" --zone="$GCP_ZONE"
 else
     echo "  No local checkpoint state to upload; bot can restore from Turso if configured."
 fi
@@ -48,12 +69,11 @@ echo "  Upload complete."
 
 # Start bot on GCP
 echo "  Starting bot on GCP..."
-gcloud compute ssh $INSTANCE --zone=$ZONE --command="sudo systemctl start dctrading" 2>/dev/null
-
+gcloud compute ssh "$GCP_INSTANCE" --zone="$GCP_ZONE" --command="sudo systemctl start '$GCP_SERVICE_NAME'" 2>/dev/null
 
 # Verify
 sleep 5
 echo "  Checking GCP bot..."
-gcloud compute ssh $INSTANCE --zone=$ZONE --command="sudo journalctl -u dctrading -n 5 --no-pager" 2>/dev/null
+gcloud compute ssh "$GCP_INSTANCE" --zone="$GCP_ZONE" --command="sudo journalctl -u '$GCP_SERVICE_NAME' -n 5 --no-pager" 2>/dev/null
 
 echo "✅ Bot running on GCP Tokyo"

--- a/services/dctrading-bot/scripts/switch-to-local.sh
+++ b/services/dctrading-bot/scripts/switch-to-local.sh
@@ -1,31 +1,119 @@
 #!/bin/bash
-# Switch trading bot from GCP Tokyo to local
-# Builds macOS binary and starts locally
-set -e
+# Switch trading bot from cloud to local.
+# Defaults to AWS Tokyo; set CLOUD_TARGET=gcp for the legacy GCP path.
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-ZONE="asia-northeast1-b"
-INSTANCE="dctrading-asia"
+CLOUD_TARGET="${CLOUD_TARGET:-aws}"
+
+GCP_ZONE="${GCP_ZONE:-asia-northeast1-b}"
+GCP_INSTANCE="${GCP_INSTANCE:-dctrading-asia}"
+
+AWS_REGION="${AWS_REGION:-ap-northeast-1}"
+AWS_INSTANCE_ID="${AWS_INSTANCE_ID:-}"
+AWS_SSH_USER="${AWS_SSH_USER:-ec2-user}"
+AWS_SSH_KEY="${AWS_SSH_KEY:-}"
+AWS_REMOTE_DIR="${AWS_REMOTE_DIR:-.}"
+AWS_SERVICE_NAME="${AWS_SERVICE_NAME:-dctrading}"
+
+ssh_opts=(-o StrictHostKeyChecking=accept-new)
+if [ -n "$AWS_SSH_KEY" ]; then
+    ssh_opts+=(-i "$AWS_SSH_KEY")
+fi
+
+aws_host() {
+    if [ -n "${AWS_SSH_HOST:-}" ]; then
+        printf "%s\n" "$AWS_SSH_HOST"
+        return
+    fi
+
+    if [ -z "$AWS_INSTANCE_ID" ]; then
+        echo "Set AWS_INSTANCE_ID or AWS_SSH_HOST for CLOUD_TARGET=aws." >&2
+        exit 1
+    fi
+
+    aws ec2 describe-instances \
+        --region "$AWS_REGION" \
+        --instance-ids "$AWS_INSTANCE_ID" \
+        --query "Reservations[0].Instances[0].PublicDnsName" \
+        --output text
+}
+
+aws_remote() {
+    local host="$1"
+    shift
+    ssh "${ssh_opts[@]}" "$AWS_SSH_USER@$host" "$@"
+}
+
+download_aws_checkpoints() {
+    local host="$1"
+
+    echo "  Downloading checkpoint state from AWS..."
+    rm -f dctrading.checkpoint.tmp dctrading.checkpoint.bak.*
+    if aws_remote "$host" "cd '$AWS_REMOTE_DIR' && bash -lc 'shopt -s nullglob; files=(dctrading.checkpoint dctrading.checkpoint.bak.*); [ \${#files[@]} -gt 0 ] && tar -czf - \"\${files[@]}\"' 2>/dev/null" | tar -xzf - 2>/dev/null; then
+        rm -f dctrading.checkpoint.tmp
+        echo "  Checkpoint state downloaded."
+    else
+        echo "  No checkpoint state on AWS; bot can restore from Turso if configured."
+    fi
+}
+
+stop_cloud() {
+    case "$CLOUD_TARGET" in
+        aws)
+            if [ -z "$AWS_INSTANCE_ID" ] && [ -z "${AWS_SSH_HOST:-}" ]; then
+                echo "Set AWS_INSTANCE_ID or AWS_SSH_HOST for CLOUD_TARGET=aws." >&2
+                exit 1
+            fi
+            local host
+            host="$(aws_host)"
+            if [ -z "$host" ] || [ "$host" = "None" ]; then
+                echo "Could not resolve AWS instance public DNS. Set AWS_SSH_HOST manually." >&2
+                exit 1
+            fi
+
+            echo "  Stopping AWS bot..."
+            aws_remote "$host" "sudo systemctl stop '$AWS_SERVICE_NAME'" 2>/dev/null || true
+            sleep 2
+            download_aws_checkpoints "$host"
+
+            if [ -n "$AWS_INSTANCE_ID" ]; then
+                echo "  Stopping AWS instance..."
+                aws ec2 stop-instances \
+                    --region "$AWS_REGION" \
+                    --instance-ids "$AWS_INSTANCE_ID" \
+                    >/dev/null &
+            else
+                echo "  AWS_SSH_HOST was used without AWS_INSTANCE_ID; leaving instance state unchanged."
+            fi
+            ;;
+        gcp)
+            echo "  Stopping GCP bot..."
+            gcloud compute ssh "$GCP_INSTANCE" --zone="$GCP_ZONE" --command="sudo systemctl stop dctrading" 2>/dev/null || true
+            sleep 2
+            echo "  Downloading checkpoint state from GCP..."
+            rm -f dctrading.checkpoint.tmp dctrading.checkpoint.bak.*
+            gcloud compute scp "$GCP_INSTANCE:~/dctrading.checkpoint*" . --zone="$GCP_ZONE" 2>/dev/null && {
+                rm -f dctrading.checkpoint.tmp
+                echo "  Checkpoint state downloaded."
+            } || echo "  No checkpoint state on GCP; bot can restore from Turso if configured."
+
+            echo "  Stopping GCP instance..."
+            gcloud compute instances stop "$GCP_INSTANCE" --zone="$GCP_ZONE" --quiet &
+            ;;
+        *)
+            echo "Unsupported CLOUD_TARGET=$CLOUD_TARGET. Use aws or gcp." >&2
+            exit 1
+            ;;
+    esac
+}
 
 cd "$PROJECT_DIR"
 
 echo "🔄 Switching to local..."
 
-# Stop bot on GCP + download checkpoint state
-echo "  Stopping GCP bot..."
-gcloud compute ssh $INSTANCE --zone=$ZONE --command="sudo systemctl stop dctrading" 2>/dev/null || true
-sleep 2
-echo "  Downloading checkpoint state from GCP..."
-rm -f dctrading.checkpoint.tmp dctrading.checkpoint.bak.*
-gcloud compute scp "$INSTANCE:~/dctrading.checkpoint*" . --zone=$ZONE 2>/dev/null && {
-    rm -f dctrading.checkpoint.tmp
-    echo "  Checkpoint state downloaded."
-} || echo "  No checkpoint state on GCP; bot can restore from Turso if configured."
-
-# Stop GCP instance
-echo "  Stopping GCP instance..."
-gcloud compute instances stop $INSTANCE --zone=$ZONE --quiet &
+stop_cloud
 
 # Build macOS binary
 echo "  Building macOS binary..."

--- a/services/dctrading-bot/scripts/switch-to-local.sh
+++ b/services/dctrading-bot/scripts/switch-to-local.sh
@@ -16,6 +16,7 @@ AWS_SSH_USER="${AWS_SSH_USER:-ec2-user}"
 AWS_SSH_KEY="${AWS_SSH_KEY:-}"
 AWS_REMOTE_DIR="${AWS_REMOTE_DIR:-.}"
 AWS_SERVICE_NAME="${AWS_SERVICE_NAME:-dctrading}"
+export AWS_PROFILE="${AWS_PROFILE:-AdministratorAccess-118740508718}"
 
 ssh_opts=(-o StrictHostKeyChecking=accept-new)
 if [ -n "$AWS_SSH_KEY" ]; then

--- a/services/dctrading-bot/scripts/switch-to-local.sh
+++ b/services/dctrading-bot/scripts/switch-to-local.sh
@@ -18,6 +18,15 @@ AWS_REMOTE_DIR="${AWS_REMOTE_DIR:-.}"
 AWS_SERVICE_NAME="${AWS_SERVICE_NAME:-dctrading}"
 export AWS_PROFILE="${AWS_PROFILE:-AdministratorAccess-118740508718}"
 
+if ! aws sts get-caller-identity >/dev/null 2>&1; then
+    echo "AWS SSO token expired or invalid. Launching login..."
+    aws sso login --profile "$AWS_PROFILE"
+    if ! aws sts get-caller-identity >/dev/null 2>&1; then
+        echo "AWS authentication failed after login." >&2
+        exit 1
+    fi
+fi
+
 ssh_opts=(-o StrictHostKeyChecking=accept-new)
 if [ -n "$AWS_SSH_KEY" ]; then
     ssh_opts+=(-i "$AWS_SSH_KEY")


### PR DESCRIPTION
## Summary
- Added an AWS Tokyo deployment path with `switch-to-aws.sh` for starting the EC2 instance, uploading the Linux binary, syncing checkpoint state, and starting the bot service.
- Updated `switch-to-local.sh` to default to AWS while preserving `CLOUD_TARGET=gcp` for the legacy GCP shutdown path.
- Documented the required AWS env vars, instance setup, and migration flow in the bot docs and `.env.example`.

## Follow-up fixes
- `nuke.sh` is now cloud-aware: stops the remote bot, removes remote checkpoint files, and stops the cloud instance for both AWS and GCP. Fixes stale Turso table drops (removed old `account_ledger` / `trade_events` / `positions`, added missing `resource_log`).
- `switch-to-aws.sh` gets an `aws` CLI preflight check, ensures `AWS_REMOTE_DIR` exists remotely, renames the SSH helper to `aws_remote()` for consistency, fails fast with a helpful message if the instance does not exist, and auto-launches `aws sso login` when the SSO token is expired.
- `switch-to-gcp.sh` upgraded to `set -euo pipefail`, configurable env vars (`GCP_ZONE`, `GCP_INSTANCE`, `GCP_REMOTE_DIR`, `GCP_SERVICE_NAME`), `gcloud` preflight, and SSH polling instead of a fixed 20s sleep.
- Added `create-aws-instance.sh` for one-time infrastructure provisioning: security group, key pair, EC2 instance (Amazon Linux 2023, 8GB gp3 root volume), and systemd service setup. Auto-launches SSO login if needed.
- Added `AWS_PROFILE` env var (default: AdministratorAccess-118740508718) to all AWS scripts.
- Added missing GCP env vars to `.env.example`.

Closes #471

## Testing
- `bash -n` on the bot deployment scripts.
- `git diff --check`.
- `zig build test` for `services/dctrading-bot`.
- `zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux` for the cloud deployment binary.