### PR TITLE
Feat/cloudwatch observability

### DIFF
--- a/services/dctrading-bot/AGENTS.md
+++ b/services/dctrading-bot/AGENTS.md
@@ -25,9 +25,10 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 - CLI `checkpoint:migrate [path] [backups]` migrates checkpoint primary/backups offline to the current DCTRADE5 layout after writing `.pre-migrate` copies.
 
 ### Scripts (`scripts/`)
-- `create-aws-instance.sh` — One-time AWS infrastructure setup: security group, key pair, EC2 instance, and systemd service.
-- `deploy-aws.sh` — Build Linux binary, upload to running AWS EC2 instance, restart systemd. Does not stop local bot or migrate checkpoints.
-- `switch-to-aws.sh` — Stop local bot, start AWS Tokyo EC2 instance + systemd service. Copies binary plus checkpoint primary/local backups, excluding temp files.
+- `create-aws-instance.sh` — One-time AWS infrastructure setup: security group, key pair, EC2 instance (with optional IAM instance profile), systemd service, and CloudWatch agent.
+- `deploy-aws.sh` — Build Linux binary, upload to running AWS EC2 instance, restart systemd. Does not stop local bot or migrate checkpoints. Ensures CloudWatch agent, log file, and IAM instance profile attachment exist.
+- `switch-to-aws.sh` — Stop local bot, start AWS Tokyo EC2 instance + systemd service. Copies binary plus checkpoint primary/local backups, excluding temp files. Ensures CloudWatch agent, log file, and IAM instance profile attachment exist.
+- `setup-aws-iam.sh` — Standalone IAM instance profile creation for CloudWatch. Creates the role, attaches `CloudWatchAgentServerPolicy`, creates the instance profile, and waits for propagation.
 - `switch-to-gcp.sh` — Stop local bot, start GCP Tokyo instance + systemd service. Copies binary plus checkpoint primary/local backups, excluding temp files.
 - `switch-to-local.sh` — Stop cloud bot + instance, download checkpoint primary/local backups, start local bot in tmux. Defaults to AWS; use `CLOUD_TARGET=gcp` for the legacy GCP path.
 - `nuke.sh` — Destructive reset for Turso state, local + remote checkpoint primary/backups, and Alpaca positions. Uses `CLOUD_TARGET` to stop and clear remote state.
@@ -77,6 +78,7 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 | `AWS_REMOTE_DIR` | No | switch-to-aws.sh/switch-to-local.sh (default: remote home via `.`) |
 | `AWS_SERVICE_NAME` | No | switch-to-aws.sh/switch-to-local.sh (default: dctrading) |
 | `AWS_PROFILE` | No | All AWS scripts (default: AdministratorAccess-118740508718) |
+| `AWS_IAM_INSTANCE_PROFILE` | No | create-aws-instance.sh — IAM instance profile name to attach to the EC2 instance. Must have `CloudWatchAgentServerPolicy` for CloudWatch Logs/Metrics.
 | `CLOUD_TARGET` | No | nuke.sh/switch-to-local.sh (default: aws; set gcp or local) |
 | `GCP_ZONE` | No | switch-to-gcp.sh/switch-to-local.sh (default: asia-northeast1-b) |
 | `GCP_INSTANCE` | No | switch-to-gcp.sh/switch-to-local.sh (default: dctrading-asia) |
@@ -98,6 +100,38 @@ zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux  # cloud Linux
 zig build test                                 # 182 tests
 ./zig-out/bin/dctrading checkpoint:migrate dctrading.checkpoint 5
 ```
+
+### CloudWatch Observability
+CloudWatch Logs and Metrics are automatically configured on AWS instances.
+
+**What is collected:**
+- **Logs:** `/var/log/dctrading.log` → CloudWatch log group `dctrading` (stream = `{instance_id}`)
+- **Metrics:** `mem_used_percent`, `disk_used_percent` → CloudWatch namespace `dctrading` every **5 minutes**
+
+**IAM Role Setup:**
+All AWS scripts automatically create the IAM instance profile if it does not exist, provided your AWS principal has IAM permissions (`iam:CreateRole`, `iam:AttachRolePolicy`, `iam:CreateInstanceProfile`, `iam:AddRoleToInstanceProfile`).
+
+1. Set `AWS_IAM_INSTANCE_PROFILE=dctrading-ec2-role` in your `.env`.
+2. For new instances: run `./scripts/create-aws-instance.sh`.
+3. For existing instances: run `./scripts/setup-aws-iam.sh` to create the IAM profile, then `./scripts/deploy-aws.sh` (or `./scripts/switch-to-aws.sh`) to attach it to the running instance and install the CloudWatch agent.
+
+If you do not have IAM permissions, create the role manually:
+- In the AWS Console, go to **IAM → Roles → Create role**.
+- Trusted entity: **AWS service → EC2**.
+- Attach the managed policy **CloudWatchAgentServerPolicy**.
+- Name the role `dctrading-ec2-role`.
+- Run `create-aws-instance.sh` with `AWS_IAM_INSTANCE_PROFILE=dctrading-ec2-role`.
+
+**For existing instances without the profile:**
+`deploy-aws.sh` and `switch-to-aws.sh` will detect a missing profile and attach it automatically if `AWS_IAM_INSTANCE_PROFILE` is set. The instance does not need to be stopped.
+
+**Estimated CloudWatch cost (Tokyo, 24/7):**
+| Item | Monthly |
+|------|---------|
+| 2 custom metrics | ~$0.60 |
+| `PutMetricData` API (5-min interval) | ~$0.17 |
+| Logs (~0.5–1 GB) | ~$0.25–0.50 |
+| **Total** | **~$1.05** |
 
 ### Trading Flow
 1. Bootstrap: fetch 87,500 1-min klines → fill MA + vol buffers → detect initial regime

--- a/services/dctrading-bot/scripts/create-aws-instance.sh
+++ b/services/dctrading-bot/scripts/create-aws-instance.sh
@@ -20,6 +20,7 @@ AWS_KEY_NAME="${AWS_KEY_NAME:-dctrading-aws}"
 AWS_SERVICE_NAME="${AWS_SERVICE_NAME:-dctrading}"
 AWS_REMOTE_DIR="${AWS_REMOTE_DIR:-.}"
 AWS_SSH_USER="${AWS_SSH_USER:-ec2-user}"
+AWS_IAM_INSTANCE_PROFILE="${AWS_IAM_INSTANCE_PROFILE:-}"
 export AWS_PROFILE="${AWS_PROFILE:-AdministratorAccess-118740508718}"
 
 if ! aws sts get-caller-identity >/dev/null 2>&1; then
@@ -131,6 +132,12 @@ if [ -n "$EXISTING" ] && [ "$EXISTING" != "None" ]; then
     fi
 else
     echo "  Launching EC2 instance ($AWS_INSTANCE_TYPE)..."
+    IAM_ARG=""
+    if [ -n "$AWS_IAM_INSTANCE_PROFILE" ]; then
+        "$SCRIPT_DIR/setup-aws-iam.sh" || true
+        IAM_ARG="--iam-instance-profile Name=$AWS_IAM_INSTANCE_PROFILE"
+    fi
+
     INSTANCE_ID=$(aws ec2 run-instances \
     --region "$AWS_REGION" \
     --image-id "$AMI_ID" \
@@ -139,9 +146,58 @@ else
     --security-group-ids "$SG_ID" \
     --block-device-mappings "[{\"DeviceName\":\"$ROOT_DEVICE\",\"Ebs\":{\"VolumeSize\":8,\"VolumeType\":\"gp3\",\"DeleteOnTermination\":true}}]" \
     --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=dctrading}]" \
+    $IAM_ARG \
     --user-data "$(cat <<EOF
 #!/bin/bash
 set -e
+
+# Install CloudWatch agent
+dnf install -y amazon-cloudwatch-agent
+
+# Create log file for bot
+touch /var/log/dctrading.log
+chown $AWS_SSH_USER:$AWS_SSH_USER /var/log/dctrading.log
+chmod 644 /var/log/dctrading.log
+
+# CloudWatch agent config (logs + memory metrics)
+cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<'CWCONFIG'
+{
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/dctrading.log",
+            "log_group_name": "dctrading",
+            "log_stream_name": "{instance_id}",
+            "timezone": "UTC"
+          }
+        ]
+      }
+    }
+  },
+  "metrics": {
+    "namespace": "dctrading",
+    "metrics_collected": {
+      "mem": {
+        "measurement": ["mem_used_percent"],
+        "metrics_collection_interval": 300
+      },
+      "disk": {
+        "measurement": ["disk_used_percent"],
+        "metrics_collection_interval": 300,
+        "resources": ["/"]
+      }
+    }
+  }
+}
+CWCONFIG
+
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+    -a fetch-config -m ec2 -s \
+    -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+
+# Systemd service
 mkdir -p /home/$AWS_SSH_USER/$AWS_REMOTE_DIR
 cat > /etc/systemd/system/$AWS_SERVICE_NAME.service <<'UNIT'
 [Unit]
@@ -152,7 +208,9 @@ After=network.target
 Type=simple
 User=$AWS_SSH_USER
 WorkingDirectory=/home/$AWS_SSH_USER
-ExecStart=/bin/bash -lc 'source /home/$AWS_SSH_USER/.env && /home/$AWS_SSH_USER/$AWS_REMOTE_DIR/dctrading -'
+ExecStart=/bin/bash -lc 'export BOT_INSTANCE=aws-tokyo && source /home/$AWS_SSH_USER/.env && /home/$AWS_SSH_USER/$AWS_REMOTE_DIR/dctrading -'
+StandardOutput=append:/var/log/dctrading.log
+StandardError=append:/var/log/dctrading.log
 Restart=on-failure
 RestartSec=5
 
@@ -212,5 +270,12 @@ echo "  AWS_SSH_HOST=$HOST"
 echo "  AWS_REMOTE_DIR=$AWS_REMOTE_DIR"
 echo "  AWS_SERVICE_NAME=$AWS_SERVICE_NAME"
 echo ""
+if [ -z "$AWS_IAM_INSTANCE_PROFILE" ]; then
+    echo "⚠️  CloudWatch requires an IAM instance profile."
+    echo "   Create a role with the CloudWatchAgentServerPolicy managed policy,"
+    echo "   then set AWS_IAM_INSTANCE_PROFILE=your-role-name before re-running."
+    echo "   See README.md for step-by-step instructions."
+    echo ""
+fi
 echo "Then deploy with:"
-echo "  ./scripts/switch-to-aws.sh"
+echo "  ./scripts/deploy-aws.sh"

--- a/services/dctrading-bot/scripts/deploy-aws.sh
+++ b/services/dctrading-bot/scripts/deploy-aws.sh
@@ -86,6 +86,45 @@ upload() {
     scp "${ssh_opts[@]}" "$@" "$AWS_SSH_USER@$host:$AWS_REMOTE_DIR/"
 }
 
+ensure_instance_iam_profile() {
+    local instance_id="$1"
+    local profile_name="$2"
+
+    # Ensure IAM profile exists
+    "$SCRIPT_DIR/setup-aws-iam.sh" || true
+
+    # Check current association
+    local assoc_json
+    assoc_json=$(aws ec2 describe-iam-instance-profile-associations \
+        --region "$AWS_REGION" \
+        --filters "Name=instance-id,Values=$instance_id" \
+        --query 'IamInstanceProfileAssociations[0]' \
+        --output json 2>/dev/null || echo 'null')
+
+    if [ "$assoc_json" != "null" ] && [ -n "$assoc_json" ] && [ "$assoc_json" != "" ]; then
+        local current_name
+        current_name=$(echo "$assoc_json" | jq -r '.IamInstanceProfile.Arn // empty' | awk -F/ '{print $NF}')
+        if [ "$current_name" = "$profile_name" ]; then
+            echo "  IAM instance profile '$profile_name' already attached to instance."
+            return 0
+        else
+            echo "  Instance already has IAM profile '$current_name'. Skipping attachment." >&2
+            echo "  To change it, stop the instance and use the AWS console or replace-iam-instance-profile-association." >&2
+            return 0
+        fi
+    fi
+
+    echo "  Attaching IAM instance profile '$profile_name' to instance $instance_id..."
+    if aws ec2 associate-iam-instance-profile \
+        --region "$AWS_REGION" \
+        --instance-id "$instance_id" \
+        --iam-instance-profile "Name=$profile_name" >/dev/null 2>&1; then
+        echo "  IAM instance profile attached."
+    else
+        echo "  WARNING: Failed to attach IAM instance profile. CloudWatch may not work." >&2
+    fi
+}
+
 cd "$PROJECT_DIR"
 
 echo "Deploying to AWS Tokyo..."
@@ -142,8 +181,59 @@ for attempt in {1..30}; do
     sleep 5
 done
 
+if [ -n "$AWS_IAM_INSTANCE_PROFILE" ]; then
+    echo "  Ensuring IAM instance profile..."
+    ensure_instance_iam_profile "$AWS_INSTANCE_ID" "$AWS_IAM_INSTANCE_PROFILE"
+fi
+
 echo "  Ensuring remote directory exists..."
 aws_remote "$HOST" "mkdir -p '$AWS_REMOTE_DIR'"
+
+echo "  Ensuring CloudWatch agent..."
+aws_remote "$HOST" "
+if [ ! -f /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent ]; then
+    sudo dnf install -y amazon-cloudwatch-agent
+fi
+sudo mkdir -p /opt/aws/amazon-cloudwatch-agent/etc
+sudo tee /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json > /dev/null <<'CWCONFIG'
+{
+  \"logs\": {
+    \"logs_collected\": {
+      \"files\": {
+        \"collect_list\": [
+          {
+            \"file_path\": \"/var/log/dctrading.log\",
+            \"log_group_name\": \"dctrading\",
+            \"log_stream_name\": \"{instance_id}\",
+            \"timezone\": \"UTC\"
+          }
+        ]
+      }
+    }
+  },
+  \"metrics\": {
+    \"namespace\": \"dctrading\",
+    \"metrics_collected\": {
+      \"mem\": {
+        \"measurement\": [\"mem_used_percent\"],
+        \"metrics_collection_interval\": 300
+      },
+      \"disk\": {
+        \"measurement\": [\"disk_used_percent\"],
+        \"metrics_collection_interval\": 300,
+        \"resources\": [\"/\"]
+      }
+    }
+  }
+}
+CWCONFIG
+sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+    -a fetch-config -m ec2 -s \
+    -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+sudo touch /var/log/dctrading.log
+sudo chown '$AWS_SSH_USER':'$AWS_SSH_USER' /var/log/dctrading.log
+sudo chmod 644 /var/log/dctrading.log
+"
 
 echo "  Stopping remote bot..."
 aws_remote "$HOST" "sudo systemctl stop '$AWS_SERVICE_NAME' 2>/dev/null || true"
@@ -169,6 +259,8 @@ Type=simple
 User=$AWS_SSH_USER
 WorkingDirectory=/home/$AWS_SSH_USER
 ExecStart=/bin/bash -lc 'export BOT_INSTANCE=aws-tokyo && source /home/$AWS_SSH_USER/.env && /home/$AWS_SSH_USER/$AWS_REMOTE_DIR/dctrading -'
+StandardOutput=append:/var/log/dctrading.log
+StandardError=append:/var/log/dctrading.log
 Restart=on-failure
 RestartSec=5
 

--- a/services/dctrading-bot/scripts/setup-aws-iam.sh
+++ b/services/dctrading-bot/scripts/setup-aws-iam.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Create or verify the IAM instance profile for CloudWatch Logs/Metrics.
+# Uses AWS_IAM_INSTANCE_PROFILE env var (default: dctrading-ec2-role).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+AWS_IAM_INSTANCE_PROFILE="${AWS_IAM_INSTANCE_PROFILE:-dctrading-ec2-role}"
+export AWS_PROFILE="${AWS_PROFILE:-AdministratorAccess-118740508718}"
+
+if ! command -v aws >/dev/null 2>&1; then
+    echo "aws CLI not found. Install it and authenticate first." >&2
+    exit 1
+fi
+
+if ! aws sts get-caller-identity >/dev/null 2>&1; then
+    echo "AWS SSO token expired or invalid. Launching login..."
+    aws sso login --profile "$AWS_PROFILE"
+    if ! aws sts get-caller-identity >/dev/null 2>&1; then
+        echo "AWS authentication failed after login." >&2
+        exit 1
+    fi
+fi
+
+if aws iam get-instance-profile --instance-profile-name "$AWS_IAM_INSTANCE_PROFILE" >/dev/null 2>&1; then
+    echo "IAM instance profile already exists: $AWS_IAM_INSTANCE_PROFILE"
+    exit 0
+fi
+
+echo "Creating IAM instance profile: $AWS_IAM_INSTANCE_PROFILE..."
+
+TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+
+if ! aws iam create-role \
+    --role-name "$AWS_IAM_INSTANCE_PROFILE" \
+    --assume-role-policy-document "$TRUST_POLICY" >/dev/null 2>&1; then
+    echo "ERROR: Failed to create IAM role '$AWS_IAM_INSTANCE_PROFILE'." >&2
+    echo "You may not have IAM permissions (iam:CreateRole, iam:AttachRolePolicy, iam:CreateInstanceProfile, iam:AddRoleToInstanceProfile)." >&2
+    exit 1
+fi
+
+if ! aws iam attach-role-policy \
+    --role-name "$AWS_IAM_INSTANCE_PROFILE" \
+    --policy-arn arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy >/dev/null 2>&1; then
+    echo "WARNING: Failed to attach CloudWatchAgentServerPolicy to role '$AWS_IAM_INSTANCE_PROFILE'." >&2
+fi
+
+if ! aws iam create-instance-profile \
+    --instance-profile-name "$AWS_IAM_INSTANCE_PROFILE" >/dev/null 2>&1; then
+    echo "ERROR: Failed to create IAM instance profile '$AWS_IAM_INSTANCE_PROFILE'." >&2
+    exit 1
+fi
+
+if ! aws iam add-role-to-instance-profile \
+    --instance-profile-name "$AWS_IAM_INSTANCE_PROFILE" \
+    --role-name "$AWS_IAM_INSTANCE_PROFILE" >/dev/null 2>&1; then
+    echo "ERROR: Failed to add role to instance profile '$AWS_IAM_INSTANCE_PROFILE'." >&2
+    exit 1
+fi
+
+# IAM is eventually consistent; wait until visible
+echo "Waiting for IAM profile propagation..."
+for attempt in {1..12}; do
+    if aws iam get-instance-profile --instance-profile-name "$AWS_IAM_INSTANCE_PROFILE" >/dev/null 2>&1; then
+        echo "IAM instance profile ready: $AWS_IAM_INSTANCE_PROFILE"
+        exit 0
+    fi
+    sleep 5
+done
+
+echo "WARNING: IAM instance profile not visible after 60s. It may not be usable yet." >&2

--- a/services/dctrading-bot/scripts/switch-to-aws.sh
+++ b/services/dctrading-bot/scripts/switch-to-aws.sh
@@ -73,6 +73,45 @@ upload() {
     scp "${ssh_opts[@]}" "$@" "$AWS_SSH_USER@$host:$AWS_REMOTE_DIR/"
 }
 
+ensure_instance_iam_profile() {
+    local instance_id="$1"
+    local profile_name="$2"
+
+    # Ensure IAM profile exists
+    "$SCRIPT_DIR/setup-aws-iam.sh" || true
+
+    # Check current association
+    local assoc_json
+    assoc_json=$(aws ec2 describe-iam-instance-profile-associations \
+        --region "$AWS_REGION" \
+        --filters "Name=instance-id,Values=$instance_id" \
+        --query 'IamInstanceProfileAssociations[0]' \
+        --output json 2>/dev/null || echo 'null')
+
+    if [ "$assoc_json" != "null" ] && [ -n "$assoc_json" ] && [ "$assoc_json" != "" ]; then
+        local current_name
+        current_name=$(echo "$assoc_json" | jq -r '.IamInstanceProfile.Arn // empty' | awk -F/ '{print $NF}')
+        if [ "$current_name" = "$profile_name" ]; then
+            echo "  IAM instance profile '$profile_name' already attached to instance."
+            return 0
+        else
+            echo "  Instance already has IAM profile '$current_name'. Skipping attachment." >&2
+            echo "  To change it, stop the instance and use the AWS console or replace-iam-instance-profile-association." >&2
+            return 0
+        fi
+    fi
+
+    echo "  Attaching IAM instance profile '$profile_name' to instance $instance_id..."
+    if aws ec2 associate-iam-instance-profile \
+        --region "$AWS_REGION" \
+        --instance-id "$instance_id" \
+        --iam-instance-profile "Name=$profile_name" >/dev/null 2>&1; then
+        echo "  IAM instance profile attached."
+    else
+        echo "  WARNING: Failed to attach IAM instance profile. CloudWatch may not work." >&2
+    fi
+}
+
 cd "$PROJECT_DIR"
 
 echo "Switching to AWS Tokyo..."
@@ -168,8 +207,59 @@ for attempt in {1..30}; do
     sleep 5
 done
 
+if [ -n "$AWS_IAM_INSTANCE_PROFILE" ]; then
+    echo "  Ensuring IAM instance profile..."
+    ensure_instance_iam_profile "$AWS_INSTANCE_ID" "$AWS_IAM_INSTANCE_PROFILE"
+fi
+
 echo "  Ensuring remote directory exists..."
 aws_remote "$HOST" "mkdir -p '$AWS_REMOTE_DIR'"
+
+echo "  Ensuring CloudWatch agent..."
+aws_remote "$HOST" "
+if [ ! -f /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent ]; then
+    sudo dnf install -y amazon-cloudwatch-agent
+fi
+sudo mkdir -p /opt/aws/amazon-cloudwatch-agent/etc
+sudo tee /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json > /dev/null <<'CWCONFIG'
+{
+  \"logs\": {
+    \"logs_collected\": {
+      \"files\": {
+        \"collect_list\": [
+          {
+            \"file_path\": \"/var/log/dctrading.log\",
+            \"log_group_name\": \"dctrading\",
+            \"log_stream_name\": \"{instance_id}\",
+            \"timezone\": \"UTC\"
+          }
+        ]
+      }
+    }
+  },
+  \"metrics\": {
+    \"namespace\": \"dctrading\",
+    \"metrics_collected\": {
+      \"mem\": {
+        \"measurement\": [\"mem_used_percent\"],
+        \"metrics_collection_interval\": 300
+      },
+      \"disk\": {
+        \"measurement\": [\"disk_used_percent\"],
+        \"metrics_collection_interval\": 300,
+        \"resources\": [\"/\"]
+      }
+    }
+  }
+}
+CWCONFIG
+sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+    -a fetch-config -m ec2 -s \
+    -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+sudo touch /var/log/dctrading.log
+sudo chown '$AWS_SSH_USER':'$AWS_SSH_USER' /var/log/dctrading.log
+sudo chmod 644 /var/log/dctrading.log
+"
 
 echo "  Uploading binary..."
 aws_remote "$HOST" "sudo systemctl stop '$AWS_SERVICE_NAME' 2>/dev/null || true; chmod +w '$AWS_REMOTE_DIR/dctrading' 2>/dev/null || true"
@@ -202,6 +292,8 @@ Type=simple
 User=$AWS_SSH_USER
 WorkingDirectory=/home/$AWS_SSH_USER
 ExecStart=/bin/bash -lc 'export BOT_INSTANCE=aws-tokyo && source /home/$AWS_SSH_USER/.env && /home/$AWS_SSH_USER/$AWS_REMOTE_DIR/dctrading -'
+StandardOutput=append:/var/log/dctrading.log
+StandardError=append:/var/log/dctrading.log
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
## Summary
Add CloudWatch Logs and Metrics observability for the dctrading-bot AWS deployment. Automatically installs and configures the CloudWatch agent, streams bot logs, and publishes memory/disk metrics with minimal cost.

## Changes

### New scripts
- **`scripts/setup-aws-iam.sh`** — Standalone IAM instance profile creation. Creates the IAM role, attaches `CloudWatchAgentServerPolicy`, creates the instance profile, and waits for IAM propagation. Can be run independently of EC2 provisioning.

### Updated scripts
- **`scripts/create-aws-instance.sh`**
  - Installs `amazon-cloudwatch-agent` via user-data
  - Configures CloudWatch agent for logs (`/var/log/dctrading.log` → `dctrading` log group) and metrics (`mem_used_percent`, `disk_used_percent`)
  - Supports `AWS_IAM_INSTANCE_PROFILE` env var; auto-creates the profile via `setup-aws-iam.sh` before launch
  - Fixes systemd service template to include `BOT_INSTANCE=aws-tokyo` and `StandardOutput`/`StandardError` append to `/var/log/dctrading.log`
  - Creates `/var/log/dctrading.log` with correct ownership

- **`scripts/deploy-aws.sh`**
  - Ensures CloudWatch agent is installed and configured on every deploy
  - Ensures IAM instance profile exists and attaches it to the running EC2 instance automatically
  - Rewrites systemd service with log redirection
  - Config is always rewritten (idempotent), so metric/log changes apply on re-deploy

- **`scripts/switch-to-aws.sh`**
  - Same CloudWatch agent and IAM profile attachment logic as `deploy-aws.sh`
  - Ensures log file exists with correct permissions

### Documentation
- **`AGENTS.md`**
  - New CloudWatch Observability section with what is collected, IAM setup steps, and estimated cost
  - Updated script descriptions
  - Added `AWS_IAM_INSTANCE_PROFILE` to env var table

## CloudWatch configuration
| Resource | Collection | Destination |
|----------|-----------|-------------|
| Bot stdout/stderr | Real-time | CloudWatch Logs group `dctrading`, stream `{instance_id}` |
| `mem_used_percent` | Every 5 min | CloudWatch Metrics namespace `dctrading` |
| `disk_used_percent` | Every 5 min | CloudWatch Metrics namespace `dctrading` |

## Cost estimate (ap-northeast-1, 24/7)
| Item | Monthly |
|------|---------|
| 2 custom metrics | ~\$0.60 |
| `PutMetricData` API (5-min interval) | ~\$0.17 |
| Logs (~0.5–1 GB) | ~\$0.25–0.50 |
| **Total** | **~\$1.05** |

## Deployment for existing instances
```bash
# Set in .env
AWS_IAM_INSTANCE_PROFILE=dctrading-ec2-role

# One command — creates IAM profile, attaches it, installs agent, deploys binary
./scripts/deploy-aws.sh
```

## Related
- Builds on PR #472 (AWS deployment) and PR #475 (deploy-aws.sh)
