### PR TITLE
docs: document DCTrading production strategy parity

### DIFF
--- a/docs/DCTRADING_SIMULATION_BASELINES.md
+++ b/docs/DCTRADING_SIMULATION_BASELINES.md
@@ -69,8 +69,17 @@ cd labs/dctrading
 PYTHONPATH=src python3 scripts/backtest_crossval.py
 ```
 
+The Python lab's production-equivalent strategy reference is
+`scripts/backtest_crossval.py`, which uses the same direct 3-regime classifier
+as Zig production:
+
+- `price > 60d MA * 1.03` -> `BULL`
+- `price < 60d MA * 0.97` -> `BEAR`
+- otherwise -> `SIDEWAYS`
+
 The Python `With Funding Filter` result should match the Zig LiveLoop simulation
-on the key totals:
+on the key totals when the Zig process sees `funding_rates.csv` in its working
+directory:
 
 | Metric | Expected |
 | --- | ---: |
@@ -80,5 +89,17 @@ on the key totals:
 | Capital | $41,390.77 |
 | Funding skips | 22 |
 
-The Python `Without Funding Filter` result is a separate research baseline and
-is not expected to match the LiveLoop simulation when funding data is present.
+The Python `Without Funding Filter` result matches Zig direct backtest and
+`sim:` LiveLoop when Zig is run from a directory without `funding_rates.csv`:
+
+| Metric | Expected |
+| --- | ---: |
+| Trades | 156 |
+| PnL | $30,128.23 |
+| Return | 3,012.82% |
+| Capital | $31,128.23 |
+
+Do not compare these production baselines to
+`labs/dctrading/src/dctrading/live/engine.py`; that module is an older
+experimental sticky BULL/BEAR prototype and does not implement the current
+production `SIDEWAYS` behavior.

--- a/labs/dctrading/AGENTS.md
+++ b/labs/dctrading/AGENTS.md
@@ -19,8 +19,9 @@ Python research environment for the DCTrading system. Vectorized backtesting, ML
 - `agents/`, `envs/`, `live/`, `risk/`, `store/`, `training/`, `dashboard/` — RL and live trading modules (experimental).
 
 ### Scripts (`scripts/`)
-- `backtest_fast.py` — Vectorized 3-regime backtest using numpy (~100x faster than per-tick).
-- `backtest_regimes.py` — 2-regime vs 3-regime comparison with date range.
+- `backtest_fast.py` — Vectorized production-equivalent direct 3-regime backtest using numpy (~100x faster than per-tick); use `3reg` results as Zig strategy reference.
+- `backtest_crossval.py` — Trade-by-trade production parity check against Zig direct backtest / `sim:` LiveLoop.
+- `backtest_regimes.py` — 2-regime vs 3-regime comparison with date range; `ThreeRegimeStrategy` matches current Zig production regime behavior.
 - `backtest_sentiment.py` — Backtest with sentiment filter overlay.
 - `backtest_yearly.py` — Year-by-year performance breakdown.
 - `fetch_1m_data.py` — Fetch Binance 1-min kline data.
@@ -30,6 +31,7 @@ Python research environment for the DCTrading system. Vectorized backtesting, ML
 
 ### Key Patterns
 - **Vectorized backtesting**: numpy arrays for price/MA/DC detection, no per-tick Python loop.
+- **Production parity**: current production is Zig `strategy.zig`, using direct BULL/SIDEWAYS/BEAR classification each strategy-minute tick (`price > MA*1.03` BULL, `price < MA*0.97` BEAR, otherwise SIDEWAYS). Python `backtest_crossval.py`, `backtest_fast.py` 3-regime, and `backtest_regimes.py` `ThreeRegimeStrategy` mirror this. `src/dctrading/live/engine.py` is an older sticky BULL/BEAR prototype and is not production-equivalent.
 - **Lazy MLX loading**: `news_monitor.py` lazy-loads the MLX model on first use (takes a few seconds).
 - **Alpaca WebSocket**: `websocket-client` library for real-time news stream.
 - **Telegram + ntfy**: Dual notification channels for sentiment alerts.

--- a/labs/dctrading/ARCHITECTURE.md
+++ b/labs/dctrading/ARCHITECTURE.md
@@ -48,6 +48,7 @@ labs/dctrading/
 │   └── types.py                # Shared type definitions
 ├── scripts/
 │   ├── backtest_fast.py        # Vectorized 3-regime backtest (numpy, ~100x faster)
+│   ├── backtest_crossval.py    # Production parity check against Zig
 │   ├── backtest_regimes.py     # 2-regime vs 3-regime comparison
 │   ├── backtest_sentiment.py   # Backtest with sentiment filter
 │   ├── backtest_yearly.py      # Year-by-year breakdown
@@ -74,18 +75,45 @@ numpy arrays: prices, timestamps
     │
     ▼
 simulate_trades() — walk forward through events
-    ├── Entry: DC UP event → buy (capital × (1 - fee))
-    ├── Exit: DC DOWN or trailing stop (BEAR only)
+    ├── BULL: buy if flat, then hold passively
+    ├── SIDEWAYS: DC UP entry, DC DOWN exit, no trailing stop
+    ├── BEAR: DC UP entry, DC DOWN exit, trailing stop enabled
     ├── Track: capital, equity, drawdown per trade
     │
     ▼
 Results: total return, max drawdown, Sharpe, trade count, win rate
 ```
 
-**Key results (2019–2026, $1K initial):**
-- 3-regime: +4,071% ($40.7K), 47 trades
-- 2-regime: +3,140% ($31.4K), 52 trades
-- Sentiment filter: hurts returns (skipped $371 winner)
+### Production Parity
+
+The Zig bot is the production implementation. The Python lab's
+production-equivalent references are the direct 3-regime backtests:
+
+- `scripts/backtest_crossval.py`
+- `scripts/backtest_fast.py` in `3reg` mode
+- `scripts/backtest_regimes.py` `ThreeRegimeStrategy`
+- funding variants that keep the same direct BULL/SIDEWAYS/BEAR classifier
+
+Production regime classification is recomputed on each one-minute strategy tick:
+
+- `price > 60d MA * 1.03` -> `BULL`
+- `price < 60d MA * 0.97` -> `BEAR`
+- otherwise -> `SIDEWAYS`
+
+`BULL` buys if flat and then holds passively. `SIDEWAYS` allows DC UP entries
+and DC DOWN exits with no trailing stop. `BEAR` allows DC UP entries, DC DOWN
+exits, and the volatility-adjusted trailing stop.
+
+The experimental async live engine in `src/dctrading/live/engine.py` is an older
+prototype. It uses sticky BULL/BEAR transitions and is not production-equivalent.
+
+**Verified production parity (2019-2024, $1K initial):**
+- Zig direct backtest, Zig `sim:` LiveLoop, and Python `backtest_crossval.py`
+  match without funding: +3,012.82%, 156 trades.
+- Zig direct backtest and Python `backtest_crossval.py` match with funding
+  filter: +4,039.08%, 136 trades.
+- Buy and hold over the same 2019-2024 BTC dataset: +2,436.87%.
+- Sentiment filter: hurts returns (skipped $371 winner).
 
 ## Sentiment Pipeline
 

--- a/labs/dctrading/README.md
+++ b/labs/dctrading/README.md
@@ -2,6 +2,28 @@
 
 Python research environment for the DCTrading system. Backtesting, sentiment analysis, and real-time news monitoring.
 
+## Production Strategy Reference
+
+Production trading runs in `services/dctrading-bot` (`src/strategy.zig`). The
+current production strategy is the direct 3-regime ZI-DCT0 model:
+
+| Regime | Condition | Behavior |
+|--------|-----------|----------|
+| BULL | Price > 60d MA + 3% | Buy if flat, then hold passively. DC trade actions are ignored. |
+| SIDEWAYS | Inside the 60d MA ± 3% band | DC UP entry, DC DOWN exit. No trailing stop. |
+| BEAR | Price < 60d MA - 3% | DC UP entry, DC DOWN exit, plus vol-trailing stop. |
+
+The Python scripts that mirror Zig production behavior are:
+
+- `scripts/backtest_crossval.py`
+- `scripts/backtest_fast.py` in `3reg` mode
+- `scripts/backtest_regimes.py` `ThreeRegimeStrategy`
+- funding backtests that use the same direct BULL/SIDEWAYS/BEAR classifier
+
+The experimental async live engine at `src/dctrading/live/engine.py` is not the
+production reference. It uses older sticky BULL/BEAR transitions and does not
+model production `SIDEWAYS` behavior.
+
 ## Setup
 
 ```bash
@@ -62,8 +84,8 @@ moon run dctrading:test-sentiment     # Sentiment mock test
 
 ## Key Results
 
-- 3-regime strategy: +4,071% over 2019–2026 on $1K (λ=0.07, 60d MA, buf=3%)
-- 2-regime baseline: +3,140% same period
+- Production 3-regime cross-validation: +4,039% over 2019-2024 on $1K with funding filter (λ=0.07, 60d MA, buf=3%)
+- Historical 2-regime baseline study: +3,140% over the prior 2019-2026 research window
 - Sentiment filter: hurts returns (skipped a $371 winner), not used for trade gating
 
 ## Environment Variables

--- a/labs/dctrading/scripts/backtest_regimes.py
+++ b/labs/dctrading/scripts/backtest_regimes.py
@@ -211,10 +211,10 @@ class BaseStrategy:
         }
 
 
-# ── Strategy A: 2-regime (current production) ──────────────────────
+# ── Strategy A: legacy 2-regime baseline ────────────────────────────
 
 class TwoRegimeStrategy(BaseStrategy):
-    """bull=hold, bear=DC+trailing_stop. Matches Zig production bot."""
+    """Legacy bull=hold, bear=DC+trailing_stop baseline."""
 
     def __init__(self, cfg: StrategyConfig) -> None:
         super().__init__(cfg)

--- a/services/dctrading-bot/AGENTS.md
+++ b/services/dctrading-bot/AGENTS.md
@@ -145,4 +145,4 @@ If you do not have IAM permissions, create the role manually:
 
 ### Companion Projects
 - **Neko Trade** — SwiftUI dashboard app (macOS + iOS). Separate repo.
-- **Python Research Lab** — Backtesting, sentiment analysis, MLX local LLM, news monitor. Separate repo.
+- **Python Research Lab** — Backtesting, sentiment analysis, MLX local LLM, news monitor. Production-equivalent strategy references are `labs/dctrading/scripts/backtest_crossval.py`, `backtest_fast.py` in `3reg` mode, and `backtest_regimes.py` `ThreeRegimeStrategy`; the experimental Python `live/engine.py` is older sticky BULL/BEAR prototype code and does not match current Zig production.

--- a/services/dctrading-bot/ARCHITECTURE.md
+++ b/services/dctrading-bot/ARCHITECTURE.md
@@ -40,10 +40,10 @@ feed.zig (downsample to 1-min candles)
     ▼
 strategy.processTick()
     ├── DC detector: UP/DOWN events when price reverses by λ=0.07
-    ├── Regime filter: BULL/SIDEWAYS/BEAR from 60-day MA ± 3% buffer
-    ├── Entry: DC UP event in any regime → BUY signal
-    ├── Exit: DC DOWN event → SELL (all regimes)
-    │         Vol-trailing stop → SELL (BEAR only)
+    ├── Regime filter: direct BULL/SIDEWAYS/BEAR from 60-day MA ± 3% buffer
+    ├── BULL: buy if flat, then ignore DC trade actions and hold passively
+    ├── SIDEWAYS: DC UP → BUY, DC DOWN → SELL, no trailing stop
+    ├── BEAR: DC UP → BUY, DC DOWN or vol-trailing stop → SELL
     │
     ▼
 main.zig (trade lifecycle)
@@ -69,9 +69,22 @@ The core strategy in `strategy.zig` (~371 lines):
 
 | Regime | Entry | Exit | Trailing Stop |
 |--------|-------|------|---------------|
-| BULL | DC UP | DC DOWN | No |
+| BULL | Immediate buy if flat | None (hold passively) | No |
 | SIDEWAYS | DC UP | DC DOWN | No |
 | BEAR | DC UP | DC DOWN + trailing | Yes (2% / 72h vol) |
+
+Regime is recomputed directly on each strategy-minute tick:
+
+- `price > MA * 1.03` → `BULL`
+- `price < MA * 0.97` → `BEAR`
+- otherwise → `SIDEWAYS`
+
+There is no debounce or sticky state between `BULL` and `SIDEWAYS`. This is the
+latest production behavior and is mirrored by the Python lab's 3-regime
+backtests (`backtest_crossval.py`, `backtest_fast.py` `3reg`, and
+`backtest_regimes.py` `ThreeRegimeStrategy`). The Python lab's experimental
+`src/dctrading/live/engine.py` is older sticky BULL/BEAR prototype code and is
+not production-equivalent.
 
 **Checkpoint (DCTRADE4):**
 Binary file with magic number validation (`0x4443_5452_4144_4534`). 24 f64 scalars (capital, entry price, regime, DC state, MA state, vol state) + two ring buffers (volatility window, MA window). Saved every 60 seconds. Old DCTRADE3 format rejected on load.

--- a/services/dctrading-bot/README.md
+++ b/services/dctrading-bot/README.md
@@ -4,17 +4,37 @@ A BTC algorithmic trading bot using Directional Change (DC) theory with a 3-regi
 
 ## Strategy
 
-**ZI-DCT0 Long-Only** with 3-regime filter:
+**ZI-DCT0 Long-Only** with direct 3-regime classification:
 
 | Regime | Condition | Behavior |
 |--------|-----------|----------|
-| BULL | Price > MA + 3% | Hold passively |
-| SIDEWAYS | MA ± 3% | DC trade (no trailing stop) |
-| BEAR | Price < MA - 3% | DC trade + vol-trailing stop |
+| BULL | Price > MA + 3% | Buy if flat, then hold passively. DC events are tracked but ignored for trading. |
+| SIDEWAYS | MA ± 3% | DC UP entry, DC DOWN exit. No trailing stop. |
+| BEAR | Price < MA - 3% | DC UP entry, DC DOWN exit, plus vol-trailing stop. |
 
 Parameters: λ=0.07, 60-day MA, 3% buffer, 2% trailing stop (72h vol lookback)
 
+Regime is recomputed on every strategy-minute tick from the current price and
+the 60-day moving-average band. `SIDEWAYS` is not sticky or debounced: price
+crossing above the upper band immediately becomes `BULL`, and moving back inside
+the band immediately becomes `SIDEWAYS`.
+
 **Backtested**: $1K → $41.4K over 2019-2024 (+4,039%) with funding filter, outperforming buy-and-hold (+2,437%).
+
+### Python Lab Parity
+
+The production strategy source of truth is `src/strategy.zig`. The matching
+Python research references are:
+
+- `labs/dctrading/scripts/backtest_crossval.py`
+- `labs/dctrading/scripts/backtest_fast.py` in `3reg` mode
+- `labs/dctrading/scripts/backtest_regimes.py` `ThreeRegimeStrategy`
+- funding variants that use the same direct BULL/SIDEWAYS/BEAR classifier
+
+`labs/dctrading/src/dctrading/live/engine.py` is an older experimental live
+prototype. It uses sticky BULL/BEAR transitions and does not model the current
+production `SIDEWAYS` behavior, so it must not be used as the production return
+reference.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- document the current Zig production strategy as direct 3-regime classification
- identify the Python lab backtests that are production-equivalent
- mark the Python async live engine and 2-regime strategy as legacy/non-production references
- update simulation baselines with verified no-funding and funding parity totals

## Verification
- PYTHONPATH=src .venv/bin/python scripts/backtest_crossval.py
- git diff --check