### PR TITLE
[codex] Fix Shadow DOM link navigation

### DIFF
--- a/apps/blog/index.html
+++ b/apps/blog/index.html
@@ -423,6 +423,27 @@
     .post-content p { font-size: var(--fd-type-body-01-font-size); line-height: var(--fd-type-body-01-line-height); margin: 0 0 var(--fd-space-2); }
     .post-content ul, .post-content ol { font-size: var(--fd-type-body-01-font-size); line-height: var(--fd-type-body-01-line-height); margin: 0 0 var(--fd-space-2); padding-left: var(--fd-space-3); }
     .post-content li { margin-bottom: var(--fd-space-0-5); }
+    .post-content a,
+    .post-content ui-link {
+      color: var(--blog-accent);
+      --ui-link-color: var(--blog-accent);
+      --ui-link-hover-color: var(--fd-text-primary, #18181b);
+      --ui-link-active-color: var(--fd-text-primary, #18181b);
+      --ui-link-visited-color: var(--blog-accent);
+    }
+    .post-content a,
+    .post-content ui-link::part(link) {
+      text-decoration: underline;
+      text-decoration-color: color-mix(in srgb, var(--blog-accent) 70%, transparent);
+      text-decoration-thickness: 1px;
+      text-underline-offset: 3px;
+      text-decoration-skip-ink: auto;
+      transition: color 150ms ease, text-decoration-color 150ms ease;
+    }
+    .post-content a:hover,
+    .post-content ui-link:hover::part(link) {
+      text-decoration-color: currentColor;
+    }
 
     /* ── Mute mode: soften all text globally (toggled via data-muted on :root) ── */
     [data-muted] { --fd-text-primary: var(--fd-color-gray-30, #C1CCD6); }

--- a/apps/blog/src/router.ts
+++ b/apps/blog/src/router.ts
@@ -45,6 +45,17 @@ export function getCurrentRoute(): string {
   return path || "home";
 }
 
+function findClickedAnchor(event: MouseEvent): HTMLAnchorElement | null {
+  for (const target of event.composedPath()) {
+    if (target instanceof HTMLAnchorElement && target.matches("a[href]")) {
+      return target;
+    }
+  }
+
+  const target = event.target;
+  return target instanceof Element ? target.closest("a[href]") : null;
+}
+
 async function resolveRoute(routeId: string): Promise<Route | undefined> {
   // Check exact match first
   const exact = routes[routeId];
@@ -160,7 +171,6 @@ function flipSignature(
     { duration, easing, fill: "forwards" },
   );
 
-
   // SVG underline: retract on forward (un-draw right-to-left), fade in on reverse
   if (svgInClone) {
     const isForward = direction === "forward";
@@ -175,10 +185,12 @@ function flipSignature(
         { duration: 250, easing: "ease-in", fill: "forwards" },
       );
     } else {
-      svgInClone.animate(
-        [{ opacity: 0 }, { opacity: 1 }],
-        { duration: 200, delay: 200, easing: "ease-in", fill: "forwards" },
-      );
+      svgInClone.animate([{ opacity: 0 }, { opacity: 1 }], {
+        duration: 200,
+        delay: 200,
+        easing: "ease-in",
+        fill: "forwards",
+      });
     }
   }
 
@@ -234,13 +246,11 @@ export async function renderRoute(): Promise<void> {
 
     // Forward: capture hero clone + rect BEFORE content swap destroys it
     // Fire FLIP immediately — don't wait for exit animation
-    let forwardClone: HTMLElement | null = null;
-    let forwardSourceRect: DOMRect | null = null;
     if (isLeavingHome && siteName) {
       const heroEl = document.querySelector(".hero-accent") as HTMLElement | null;
       if (heroEl) {
-        forwardSourceRect = heroEl.getBoundingClientRect();
-        forwardClone = heroEl.cloneNode(true) as HTMLElement;
+        const forwardSourceRect = heroEl.getBoundingClientRect();
+        const forwardClone = heroEl.cloneNode(true) as HTMLElement;
         // Capture computed font-size while hero is still in its original context
         // (1.8em resolves differently on <body> vs inside <h1>)
         forwardClone.style.fontSize = getComputedStyle(heroEl).fontSize;
@@ -321,8 +331,6 @@ function updateMeta(routeId: string, route: Route | undefined): void {
   // Toggle page identifier for conditional styling (e.g., hide site-name on home)
   document.documentElement.dataset.page = routeId === "home" ? "home" : "";
 
-
-
   // Update active nav link with directional underline
   const navLinks = Array.from(document.querySelectorAll("nav a[data-route]")) as HTMLAnchorElement[];
   const oldIndex = navLinks.findIndex((a) => a.classList.contains("active"));
@@ -332,7 +340,7 @@ function updateMeta(routeId: string, route: Route | undefined): void {
       el.dataset.route === routeId ||
       (routeId === "home" && !el.dataset.route) ||
       (routeId.startsWith("post/") && el.dataset.route === "blog");
-      (routeId.startsWith("photography/") && el.dataset.route === "photography");
+    routeId.startsWith("photography/") && el.dataset.route === "photography";
     if (isActive) newIndex = i;
   });
   const dir = oldIndex >= 0 && newIndex >= 0 && oldIndex !== newIndex ? (newIndex > oldIndex ? "right" : "left") : null;
@@ -341,7 +349,7 @@ function updateMeta(routeId: string, route: Route | undefined): void {
       el.dataset.route === routeId ||
       (routeId === "home" && !el.dataset.route) ||
       (routeId.startsWith("post/") && el.dataset.route === "blog");
-      (routeId.startsWith("photography/") && el.dataset.route === "photography");
+    routeId.startsWith("photography/") && el.dataset.route === "photography";
     if (dir) {
       // Outgoing: shrink toward the new item. Incoming: grow from the old item.
       el.dataset.navDir = i === oldIndex ? dir : i === newIndex ? (dir === "right" ? "left" : "right") : "";
@@ -366,10 +374,17 @@ export function initRouter(): void {
 
   // Intercept link clicks for SPA navigation
   document.addEventListener("click", (e) => {
-    const anchor = (e.target as Element).closest("a[href]") as HTMLAnchorElement | null;
+    const anchor = findClickedAnchor(e);
     if (!anchor) return;
     const href = anchor.getAttribute("href");
-    if (!href || href.startsWith("http") || href.startsWith("mailto:") || anchor.hasAttribute("external") || /\.[a-z]+$/i.test(href)) return;
+    if (
+      !href ||
+      href.startsWith("http") ||
+      href.startsWith("mailto:") ||
+      anchor.hasAttribute("external") ||
+      /\.[a-z]+$/i.test(href)
+    )
+      return;
     if (href.startsWith("/")) {
       e.preventDefault();
       history.pushState(null, "", href);


### PR DESCRIPTION
## Summary

Fix SPA navigation for links rendered inside open Shadow DOM components, including markdown-generated `<ui-link>` body links on the blog.

## Root Cause

The document-level router looked for anchors with `event.target.closest("a[href]")`. For clicks inside `<ui-link>`, the browser retargets the composed event to the custom element host, so the router never saw the internal anchor and the browser performed a full page load. That skipped the SPA route transition path and its animations.

## Changes

- Resolve clicked anchors from `event.composedPath()` before falling back to `closest("a[href]")`.
- Keep existing external, mailto, and file-extension navigation exclusions unchanged.
- Clean up unused FLIP locals that were blocking the pre-commit lint hook.

## Validation

- `npx tsc --noEmit` in `apps/blog`
- Pre-commit hook ran `eslint --fix` and `prettier --write` for the staged router file