### PR TITLE
[feat] Fix website reveal and empty states

### DIFF
--- a/apps/blog/index.html
+++ b/apps/blog/index.html
@@ -409,41 +409,21 @@
     }
 
     .empty-state {
-      position: relative;
-      overflow: hidden;
-      padding: var(--fd-space-5);
-      border: 1px solid var(--fd-border-minimal, #e4e4e7);
-      border-radius: var(--fd-radius-md);
+      padding: var(--fd-space-3) var(--fd-space-2);
+      border-top: 1px solid var(--fd-border-minimal, #e4e4e7);
+      border-bottom: 1px solid var(--fd-border-minimal, #e4e4e7);
       margin-top: var(--fd-space-4);
-      background:
-        radial-gradient(ellipse 80% 120% at 0% 0%, var(--blog-accent-subtle) 0%, transparent 55%),
-        var(--fd-surface-primary, #fff);
-    }
-
-    .empty-state::after {
-      content: "";
-      position: absolute;
-      right: var(--fd-space-4);
-      bottom: var(--fd-space-4);
-      width: 72px;
-      height: 72px;
-      border-right: 1px solid color-mix(in srgb, var(--blog-accent) 35%, transparent);
-      border-bottom: 1px solid color-mix(in srgb, var(--blog-accent) 35%, transparent);
-      opacity: 0.45;
-      pointer-events: none;
+      margin-left: calc(-1 * var(--fd-space-2));
+      margin-right: calc(-1 * var(--fd-space-2));
     }
 
     .empty-state-kicker {
       margin: 0 0 var(--fd-space-1);
-      color: var(--blog-accent);
-      font-weight: var(--fd-font-weight-semibold, 600);
-      text-transform: uppercase;
-      letter-spacing: 0;
+      color: var(--fd-text-tertiary, #71717a);
     }
 
     .empty-state h2 {
-      max-width: 20ch;
-      margin: 0 0 var(--fd-space-1-5);
+      margin: 0 0 var(--fd-space-1);
     }
 
     .empty-state p {
@@ -452,7 +432,7 @@
     }
 
     .empty-state-actions {
-      margin-top: var(--fd-space-3);
+      margin-top: var(--fd-space-2);
     }
 
     .tags {

--- a/apps/blog/index.html
+++ b/apps/blog/index.html
@@ -408,6 +408,18 @@
       margin-top: var(--fd-space-1);
     }
 
+    .empty-state {
+      padding: var(--fd-space-4) var(--fd-space-2);
+      border-top: 1px solid var(--fd-border-minimal, #e4e4e7);
+      border-bottom: 1px solid var(--fd-border-minimal, #e4e4e7);
+      margin-top: var(--fd-space-4);
+    }
+
+    .empty-state p {
+      max-width: 58ch;
+      margin: 0 0 var(--fd-space-2);
+    }
+
     .tags {
       display: flex;
       flex-wrap: wrap;

--- a/apps/blog/index.html
+++ b/apps/blog/index.html
@@ -409,21 +409,7 @@
     }
 
     .empty-state {
-      padding: var(--fd-space-3) var(--fd-space-2);
-      border-top: 1px solid var(--fd-border-minimal, #e4e4e7);
-      border-bottom: 1px solid var(--fd-border-minimal, #e4e4e7);
-      margin-top: var(--fd-space-4);
-      margin-left: calc(-1 * var(--fd-space-2));
-      margin-right: calc(-1 * var(--fd-space-2));
-    }
-
-    .empty-state-kicker {
-      margin: 0 0 var(--fd-space-1);
-      color: var(--fd-text-tertiary, #71717a);
-    }
-
-    .empty-state h2 {
-      margin: 0 0 var(--fd-space-1);
+      margin-top: var(--fd-space-2);
     }
 
     .empty-state p {

--- a/apps/blog/index.html
+++ b/apps/blog/index.html
@@ -409,15 +409,50 @@
     }
 
     .empty-state {
-      padding: var(--fd-space-4) var(--fd-space-2);
-      border-top: 1px solid var(--fd-border-minimal, #e4e4e7);
-      border-bottom: 1px solid var(--fd-border-minimal, #e4e4e7);
+      position: relative;
+      overflow: hidden;
+      padding: var(--fd-space-5);
+      border: 1px solid var(--fd-border-minimal, #e4e4e7);
+      border-radius: var(--fd-radius-md);
       margin-top: var(--fd-space-4);
+      background:
+        radial-gradient(ellipse 80% 120% at 0% 0%, var(--blog-accent-subtle) 0%, transparent 55%),
+        var(--fd-surface-primary, #fff);
+    }
+
+    .empty-state::after {
+      content: "";
+      position: absolute;
+      right: var(--fd-space-4);
+      bottom: var(--fd-space-4);
+      width: 72px;
+      height: 72px;
+      border-right: 1px solid color-mix(in srgb, var(--blog-accent) 35%, transparent);
+      border-bottom: 1px solid color-mix(in srgb, var(--blog-accent) 35%, transparent);
+      opacity: 0.45;
+      pointer-events: none;
+    }
+
+    .empty-state-kicker {
+      margin: 0 0 var(--fd-space-1);
+      color: var(--blog-accent);
+      font-weight: var(--fd-font-weight-semibold, 600);
+      text-transform: uppercase;
+      letter-spacing: 0;
+    }
+
+    .empty-state h2 {
+      max-width: 20ch;
+      margin: 0 0 var(--fd-space-1-5);
     }
 
     .empty-state p {
       max-width: 58ch;
       margin: 0 0 var(--fd-space-2);
+    }
+
+    .empty-state-actions {
+      margin-top: var(--fd-space-3);
     }
 
     .tags {

--- a/apps/blog/src/main.ts
+++ b/apps/blog/src/main.ts
@@ -70,11 +70,6 @@ function initReadingProgress(): void {
   );
 }
 
-// ─── Init ──────────────────────────────────────────────────────────────────
-
-initReadingProgress();
-initRouter();
-
 // ─── Scroll Reveal ──────────────────────────────────────────────────────
 
 const revealObserver = new IntersectionObserver(
@@ -89,12 +84,28 @@ const revealObserver = new IntersectionObserver(
   { threshold: 0.1, rootMargin: "0px 0px -40px 0px" },
 );
 
-function observeReveals(): void {
-  document.querySelectorAll(".reveal:not(.revealed)").forEach((el) => revealObserver.observe(el));
+function isAlreadyVisible(el: Element): boolean {
+  const rect = el.getBoundingClientRect();
+  return rect.bottom > 0 && rect.top < window.innerHeight - 40;
 }
 
-observeReveals();
+function observeReveals(): void {
+  document.querySelectorAll(".reveal:not(.revealed)").forEach((el) => {
+    if (isAlreadyVisible(el)) {
+      el.classList.add("revealed");
+      return;
+    }
+    revealObserver.observe(el);
+  });
+}
+
 window.addEventListener("route-changed", observeReveals);
+
+// ─── Init ──────────────────────────────────────────────────────────────────
+
+observeReveals();
+initReadingProgress();
+initRouter();
 
 // Auto-refresh on service worker update (reload when user returns to tab)
 import "./sw-refresh.js";

--- a/apps/blog/src/pages/blog.ts
+++ b/apps/blog/src/pages/blog.ts
@@ -18,8 +18,13 @@ export const blogRoute: Route = {
       posts.length === 0
         ? `
     <div class="empty-state reveal">
-      <p class="body-01 text-secondary">No published posts yet. The writing section is here for engineering notes and longer essays once they are ready.</p>
-      <a href="/portfolio" class="inline-link body-02 arrow-link"><span class="link-text">View my portfolio instead</span> <span class="arrow-right">→</span></a>
+      <p class="empty-state-kicker body-03">Writing desk</p>
+      <h2 class="heading-04">I have not published any posts here yet.</h2>
+      <p class="body-01 text-secondary">I use this space for engineering notes, design-system lessons, and longer write-ups once they are ready. For now, the best way to understand my work is through the projects I have shipped.</p>
+      <div class="row gap-2 empty-state-actions">
+        <a href="/portfolio" class="inline-link body-02 arrow-link"><span class="link-text">View my portfolio</span> <span class="arrow-right">→</span></a>
+        <a href="/resume" class="inline-link body-02 arrow-link"><span class="link-text">Read my resume</span> <span class="arrow-right">→</span></a>
+      </div>
     </div>`
         : `
     <ui-search id="post-search" placeholder="Search posts..." size="m" class="mb-4"></ui-search>

--- a/apps/blog/src/pages/blog.ts
+++ b/apps/blog/src/pages/blog.ts
@@ -18,9 +18,9 @@ export const blogRoute: Route = {
       posts.length === 0
         ? `
     <div class="empty-state reveal">
-      <p class="empty-state-kicker body-03">Writing desk</p>
-      <h2 class="heading-04">I have not published any posts here yet.</h2>
-      <p class="body-01 text-secondary">I use this space for engineering notes, design-system lessons, and longer write-ups once they are ready. For now, the best way to understand my work is through the projects I have shipped.</p>
+      <p class="empty-state-kicker body-03">No posts yet</p>
+      <h2 class="heading-04">I have not published writing here yet.</h2>
+      <p class="body-01 text-secondary">I use this space for engineering notes and longer write-ups when they are ready. For now, my portfolio and resume are the best places to understand my work.</p>
       <div class="row gap-2 empty-state-actions">
         <a href="/portfolio" class="inline-link body-02 arrow-link"><span class="link-text">View my portfolio</span> <span class="arrow-right">→</span></a>
         <a href="/resume" class="inline-link body-02 arrow-link"><span class="link-text">Read my resume</span> <span class="arrow-right">→</span></a>

--- a/apps/blog/src/pages/blog.ts
+++ b/apps/blog/src/pages/blog.ts
@@ -19,7 +19,7 @@ export const blogRoute: Route = {
         ? `
     <div class="empty-state reveal">
       <p class="body-01 text-secondary">No published posts yet. The writing section is here for engineering notes and longer essays once they are ready.</p>
-      <a href="/portfolio" class="inline-link body-02 arrow-link"><span class="link-text">View portfolio instead</span> <span class="arrow-right">→</span></a>
+      <a href="/portfolio" class="inline-link body-02 arrow-link"><span class="link-text">View my portfolio instead</span> <span class="arrow-right">→</span></a>
     </div>`
         : `
     <ui-search id="post-search" placeholder="Search posts..." size="m" class="mb-4"></ui-search>

--- a/apps/blog/src/pages/blog.ts
+++ b/apps/blog/src/pages/blog.ts
@@ -18,8 +18,6 @@ export const blogRoute: Route = {
       posts.length === 0
         ? `
     <div class="empty-state reveal">
-      <p class="empty-state-kicker body-03">No posts yet</p>
-      <h2 class="heading-04">I have not published writing here yet.</h2>
       <p class="body-01 text-secondary">I use this space for engineering notes and longer write-ups when they are ready. For now, my portfolio and resume are the best places to understand my work.</p>
       <div class="row gap-2 empty-state-actions">
         <a href="/portfolio" class="inline-link body-02 arrow-link"><span class="link-text">View my portfolio</span> <span class="arrow-right">→</span></a>

--- a/apps/blog/src/pages/blog.ts
+++ b/apps/blog/src/pages/blog.ts
@@ -14,9 +14,19 @@ export const blogRoute: Route = {
   meta: { title: "Blog", description: "Posts about fullstack development, design systems, and the web." },
   render: () => `
     <h1 class="heading-02 mb-2">Blog</h1>
+    ${
+      posts.length === 0
+        ? `
+    <div class="empty-state reveal">
+      <p class="body-01 text-secondary">No published posts yet. The writing section is here for engineering notes and longer essays once they are ready.</p>
+      <a href="/portfolio" class="inline-link body-02 arrow-link"><span class="link-text">View portfolio instead</span> <span class="arrow-right">→</span></a>
+    </div>`
+        : `
     <ui-search id="post-search" placeholder="Search posts..." size="m" class="mb-4"></ui-search>
     <div id="post-list" class="stack reveal-stagger">
-      ${posts.map((post) => `
+      ${posts
+        .map(
+          (post) => `
         <div class="post-card reveal" data-title="${post.title.toLowerCase()}" data-tags="${post.tags.join(",").toLowerCase()}" data-excerpt="${post.excerpt.toLowerCase()}">
           <a class="post-card-title" href="/post/${post.slug}">${post.title}</a>
           <div class="post-meta">${formatDate(post.date)} \u00b7 ${post.readTime}</div>
@@ -25,9 +35,12 @@ export const blogRoute: Route = {
             ${post.tags.map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
           </div>
         </div>
-      `).join("")}
+      `,
+        )
+        .join("")}
     </div>
-    <p id="no-results" class="body-01 text-secondary" style="display:none;">No posts found.</p>
+    <p id="no-results" class="body-01 text-secondary" style="display:none;">No posts found.</p>`
+    }
   `,
   setup: () => {
     const search = document.getElementById("post-search") as HTMLElement;

--- a/apps/blog/src/pages/home.ts
+++ b/apps/blog/src/pages/home.ts
@@ -23,8 +23,8 @@ export const homeRoute: Route = {
       <h1 class="display-03" style="margin-bottom:var(--fd-space-3);">Hey, I'm <strong class="hero-accent">Kien Nguyen<svg class="sig-underline" viewBox="0 0 200 18" preserveAspectRatio="none"><path d="M0 16 C25 14, 45 15, 70 12 S110 8, 140 9 S175 4, 200 3 L200 1.5 C175 2.5, 140 6, 110 5 S70 8, 45 11 S25 9, 0 11 Z"/></svg></strong></h1>
       <p class="body-01 text-secondary mt-2">Senior Software Engineer. Distributed systems, micro-frontends, and design systems. Amateur photographer.</p>
       <div class="row gap-2 mt-3">
-        <a href="/portfolio" class="inline-link body-02 arrow-link"><span class="link-text">View portfolio</span> <span class="arrow-right">→</span></a>
-        <a href="/resume" class="inline-link body-02 arrow-link"><span class="link-text">Read resume</span> <span class="arrow-right">→</span></a>
+        <a href="/portfolio" class="inline-link body-02 arrow-link"><span class="link-text">View my portfolio</span> <span class="arrow-right">→</span></a>
+        <a href="/resume" class="inline-link body-02 arrow-link"><span class="link-text">Read my resume</span> <span class="arrow-right">→</span></a>
       </div>
     </section>
 
@@ -34,7 +34,7 @@ export const homeRoute: Route = {
     <section class="mb-5 reveal">
       <div class="row items-center" style="justify-content:space-between;">
         <h2 class="heading-05">Recent posts</h2>
-        <a href="/blog" class="body-02 text-link arrow-link" style="text-decoration:none;">View all <span class="arrow-right">→</span></a>
+        <a href="/blog" class="body-02 text-link arrow-link" style="text-decoration:none;">Read my posts <span class="arrow-right">→</span></a>
       </div>
       <div class="stack mt-3 reveal-stagger">
         ${posts
@@ -61,7 +61,7 @@ export const homeRoute: Route = {
     <section class="mb-5 reveal">
       <div class="row items-center" style="justify-content:space-between;">
         <h2 class="heading-05">Photography</h2>
-        <a href="/photography" class="body-02 text-link arrow-link" style="text-decoration:none;">View all <span class="arrow-right">→</span></a>
+        <a href="/photography" class="body-02 text-link arrow-link" style="text-decoration:none;">View my photos <span class="arrow-right">→</span></a>
       </div>
       <a href="/photography" class="polaroid-stack mt-3" id="polaroid-stack" aria-label="View photography gallery">
         ${(() => {
@@ -105,7 +105,7 @@ export const homeRoute: Route = {
     <section class="reveal">
       <div class="row items-center" style="justify-content:space-between;">
         <h2 class="heading-05">Featured projects</h2>
-        <a href="/portfolio" class="body-02 text-link arrow-link" style="text-decoration:none;">View all <span class="arrow-right">→</span></a>
+        <a href="/portfolio" class="body-02 text-link arrow-link" style="text-decoration:none;">View my projects <span class="arrow-right">→</span></a>
       </div>
       <div class="project-grid mt-3 reveal-stagger">
         ${pinnedProjects

--- a/apps/blog/src/pages/home.ts
+++ b/apps/blog/src/pages/home.ts
@@ -22,17 +22,81 @@ export const homeRoute: Route = {
     <section class="mb-5 reveal">
       <h1 class="display-03" style="margin-bottom:var(--fd-space-3);">Hey, I'm <strong class="hero-accent">Kien Nguyen<svg class="sig-underline" viewBox="0 0 200 18" preserveAspectRatio="none"><path d="M0 16 C25 14, 45 15, 70 12 S110 8, 140 9 S175 4, 200 3 L200 1.5 C175 2.5, 140 6, 110 5 S70 8, 45 11 S25 9, 0 11 Z"/></svg></strong></h1>
       <p class="body-01 text-secondary mt-2">Senior Software Engineer. Distributed systems, micro-frontends, and design systems. Amateur photographer.</p>
+      <div class="row gap-2 mt-3">
+        <a href="/portfolio" class="inline-link body-02 arrow-link"><span class="link-text">View portfolio</span> <span class="arrow-right">→</span></a>
+        <a href="/resume" class="inline-link body-02 arrow-link"><span class="link-text">Read resume</span> <span class="arrow-right">→</span></a>
+      </div>
     </section>
+
+    <section class="mb-5 reveal">
+      <div class="row items-center" style="justify-content:space-between;">
+        <h2 class="heading-05">Featured projects</h2>
+        <a href="/portfolio" class="body-02 text-link arrow-link" style="text-decoration:none;">View all <span class="arrow-right">→</span></a>
+      </div>
+      <div class="project-grid mt-3 reveal-stagger">
+        ${pinnedProjects
+          .map(
+            (project) => `
+          <div class="reveal">
+            <ui-card class="featured-project-card" size="m" bordered>
+              <div class="project-card-media project-card-media--featured${project.image ? "" : " is-empty"}" slot="image">
+                ${project.image ? `<ui-image src="${project.image}" alt="${project.title}" style="width:100%;height:100%;--ui-image-fit:cover;"></ui-image>` : ""}
+              </div>
+              <div class="stack gap-1" style="padding:20px;">
+                <a href="/project/${project.slug}" class="project-card-title heading-05">${project.title}</a>
+                <p class="featured-project-description body-02 text-secondary">${project.description}</p>
+                <div class="tags">
+                  ${project.tech.map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
+                </div>
+                <div class="row gap-2 mt-1">
+                  ${project.url ? `<ui-link size="s" href="${project.url}" external>Live</ui-link>` : ""}
+                  ${project.repo ? `<ui-link size="s" href="${project.repo}" external>Source</ui-link>` : ""}
+                </div>
+              </div>
+            </ui-card>
+          </div>
+        `,
+          )
+          .join("")}
+      </div>
+    </section>
+
+    ${
+      posts.length > 0
+        ? `
+    <section class="mb-5 reveal">
+      <div class="row items-center" style="justify-content:space-between;">
+        <h2 class="heading-05">Recent posts</h2>
+        <a href="/blog" class="body-02 text-link arrow-link" style="text-decoration:none;">View all <span class="arrow-right">→</span></a>
+      </div>
+      <div class="stack mt-3 reveal-stagger">
+        ${posts
+          .slice(0, 3)
+          .map(
+            (post) => `
+          <div class="post-card reveal">
+            <a class="post-card-title" href="/post/${post.slug}">${post.title}</a>
+            <div class="post-meta">${formatDate(post.date)} \u00b7 ${post.readTime}</div>
+            <p class="post-excerpt">${post.excerpt}</p>
+          </div>
+        `,
+          )
+          .join("")}
+      </div>
+    </section>
+    `
+        : ""
+    }
 
     ${
       featuredPhotos.length > 0
         ? `
-    <section class="mb-5 reveal">
+    <section class="reveal">
       <div class="row items-center" style="justify-content:space-between;">
         <h2 class="heading-05">Photography</h2>
         <a href="/photography" class="body-02 text-link arrow-link" style="text-decoration:none;">View all <span class="arrow-right">→</span></a>
       </div>
-      <a href="/photography" class="polaroid-stack mt-3" id="polaroid-stack" aria-label="View photography">
+      <a href="/photography" class="polaroid-stack mt-3" id="polaroid-stack" aria-label="View photography gallery">
         ${(() => {
           const count = Math.min(featuredPhotos.length, 5);
           const angles = [-10, 3, 8, -6, 11];
@@ -60,7 +124,7 @@ export const homeRoute: Route = {
                          })()}"`
                        : ""
                    }
-                   loading="eager" decoding="async" fetchpriority="high"></ui-image>
+                   loading="lazy" decoding="async"></ui-image>
             </div>`;
             })
             .join("");
@@ -70,60 +134,6 @@ export const homeRoute: Route = {
     `
         : ""
     }
-
-    <section class="mb-5 reveal">
-      <div class="row items-center" style="justify-content:space-between;">
-        <h2 class="heading-05">Recent posts</h2>
-        <a href="/blog" class="body-02 text-link arrow-link" style="text-decoration:none;">View all <span class="arrow-right">→</span></a>
-      </div>
-      <div class="stack mt-3 reveal-stagger">
-        ${posts
-          .slice(0, 3)
-          .map(
-            (post) => `
-          <div class="post-card reveal">
-            <a class="post-card-title" href="/post/${post.slug}">${post.title}</a>
-            <div class="post-meta">${formatDate(post.date)} \u00b7 ${post.readTime}</div>
-            <p class="post-excerpt">${post.excerpt}</p>
-          </div>
-        `,
-          )
-          .join("")}
-      </div>
-    </section>
-
-    <section class="reveal">
-      <div class="row items-center" style="justify-content:space-between;">
-        <h2 class="heading-05">Featured projects</h2>
-        <a href="/portfolio" class="body-02 text-link arrow-link" style="text-decoration:none;">View all <span class="arrow-right">→</span></a>
-      </div>
-      <div class="project-grid mt-3 reveal-stagger">
-        ${pinnedProjects
-          .map(
-            (project: any) => `
-          <div class="reveal">
-            <ui-card class="featured-project-card" size="m" bordered>
-              <div class="project-card-media project-card-media--featured${project.image ? "" : " is-empty"}" slot="image">
-                ${project.image ? `<ui-image src="${project.image}" alt="${project.title}" style="width:100%;height:100%;--ui-image-fit:cover;"></ui-image>` : ""}
-              </div>
-              <div class="stack gap-1" style="padding:20px;">
-                <a href="/project/${project.slug}" class="project-card-title heading-05">${project.title}</a>
-                <p class="featured-project-description body-02 text-secondary">${project.description}</p>
-                <div class="tags">
-                  ${project.tech.map((t: string) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
-                </div>
-                <div class="row gap-2 mt-1">
-                  ${project.url ? `<ui-link size="s" href="${project.url}" external>Live</ui-link>` : ""}
-                  ${project.repo ? `<ui-link size="s" href="${project.repo}" external>Source</ui-link>` : ""}
-                </div>
-              </div>
-            </ui-card>
-          </div>
-        `,
-          )
-          .join("")}
-      </div>
-    </section>
   `,
   setup: () => {
     const stack = document.getElementById("polaroid-stack");

--- a/apps/blog/src/pages/home.ts
+++ b/apps/blog/src/pages/home.ts
@@ -28,39 +28,6 @@ export const homeRoute: Route = {
       </div>
     </section>
 
-    <section class="mb-5 reveal">
-      <div class="row items-center" style="justify-content:space-between;">
-        <h2 class="heading-05">Featured projects</h2>
-        <a href="/portfolio" class="body-02 text-link arrow-link" style="text-decoration:none;">View all <span class="arrow-right">→</span></a>
-      </div>
-      <div class="project-grid mt-3 reveal-stagger">
-        ${pinnedProjects
-          .map(
-            (project) => `
-          <div class="reveal">
-            <ui-card class="featured-project-card" size="m" bordered>
-              <div class="project-card-media project-card-media--featured${project.image ? "" : " is-empty"}" slot="image">
-                ${project.image ? `<ui-image src="${project.image}" alt="${project.title}" style="width:100%;height:100%;--ui-image-fit:cover;"></ui-image>` : ""}
-              </div>
-              <div class="stack gap-1" style="padding:20px;">
-                <a href="/project/${project.slug}" class="project-card-title heading-05">${project.title}</a>
-                <p class="featured-project-description body-02 text-secondary">${project.description}</p>
-                <div class="tags">
-                  ${project.tech.map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
-                </div>
-                <div class="row gap-2 mt-1">
-                  ${project.url ? `<ui-link size="s" href="${project.url}" external>Live</ui-link>` : ""}
-                  ${project.repo ? `<ui-link size="s" href="${project.repo}" external>Source</ui-link>` : ""}
-                </div>
-              </div>
-            </ui-card>
-          </div>
-        `,
-          )
-          .join("")}
-      </div>
-    </section>
-
     ${
       posts.length > 0
         ? `
@@ -91,7 +58,7 @@ export const homeRoute: Route = {
     ${
       featuredPhotos.length > 0
         ? `
-    <section class="reveal">
+    <section class="mb-5 reveal">
       <div class="row items-center" style="justify-content:space-between;">
         <h2 class="heading-05">Photography</h2>
         <a href="/photography" class="body-02 text-link arrow-link" style="text-decoration:none;">View all <span class="arrow-right">→</span></a>
@@ -124,7 +91,7 @@ export const homeRoute: Route = {
                          })()}"`
                        : ""
                    }
-                   loading="lazy" decoding="async"></ui-image>
+                   loading="eager" decoding="async" fetchpriority="high"></ui-image>
             </div>`;
             })
             .join("");
@@ -134,6 +101,39 @@ export const homeRoute: Route = {
     `
         : ""
     }
+
+    <section class="reveal">
+      <div class="row items-center" style="justify-content:space-between;">
+        <h2 class="heading-05">Featured projects</h2>
+        <a href="/portfolio" class="body-02 text-link arrow-link" style="text-decoration:none;">View all <span class="arrow-right">→</span></a>
+      </div>
+      <div class="project-grid mt-3 reveal-stagger">
+        ${pinnedProjects
+          .map(
+            (project) => `
+          <div class="reveal">
+            <ui-card class="featured-project-card" size="m" bordered>
+              <div class="project-card-media project-card-media--featured${project.image ? "" : " is-empty"}" slot="image">
+                ${project.image ? `<ui-image src="${project.image}" alt="${project.title}" style="width:100%;height:100%;--ui-image-fit:cover;"></ui-image>` : ""}
+              </div>
+              <div class="stack gap-1" style="padding:20px;">
+                <a href="/project/${project.slug}" class="project-card-title heading-05">${project.title}</a>
+                <p class="featured-project-description body-02 text-secondary">${project.description}</p>
+                <div class="tags">
+                  ${project.tech.map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
+                </div>
+                <div class="row gap-2 mt-1">
+                  ${project.url ? `<ui-link size="s" href="${project.url}" external>Live</ui-link>` : ""}
+                  ${project.repo ? `<ui-link size="s" href="${project.repo}" external>Source</ui-link>` : ""}
+                </div>
+              </div>
+            </ui-card>
+          </div>
+        `,
+          )
+          .join("")}
+      </div>
+    </section>
   `,
   setup: () => {
     const stack = document.getElementById("polaroid-stack");

--- a/apps/blog/src/pages/portfolio.ts
+++ b/apps/blog/src/pages/portfolio.ts
@@ -3,14 +3,17 @@ import type { Route } from "../router.js";
 
 export const portfolioRoute: Route = {
   id: "portfolio",
-  meta: { title: "Portfolio", description: "Things I've built \u2014 from design systems to CLI tools." },
+  meta: {
+    title: "Portfolio",
+    description: "Selected engineering work across authorization, fintech dashboards, and frontend platforms.",
+  },
   render: () => `
     <h1 class="heading-02 mb-2">Portfolio</h1>
-    <p class="body-01 text-secondary mb-4">Things I've built \u2014 from design systems to CLI tools.</p>
+    <p class="body-01 text-secondary mb-4">Selected engineering work across authorization, fintech dashboards, and frontend platforms.</p>
     <div class="project-grid reveal-stagger">
       ${projects
         .map(
-          (project: any) => `
+          (project) => `
         <div class="reveal">
           <ui-card size="m" bordered>
             <div class="project-card-media${project.image ? "" : " is-empty"}" slot="image">
@@ -20,7 +23,7 @@ export const portfolioRoute: Route = {
               <a href="/project/${project.slug}" class="project-card-title heading-05">${project.title}</a>
               <p class="body-02 text-secondary">${project.description}</p>
               <div class="tags">
-                ${project.tech.map((t: string) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
+                ${project.tech.map((t) => `<ui-badge size="s" emphasis="subtle">${t}</ui-badge>`).join("")}
               </div>
               <div class="row gap-2 mt-1">
                 ${project.url ? `<ui-link size="s" href="${project.url}" external>Live</ui-link>` : ""}

--- a/apps/blog/src/routes.ts
+++ b/apps/blog/src/routes.ts
@@ -25,7 +25,10 @@ export const routes: Route[] = [
   },
   {
     id: "portfolio",
-    meta: { title: "Portfolio", description: "Things I've built — from design systems to CLI tools." },
+    meta: {
+      title: "Portfolio",
+      description: "Selected engineering work across authorization, fintech dashboards, and frontend platforms.",
+    },
     load: () => import("./pages/portfolio.js").then((m) => m.portfolioRoute),
   },
   {


### PR DESCRIPTION
## Summary

- Fix the blog reveal lifecycle so visible content is readable on initial route loads.
- Move featured projects higher on the home page and add direct portfolio/resume links.
- Hide the empty recent posts section on the home page and add a proper empty state on the blog page.
- Tighten portfolio page copy and keep route metadata consistent.
- Add shared empty-state styling and a clearer accessible label for the photography gallery link.

## Root Cause

The reveal observer was initialized after router hydration, so prerendered or already-visible .reveal elements could remain stuck at the hidden/blurred starting state. The fix registers reveal handling before router init and immediately reveals elements already in the viewport.

## Validation

- npx tsc --noEmit in apps/blog
- Pre-commit hook ran html-validate, eslint --fix, and prettier --write

## Notes

npm run build is still blocked locally without TURSO_URL because the sitemap plugin needs Turso access during build.