### PR TITLE
Render project body markdown in the portfolio feed

### DIFF
--- a/apps/blog/index.html
+++ b/apps/blog/index.html
@@ -521,6 +521,14 @@
       }
     }
 
+    .featured-project-card .featured-project-description {
+      display: -webkit-box;
+      margin: 0;
+      overflow: hidden;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 3;
+    }
+
     /* ─── Polaroid Stack ─── */
 
     .polaroid-stack {

--- a/apps/blog/plugins/portfolio-projects.ts
+++ b/apps/blog/plugins/portfolio-projects.ts
@@ -10,9 +10,49 @@
 
 import { type Plugin } from "vite";
 import { getDb } from "./db.js";
+import MarkdownIt from "markdown-it";
+import anchor from "markdown-it-anchor";
+import { createHighlighter } from "shiki";
+import { fromHighlighter } from "@shikijs/markdown-it";
+import { applyManekiRenderers } from "./markdown-utils.js";
 
 const VIRTUAL_MODULE_ID = "virtual:projects";
 const RESOLVED_ID = "\0" + VIRTUAL_MODULE_ID;
+
+let mdInstance: MarkdownIt | null = null;
+
+async function getMd(): Promise<MarkdownIt> {
+  if (mdInstance) return mdInstance;
+
+  const highlighter = await createHighlighter({
+    themes: ["github-light", "github-dark"],
+    langs: ["typescript", "javascript", "html", "css", "json", "bash", "markdown", "yaml", "rust", "sql"],
+  });
+
+  const md = new MarkdownIt({
+    html: true,
+    linkify: true,
+    typographer: true,
+  });
+
+  md.use(fromHighlighter(highlighter, {
+    themes: {
+      light: "github-light",
+      dark: "github-dark",
+    },
+    defaultColor: false,
+  }));
+
+  md.use(anchor, {
+    slugify: (s: string) => s.toLowerCase().replace(/[^\w]+/g, "-").replace(/(^-|-$)/g, ""),
+    permalink: false,
+  });
+
+  applyManekiRenderers(md);
+
+  mdInstance = md;
+  return md;
+}
 
 export function portfolioProjectsPlugin(): Plugin {
   async function loadProjects(): Promise<string> {
@@ -22,11 +62,12 @@ export function portfolioProjectsPlugin(): Plugin {
         "SELECT slug, title, description, body_md, tech, url, repo, image, pinned, sort_order FROM projects WHERE status = 'published' ORDER BY sort_order ASC, created_at DESC",
       );
 
+      const md = await getMd();
       const projects = result.rows.map((row) => ({
         slug: row.slug as string,
         title: row.title as string,
         description: row.description as string,
-        content: row.body_md as string,
+        content: md.render(row.body_md as string),
         tech: JSON.parse((row.tech as string) || "[]"),
         url: (row.url as string) ?? null,
         repo: (row.repo as string) ?? null,

--- a/apps/blog/src/pages/home.ts
+++ b/apps/blog/src/pages/home.ts
@@ -75,11 +75,11 @@ export const homeRoute: Route = {
       <div class="project-grid mt-3 reveal-stagger">
         ${pinnedProjects.map((project: any) => `
           <div class="reveal">
-            <ui-card size="m" bordered>
-              ${project.image ? `<ui-image src="${project.image}" alt="${project.title}" slot="image" style="width:100%;height:180px;--ui-image-fit:cover;"></ui-image>` : ""}
+            <ui-card class="featured-project-card" size="m" bordered>
+              ${project.image ? `<ui-image src="${project.image}" alt="${project.title}" slot="image" style="width:100%;height:150px;--ui-image-fit:cover;"></ui-image>` : ""}
               <div class="stack gap-1" style="padding:20px;">
                 <a href="/project/${project.slug}" class="project-card-title heading-05">${project.title}</a>
-                <p class="body-02 text-secondary">${project.description}</p>
+                <p class="featured-project-description body-02 text-secondary">${project.description}</p>
                 <div class="tags">
                   ${project.tech.map((t: string) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
                 </div>


### PR DESCRIPTION
## Summary
- Render `projects.body_md` to HTML in the `virtual:projects` plugin instead of passing raw markdown through.
- Reuse the same markdown-it, Shiki, and Maneki renderer pipeline used for posts so project pages format lists, links, and code blocks consistently.

## Testing
- Not run (not requested).