### PR TITLE
Add OCI Always Free deployment scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,8 +30,28 @@ NTFY_TOPIC=
 # Instance tracking
 # BOT_INSTANCE=local
 
-# Cloud deployment switch scripts (AWS Tokyo by default)
-# CLOUD_TARGET=aws
+# Cloud deployment switch scripts (OCI Ampere A1 by default)
+# CLOUD_TARGET=oci
+# OCI_REGION=ap-singapore-1
+# OCI_HOME_REGION=ap-singapore-1
+# OCI_COMPARTMENT_OCID=ocid1.compartment...
+# OCI_INSTANCE_NAME=dctrading
+# OCI_SHAPE=VM.Standard.A1.Flex
+# OCI_OCPUS=4
+# OCI_MEMORY_GB=24
+# OCI_FALLBACK_SIZES="4:24 3:18 2:12 1:6"
+# OCI_BOOT_VOLUME_GB=50
+# OCI_SSH_HOST=...
+# OCI_SSH_USER=ubuntu
+# OCI_SSH_KEY=~/.ssh/dctrading-oci.key
+# OCI_REMOTE_DIR=.
+# OCI_SERVICE_NAME=dctrading
+# Optional: lets deploy/switch scripts start/stop the instance with OCI CLI
+# OCI_INSTANCE_OCID=ocid1.instance...
+# Optional: pin an image if automatic Ubuntu image lookup fails
+# OCI_IMAGE_OCID=ocid1.image...
+
+# Legacy AWS deployment variables (used when CLOUD_TARGET=aws)
 # AWS_PROFILE=AdministratorAccess-118740508718
 # AWS_REGION=ap-northeast-1
 # AWS_INSTANCE_ID=i-...

--- a/services/dctrading-bot/.gitignore
+++ b/services/dctrading-bot/.gitignore
@@ -4,3 +4,5 @@
 zig-out/
 .zig-cache/
 *.pem
+*.key
+*.key.pub

--- a/services/dctrading-bot/AGENTS.md
+++ b/services/dctrading-bot/AGENTS.md
@@ -25,12 +25,15 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 - CLI `checkpoint:migrate [path] [backups]` migrates checkpoint primary/backups offline to the current DCTRADE5 layout after writing `.pre-migrate` copies.
 
 ### Scripts (`scripts/`)
-- `create-aws-instance.sh` — One-time AWS infrastructure setup: security group, key pair, EC2 instance (with optional IAM instance profile), systemd service, and CloudWatch agent.
-- `deploy-aws.sh` — Build Linux binary, upload to running AWS EC2 instance, restart systemd. Does not stop local bot or migrate checkpoints. Ensures CloudWatch agent, log file, and IAM instance profile attachment exist.
-- `switch-to-aws.sh` — Stop local bot, start AWS Tokyo EC2 instance + systemd service. Copies binary plus checkpoint primary/local backups, excluding temp files. Ensures CloudWatch agent, log file, and IAM instance profile attachment exist.
+- `create-oci-instance.sh` — One-time OCI Ampere A1 setup: creates or reuses VCN, public subnet, internet gateway, route table, SSH-restricted security list, SSH key, max Always Free A1 VM by default (4 OCPUs/24GB RAM), log file, and systemd service.
+- `deploy-oci.sh` — Build ARM Linux binary for OCI Ampere A1, upload to running OCI instance, restart systemd. Does not stop local bot or migrate checkpoints.
+- `switch-to-oci.sh` — Stop local bot, optionally start OCI instance via OCI CLI, upload ARM Linux binary plus checkpoint primary/local backups, excluding temp files, and start systemd.
+- `create-aws-instance.sh` — Legacy one-time AWS infrastructure setup: security group, key pair, EC2 instance (with optional IAM instance profile), systemd service, and CloudWatch agent.
+- `deploy-aws.sh` — Legacy AWS deploy: build Linux binary, upload to running AWS EC2 instance, restart systemd.
+- `switch-to-aws.sh` — Legacy AWS switch path.
 - `setup-aws-iam.sh` — Standalone IAM instance profile creation for CloudWatch. Creates the role, attaches `CloudWatchAgentServerPolicy`, creates the instance profile, and waits for propagation.
 - `switch-to-gcp.sh` — Stop local bot, start GCP Tokyo instance + systemd service. Copies binary plus checkpoint primary/local backups, excluding temp files.
-- `switch-to-local.sh` — Stop cloud bot + instance, download checkpoint primary/local backups, start local bot in tmux. Defaults to AWS; use `CLOUD_TARGET=gcp` for the legacy GCP path.
+- `switch-to-local.sh` — Stop cloud bot + instance, download checkpoint primary/local backups, start local bot in tmux. Defaults to OCI; use `CLOUD_TARGET=aws` or `gcp` for legacy paths.
 - `nuke.sh` — Destructive reset for Turso state, local + remote checkpoint primary/backups, and Alpaca positions. Uses `CLOUD_TARGET` to stop and clear remote state.
 
 ### Key Patterns
@@ -69,7 +72,24 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 | `BOT_INSTANCE` | No | main.zig (default: "local") |
 | `CHECKPOINT_BACKUP_RETENTION` | No | main.zig (default: 5 local rotated backups; 0 disables) |
 | `CHECKPOINT_REMOTE_BACKUP_INTERVAL` | No | main.zig/Turso (default: 3600 seconds; 0 disables) |
-| `CLOUD_TARGET` | No | switch-to-local.sh (default: aws; set gcp for legacy GCP) |
+| `CLOUD_TARGET` | No | switch-to-local.sh/nuke.sh (default: oci; set aws/gcp/local for legacy or local-only paths) |
+| `OCI_REGION` | No | create-oci-instance.sh and OCI CLI calls; defaults to ap-singapore-1 |
+| `OCI_HOME_REGION` | No | create-oci-instance.sh warning guard; defaults to ap-singapore-1 |
+| `OCI_COMPARTMENT_OCID` | Yes for OCI create | create-oci-instance.sh |
+| `OCI_INSTANCE_NAME` | No | create-oci-instance.sh (default: dctrading) |
+| `OCI_SHAPE` | No | create-oci-instance.sh (default: VM.Standard.A1.Flex) |
+| `OCI_OCPUS` | No | create-oci-instance.sh (default: 4, max Always Free A1 pool as one VM) |
+| `OCI_MEMORY_GB` | No | create-oci-instance.sh (default: 24, max Always Free A1 pool as one VM) |
+| `OCI_FALLBACK_SIZES` | No | create-oci-instance.sh fallback list when A1 capacity is unavailable (default: `4:24 3:18 2:12 1:6`) |
+| `OCI_BOOT_VOLUME_GB` | No | create-oci-instance.sh (default: 50) |
+| `OCI_IMAGE_OCID` | No | create-oci-instance.sh image override when automatic Ubuntu lookup fails |
+| `OCI_AVAILABILITY_DOMAIN` | No | create-oci-instance.sh AD override when default AD has no A1 capacity |
+| `OCI_SSH_HOST` | Yes for OCI scripts | deploy-oci.sh/switch-to-oci.sh/switch-to-local.sh/nuke.sh |
+| `OCI_SSH_USER` | No | OCI scripts (default: ubuntu) |
+| `OCI_SSH_KEY` | No | OCI scripts |
+| `OCI_REMOTE_DIR` | No | OCI scripts (default: `.`) |
+| `OCI_SERVICE_NAME` | No | OCI scripts (default: dctrading) |
+| `OCI_INSTANCE_OCID` | No | OCI scripts; optional OCI CLI start/stop |
 | `AWS_REGION` | No | switch-to-aws.sh/switch-to-local.sh (default: ap-northeast-1) |
 | `AWS_INSTANCE_ID` | Yes for AWS scripts | switch-to-aws.sh/switch-to-local.sh |
 | `AWS_SSH_USER` | No | switch-to-aws.sh/switch-to-local.sh (default: ec2-user) |
@@ -79,7 +99,6 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 | `AWS_SERVICE_NAME` | No | switch-to-aws.sh/switch-to-local.sh (default: dctrading) |
 | `AWS_PROFILE` | No | All AWS scripts (default: AdministratorAccess-118740508718) |
 | `AWS_IAM_INSTANCE_PROFILE` | No | create-aws-instance.sh — IAM instance profile name to attach to the EC2 instance. Must have `CloudWatchAgentServerPolicy` for CloudWatch Logs/Metrics.
-| `CLOUD_TARGET` | No | nuke.sh/switch-to-local.sh (default: aws; set gcp or local) |
 | `GCP_ZONE` | No | switch-to-gcp.sh/switch-to-local.sh (default: asia-northeast1-b) |
 | `GCP_INSTANCE` | No | switch-to-gcp.sh/switch-to-local.sh (default: dctrading-asia) |
 | `GCP_REMOTE_DIR` | No | switch-to-gcp.sh (default: remote home via `.`) |
@@ -96,7 +115,8 @@ BTC algorithmic trading bot using Directional Change (DC) theory. Zig 0.16 produ
 ### Build
 ```bash
 zig build -Doptimize=ReleaseFast              # macOS arm64
-zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux  # cloud Linux
+zig build -Doptimize=ReleaseFast -Dtarget=aarch64-linux  # OCI Ampere A1 ARM Linux
+zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux  # legacy AWS/GCP x86_64 Linux
 zig build test                                 # 182 tests
 ./zig-out/bin/dctrading checkpoint:migrate dctrading.checkpoint 5
 ```

--- a/services/dctrading-bot/README.md
+++ b/services/dctrading-bot/README.md
@@ -130,65 +130,92 @@ source .env && ./zig-out/bin/dctrading -
 # Run tests
 zig build test
 
-# Cross-compile for Linux (cloud deployment)
+# Cross-compile for x86_64 Linux (legacy AWS/GCP)
 zig build -Doptimize=ReleaseFast -Dtarget=x86_64-linux
+
+# Cross-compile for ARM Linux (OCI Ampere A1)
+zig build -Doptimize=ReleaseFast -Dtarget=aarch64-linux
 ```
 
 Known-good historical simulation outputs are recorded in
 [`docs/DCTRADING_SIMULATION_BASELINES.md`](../../docs/DCTRADING_SIMULATION_BASELINES.md).
 
-### AWS Tokyo Deployment
+### OCI Ampere A1 Deployment
+
+Requires OCI CLI configured with an API key, plus `jq`, `curl`, and `ssh`.
 
 ```bash
-# One-time: create the EC2 instance, security group, and key pair
-./scripts/create-aws-instance.sh
+# Create the VM once with OCI CLI:
+export OCI_REGION=ap-singapore-1
+export OCI_COMPARTMENT_OCID=ocid1.compartment...
+./scripts/create-oci-instance.sh
 
-# Required once in your shell or .env
-export AWS_REGION=ap-northeast-1
-export AWS_INSTANCE_ID=i-...
-export AWS_SSH_USER=ec2-user
-export AWS_SSH_KEY=~/.ssh/dctrading-aws.pem
-
-# Optional when the instance DNS cannot be derived from AWS CLI
-export AWS_SSH_HOST=ec2-...ap-northeast-1.compute.amazonaws.com
+# The create script prints these values for your shell or .env:
+export CLOUD_TARGET=oci
+export OCI_SSH_HOST=...
+export OCI_SSH_USER=ubuntu
+export OCI_INSTANCE_OCID=ocid1.instance...
+export OCI_SSH_KEY=/path/to/dctrading-oci.key
 
 # Quick deploy (update binary + restart, don't touch local bot)
-./scripts/deploy-aws.sh
+./scripts/deploy-oci.sh
 
-# Switch to AWS Tokyo
-./scripts/switch-to-aws.sh
+# Switch to OCI
+./scripts/switch-to-oci.sh
 
 # Switch back to local
 ./scripts/switch-to-local.sh
 ```
 
-`switch-to-aws.sh` starts the EC2 instance, waits for SSH, uploads the Linux
-binary and checkpoint state, then starts the `dctrading` systemd service.
-`switch-to-local.sh` defaults to AWS, stops the remote service, downloads
-checkpoint state, stops the EC2 instance, then starts the local tmux process.
+OCI Always Free Ampere A1 allows up to 4 OCPUs and 24GB memory total across A1
+instances in the tenancy home region. `create-oci-instance.sh` defaults to
+using that full pool as one `VM.Standard.A1.Flex` instance: 4 OCPUs, 24GB RAM,
+a 50GB boot volume, Ubuntu 22.04, and the Singapore home region
+(`ap-singapore-1`). It creates or reuses a VCN, public
+subnet, internet gateway, route table, security list with SSH ingress from your
+current public IP, SSH key, instance, log file, and `dctrading` systemd
+service. Override `OCI_OCPUS`, `OCI_MEMORY_GB`, `OCI_BOOT_VOLUME_GB`,
+`OCI_IMAGE_OCID`, `OCI_AVAILABILITY_DOMAIN`, or `OCI_REGION` when needed.
+If OCI returns `Out of host capacity`, the create script tries every
+availability domain and falls back through `OCI_FALLBACK_SIZES`
+(`4:24 3:18 2:12 1:6`) before failing. Rerun later if all sizes are out of
+capacity.
+
+`switch-to-oci.sh` stops the local bot, builds an ARM Linux binary
+(`aarch64-linux`), uploads the binary, `.env`, and checkpoint state, then starts
+the `dctrading` systemd service.
+`switch-to-local.sh` now defaults to OCI, downloads checkpoint state, optionally
+stops the OCI instance when `OCI_INSTANCE_OCID` and the OCI CLI are configured,
+then starts the local tmux process.
 
 The switch scripts move the checkpoint primary plus local backup files between
 hosts and intentionally ignore `dctrading.checkpoint.tmp`. If no local files are
 available, startup can still restore from Turso when remote checkpoint backup is
 configured.
 
-Expected AWS instance setup:
-- Tokyo region (`ap-northeast-1`) with a free-tier-compatible Linux EC2 instance
-  (`t2.micro` by default, 8GB gp3 root volume to stay within free-tier limits)
-- Security group allowing SSH from your IP and outbound HTTPS
-- AWS CLI authenticated locally with permission to start, stop, wait, and
-  describe the instance
-- SSH access through `AWS_SSH_USER` and `AWS_SSH_KEY`
-- `~/dctrading`, `~/.env`, and a systemd service named `dctrading` that runs
-  the binary from the same remote directory
+Expected OCI instance setup:
+- Always Free eligible `VM.Standard.A1.Flex` shape.
+- No more than 4 OCPUs and 24GB memory total across all Always Free A1
+  instances.
+- Boot volume allocation kept within the Always Free block-volume allowance.
+- SSH ingress from your IP and outbound HTTPS. Rerun
+  `create-oci-instance.sh` if your public IP changes and SSH stops working.
+- SSH access through `OCI_SSH_USER`, `OCI_SSH_HOST`, and `OCI_SSH_KEY`.
+- `~/dctrading`, `~/.env`, and a systemd service named `dctrading` managed by
+  the scripts.
 
-> **Billing warning:** Data transfer out is not free-tier. Monitor your AWS
-> bill and set up billing alerts. The bot only needs outbound HTTPS so costs
-> are typically negligible, but not zero.
+> **OCI capacity note:** Always Free A1 capacity can be temporarily unavailable
+> in a region or availability domain. If provisioning returns an out-of-capacity
+> error, try another availability domain or wait and retry.
 
-The previous GCP flow remains available while AWS is verified:
+The previous AWS/GCP flows remain available as legacy targets:
 
 ```bash
+./scripts/create-aws-instance.sh
+./scripts/deploy-aws.sh
+./scripts/switch-to-aws.sh
+CLOUD_TARGET=aws ./scripts/switch-to-local.sh
+
 ./scripts/switch-to-gcp.sh
 CLOUD_TARGET=gcp ./scripts/switch-to-local.sh
 ```
@@ -197,7 +224,7 @@ CLOUD_TARGET=gcp ./scripts/switch-to-local.sh
 
 ```bash
 # Nuke everything — stops remote bot, drops Turso tables, deletes checkpoints, closes Alpaca positions
-CLOUD_TARGET=aws ./scripts/nuke.sh
+CLOUD_TARGET=oci ./scripts/nuke.sh
 
 # Or skip remote cleanup and only nuke local state + Turso + Alpaca
 CLOUD_TARGET=local ./scripts/nuke.sh

--- a/services/dctrading-bot/scripts/create-oci-instance.sh
+++ b/services/dctrading-bot/scripts/create-oci-instance.sh
@@ -1,0 +1,423 @@
+#!/bin/bash
+# One-time OCI infrastructure setup for DCTrading bot.
+# Provisions: VCN, subnet, internet gateway, route table, security list,
+#             SSH key, Ampere A1 instance, log file, and systemd service.
+# Run this once, then use deploy-oci.sh or switch-to-oci.sh for deployments.
+#
+# Always Free notes:
+#   - VM.Standard.A1.Flex is Always Free eligible in the tenancy home region.
+#   - The free pool is shared across A1 instances: up to 4 OCPUs and 24GB RAM.
+#   - Capacity can be temporarily unavailable; rerun later or try another AD.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+OCI_COMPARTMENT_OCID="${OCI_COMPARTMENT_OCID:-}"
+OCI_REGION="${OCI_REGION:-ap-singapore-1}"
+OCI_HOME_REGION="${OCI_HOME_REGION:-ap-singapore-1}"
+OCI_INSTANCE_NAME="${OCI_INSTANCE_NAME:-dctrading}"
+OCI_SHAPE="${OCI_SHAPE:-VM.Standard.A1.Flex}"
+OCI_OCPUS="${OCI_OCPUS:-4}"
+OCI_MEMORY_GB="${OCI_MEMORY_GB:-24}"
+OCI_FALLBACK_SIZES="${OCI_FALLBACK_SIZES:-4:24 3:18 2:12 1:6}"
+OCI_BOOT_VOLUME_GB="${OCI_BOOT_VOLUME_GB:-50}"
+OCI_IMAGE_OCID="${OCI_IMAGE_OCID:-}"
+OCI_IMAGE_OS="${OCI_IMAGE_OS:-Canonical Ubuntu}"
+OCI_IMAGE_OS_VERSION="${OCI_IMAGE_OS_VERSION:-22.04}"
+OCI_KEY_NAME="${OCI_KEY_NAME:-dctrading-oci}"
+OCI_SSH_KEY="${OCI_SSH_KEY:-$PROJECT_DIR/${OCI_KEY_NAME}.key}"
+OCI_SSH_USER="${OCI_SSH_USER:-ubuntu}"
+OCI_REMOTE_DIR="${OCI_REMOTE_DIR:-.}"
+OCI_SERVICE_NAME="${OCI_SERVICE_NAME:-dctrading}"
+
+OCI_VCN_NAME="${OCI_VCN_NAME:-dctrading-vcn}"
+OCI_SUBNET_NAME="${OCI_SUBNET_NAME:-dctrading-subnet}"
+OCI_SECURITY_LIST_NAME="${OCI_SECURITY_LIST_NAME:-dctrading-security-list}"
+OCI_INTERNET_GATEWAY_NAME="${OCI_INTERNET_GATEWAY_NAME:-dctrading-igw}"
+OCI_ROUTE_TABLE_NAME="${OCI_ROUTE_TABLE_NAME:-dctrading-route-table}"
+OCI_VCN_CIDR="${OCI_VCN_CIDR:-10.0.0.0/16}"
+OCI_SUBNET_CIDR="${OCI_SUBNET_CIDR:-10.0.1.0/24}"
+OCI_VCN_DNS_LABEL="${OCI_VCN_DNS_LABEL:-dctrading}"
+OCI_SUBNET_DNS_LABEL="${OCI_SUBNET_DNS_LABEL:-dctrade}"
+
+if [ -z "$OCI_COMPARTMENT_OCID" ]; then
+    echo "OCI_COMPARTMENT_OCID is required." >&2
+    echo "Set it to the compartment OCID where the bot instance should be created." >&2
+    exit 1
+fi
+
+for cmd in oci jq curl ssh ssh-keygen; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "$cmd is required but not installed." >&2
+        exit 1
+    fi
+done
+
+OCI_GLOBAL_ARGS=()
+if [ -n "$OCI_REGION" ]; then
+    OCI_GLOBAL_ARGS+=(--region "$OCI_REGION")
+fi
+
+oci_cli() {
+    oci "${OCI_GLOBAL_ARGS[@]}" "$@"
+}
+
+json_id_by_display_name() {
+    jq -r --arg name "$1" '.data[] | select(."display-name" == $name and ."lifecycle-state" != "TERMINATED") | .id' | head -n 1
+}
+
+echo "Creating OCI resources for $OCI_INSTANCE_NAME..."
+if [ -n "$OCI_REGION" ]; then
+    echo "  Region: $OCI_REGION"
+else
+    echo "  Region: OCI CLI profile default"
+fi
+if [ -n "$OCI_HOME_REGION" ] && [ "$OCI_REGION" != "$OCI_HOME_REGION" ]; then
+    echo "  Warning: OCI_REGION=$OCI_REGION differs from OCI_HOME_REGION=$OCI_HOME_REGION." >&2
+    echo "  Always Free compute and block-volume resources must be created in the tenancy home region." >&2
+fi
+
+echo "  Checking OCI authentication..."
+oci_cli iam availability-domain list --compartment-id "$OCI_COMPARTMENT_OCID" >/dev/null
+
+if [ -n "${OCI_AVAILABILITY_DOMAIN:-}" ]; then
+    AVAILABILITY_DOMAINS="$OCI_AVAILABILITY_DOMAIN"
+else
+    AVAILABILITY_DOMAINS=$(oci_cli iam availability-domain list \
+        --compartment-id "$OCI_COMPARTMENT_OCID" \
+        --output json | jq -r '.data[].name')
+fi
+echo "  Availability domains:"
+while IFS= read -r ad; do
+    [ -n "$ad" ] && echo "    - $ad"
+done <<< "$AVAILABILITY_DOMAINS"
+
+# --- SSH Key ---
+if [ ! -f "$OCI_SSH_KEY" ]; then
+    echo "  Creating SSH key: $OCI_SSH_KEY..."
+    mkdir -p "$(dirname "$OCI_SSH_KEY")"
+    ssh-keygen -t ed25519 -f "$OCI_SSH_KEY" -N "" -C "$OCI_KEY_NAME" >/dev/null
+    chmod 600 "$OCI_SSH_KEY"
+else
+    echo "  Using existing SSH key: $OCI_SSH_KEY"
+fi
+if [ ! -f "$OCI_SSH_KEY.pub" ]; then
+    ssh-keygen -y -f "$OCI_SSH_KEY" > "$OCI_SSH_KEY.pub"
+fi
+SSH_PUBLIC_KEY=$(cat "$OCI_SSH_KEY.pub")
+
+# --- VCN ---
+VCN_ID=$(oci_cli network vcn list \
+    --compartment-id "$OCI_COMPARTMENT_OCID" \
+    --display-name "$OCI_VCN_NAME" \
+    --output json | json_id_by_display_name "$OCI_VCN_NAME")
+
+if [ -z "$VCN_ID" ]; then
+    echo "  Creating VCN $OCI_VCN_NAME..."
+    VCN_ID=$(oci_cli network vcn create \
+        --compartment-id "$OCI_COMPARTMENT_OCID" \
+        --cidr-block "$OCI_VCN_CIDR" \
+        --display-name "$OCI_VCN_NAME" \
+        --dns-label "$OCI_VCN_DNS_LABEL" \
+        --wait-for-state AVAILABLE \
+        --query 'data.id' \
+        --raw-output)
+else
+    echo "  Using existing VCN: $VCN_ID"
+fi
+
+# --- Internet Gateway ---
+IGW_ID=$(oci_cli network internet-gateway list \
+    --compartment-id "$OCI_COMPARTMENT_OCID" \
+    --vcn-id "$VCN_ID" \
+    --display-name "$OCI_INTERNET_GATEWAY_NAME" \
+    --output json | json_id_by_display_name "$OCI_INTERNET_GATEWAY_NAME")
+
+if [ -z "$IGW_ID" ]; then
+    echo "  Creating internet gateway $OCI_INTERNET_GATEWAY_NAME..."
+    IGW_ID=$(oci_cli network internet-gateway create \
+        --compartment-id "$OCI_COMPARTMENT_OCID" \
+        --vcn-id "$VCN_ID" \
+        --is-enabled true \
+        --display-name "$OCI_INTERNET_GATEWAY_NAME" \
+        --wait-for-state AVAILABLE \
+        --query 'data.id' \
+        --raw-output)
+else
+    echo "  Using existing internet gateway: $IGW_ID"
+fi
+
+# --- Route Table ---
+ROUTE_RULES=$(jq -nc --arg igw "$IGW_ID" '[{cidrBlock:"0.0.0.0/0",networkEntityId:$igw}]')
+RT_ID=$(oci_cli network route-table list \
+    --compartment-id "$OCI_COMPARTMENT_OCID" \
+    --vcn-id "$VCN_ID" \
+    --display-name "$OCI_ROUTE_TABLE_NAME" \
+    --output json | json_id_by_display_name "$OCI_ROUTE_TABLE_NAME")
+
+if [ -z "$RT_ID" ]; then
+    echo "  Creating route table $OCI_ROUTE_TABLE_NAME..."
+    RT_ID=$(oci_cli network route-table create \
+        --compartment-id "$OCI_COMPARTMENT_OCID" \
+        --vcn-id "$VCN_ID" \
+        --display-name "$OCI_ROUTE_TABLE_NAME" \
+        --route-rules "$ROUTE_RULES" \
+        --wait-for-state AVAILABLE \
+        --query 'data.id' \
+        --raw-output)
+else
+    echo "  Using existing route table: $RT_ID"
+    oci_cli network route-table update \
+        --rt-id "$RT_ID" \
+        --route-rules "$ROUTE_RULES" \
+        --force >/dev/null
+fi
+
+# --- Security List ---
+MY_IP=$(curl -fsS https://checkip.amazonaws.com 2>/dev/null || curl -fsS https://api.ipify.org)
+MY_IP="${MY_IP//$'\n'/}"
+INGRESS_RULES=$(jq -nc --arg source "$MY_IP/32" '[
+    {
+        protocol:"6",
+        source:$source,
+        tcpOptions:{destinationPortRange:{min:22,max:22}}
+    },
+    {
+        protocol:"1",
+        source:"0.0.0.0/0",
+        icmpOptions:{type:3,code:4}
+    }
+]')
+EGRESS_RULES=$(jq -nc '[{protocol:"all",destination:"0.0.0.0/0"}]')
+
+SL_ID=$(oci_cli network security-list list \
+    --compartment-id "$OCI_COMPARTMENT_OCID" \
+    --vcn-id "$VCN_ID" \
+    --display-name "$OCI_SECURITY_LIST_NAME" \
+    --output json | json_id_by_display_name "$OCI_SECURITY_LIST_NAME")
+
+if [ -z "$SL_ID" ]; then
+    echo "  Creating security list $OCI_SECURITY_LIST_NAME (SSH from $MY_IP)..."
+    SL_ID=$(oci_cli network security-list create \
+        --compartment-id "$OCI_COMPARTMENT_OCID" \
+        --vcn-id "$VCN_ID" \
+        --display-name "$OCI_SECURITY_LIST_NAME" \
+        --ingress-security-rules "$INGRESS_RULES" \
+        --egress-security-rules "$EGRESS_RULES" \
+        --wait-for-state AVAILABLE \
+        --query 'data.id' \
+        --raw-output)
+else
+    echo "  Using existing security list: $SL_ID (refreshing SSH source to $MY_IP)"
+    oci_cli network security-list update \
+        --security-list-id "$SL_ID" \
+        --ingress-security-rules "$INGRESS_RULES" \
+        --egress-security-rules "$EGRESS_RULES" \
+        --force >/dev/null
+fi
+
+# --- Subnet ---
+SUBNET_ID=$(oci_cli network subnet list \
+    --compartment-id "$OCI_COMPARTMENT_OCID" \
+    --vcn-id "$VCN_ID" \
+    --display-name "$OCI_SUBNET_NAME" \
+    --output json | json_id_by_display_name "$OCI_SUBNET_NAME")
+
+if [ -z "$SUBNET_ID" ]; then
+    echo "  Creating public subnet $OCI_SUBNET_NAME..."
+    SUBNET_ID=$(oci_cli network subnet create \
+        --compartment-id "$OCI_COMPARTMENT_OCID" \
+        --vcn-id "$VCN_ID" \
+        --cidr-block "$OCI_SUBNET_CIDR" \
+        --display-name "$OCI_SUBNET_NAME" \
+        --dns-label "$OCI_SUBNET_DNS_LABEL" \
+        --route-table-id "$RT_ID" \
+        --security-list-ids "[\"$SL_ID\"]" \
+        --prohibit-public-ip-on-vnic false \
+        --wait-for-state AVAILABLE \
+        --query 'data.id' \
+        --raw-output)
+else
+    echo "  Using existing subnet: $SUBNET_ID"
+fi
+
+# --- Image ---
+IMAGE_ID="$OCI_IMAGE_OCID"
+if [ -z "$IMAGE_ID" ]; then
+    echo "  Finding latest $OCI_IMAGE_OS $OCI_IMAGE_OS_VERSION image for $OCI_SHAPE..."
+    IMAGE_ID=$(oci_cli compute image list \
+        --compartment-id "$OCI_COMPARTMENT_OCID" \
+        --operating-system "$OCI_IMAGE_OS" \
+        --operating-system-version "$OCI_IMAGE_OS_VERSION" \
+        --shape "$OCI_SHAPE" \
+        --sort-by TIMECREATED \
+        --sort-order DESC \
+        --all \
+        --query 'data[0].id' \
+        --raw-output)
+fi
+if [ -z "$IMAGE_ID" ] || [ "$IMAGE_ID" = "null" ]; then
+    echo "Could not find an OCI image. Set OCI_IMAGE_OCID explicitly and rerun." >&2
+    exit 1
+fi
+echo "  Image: $IMAGE_ID"
+
+# --- Instance ---
+INSTANCE_ID=$(oci_cli compute instance list \
+    --compartment-id "$OCI_COMPARTMENT_OCID" \
+    --display-name "$OCI_INSTANCE_NAME" \
+    --all \
+    --output json | json_id_by_display_name "$OCI_INSTANCE_NAME")
+
+if [ -n "$INSTANCE_ID" ]; then
+    echo "  Existing instance found: $INSTANCE_ID"
+    STATE=$(oci_cli compute instance get \
+        --instance-id "$INSTANCE_ID" \
+        --query 'data."lifecycle-state"' \
+        --raw-output)
+    if [ "$STATE" = "STOPPED" ]; then
+        echo "  Instance is stopped. Starting it..."
+        oci_cli compute instance action \
+            --instance-id "$INSTANCE_ID" \
+            --action START \
+            --wait-for-state RUNNING >/dev/null
+    else
+        echo "  Instance state: $STATE"
+    fi
+else
+    METADATA=$(jq -nc --arg key "$SSH_PUBLIC_KEY" '{ssh_authorized_keys:$key}')
+
+    LAUNCH_LOG=$(mktemp)
+    trap 'rm -f "$LAUNCH_LOG"' EXIT
+    for ad_name in $AVAILABILITY_DOMAINS; do
+        for size in $OCI_FALLBACK_SIZES; do
+            attempt_ocpus="${size%%:*}"
+            attempt_memory="${size##*:}"
+            echo "  Launching OCI instance ($OCI_SHAPE, ${attempt_ocpus} OCPU, ${attempt_memory}GB RAM) in $ad_name..."
+            SHAPE_CONFIG=$(jq -nc \
+                --argjson ocpus "$attempt_ocpus" \
+                --argjson memory "$attempt_memory" \
+                '{ocpus:$ocpus,memoryInGBs:$memory}')
+
+            if INSTANCE_ID=$(oci_cli compute instance launch \
+                --compartment-id "$OCI_COMPARTMENT_OCID" \
+                --availability-domain "$ad_name" \
+                --display-name "$OCI_INSTANCE_NAME" \
+                --shape "$OCI_SHAPE" \
+                --subnet-id "$SUBNET_ID" \
+                --assign-public-ip true \
+                --image-id "$IMAGE_ID" \
+                --boot-volume-size-in-gbs "$OCI_BOOT_VOLUME_GB" \
+                --shape-config "$SHAPE_CONFIG" \
+                --metadata "$METADATA" \
+                --wait-for-state RUNNING \
+                --query 'data.id' \
+                --raw-output 2>"$LAUNCH_LOG"); then
+                OCI_OCPUS="$attempt_ocpus"
+                OCI_MEMORY_GB="$attempt_memory"
+                break 2
+            fi
+
+            if grep -qi "Out of host capacity" "$LAUNCH_LOG"; then
+                echo "    No A1 capacity for ${attempt_ocpus} OCPU/${attempt_memory}GB in $ad_name; trying next option."
+            else
+                cat "$LAUNCH_LOG" >&2
+                exit 1
+            fi
+        done
+    done
+
+    if [ -z "$INSTANCE_ID" ]; then
+        echo "No OCI A1 capacity was available for fallback sizes: $OCI_FALLBACK_SIZES" >&2
+        echo "Try rerunning later, setting OCI_AVAILABILITY_DOMAIN to a specific AD, or setting OCI_FALLBACK_SIZES to smaller sizes." >&2
+        exit 1
+    fi
+fi
+
+echo "  Instance ready: $INSTANCE_ID"
+
+echo "  Resolving public IP..."
+PUBLIC_IP=""
+for _ in {1..30}; do
+    VNIC_ID=$(oci_cli compute instance list-vnics \
+        --instance-id "$INSTANCE_ID" \
+        --query 'data[0].id' \
+        --raw-output 2>/dev/null || true)
+    if [ -n "$VNIC_ID" ] && [ "$VNIC_ID" != "null" ]; then
+        PUBLIC_IP=$(oci_cli network vnic get \
+            --vnic-id "$VNIC_ID" \
+            --query 'data."public-ip"' \
+            --raw-output 2>/dev/null || true)
+    fi
+    if [ -n "$PUBLIC_IP" ] && [ "$PUBLIC_IP" != "null" ]; then
+        break
+    fi
+    sleep 5
+done
+
+if [ -z "$PUBLIC_IP" ] || [ "$PUBLIC_IP" = "null" ]; then
+    echo "Instance has no public IP. Check subnet public IP settings in OCI." >&2
+    exit 1
+fi
+
+echo "  Waiting for SSH at $PUBLIC_IP..."
+for attempt in {1..40}; do
+    if ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=5 \
+        -i "$OCI_SSH_KEY" "$OCI_SSH_USER@$PUBLIC_IP" "true" 2>/dev/null; then
+        break
+    fi
+    if [ "$attempt" -eq 40 ]; then
+        echo "Timed out waiting for SSH." >&2
+        echo "If you used Oracle Linux, rerun with OCI_SSH_USER=opc." >&2
+        exit 1
+    fi
+    sleep 6
+done
+
+echo "  Installing systemd service..."
+ssh -o StrictHostKeyChecking=accept-new -i "$OCI_SSH_KEY" "$OCI_SSH_USER@$PUBLIC_IP" \
+    "sudo mkdir -p /home/$OCI_SSH_USER/$OCI_REMOTE_DIR && \
+     sudo touch /var/log/dctrading.log && \
+     sudo chown $OCI_SSH_USER:$OCI_SSH_USER /var/log/dctrading.log && \
+     sudo chmod 644 /var/log/dctrading.log && \
+     sudo tee /etc/systemd/system/$OCI_SERVICE_NAME.service >/dev/null <<'UNIT'
+[Unit]
+Description=DCTrading Bot
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=$OCI_SSH_USER
+WorkingDirectory=/home/$OCI_SSH_USER
+ExecStart=/bin/bash -lc 'export BOT_INSTANCE=oci-arm && source /home/$OCI_SSH_USER/.env && /home/$OCI_SSH_USER/$OCI_REMOTE_DIR/dctrading -'
+StandardOutput=append:/var/log/dctrading.log
+StandardError=append:/var/log/dctrading.log
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+     sudo systemctl daemon-reload && \
+     sudo systemctl enable $OCI_SERVICE_NAME"
+
+echo ""
+echo "OCI instance ready."
+echo ""
+echo "Add these to your .env:"
+echo "  CLOUD_TARGET=oci"
+if [ -n "$OCI_REGION" ]; then
+    echo "  OCI_REGION=$OCI_REGION"
+fi
+echo "  OCI_COMPARTMENT_OCID=$OCI_COMPARTMENT_OCID"
+echo "  OCI_INSTANCE_OCID=$INSTANCE_ID"
+echo "  OCI_SSH_HOST=$PUBLIC_IP"
+echo "  OCI_SSH_USER=$OCI_SSH_USER"
+echo "  OCI_SSH_KEY=$OCI_SSH_KEY"
+echo "  OCI_REMOTE_DIR=$OCI_REMOTE_DIR"
+echo "  OCI_SERVICE_NAME=$OCI_SERVICE_NAME"
+echo ""
+echo "Then deploy with:"
+echo "  ./scripts/deploy-oci.sh"

--- a/services/dctrading-bot/scripts/deploy-oci.sh
+++ b/services/dctrading-bot/scripts/deploy-oci.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# Deploy trading bot to Oracle Cloud Infrastructure Ampere A1 in place.
+# Builds ARM Linux binary, uploads it + .env, restarts systemd.
+# Does NOT stop local bot or migrate checkpoints.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+OCI_SSH_HOST="${OCI_SSH_HOST:?Set OCI_SSH_HOST to the instance public IP or DNS}"
+OCI_SSH_USER="${OCI_SSH_USER:-ubuntu}"
+OCI_SSH_KEY="${OCI_SSH_KEY:-}"
+OCI_REMOTE_DIR="${OCI_REMOTE_DIR:-.}"
+OCI_SERVICE_NAME="${OCI_SERVICE_NAME:-dctrading}"
+OCI_INSTANCE_OCID="${OCI_INSTANCE_OCID:-}"
+
+ssh_opts=(-o StrictHostKeyChecking=accept-new -o LogLevel=ERROR)
+if [ -n "$OCI_SSH_KEY" ]; then
+    ssh_opts+=(-i "$OCI_SSH_KEY")
+fi
+
+oci_remote() {
+    ssh "${ssh_opts[@]}" "$OCI_SSH_USER@$OCI_SSH_HOST" "$@"
+}
+
+upload() {
+    scp "${ssh_opts[@]}" "$@" "$OCI_SSH_USER@$OCI_SSH_HOST:$OCI_REMOTE_DIR/"
+}
+
+start_oci_if_configured() {
+    if [ -z "$OCI_INSTANCE_OCID" ]; then
+        return
+    fi
+    if ! command -v oci >/dev/null 2>&1; then
+        echo "OCI_INSTANCE_OCID is set but oci CLI is unavailable. Skipping instance start." >&2
+        return
+    fi
+
+    echo "  Starting OCI instance if needed..."
+    oci compute instance action --instance-id "$OCI_INSTANCE_OCID" --action START >/dev/null 2>&1 || true
+    for attempt in {1..60}; do
+        state=$(oci compute instance get --instance-id "$OCI_INSTANCE_OCID" --query 'data."lifecycle-state"' --raw-output 2>/dev/null || echo "")
+        if [ "$state" = "RUNNING" ]; then
+            return
+        fi
+        sleep 2
+    done
+    echo "  WARNING: OCI instance did not report RUNNING after waiting." >&2
+}
+
+wait_for_ssh() {
+    echo "  Waiting for SSH at $OCI_SSH_HOST..."
+    for attempt in {1..30}; do
+        printf "    attempt %d/30...\r" "$attempt"
+        if ssh -o ConnectTimeout=5 -o BatchMode=yes "${ssh_opts[@]}" "$OCI_SSH_USER@$OCI_SSH_HOST" "true" 2>/dev/null; then
+            echo ""
+            return
+        fi
+        sleep 5
+    done
+    echo ""
+    echo "Timed out waiting for SSH. Check OCI security list/NSG allows TCP 22 from your IP." >&2
+    exit 1
+}
+
+install_service() {
+    oci_remote "sudo tee /etc/systemd/system/$OCI_SERVICE_NAME.service > /dev/null <<'EOF'
+[Unit]
+Description=DCTrading Bot
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=$OCI_SSH_USER
+WorkingDirectory=/home/$OCI_SSH_USER
+ExecStart=/bin/bash -lc 'export BOT_INSTANCE=oci-arm && source /home/$OCI_SSH_USER/.env && /home/$OCI_SSH_USER/$OCI_REMOTE_DIR/dctrading -'
+StandardOutput=append:/var/log/dctrading.log
+StandardError=append:/var/log/dctrading.log
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+sudo systemctl daemon-reload
+sudo systemctl enable '$OCI_SERVICE_NAME' >/dev/null"
+}
+
+cd "$PROJECT_DIR"
+
+echo "Deploying to OCI Ampere A1..."
+start_oci_if_configured
+wait_for_ssh
+
+echo "  Building ARM Linux binary..."
+zig build -Doptimize=ReleaseFast -Dtarget=aarch64-linux
+echo "  ARM Linux binary ready."
+
+echo "  Ensuring remote directory and log file..."
+oci_remote "mkdir -p '$OCI_REMOTE_DIR'; sudo touch /var/log/dctrading.log; sudo chown '$OCI_SSH_USER':'$OCI_SSH_USER' /var/log/dctrading.log; sudo chmod 644 /var/log/dctrading.log"
+
+echo "  Stopping remote bot..."
+oci_remote "sudo systemctl stop '$OCI_SERVICE_NAME' 2>/dev/null || true"
+
+echo "  Uploading binary..."
+oci_remote "chmod +w '$OCI_REMOTE_DIR/dctrading' 2>/dev/null || true"
+upload zig-out/bin/dctrading
+oci_remote "chmod +x '$OCI_REMOTE_DIR/dctrading'"
+
+if [ -f "$PROJECT_DIR/.env" ]; then
+    echo "  Uploading .env..."
+    upload "$PROJECT_DIR/.env"
+fi
+
+echo "  Updating systemd service..."
+install_service
+
+echo "  Starting bot on OCI..."
+oci_remote "sudo systemctl start '$OCI_SERVICE_NAME'"
+
+echo "  Waiting for bot to bootstrap..."
+sleep 5
+for i in {1..20}; do
+    printf "    checking %d/20...\r" "$i"
+    if oci_remote "sudo systemctl is-active '$OCI_SERVICE_NAME' >/dev/null 2>&1"; then
+        echo ""
+        break
+    fi
+    sleep 1
+done
+
+echo ""
+echo "  --- Recent logs ---"
+oci_remote "sudo journalctl -u '$OCI_SERVICE_NAME' -n 20 --no-pager"
+
+echo ""
+echo "Deployed to OCI Ampere A1"

--- a/services/dctrading-bot/scripts/nuke.sh
+++ b/services/dctrading-bot/scripts/nuke.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 
-CLOUD_TARGET="${CLOUD_TARGET:-aws}"
+CLOUD_TARGET="${CLOUD_TARGET:-oci}"
 
 AWS_REGION="${AWS_REGION:-ap-northeast-1}"
 AWS_INSTANCE_ID="${AWS_INSTANCE_ID:-}"
@@ -15,7 +15,7 @@ AWS_REMOTE_DIR="${AWS_REMOTE_DIR:-.}"
 AWS_SERVICE_NAME="${AWS_SERVICE_NAME:-dctrading}"
 export AWS_PROFILE="${AWS_PROFILE:-AdministratorAccess-118740508718}"
 
-if ! aws sts get-caller-identity >/dev/null 2>&1; then
+if [ "$CLOUD_TARGET" = "aws" ] && ! aws sts get-caller-identity >/dev/null 2>&1; then
     echo "AWS SSO token expired or invalid. Launching login..."
     aws sso login --profile "$AWS_PROFILE"
     if ! aws sts get-caller-identity >/dev/null 2>&1; then
@@ -29,6 +29,13 @@ GCP_INSTANCE="${GCP_INSTANCE:-dctrading-asia}"
 GCP_REMOTE_DIR="${GCP_REMOTE_DIR:-.}"
 GCP_SERVICE_NAME="${GCP_SERVICE_NAME:-dctrading}"
 
+OCI_SSH_HOST="${OCI_SSH_HOST:-}"
+OCI_SSH_USER="${OCI_SSH_USER:-ubuntu}"
+OCI_SSH_KEY="${OCI_SSH_KEY:-}"
+OCI_REMOTE_DIR="${OCI_REMOTE_DIR:-.}"
+OCI_SERVICE_NAME="${OCI_SERVICE_NAME:-dctrading}"
+OCI_INSTANCE_OCID="${OCI_INSTANCE_OCID:-}"
+
 source "$PROJECT_DIR/.env"
 
 TURSO_HOST=$(echo "$TURSO_URL" | sed 's|libsql://||; s|https://||')
@@ -36,6 +43,11 @@ TURSO_HOST=$(echo "$TURSO_URL" | sed 's|libsql://||; s|https://||')
 ssh_opts=(-o StrictHostKeyChecking=accept-new)
 if [ -n "$AWS_SSH_KEY" ]; then
     ssh_opts+=(-i "$AWS_SSH_KEY")
+fi
+
+oci_ssh_opts=(-o StrictHostKeyChecking=accept-new)
+if [ -n "$OCI_SSH_KEY" ]; then
+    oci_ssh_opts+=(-i "$OCI_SSH_KEY")
 fi
 
 aws_host() {
@@ -58,6 +70,24 @@ stop_remote() {
     case "$CLOUD_TARGET" in
         local)
             echo "  Skipping remote cleanup (CLOUD_TARGET=local)."
+            ;;
+        oci)
+            if [ -z "$OCI_SSH_HOST" ]; then
+                echo "  OCI_SSH_HOST not set. Skipping OCI remote cleanup." >&2
+                return
+            fi
+
+            echo "  Stopping OCI bot..."
+            ssh "${oci_ssh_opts[@]}" "$OCI_SSH_USER@$OCI_SSH_HOST" "sudo systemctl stop '$OCI_SERVICE_NAME' 2>/dev/null || true" 2>/dev/null || true
+            sleep 2
+
+            echo "  Removing OCI checkpoint state..."
+            ssh "${oci_ssh_opts[@]}" "$OCI_SSH_USER@$OCI_SSH_HOST" "rm -f '$OCI_REMOTE_DIR'/dctrading.checkpoint '$OCI_REMOTE_DIR'/dctrading.checkpoint.tmp '$OCI_REMOTE_DIR'/dctrading.checkpoint.bak.*" 2>/dev/null || true
+
+            if [ -n "$OCI_INSTANCE_OCID" ] && command -v oci >/dev/null 2>&1; then
+                echo "  Stopping OCI instance..."
+                oci compute instance action --instance-id "$OCI_INSTANCE_OCID" --action STOP >/dev/null || true
+            fi
             ;;
         aws)
             local host
@@ -94,7 +124,7 @@ stop_remote() {
             gcloud compute instances stop "$GCP_INSTANCE" --zone="$GCP_ZONE" --quiet >/dev/null || true
             ;;
         *)
-            echo "Unsupported CLOUD_TARGET=$CLOUD_TARGET. Use aws, gcp, or local." >&2
+            echo "Unsupported CLOUD_TARGET=$CLOUD_TARGET. Use oci, aws, gcp, or local." >&2
             exit 1
             ;;
     esac

--- a/services/dctrading-bot/scripts/switch-to-local.sh
+++ b/services/dctrading-bot/scripts/switch-to-local.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # Switch trading bot from cloud to local.
-# Defaults to AWS Tokyo; set CLOUD_TARGET=gcp for the legacy GCP path.
+# Defaults to OCI Ampere A1; set CLOUD_TARGET=aws or gcp for legacy paths.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
-CLOUD_TARGET="${CLOUD_TARGET:-aws}"
+CLOUD_TARGET="${CLOUD_TARGET:-oci}"
 
 GCP_ZONE="${GCP_ZONE:-asia-northeast1-b}"
 GCP_INSTANCE="${GCP_INSTANCE:-dctrading-asia}"
@@ -18,7 +18,14 @@ AWS_REMOTE_DIR="${AWS_REMOTE_DIR:-.}"
 AWS_SERVICE_NAME="${AWS_SERVICE_NAME:-dctrading}"
 export AWS_PROFILE="${AWS_PROFILE:-AdministratorAccess-118740508718}"
 
-if ! aws sts get-caller-identity >/dev/null 2>&1; then
+OCI_SSH_HOST="${OCI_SSH_HOST:-}"
+OCI_SSH_USER="${OCI_SSH_USER:-ubuntu}"
+OCI_SSH_KEY="${OCI_SSH_KEY:-}"
+OCI_REMOTE_DIR="${OCI_REMOTE_DIR:-.}"
+OCI_SERVICE_NAME="${OCI_SERVICE_NAME:-dctrading}"
+OCI_INSTANCE_OCID="${OCI_INSTANCE_OCID:-}"
+
+if [ "$CLOUD_TARGET" = "aws" ] && ! aws sts get-caller-identity >/dev/null 2>&1; then
     echo "AWS SSO token expired or invalid. Launching login..."
     aws sso login --profile "$AWS_PROFILE"
     if ! aws sts get-caller-identity >/dev/null 2>&1; then
@@ -30,6 +37,11 @@ fi
 ssh_opts=(-o StrictHostKeyChecking=accept-new -o LogLevel=ERROR)
 if [ -n "$AWS_SSH_KEY" ]; then
     ssh_opts+=(-i "$AWS_SSH_KEY")
+fi
+
+oci_ssh_opts=(-o StrictHostKeyChecking=accept-new -o LogLevel=ERROR)
+if [ -n "$OCI_SSH_KEY" ]; then
+    oci_ssh_opts+=(-i "$OCI_SSH_KEY")
 fi
 
 aws_host() {
@@ -56,6 +68,12 @@ aws_remote() {
     ssh "${ssh_opts[@]}" "$AWS_SSH_USER@$host" "$@"
 }
 
+oci_remote() {
+    local host="$1"
+    shift
+    ssh "${oci_ssh_opts[@]}" "$OCI_SSH_USER@$host" "$@"
+}
+
 download_aws_checkpoints() {
     local host="$1"
 
@@ -69,8 +87,46 @@ download_aws_checkpoints() {
     fi
 }
 
+download_oci_checkpoints() {
+    local host="$1"
+
+    echo "  Downloading checkpoint state from OCI..."
+    rm -f dctrading.checkpoint.tmp dctrading.checkpoint.bak.*
+    if oci_remote "$host" "cd '$OCI_REMOTE_DIR' && bash -lc 'shopt -s nullglob; files=(dctrading.checkpoint dctrading.checkpoint.bak.*); [ \${#files[@]} -gt 0 ] && tar -czf - \"\${files[@]}\"' 2>/dev/null" | tar -xzf - 2>/dev/null; then
+        rm -f dctrading.checkpoint.tmp
+        echo "  Checkpoint state downloaded."
+    else
+        echo "  No checkpoint state on OCI; bot can restore from Turso if configured."
+    fi
+}
+
+stop_oci_instance_if_configured() {
+    if [ -z "$OCI_INSTANCE_OCID" ]; then
+        echo "  OCI_INSTANCE_OCID not set; leaving instance running."
+        return
+    fi
+    if ! command -v oci >/dev/null 2>&1; then
+        echo "  oci CLI unavailable; leaving instance running." >&2
+        return
+    fi
+    echo "  Stopping OCI instance..."
+    oci compute instance action --instance-id "$OCI_INSTANCE_OCID" --action STOP >/dev/null &
+}
+
 stop_cloud() {
     case "$CLOUD_TARGET" in
+        oci)
+            if [ -z "$OCI_SSH_HOST" ]; then
+                echo "Set OCI_SSH_HOST for CLOUD_TARGET=oci." >&2
+                exit 1
+            fi
+
+            echo "  Stopping OCI bot..."
+            oci_remote "$OCI_SSH_HOST" "sudo systemctl stop '$OCI_SERVICE_NAME'" 2>/dev/null || true
+            sleep 2
+            download_oci_checkpoints "$OCI_SSH_HOST"
+            stop_oci_instance_if_configured
+            ;;
         aws)
             if [ -z "$AWS_INSTANCE_ID" ] && [ -z "${AWS_SSH_HOST:-}" ]; then
                 echo "Set AWS_INSTANCE_ID or AWS_SSH_HOST for CLOUD_TARGET=aws." >&2
@@ -113,7 +169,7 @@ stop_cloud() {
             gcloud compute instances stop "$GCP_INSTANCE" --zone="$GCP_ZONE" --quiet &
             ;;
         *)
-            echo "Unsupported CLOUD_TARGET=$CLOUD_TARGET. Use aws or gcp." >&2
+            echo "Unsupported CLOUD_TARGET=$CLOUD_TARGET. Use oci, aws, or gcp." >&2
             exit 1
             ;;
     esac

--- a/services/dctrading-bot/scripts/switch-to-oci.sh
+++ b/services/dctrading-bot/scripts/switch-to-oci.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# Switch trading bot from local to Oracle Cloud Infrastructure Ampere A1.
+# Builds ARM Linux binary, uploads it with checkpoint state, and starts systemd.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+OCI_SSH_HOST="${OCI_SSH_HOST:?Set OCI_SSH_HOST to the instance public IP or DNS}"
+OCI_SSH_USER="${OCI_SSH_USER:-ubuntu}"
+OCI_SSH_KEY="${OCI_SSH_KEY:-}"
+OCI_REMOTE_DIR="${OCI_REMOTE_DIR:-.}"
+OCI_SERVICE_NAME="${OCI_SERVICE_NAME:-dctrading}"
+OCI_INSTANCE_OCID="${OCI_INSTANCE_OCID:-}"
+
+ssh_opts=(-o StrictHostKeyChecking=accept-new -o LogLevel=ERROR)
+if [ -n "$OCI_SSH_KEY" ]; then
+    ssh_opts+=(-i "$OCI_SSH_KEY")
+fi
+
+oci_remote() {
+    ssh "${ssh_opts[@]}" "$OCI_SSH_USER@$OCI_SSH_HOST" "$@"
+}
+
+upload() {
+    scp "${ssh_opts[@]}" "$@" "$OCI_SSH_USER@$OCI_SSH_HOST:$OCI_REMOTE_DIR/"
+}
+
+stop_local_bot() {
+    local pid
+    pid=$(ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {print $2}' | head -1)
+    if [ -z "$pid" ]; then
+        echo "  Local bot not running."
+        return
+    fi
+
+    echo "  Stopping local bot (PID $pid, SIGINT)..."
+    kill -INT "$pid" 2>/dev/null || true
+
+    echo "  Waiting for graceful shutdown (checkpoint save + Turso flush)..."
+    for i in {1..30}; do
+        if ! ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {found=1} END {exit !found}'; then
+            echo "  Local bot stopped gracefully."
+            return
+        fi
+        sleep 1
+    done
+
+    pid=$(ps aux | awk '/[d]ctrading -/ && !/caffeinate/ {print $2}' | head -1)
+    if [ -n "$pid" ]; then
+        echo "  WARNING: Bot still running after 30s. Force-killing (checkpoint may be lost)..." >&2
+        kill -KILL "$pid" 2>/dev/null || true
+        sleep 2
+    fi
+}
+
+start_oci_if_configured() {
+    if [ -z "$OCI_INSTANCE_OCID" ]; then
+        return
+    fi
+    if ! command -v oci >/dev/null 2>&1; then
+        echo "OCI_INSTANCE_OCID is set but oci CLI is unavailable. Skipping instance start." >&2
+        return
+    fi
+
+    echo "  Starting OCI instance if needed..."
+    oci compute instance action --instance-id "$OCI_INSTANCE_OCID" --action START >/dev/null 2>&1 || true
+    for attempt in {1..60}; do
+        state=$(oci compute instance get --instance-id "$OCI_INSTANCE_OCID" --query 'data."lifecycle-state"' --raw-output 2>/dev/null || echo "")
+        if [ "$state" = "RUNNING" ]; then
+            return
+        fi
+        sleep 2
+    done
+    echo "  WARNING: OCI instance did not report RUNNING after waiting." >&2
+}
+
+wait_for_ssh() {
+    echo "  Waiting for SSH at $OCI_SSH_HOST..."
+    for attempt in {1..30}; do
+        printf "    attempt %d/30...\r" "$attempt"
+        if ssh -o ConnectTimeout=5 -o BatchMode=yes "${ssh_opts[@]}" "$OCI_SSH_USER@$OCI_SSH_HOST" "true" 2>/dev/null; then
+            echo ""
+            return
+        fi
+        sleep 5
+    done
+    echo ""
+    echo "Timed out waiting for SSH. Check OCI security list/NSG allows TCP 22 from your IP." >&2
+    exit 1
+}
+
+install_service() {
+    oci_remote "sudo tee /etc/systemd/system/$OCI_SERVICE_NAME.service > /dev/null <<'EOF'
+[Unit]
+Description=DCTrading Bot
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=$OCI_SSH_USER
+WorkingDirectory=/home/$OCI_SSH_USER
+ExecStart=/bin/bash -lc 'export BOT_INSTANCE=oci-arm && source /home/$OCI_SSH_USER/.env && /home/$OCI_SSH_USER/$OCI_REMOTE_DIR/dctrading -'
+StandardOutput=append:/var/log/dctrading.log
+StandardError=append:/var/log/dctrading.log
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+sudo systemctl daemon-reload
+sudo systemctl enable '$OCI_SERVICE_NAME' >/dev/null"
+}
+
+cd "$PROJECT_DIR"
+
+echo "Switching to OCI Ampere A1..."
+stop_local_bot
+
+echo "  Building ARM Linux binary..."
+zig build -Doptimize=ReleaseFast -Dtarget=aarch64-linux
+echo "  ARM Linux binary ready."
+
+start_oci_if_configured
+wait_for_ssh
+
+echo "  Ensuring remote directory and log file..."
+oci_remote "mkdir -p '$OCI_REMOTE_DIR'; sudo touch /var/log/dctrading.log; sudo chown '$OCI_SSH_USER':'$OCI_SSH_USER' /var/log/dctrading.log; sudo chmod 644 /var/log/dctrading.log"
+
+echo "  Uploading binary..."
+oci_remote "sudo systemctl stop '$OCI_SERVICE_NAME' 2>/dev/null || true; chmod +w '$OCI_REMOTE_DIR/dctrading' 2>/dev/null || true"
+upload zig-out/bin/dctrading
+oci_remote "chmod +x '$OCI_REMOTE_DIR/dctrading'"
+
+if [ -f "$PROJECT_DIR/.env" ]; then
+    echo "  Uploading .env..."
+    upload "$PROJECT_DIR/.env"
+fi
+
+shopt -s nullglob
+checkpoint_files=(dctrading.checkpoint dctrading.checkpoint.bak.*)
+if [ ${#checkpoint_files[@]} -gt 0 ]; then
+    echo "  Uploading checkpoint state..."
+    oci_remote "rm -f '$OCI_REMOTE_DIR/dctrading.checkpoint.tmp' '$OCI_REMOTE_DIR'/dctrading.checkpoint.bak.*"
+    upload "${checkpoint_files[@]}"
+else
+    echo "  No local checkpoint state to upload; bot can restore from Turso if configured."
+fi
+
+echo "  Updating systemd service..."
+install_service
+
+echo "  Starting bot on OCI..."
+oci_remote "sudo systemctl start '$OCI_SERVICE_NAME'"
+
+sleep 5
+echo "  Checking OCI bot..."
+oci_remote "sudo journalctl -u '$OCI_SERVICE_NAME' -n 10 --no-pager"
+
+echo "Bot running on OCI Ampere A1"


### PR DESCRIPTION
## Summary
- add one-time OCI Ampere A1 provisioning script for the DCTrading bot
- add OCI deploy and switch scripts for ARM Linux deployments
- update local switch/nuke scripts to support OCI as the default cloud target
- document Singapore home-region defaults, Always Free sizing, fallback capacity behavior, and required env vars
- ignore generated OCI SSH key files

## OCI behavior
- defaults to Singapore (`ap-singapore-1`) and max Always Free A1 sizing as one VM: 4 OCPUs / 24GB RAM
- provisions/reuses VCN, public subnet, internet gateway, route table, SSH security list, SSH key, VM, log file, and systemd service
- if A1 capacity is unavailable, tries every availability domain and falls back through `4:24 3:18 2:12 1:6`
- deploy/switch scripts build `aarch64-linux`, upload the bot binary/env/checkpoints, and manage the remote systemd service

## Validation
- `bash -n services/dctrading-bot/scripts/create-oci-instance.sh services/dctrading-bot/scripts/deploy-oci.sh services/dctrading-bot/scripts/switch-to-oci.sh services/dctrading-bot/scripts/switch-to-local.sh services/dctrading-bot/scripts/nuke.sh`
- `git diff --check`

## Notes
- I did not live-provision OCI from this machine in the final validation. Earlier user run reached OCI and returned `Out of host capacity`, which this PR now handles with AD/size fallback.
- Generated local SSH key files are ignored and not included in the PR.